### PR TITLE
Issue #98: Fixed an error caused by changed string handling in PHP 5.4 a...

### DIFF
--- a/core/includes/database/query.inc
+++ b/core/includes/database/query.inc
@@ -1895,7 +1895,7 @@ class DatabaseCondition implements QueryConditionInterface, Countable {
   function __clone() {
     $this->changed = TRUE;
     foreach ($this->conditions as $key => $condition) {
-      if ($condition['field'] instanceOf QueryConditionInterface) {
+      if ($key !== '#conjunction' && $condition['field'] instanceOf QueryConditionInterface) {
         $this->conditions[$key]['field'] = clone($condition['field']);
       }
     }


### PR DESCRIPTION
...nd later. Found fix at https://drupal.org/node/1414412

https://github.com/backdrop/backdrop-issues/issues/98
