### PR TITLE
Issue #10: Fixing Dashboard test causing current failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ before_script:
   - drush si --db-url=mysql://travis:@localhost/backdrop -y
   - chmod go-w sites/default
   - drush en simpletest -y
-script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --all
+script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose SimpleTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,16 @@ php:
 before_script:
   # Install Apache and FastCGI extension to connect to PHP-FPM.
   - sudo apt-get update > /dev/null
-  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo apt-get install apache2 libapache2-mod-fastcgi > /dev/null
   - sudo a2enmod rewrite actions fastcgi alias
   - sudo cp -f core/misc/travis-ci/vhost.conf /etc/apache2/sites-available/default
   - sudo sed -i -e "s,/var/www,`pwd`,g" /etc/apache2/sites-available/default
   - sudo apachectl restart
-  - sudo find / -name error.log
 
   # Start PHP-FPM. There is no process manager available to start PHP-FPM on
   # Travis CI currently, so we have to locate and enable it manually.
-  - sudo cp /home/travis/.phpenv/versions/`php -r "print PHP_VERSION;"`/etc/php-fpm.conf.default /home/travis/.phpenv/versions/`php -r "print PHP_VERSION;"`/etc/php-fpm.conf
-  - /home/travis/.phpenv/versions/`php -r "print PHP_VERSION;"`/sbin/php-fpm
+  - sudo cp $HOME/.phpenv/versions/`php -r "print PHP_VERSION;"`/etc/php-fpm.conf.default $HOME/.phpenv/versions/`php -r "print PHP_VERSION;"`/etc/php-fpm.conf
+  - $HOME/.phpenv/versions/`php -r "print PHP_VERSION;"`/sbin/php-fpm
 
   # Install Drush. Newer drush versions won't run site-install because Backdrop
   # doesn't match expectations about Drupal 7/8 versions. Drush 5.7 doesn't
@@ -40,5 +39,6 @@ before_script:
   - sudo find / -name error.log
 script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose SimpleTest
 after_failure:
-  - echo "Failures detected. Outputing additional"
+  - echo "Failures detected. Outputing additional logs:"
   - sudo cat /var/log/apache2/error.log
+  - sudo cat /var/log/mysql/error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
   - sudo cp -f core/misc/travis-ci/vhost.conf /etc/apache2/sites-available/default
   - sudo sed -i -e "s,/var/www,`pwd`,g" /etc/apache2/sites-available/default
   - sudo apachectl restart
+  - sudo find / -name error.log
 
   # Start PHP-FPM. There is no process manager available to start PHP-FPM on
   # Travis CI currently, so we have to locate and enable it manually.
@@ -36,4 +37,8 @@ before_script:
   - drush si --db-url=mysql://travis:@localhost/backdrop -y
   - chmod go-w sites/default
   - drush en simpletest -y
+  - sudo find / -name error.log
 script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose SimpleTest
+after_failure:
+  - echo "Failures detected. Outputing additional"
+  - sudo cat /var/log/apache2/error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - chmod go-w sites/default
   - drush en simpletest -y
   - sudo find / -name error.log
-script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose SimpleTest
+script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --all
 after_failure:
   - echo "Failures detected. Outputing additional logs:"
   - sudo cat /var/log/apache2/error.log

--- a/core/misc/travis-ci/php.ini
+++ b/core/misc/travis-ci/php.ini
@@ -12,5 +12,9 @@ sendmail_path = 'true'
 ; Set memory limit.
 memory_limit = 128M
 
+; Allow for a longer than normal execution time for long-running operations.
+max_execution_time = 120
+max_input_time = 120
+
 ; Ensure a default of fixing paths is enabled.
 cgi.fix_pathinfo = 1

--- a/core/misc/travis-ci/vhost.conf
+++ b/core/misc/travis-ci/vhost.conf
@@ -28,7 +28,7 @@
     AddHandler php5-fcgi .php
     Action php5-fcgi /php5-fcgi
     Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
-    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -idle-timeout 120 -host 127.0.0.1:9000 -pass-header Authorization
   </IfModule>
 
   # Possible values include: debug, info, notice, warn, error, crit,

--- a/core/modules/system/system.test
+++ b/core/modules/system/system.test
@@ -1536,10 +1536,6 @@ class SystemMainContentFallback extends DrupalWebTestCase {
    */
   function testMainContentFallback() {
     $edit = array();
-    // Disable the dashboard module, which depends on the block module.
-    $edit['modules[Core][dashboard][enable]'] = FALSE;
-    $this->drupalPost('admin/modules', $edit, t('Save configuration'));
-    $this->assertText(t('The configuration options have been saved.'), t('Modules status has been updated.'));
     // Disable the block module.
     $edit['modules[Core][block][enable]'] = FALSE;
     $this->drupalPost('admin/modules', $edit, t('Save configuration'));


### PR DESCRIPTION
This fixes a current failure in testing the page fallback. It was broken by our disabling Dashboard by default.
