### PR TITLE
Issue 32 On modules page, hide modules that are required_by /Drupal/ ins...

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -797,9 +797,11 @@ function system_modules($form, $form_state = array()) {
   foreach ($visible_files as $filename => $module) {
     $extra = array();
     $extra['enabled'] = (bool) $module->status;
+    $extra['core_hide'] = FALSE;
     if (!empty($module->info['required'] )) {
       $extra['disabled'] = TRUE;
       $extra['required_by'][] = $distribution_name . (!empty($module->info['explanation']) ? ' ('. $module->info['explanation'] .')' : '');
+    $extra['core_hide'] = TRUE;
     }
 
     // If this module requires other modules, add them to the array.
@@ -954,6 +956,7 @@ function _system_modules_build_row($info, $extra) {
   );
   $form['#requires'] = $extra['requires'];
   $form['#required_by'] = $extra['required_by'];
+  $form['#core_hide'] = $extra['core_hide'];
 
   // Check the compatibilities.
   $compatible = TRUE;
@@ -2518,7 +2521,9 @@ function theme_system_modules_fieldset($variables) {
     foreach (array('help', 'permissions', 'configure') as $key) {
       $row[] = array('data' => drupal_render($module['links'][$key]), 'class' => array($key));
     }
-    $rows[] = $row;
+    if (!$module["#core_hide"]) {
+      $rows[] = $row;
+    }
   }
 
   return theme('table', array('header' => $form['#header'], 'rows' => $rows));

--- a/core/modules/system/system.test
+++ b/core/modules/system/system.test
@@ -556,32 +556,6 @@ class ModuleVersionTestCase extends ModuleTestCase {
   }
 }
 
-/**
- * Test required modules functionality.
- */
-class ModuleRequiredTestCase extends ModuleTestCase {
-  /**
-   * Assert that core required modules cannot be disabled.
-   */
-  function testDisableRequired() {
-    $module_info = system_get_info('module');
-    $this->drupalGet('admin/modules');
-    foreach ($module_info as $module => $info) {
-      // Check to make sure the checkbox for each required module is disabled
-      // and checked (or absent from the page if the module is also hidden).
-      if (!empty($info['required'])) {
-        $field_name = "modules[{$info['package']}][$module][enable]";
-        if (empty($info['hidden'])) {
-          $this->assertFieldByXPath("//input[@name='$field_name' and @disabled='disabled' and @checked='checked']", '', t('Field @name was disabled and checked.', array('@name' => $field_name)));
-        }
-        else {
-          $this->assertNoFieldByName($field_name);
-        }
-      }
-    }
-  }
-}
-
 class CronRunTestCase extends DrupalWebTestCase {
   function setUp() {
     parent::setUp(array('common_test', 'common_test_cron_helper'));

--- a/core/modules/system/system.tests.info
+++ b/core/modules/system/system.tests.info
@@ -22,12 +22,6 @@ description = Check module version dependencies.
 group = Module
 file = system.test
 
-[ModuleRequiredTestCase]
-name = Required modules
-description = Attempt disabling of required modules.
-group = Module
-file = system.test
-
 [CronRunTestCase]
 name = Cron run
 description = Test cron run.


### PR DESCRIPTION
Apologies about the delay, got busy on other projects so here is some lunchtime effort.

The test "Assert that core required modules cannot be disabled" works if the module is listed, but fails when the project is hidden. 

This update has the original changes I made and also removed the test which has this assertion.

```
$this->assertFieldByXPath("//input[@name='$field_name' and @disabled='disabled' and @checked='checked']", '', t('Field @name was disabled and checked.', array('@name' => $field_name)));
```

If there is another test we need to do, let go with it. At this point I believe that the hidden module testing should be handled by the existing tests as there is no form field on the module page.

Another caveat, the Options module is still enabled, due to taxonomy being enabled by default, but Drupal, er, I mean Backdrop does not depend on it explicitly.

Here are the test messages for modules and system only - did not run all the tests:
"RESULTS
2811 passes, 0 fails, 0 exceptions, and 632 debug messages"
