### PR TITLE
Support for DRUPAL_SETTINGS as an override for Drupal configuration

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -774,7 +774,7 @@ function drupal_settings_initialize() {
   // Load Drupal settings specified by the server, if present
   if (isset($_SERVER['DRUPAL_SETTINGS'])) {
     $drupal_settings = json_decode($_SERVER['DRUPAL_SETTINGS'], TRUE);
-    foreach ($server_drupal_settings as $key => $value) {
+    foreach ($drupal_settings as $key => $value) {
       // One level of depth should be enough for $conf and $databases.
       if ($key == 'conf') {
         foreach($value as $conf_key => $conf_value) {

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -771,6 +771,30 @@ function drupal_settings_initialize() {
   }
   $is_https = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on';
 
+  // Load Drupal settings specified by the server, if present
+  if (isset($_SERVER['DRUPAL_SETTINGS'])) {
+    $drupal_settings = json_decode($_SERVER['DRUPAL_SETTINGS'], TRUE);
+    foreach ($server_drupal_settings as $key => $value) {
+      // One level of depth should be enough for $conf and $databases.
+      if ($key == 'conf') {
+        foreach($value as $conf_key => $conf_value) {
+          $conf[$conf_key] = $conf_value;
+        }
+      }
+      elseif ($key == 'databases') {
+        // Protect default configuration but allow the specification of
+        // additional databases. 
+        if (!isset($databases) || !is_array($databases)) {
+          $databases = array();
+        }
+        $databases = array_replace_recursive($databases, $value);
+      }
+      else {
+        $$key = $value;
+      }
+    }
+  }
+
   if (isset($base_url)) {
     // Parse fixed base URL from settings.php.
     $parts = parse_url($base_url);

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -772,8 +772,8 @@ function drupal_settings_initialize() {
   $is_https = isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on';
 
   // Load Drupal settings specified by the server, if present
-  if (isset($_SERVER['DRUPAL_SETTINGS'])) {
-    $drupal_settings = json_decode($_SERVER['DRUPAL_SETTINGS'], TRUE);
+  if (isset($_SERVER['SERVER_SETTINGS'])) {
+    $drupal_settings = json_decode($_SERVER['SERVER_SETTINGS'], TRUE);
     foreach ($drupal_settings as $key => $value) {
       // One level of depth should be enough for $conf and $databases.
       if ($key == 'conf') {


### PR DESCRIPTION
There are many different Drupal development and hosting platforms that would like to inject their settings into a Drupal installation without formally writing it to the settings.php.

This pull request allows this through a $_SERVER['DRUPAL_SETTINGS'] value that can be injected in a variety of ways. This is the method we have used at Pantheon to inject our settings for years, but would love for it to be more cleanly supported in Backdrop.
