### PR TITLE
Some simple changes to get Drush 6 to recognize Backdrop as Drupal 7.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -8,12 +8,12 @@
 /**
  * The current system version.
  */
-const VERSION = '8.0-dev';
+const VERSION = '7.0-dev';
 
 /**
  * Core API compatibility.
  */
-const DRUPAL_CORE_COMPATIBILITY = '8.x';
+const DRUPAL_CORE_COMPATIBILITY = '7.x';
 
 /**
  * Minimum supported version of PHP.

--- a/includes
+++ b/includes
@@ -1,0 +1,1 @@
+core/includes

--- a/misc
+++ b/misc
@@ -1,0 +1,1 @@
+core/misc

--- a/modules
+++ b/modules
@@ -1,0 +1,1 @@
+core/modules


### PR DESCRIPTION
Messing around to see what would be involved with getting Backdrop to install in Aegir, I came up with this simple solution: https://drupal.org/node/2094221#comment-7953811. Basically, just symlink some directories, so Drush 6 recognizes Backdrop as Drupal 7, and change the version strings.
