### PR TITLE
Issue #156: Make the Minimal install profile hidden, includes patch from https://drupal.org/node/1727430

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1058,10 +1058,31 @@ function _install_select_profile($profiles) {
     return $profile->name;
   }
   else {
+    $available_profiles = array();
+    $exclusive_profiles = array();
     foreach ($profiles as $profile) {
       if (!empty($_POST['profile']) && ($_POST['profile'] == $profile->name)) {
         return $profile->name;
       }
+
+      $profile_info = install_profile_info($profile->name);
+      // Check for profiles marked as "hidden".
+      if (empty($profile_info['hidden'])) {
+        $available_profiles[] = $profile->name;
+      }
+      // Check for a profile marked as "exclusive".
+      else if (!empty($profile_info['exclusive'])) {
+        $exclusive_profiles[] = $profile->name;
+      }
+    }
+
+    // If there is only one available profile, return it.
+    if (count($available_profiles) == 1) {
+      return reset($available_profiles);
+    }
+    // If there is only one exclusive profile, return it.
+    else if (count($exclusive_profiles) == 1) {
+      return reset($exclusive_profiles);
     }
   }
 }

--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -1230,6 +1230,12 @@ function drupal_check_module($module) {
  * - distribution_name: The name of the Drupal distribution that is being
  *   installed, to be shown throughout the installation process. Defaults to
  *   'Drupal'.
+ * - exclusive: If the install profile is intended to be the only eligible
+ *   choice in a distribution, setting exclusive = TRUE will auto-select it
+ *   during installation, and the install profile selection screen will be
+ *   skipped. If more than one profile is found where exclusive = TRUE then
+ *   this property will have no effect and the profile selection screen will
+ *   be shown as normal with all available profiles shown.
  *
  * Note that this function does an expensive file system scan to get info file
  * information for dependencies. If you only need information from the info

--- a/profiles/minimal/minimal.info
+++ b/profiles/minimal/minimal.info
@@ -2,6 +2,7 @@ name = Minimal
 description = Start with only a few modules enabled.
 version = VERSION
 core = 8.x
+hidden = TRUE
 dependencies[] = node
 dependencies[] = block
 dependencies[] = dblog


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/156
