### PR TITLE
Issue #6 and #10: Complete Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,13 @@ before_script:
   # Import the PHP configuration.
   - phpenv config-add core/misc/travis-ci/php.ini
 
-  # Install Backdrop with Drush.
+  # Set MySQL configuration and create the database.
+  - mysql -e 'SET GLOBAL wait_timeout = 5400;'
   - mysql -e 'create database backdrop;'
+
+  # Install Backdrop with Drush.
   - chmod a+w sites/default
-  - drush si --db-url=mysql://root:@localhost/backdrop -y
+  - drush si --db-url=mysql://travis:@localhost/backdrop -y
   - chmod go-w sites/default
   - drush en simpletest -y
 script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ before_script:
   - drush si --db-url=mysql://travis:@localhost/backdrop -y
   - chmod go-w sites/default
   - drush en simpletest -y
-script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose --all
+script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --all

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -907,7 +907,7 @@ function drupal_get_filename($type, $name, $filename = NULL) {
     try {
       if (function_exists('db_query')) {
         $file = db_query("SELECT filename FROM {system} WHERE name = :name AND type = :type", array(':name' => $name, ':type' => $type))->fetchField();
-        if (file_exists(DRUPAL_ROOT . '/' . $file)) {
+        if ($file && file_exists(DRUPAL_ROOT . '/' . $file)) {
           $files[$type][$name] = $file;
         }
       }

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -2332,61 +2332,51 @@ function drupal_attributes(array $attributes = array()) {
  *
  * @return
  *   An HTML string containing a link to the given path.
+ *
+ * @see url()
+ * @see theme_link()
  */
 function l($text, $path, array $options = array()) {
   global $language_url;
-  static $use_theme = NULL;
 
-  // Merge in defaults.
-  $options += array(
+  // Build a variables array to keep the structure of the alter consistent with
+  // theme_link().
+  $variables = array(
+    'text' => $text,
+    'path' => $path,
+    'options' => $options,
+  );
+
+  // Merge in default options.
+  $variables['options'] += array(
     'attributes' => array(),
+    'query' => array(),
     'html' => FALSE,
+    'language' => NULL,
   );
 
   // Append active class.
   if (($path == $_GET['q'] || ($path == '<front>' && drupal_is_front_page())) &&
       (empty($options['language']) || $options['language']->langcode == $language_url->langcode)) {
-    $options['attributes']['class'][] = 'active';
+    $variables['options']['attributes']['class'][] = 'active';
   }
 
-  // Remove all HTML and PHP tags from a tooltip. For best performance, we act only
-  // if a quick strpos() pre-check gave a suspicion (because strip_tags() is expensive).
-  if (isset($options['attributes']['title']) && strpos($options['attributes']['title'], '<') !== FALSE) {
-    $options['attributes']['title'] = strip_tags($options['attributes']['title']);
+  // Remove all HTML and PHP tags from a tooltip, calling expensive strip_tags()
+  // only when a quick strpos() gives suspicion tags are present.
+  if (isset($variables['options']['attributes']['title']) && strpos($variables['options']['attributes']['title'], '<') !== FALSE) {
+    $variables['options']['attributes']['title'] = strip_tags($variables['options']['attributes']['title']);
   }
 
-  // Determine if rendering of the link is to be done with a theme function
-  // or the inline default. Inline is faster, but if the theme system has been
-  // loaded and a module or theme implements a preprocess or process function
-  // or overrides the theme_link() function, then invoke theme(). Preliminary
-  // benchmarks indicate that invoking theme() can slow down the l() function
-  // by 20% or more, and that some of the link-heavy Drupal pages spend more
-  // than 10% of the total page request time in the l() function.
-  if (!isset($use_theme) && function_exists('theme')) {
-    // Allow edge cases to prevent theme initialization and force inline link
-    // rendering.
-    if (variable_get('theme_link', TRUE)) {
-      drupal_theme_initialize();
-      $registry = theme_get_registry(FALSE);
-      // We don't want to duplicate functionality that's in theme(), so any
-      // hint of a module or theme doing anything at all special with the 'link'
-      // theme hook should simply result in theme() being called. This includes
-      // the overriding of theme_link() with an alternate function or template,
-      // the presence of preprocess or process functions, or the presence of
-      // include files.
-      $use_theme = !isset($registry['link']['function']) || ($registry['link']['function'] != 'theme_link');
-      $use_theme = $use_theme || !empty($registry['link']['preprocess functions']) || !empty($registry['link']['process functions']) || !empty($registry['link']['includes']);
-    }
-    else {
-      $use_theme = FALSE;
-    }
-  }
-  if ($use_theme) {
-    return theme('link', array('text' => $text, 'path' => $path, 'options' => $options));
-  }
-  // The result of url() is a plain-text URL. Because we are using it here
-  // in an HTML argument context, we need to encode it properly.
-  return '<a href="' . check_plain(url($path, $options)) . '"' . drupal_attributes($options['attributes']) . '>' . ($options['html'] ? $text : check_plain($text)) . '</a>';
+  // Move attributes out of options. url() doesn't need them.
+  $attributes = drupal_attributes($variables['options']['attributes']);
+  unset($variables['options']['attributes']);
+
+  $url = check_plain(url($variables['path'], $variables['options']));
+
+  // Sanitize the link text if necessary.
+  $text = $variables['options']['html'] ? $variables['text'] : check_plain($variables['text']);
+
+  return '<a href="' . $url . '"' . $attributes . '>' . $text . '</a>';
 }
 
 /**

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1629,23 +1629,22 @@ function theme_status_messages($variables) {
 /**
  * Returns HTML for a link.
  *
- * All Drupal code that outputs a link should call the l() function. That
- * function performs some initial preprocessing, and then, if necessary, calls
- * theme('link') for rendering the anchor tag.
+ * This is a wrapper around l() to allow for more flexible link themeing.
  *
- * To optimize performance for sites that don't need custom theming of links,
- * the l() function includes an inline copy of this function, and uses that copy
- * if none of the enabled modules or the active theme implement any preprocess
- * or process functions or override this theme implementation.
+ * Where performance is more important than theme flexibility, Drupal code that
+ * outputs a link should call the l() function directly, as #theme 'link'
+ * implementations have a measurable performance impact.
  *
  * @param $variables
  *   An associative array containing the keys 'text', 'path', and 'options'. See
- *   the l() function for information about these variables.
+ *   See the l() function for information about these variables. However, unlike
+ *   'text' in l(), both render arrays and strings are supported here.
  *
  * @see l()
  */
 function theme_link($variables) {
-  return '<a href="' . check_plain(url($variables['path'], $variables['options'])) . '"' . drupal_attributes($variables['options']['attributes']) . '>' . ($variables['options']['html'] ? $variables['text'] : check_plain($variables['text'])) . '</a>';
+  $rendered_text = is_array($variables['text']) ? drupal_render($variables['text']) : $variables['text'];
+  return l($rendered_text, $variables['path'], $variables['options']);
 }
 
 /**

--- a/core/modules/simpletest/drupal_web_test_case.php
+++ b/core/modules/simpletest/drupal_web_test_case.php
@@ -443,7 +443,7 @@ abstract class DrupalTestCase {
   /**
    * Logs verbose message in a text file.
    *
-   * The a link to the vebose message will be placed in the test results via
+   * The a link to the verbose message will be placed in the test results via
    * as a passing assertion with the text '[verbose message]'.
    *
    * @param $message
@@ -705,6 +705,13 @@ class DrupalUnitTestCase extends DrupalTestCase {
 
     // Store necessary current values before switching to the test environment.
     $this->originalFileDirectory = variable_get('file_public_path', conf_path() . '/files');
+
+    // Generate a temporary prefixed database to ensure that tests have a clean starting point.
+    $this->databasePrefix = 'simpletest' . mt_rand(1000, 1000000);
+    db_update('simpletest_test_id')
+      ->fields(array('last_prefix' => $this->databasePrefix))
+      ->condition('test_id', $this->testId)
+      ->execute();
 
     // Reset all statics so that test is performed with a clean environment.
     drupal_static_reset();

--- a/core/modules/simpletest/drupal_web_test_case.php
+++ b/core/modules/simpletest/drupal_web_test_case.php
@@ -709,9 +709,6 @@ class DrupalUnitTestCase extends DrupalTestCase {
     // Reset all statics so that test is performed with a clean environment.
     drupal_static_reset();
 
-    // Generate temporary prefixed database to ensure that tests have a clean starting point.
-    $this->databasePrefix = Database::getConnection()->prefixTables('{simpletest' . mt_rand(1000, 1000000) . '}');
-
     // Create test directory.
     $public_files_directory = $this->originalFileDirectory . '/simpletest/' . substr($this->databasePrefix, 10);
     file_prepare_directory($public_files_directory, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);


### PR DESCRIPTION
This pull request fixes both #6 (Fixing issues with Travis CI) and #6 (Fixing lingering test failures). It backported the modification to the l() function that removes calls to theme_link(), which unbelievably was causing the failure in the TablesortTest. Apparently unit tests that called l() resulted in theme layer getting initialized, but since unit tests don't have Drupal installed, the theme system initialization would cause a DB error. Backporting the patch to remove the theme call from l() seemed like the easiest fix (and good for performance too).
