### PR TITLE
Issue #141: Introduce state system for environment-specific,  non-configuration settings.

### DIFF
--- a/core/cron.php
+++ b/core/cron.php
@@ -16,11 +16,11 @@ define('DRUPAL_ROOT', getcwd());
 include_once DRUPAL_ROOT . '/core/includes/bootstrap.inc';
 drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
 
-if (!isset($_GET['cron_key']) || variable_get('cron_key', 'drupal') != $_GET['cron_key']) {
+if (!isset($_GET['cron_key']) || state_get('cron_key') != $_GET['cron_key']) {
   watchdog('cron', 'Cron could not run because an invalid key was used.', array(), WATCHDOG_NOTICE);
   drupal_access_denied();
 }
-elseif (variable_get('maintenance_mode', 0)) {
+elseif (state_get('maintenance_mode', 0)) {
   watchdog('cron', 'Cron could not run because the site is in maintenance mode.', array(), WATCHDOG_NOTICE);
   drupal_access_denied();
 }

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1067,6 +1067,80 @@ function variable_del($name) {
 }
 
 /**
+ * Retrieves a "state" value from the database.
+ *
+ * States are used for saving long-term values in the database that are
+ * environment-specific. Some examples of values appropriate for utilizing
+ * states include the last time cron was run or the current query string
+ * appended to CSS/JS files. These values should not be copied between
+ * environments, so they are stored in the state system instead of as
+ * configuration files.
+ *
+ * Case-sensitivity of the state_* functions depends on the database
+ * collation used. To avoid problems, always use lower case for persistent
+ * state names.
+ *
+ * @param $name
+ *   The name of the state to return.
+ * @param $default
+ *   The default value to use if this state has never been set.
+ *
+ * @return
+ *   The value of the state. Complex data types such as objects and arrays are
+ *   unserialized when returned.
+ *
+ * @see state_set()
+ * @see state_del()
+ */
+function state_get($name, $default = NULL) {
+  $states = &drupal_static('states', array());
+  if (!isset($states[$name])) {
+    $value = db_query('SELECT value FROM {state} WHERE name = :name', array(':name' => $name))->fetchField();
+    $states[$name] = $value ? unserialize($value) : NULL;
+  }
+  return isset($states[$name]) ? $states[$name] : $default;
+}
+
+/**
+ * Sets a persistent state value.
+ *
+ * @param $name
+ *   The name of the state to set.
+ * @param $value
+ *   The value to set. Complex data types will be serialized upon storage.
+ *
+ * @see state_get()
+ * @see state_del()
+ */
+function state_set($name, $value) {
+  $states = &drupal_static('states', array());
+  db_merge('state')
+    ->key(array('name' => $name))
+    ->fields(array('value' => serialize($value)))
+    ->execute();
+  $states[$name] = $value;
+}
+
+/**
+ * Unsets a persistent state value.
+ *
+ * @param $name
+ *   The name of the state to delete.
+ *
+ * @see state_get()
+ * @see state_set()
+ */
+function state_del($name) {
+  $states = &drupal_static('states', array());
+  db_delete('state')
+    ->condition('name', $name)
+    ->execute();
+  if (array_key_exists($name, $states)) {
+    unset($states[$name]);
+  }
+}
+
+/**
  * Retrieves the current page from the cache.
  *
  * Note: we do not serve cached pages to authenticated users, or to anonymous

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1165,6 +1165,7 @@ function state_del($name) {
   db_delete('state')
     ->condition('name', $name)
     ->execute();
+  cache('cache')->delete('states');
   if (array_key_exists($name, $states)) {
     unset($states[$name]);
   }

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1067,6 +1067,36 @@ function variable_del($name) {
 }
 
 /**
+ * Loads the persistent state table.
+ *
+ * The state table is composed of values that have been saved in the table
+ * with state_set().
+ */
+function state_initialize() {
+  if ($cached = cache('cache')->get('state')) {
+    $states = $cached->data;
+  }
+  else {
+    // Cache miss. Avoid a stampede.
+    $name = 'state_init';
+    if (!lock_acquire($name, 1)) {
+      // Another request is building the variable cache.
+      // Wait, then re-run this function.
+      lock_wait($name);
+      return state_initialize();
+    }
+    else {
+      // Proceed with variable rebuild.
+      $states = array_map('unserialize', db_query('SELECT name, value FROM {state}')->fetchAllKeyed());
+      cache('cache')->set('state', $states);
+      lock_release($name);
+    }
+  }
+
+  return $states;
+}
+
+/**
  * Retrieves a "state" value from the database.
  *
  * States are used for saving long-term values in the database that are
@@ -1094,9 +1124,8 @@ function variable_del($name) {
  */
 function state_get($name, $default = NULL) {
   $states = &drupal_static('states', array());
-  if (!isset($states[$name])) {
-    $value = db_query('SELECT value FROM {state} WHERE name = :name', array(':name' => $name))->fetchField();
-    $states[$name] = $value ? unserialize($value) : NULL;
+  if (empty($states)) {
+    $states = state_initialize();
   }
   return isset($states[$name]) ? $states[$name] : $default;
 }
@@ -1118,6 +1147,7 @@ function state_set($name, $value) {
     ->key(array('name' => $name))
     ->fields(array('value' => serialize($value)))
     ->execute();
+  cache('cache')->delete('states');
   $states[$name] = $value;
 }
 

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1073,7 +1073,7 @@ function variable_del($name) {
  * with state_set().
  */
 function state_initialize() {
-  if ($cached = cache('cache')->get('state')) {
+  if ($cached = cache('cache')->get('states')) {
     $states = $cached->data;
   }
   else {
@@ -1088,7 +1088,7 @@ function state_initialize() {
     else {
       // Proceed with variable rebuild.
       $states = array_map('unserialize', db_query('SELECT name, value FROM {state}')->fetchAllKeyed());
-      cache('cache')->set('state', $states);
+      cache('cache')->set('states', $states);
       lock_release($name);
     }
   }
@@ -1123,8 +1123,8 @@ function state_initialize() {
  * @see state_del()
  */
 function state_get($name, $default = NULL) {
-  $states = &drupal_static('states', array());
-  if (empty($states)) {
+  $states = &drupal_static('states');
+  if (!isset($states)) {
     $states = state_initialize();
   }
   return isset($states[$name]) ? $states[$name] : $default;
@@ -1142,13 +1142,15 @@ function state_get($name, $default = NULL) {
  * @see state_del()
  */
 function state_set($name, $value) {
-  $states = &drupal_static('states', array());
+  $states = &drupal_static('states');
   db_merge('state')
     ->key(array('name' => $name))
     ->fields(array('value' => serialize($value)))
     ->execute();
   cache('cache')->delete('states');
-  $states[$name] = $value;
+  if (isset($states)) {
+    $states[$name] = $value;
+  }
 }
 
 /**

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3267,7 +3267,7 @@ function drupal_pre_render_styles($elements) {
   // browser-caching. The string changes on every update or full cache
   // flush, forcing browsers to load a new copy of the files, as the
   // URL changed.
-  $query_string = variable_get('css_js_query_string', '0');
+  $query_string = state_get('css_js_query_string', '0');
 
   // For inline CSS to validate as XHTML, all CSS containing XHTML needs to be
   // wrapped in CDATA. To make that backwards compatible with HTML 4, we need to
@@ -4231,7 +4231,7 @@ function drupal_pre_render_scripts($elements) {
   // URL changed. Files that should not be cached (see drupal_add_js())
   // get REQUEST_TIME as query-string instead, to enforce reload on every
   // page request.
-  $default_query_string = variable_get('css_js_query_string', '0');
+  $default_query_string = state_get('css_js_query_string', '0');
 
   // For inline JavaScript to validate as XHTML, all JavaScript containing
   // XHTML needs to be wrapped in CDATA. To make that backwards compatible
@@ -5356,7 +5356,7 @@ function drupal_cron_run() {
     }
 
     // Record cron time.
-    variable_set('cron_last', REQUEST_TIME);
+    state_set('cron_last', REQUEST_TIME);
     watchdog('cron', 'Cron run completed.', array(), WATCHDOG_NOTICE);
 
     // Release cron lock.
@@ -7695,7 +7695,7 @@ function drupal_flush_all_caches() {
  */
 function _drupal_flush_css_js() {
   // The timestamp is converted to base 36 in order to make it more compact.
-  variable_set('css_js_query_string', base_convert(REQUEST_TIME, 10, 36));
+  state_set('css_js_query_string', base_convert(REQUEST_TIME, 10, 36));
 }
 
 /**

--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -354,7 +354,7 @@ function install_run_tasks(&$install_state) {
       $install_state['tasks_performed'][] = $task_name;
       $install_state['installation_finished'] = empty($tasks_to_perform);
       if ($install_state['database_tables_exist'] && ($task['run'] == INSTALL_TASK_RUN_IF_NOT_COMPLETED || $install_state['installation_finished'])) {
-        variable_set('install_task', $install_state['installation_finished'] ? 'done' : $task_name);
+        state_set('install_task', $install_state['installation_finished'] ? 'done' : $task_name);
       }
     }
     // Stop when there are no tasks left. In the case of an interactive
@@ -802,7 +802,7 @@ function install_system_module(&$install_state) {
  */
 function install_verify_completed_task() {
   try {
-    if ($result = db_query("SELECT value FROM {variable} WHERE name = :name", array('name' => 'install_task'))) {
+    if ($result = db_query("SELECT value FROM {state} WHERE name = :name", array('name' => 'install_task'))) {
       $task = unserialize($result->fetchField());
     }
   }
@@ -1902,5 +1902,5 @@ function install_configure_form_submit($form, &$form_state) {
   }
 
   // Record when this install ran.
-  variable_set('install_time', $_SERVER['REQUEST_TIME']);
+  state_set('install_time', $_SERVER['REQUEST_TIME']);
 }

--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -3772,7 +3772,7 @@ function _menu_router_save($menu, $masks) {
  */
 function _menu_site_is_offline($check_only = FALSE) {
   // Check if site is in maintenance mode.
-  if (variable_get('maintenance_mode', 0)) {
+  if (state_get('maintenance_mode', 0)) {
     if (user_access('access site in maintenance mode')) {
       // Ensure that the maintenance mode message is displayed only once
       // (allowing for page redirects) and specifically suppress its display on

--- a/core/includes/update.inc
+++ b/core/includes/update.inc
@@ -160,6 +160,30 @@ function update_prepare_d8_bootstrap() {
         );
         db_change_field('url_alias', 'language', 'langcode', $langcode_spec, $langcode_indexes);
       }
+
+      // Create the state table.
+      if (!db_table_exists('state')) {
+        $schema = array(
+          'description' => 'Stores environment-specific state values.',
+          'fields' => array(
+            'name' => array(
+              'description' => 'The name of the state.',
+              'type' => 'varchar',
+              'length' => 128,
+              'not null' => TRUE,
+              'default' => '',
+            ),
+            'value' => array(
+              'description' => 'The value of the state.',
+              'type' => 'blob',
+              'not null' => TRUE,
+              'size' => 'big',
+            ),
+          ),
+          'primary key' => array('name'),
+        );
+        db_create_table('state', $schema);
+      }
     }
   }
 }
@@ -440,9 +464,9 @@ class DrupalUpdateException extends Exception { }
 function update_batch($start, $redirect = NULL, $url = NULL, $batch = array(), $redirect_callback = 'drupal_goto') {
   // During the update, bring the site offline so that schema changes do not
   // affect visiting users.
-  $_SESSION['maintenance_mode'] = variable_get('maintenance_mode', FALSE);
+  $_SESSION['maintenance_mode'] = state_get('maintenance_mode', FALSE);
   if ($_SESSION['maintenance_mode'] == FALSE) {
-    variable_set('maintenance_mode', TRUE);
+    state_set('maintenance_mode', TRUE);
   }
 
   // Resolve any update dependencies to determine the actual updates that will
@@ -513,7 +537,7 @@ function update_finished($success, $results, $operations) {
   // Now that the update is done, we can put the site back online if it was
   // previously in maintenance mode.
   if (isset($_SESSION['maintenance_mode']) && $_SESSION['maintenance_mode'] == FALSE) {
-    variable_set('maintenance_mode', FALSE);
+    state_set('maintenance_mode', FALSE);
     unset($_SESSION['maintenance_mode']);
   }
 }

--- a/core/modules/aggregator/aggregator.test
+++ b/core/modules/aggregator/aggregator.test
@@ -711,7 +711,7 @@ class AggregatorCronTestCase extends AggregatorTestCase {
   public function testCron() {
     // Create feed and test basic updating on cron.
     global $base_url;
-    $key = variable_get('cron_key', 'drupal');
+    $key = state_get('cron_key');
     $this->createSampleNodes();
     $feed = $this->createFeed();
     $this->drupalGet($base_url . '/core/cron.php', array('external' => TRUE, 'query' => array('cron_key' => $key)));

--- a/core/modules/simpletest/drupal_web_test_case.php
+++ b/core/modules/simpletest/drupal_web_test_case.php
@@ -1449,7 +1449,7 @@ class DrupalWebTestCase extends DrupalTestCase {
     $user = user_load(1);
 
     // Restore necessary variables.
-    variable_set('install_task', 'done');
+    state_set('install_task', 'done');
     variable_set('clean_url', $clean_url_original);
     variable_set('site_mail', 'simpletest@example.com');
     variable_set('date_default_timezone', date_default_timezone_get());
@@ -2200,7 +2200,7 @@ class DrupalWebTestCase extends DrupalTestCase {
    * Runs cron in the Drupal installed by Simpletest.
    */
   protected function cronRun() {
-    $this->drupalGet($GLOBALS['base_url'] . '/core/cron.php', array('external' => TRUE, 'query' => array('cron_key' => variable_get('cron_key', 'drupal'))));
+    $this->drupalGet($GLOBALS['base_url'] . '/core/cron.php', array('external' => TRUE, 'query' => array('cron_key' => state_get('cron_key'))));
   }
 
   /**

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -741,7 +741,7 @@ class CommonCascadingStylesheetsTestCase extends DrupalWebTestCase {
    */
   function testAddCssFileWithQueryString() {
     $this->drupalGet('common-test/query-string');
-    $query_string = variable_get('css_js_query_string', '0');
+    $query_string = state_get('css_js_query_string', '0');
     $this->assertRaw(drupal_get_path('module', 'node') . '/node.admin.css?' . $query_string, t('Query string was appended correctly to css.'));
     $this->assertRaw(drupal_get_path('module', 'node') . '/node-fake.css?arg1=value1&amp;arg2=value2', t('Query string not escaped on a URI.'));
   }
@@ -1238,7 +1238,7 @@ class CommonJavaScriptTestCase extends DrupalWebTestCase {
    * @see drupal_pre_render_conditional_comments()
    */
   function testBrowserConditionalComments() {
-    $default_query_string = variable_get('css_js_query_string', '0');
+    $default_query_string = state_get('css_js_query_string', '0');
 
     drupal_add_js('core/misc/collapse.js', array('browsers' => array('IE' => 'lte IE 8', '!IE' => FALSE)));
     drupal_add_js('jQuery(function () { });', array('type' => 'inline', 'browsers' => array('IE' => FALSE)));
@@ -1265,7 +1265,7 @@ class CommonJavaScriptTestCase extends DrupalWebTestCase {
    * Test JavaScript grouping and aggregation.
    */
   function testAggregation() {
-    $default_query_string = variable_get('css_js_query_string', '0');
+    $default_query_string = state_get('css_js_query_string', '0');
 
     // To optimize aggregation, items with the 'every_page' option are ordered
     // ahead of ones without. The order of JavaScript execution must be the
@@ -1502,7 +1502,7 @@ class CommonJavaScriptTestCase extends DrupalWebTestCase {
    */
   function testAddJsFileWithQueryString() {
     $this->drupalGet('common-test/query-string');
-    $query_string = variable_get('css_js_query_string', '0');
+    $query_string = state_get('css_js_query_string', '0');
     $this->assertRaw(drupal_get_path('module', 'node') . '/node.js?' . $query_string, t('Query string was appended correctly to js.'));
   }
 }

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -195,7 +195,7 @@ class MenuRouterTestCase extends DrupalWebTestCase {
    * Test the theme callback when the site is in maintenance mode.
    */
   function testThemeCallbackMaintenanceMode() {
-    variable_set('maintenance_mode', TRUE);
+    state_set('maintenance_mode', TRUE);
 
     // For a regular user, the fact that the site is in maintenance mode means
     // we expect the theme callback system to be bypassed entirely.
@@ -216,7 +216,7 @@ class MenuRouterTestCase extends DrupalWebTestCase {
    * @see hook_menu_site_status_alter().
    */
   function testMaintenanceModeLoginPaths() {
-    variable_set('maintenance_mode', TRUE);
+    state_set('maintenance_mode', TRUE);
 
     $offline_message = t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => variable_get('site_name', 'Drupal')));
     $this->drupalLogout();

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1465,7 +1465,7 @@ function system_cron_settings() {
     '#value' => t('Run cron'),
     '#submit' => array('system_run_cron_submit'),
   );
-  $status = '<p>' . t('Last run: %cron-last ago.', array('%cron-last' => format_interval(REQUEST_TIME - variable_get('cron_last')),)) . '</p>';
+  $status = '<p>' . t('Last run: %cron-last ago.', array('%cron-last' => format_interval(REQUEST_TIME - state_get('cron_last')),)) . '</p>';
   $form['status'] = array(
     '#markup' => $status,
   );
@@ -2092,7 +2092,7 @@ function system_site_maintenance_mode() {
   $form['maintenance_mode'] = array(
     '#type' => 'checkbox',
     '#title' => t('Put site into maintenance mode'),
-    '#default_value' => variable_get('maintenance_mode', 0),
+    '#default_value' => state_get('maintenance_mode', 0),
     '#description' => t('Visitors will only see the maintenance mode message. Only users with the "Access site in maintenance mode" <a href="@permissions-url">permission</a> will be able to access the site. Authorized users can log in directly via the <a href="@user-login">user login</a> page.', array('@permissions-url' => url('admin/config/people/permissions'), '@user-login' => url('user'))),
   );
   $form['maintenance_mode_message'] = array(
@@ -2101,7 +2101,31 @@ function system_site_maintenance_mode() {
     '#default_value' => variable_get('maintenance_mode_message', t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => variable_get('site_name', 'Drupal')))),
   );
 
-  return system_settings_form($form);
+  $form['actions']['#type'] = 'actions';
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+  );
+  return $form;
+}
+
+/**
+ * Submit handler for the system_site_maintenance_mode() form.
+ */
+function system_site_maintenance_mode_submit($form, &$form_state) {
+  state_set('maintenance_mode', (int) $form_state['values']['maintenance_mode']);
+  variable_set('maintenance_mode_message', $form_state['values']['maintenance_mode_message']);
+
+  // Give specific messages on the primary action for this form.
+  if ($form_state['values']['maintenance_mode']) {
+    drupal_set_message(t('The site is now in maintenance mode. Only users with the "Access site in maintenance mode" permission will be able to access the site.'), 'warning');
+  }
+  elseif ($form['maintenance_mode']['#default_value'] != $form_state['values']['maintenance_mode']) {
+    drupal_set_message(t('The site is no longer in maintenance mode.'));
+  }
+  else {
+    drupal_set_message(t('The configuration options have been saved.'));
+  }
 }
 
 /**

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -125,11 +125,11 @@ function hook_admin_paths_alter(&$paths) {
 function hook_cron() {
   // Short-running operation example, not using a queue:
   // Delete all expired records since the last cron run.
-  $expires = variable_get('mymodule_cron_last_run', REQUEST_TIME);
+  $expires = state_get('mymodule_cron_last_run', REQUEST_TIME);
   db_delete('mymodule_table')
     ->condition('expires', $expires, '>=')
     ->execute();
-  variable_set('mymodule_cron_last_run', REQUEST_TIME);
+  state_set('mymodule_cron_last_run', REQUEST_TIME);
 
   // Long-running operation example, leveraging a queue:
   // Fetch feeds from other sites.
@@ -2537,7 +2537,7 @@ function hook_requirements($phase) {
 
   // Report cron status
   if ($phase == 'runtime') {
-    $cron_last = variable_get('cron_last');
+    $cron_last = state_get('cron_last');
 
     if (is_numeric($cron_last)) {
       $requirements['cron']['value'] = $t('Last run !time ago', array('!time' => format_interval(REQUEST_TIME - $cron_last)));

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -259,9 +259,9 @@ function system_requirements($phase) {
     $help = $t('For more information, see the online handbook entry for <a href="@cron-handbook">configuring cron jobs</a>.', array('@cron-handbook' => 'http://drupal.org/cron'));
 
     // Determine when cron last ran.
-    $cron_last = variable_get('cron_last');
+    $cron_last = state_get('cron_last');
     if (!is_numeric($cron_last)) {
-      $cron_last = variable_get('install_time', 0);
+      $cron_last = state_get('install_time', 0);
     }
 
     // Determine severity based on time since cron last ran.
@@ -281,7 +281,7 @@ function system_requirements($phase) {
     }
 
     $description .= ' ' . $t('You can <a href="@cron">run cron manually</a>.', array('@cron' => url('admin/reports/status/run-cron')));
-    $description .= '<br />' . $t('To run cron from outside the site, go to <a href="!cron">!cron</a>', array('!cron' => url($base_url . '/core/cron.php', array('external' => TRUE, 'query' => array('cron_key' => variable_get('cron_key', 'drupal'))))));
+    $description .= '<br />' . $t('To run cron from outside the site, go to <a href="!cron">!cron</a>', array('!cron' => url($base_url . '/core/cron.php', array('external' => TRUE, 'query' => array('cron_key' => state_get('cron_key'))))));
 
     $requirements['cron'] = array(
       'title' => $t('Cron maintenance tasks'),
@@ -513,7 +513,7 @@ function system_install() {
 
   // Populate the cron key variable.
   $cron_key = drupal_hash_base64(drupal_random_bytes(55));
-  variable_set('cron_key', $cron_key);
+  state_set('cron_key', $cron_key);
 }
 
 /**
@@ -1482,6 +1482,26 @@ function system_schema() {
     ),
   );
 
+  $schema['state'] = array(
+    'description' => 'Stores environment-specific state values.',
+    'fields' => array(
+      'name' => array(
+        'description' => 'The name of the state.',
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'value' => array(
+        'description' => 'The value of the state.',
+        'type' => 'blob',
+        'not null' => TRUE,
+        'size' => 'big',
+      ),
+    ),
+    'primary key' => array('name'),
+  );
+
   $schema['system'] = array(
     'description' => "A list of all modules, themes, and theme engines that are or have been installed in Drupal's file system.",
     'fields' => array(
@@ -1655,6 +1675,52 @@ function system_update_8003() {
   $config->set('preprocess_css', variable_get('preprocess_css', 0));
   $config->set('preprocess_js', variable_get('preprocess_js', 0));
   $config->save();
+}
+
+/**
+ * Create the "state" table for the state storage system.
+ */
+function system_update_8004() {
+  if (!db_table_exists('state')) {
+    $schema = array(
+      'description' => 'Stores environment-specific state values.',
+      'fields' => array(
+        'name' => array(
+          'description' => 'The name of the state.',
+          'type' => 'varchar',
+          'length' => 128,
+          'not null' => TRUE,
+          'default' => '',
+        ),
+        'value' => array(
+          'description' => 'The value of the state.',
+          'type' => 'blob',
+          'not null' => TRUE,
+          'size' => 'big',
+        ),
+      ),
+      'primary key' => array('name'),
+    );
+    db_create_table('state', $schema);
+  }
+}
+
+/**
+ * Convert basic system variables to the state system.
+ */
+function system_update_8005() {
+  $variables = array(
+    'install_time' => REQUEST_TIME,
+    'install_task' => 'done',
+    'maintenance_mode' => FALSE,
+    'cron_key' => NULL,
+    'cron_last' => REQUEST_TIME,
+    'css_js_query_string' => '',
+  );
+  foreach ($variables as $name => $default) {
+    state_set($name, variable_get($name, $default));
+    variable_del($name);
+  }
 }
 
 /**

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3547,8 +3547,8 @@ function system_run_automated_cron() {
   // If the site is not fully installed, suppress the automated cron run.
   // Otherwise it could be triggered prematurely by Ajax requests during
   // installation.
-  if (($threshold = variable_get('cron_safe_threshold', DRUPAL_CRON_DEFAULT_THRESHOLD)) > 0 && variable_get('install_task') == 'done') {
-    $cron_last = variable_get('cron_last', NULL);
+  if (($threshold = variable_get('cron_safe_threshold', DRUPAL_CRON_DEFAULT_THRESHOLD)) > 0 && state_get('install_task') == 'done') {
+    $cron_last = state_get('cron_last', NULL);
     if (!isset($cron_last) || (REQUEST_TIME - $cron_last > $threshold)) {
       drupal_cron_run();
     }

--- a/core/modules/system/system.test
+++ b/core/modules/system/system.test
@@ -577,7 +577,7 @@ class CronRunTestCase extends DrupalWebTestCase {
     $this->assertResponse(403);
 
     // Run cron anonymously with the valid cron key.
-    $key = variable_get('cron_key', 'drupal');
+    $key = state_get('cron_key');
     $this->drupalGet($base_url . '/core/cron.php', array('external' => TRUE, 'query' => array('cron_key' => $key)));
     $this->assertResponse(200);
   }
@@ -593,17 +593,19 @@ class CronRunTestCase extends DrupalWebTestCase {
     // not passed.
     $cron_last = time();
     $cron_safe_threshold = 100;
-    variable_set('cron_last', $cron_last);
+    state_set('cron_last', $cron_last);
     variable_set('cron_safe_threshold', $cron_safe_threshold);
     $this->drupalGet('');
-    $this->assertTrue($cron_last == variable_get('cron_last', NULL), t('Cron does not run when the cron threshold is not passed.'));
+    drupal_static_reset('states');
+    $this->assertTrue($cron_last == state_get('cron_last'), t('Cron does not run when the cron threshold is not passed.'));
 
     // Test if cron runs when the cron threshold was passed.
     $cron_last = time() - 200;
-    variable_set('cron_last', $cron_last);
+    state_set('cron_last', $cron_last);
     $this->drupalGet('');
     sleep(1);
-    $this->assertTrue($cron_last < variable_get('cron_last', NULL), t('Cron runs when the cron threshold is passed.'));
+    drupal_static_reset('states');
+    $this->assertTrue($cron_last < state_get('cron_last'), t('Cron runs when the cron threshold is passed.'));
 
     // Disable the cron threshold through the interface.
     $admin_user = $this->drupalCreateUser(array('administer site configuration'));
@@ -614,9 +616,10 @@ class CronRunTestCase extends DrupalWebTestCase {
 
     // Test if cron does not run when the cron threshold is disabled.
     $cron_last = time() - 200;
-    variable_set('cron_last', $cron_last);
+    state_set('cron_last', $cron_last);
     $this->drupalGet('');
-    $this->assertTrue($cron_last == variable_get('cron_last', NULL), t('Cron does not run when the cron threshold is disabled.'));
+    drupal_static_reset('states');
+    $this->assertTrue($cron_last == state_get('cron_last'), t('Cron does not run when the cron threshold is disabled.'));
   }
 
   /**
@@ -817,14 +820,15 @@ class SiteMaintenanceTestCase extends DrupalWebTestCase {
     $edit = array(
       'maintenance_mode' => 1,
     );
-    $this->drupalPost('admin/config/development/maintenance', $edit, t('Save configuration'));
+    $this->drupalPost('admin/config/development/maintenance', $edit, 'Save configuration');
+    $this->assertRaw('The site is now in maintenance mode. Only users with the "Access site in maintenance mode" permission will be able to access the site.', 'Maintenance confirmation message shown.');
 
-    $admin_message = t('Operating in maintenance mode. <a href="@url">Go online.</a>', array('@url' => url('admin/config/development/maintenance')));
-    $user_message = t('Operating in maintenance mode.');
-    $offline_message = t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => variable_get('site_name', 'Drupal')));
+    $admin_message = format_string('Operating in maintenance mode. <a href="@url">Go online.</a>', array('@url' => url('admin/config/development/maintenance')));
+    $user_message = 'Operating in maintenance mode.';
+    $offline_message = format_string('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => variable_get('site_name', 'Drupal')));
 
     $this->drupalGet('');
-    $this->assertRaw($admin_message, t('Found the site maintenance mode message.'));
+    $this->assertRaw($admin_message, 'Found the site maintenance mode message.');
 
     // Logout and verify that offline message is displayed.
     $this->drupalLogout();
@@ -847,42 +851,51 @@ class SiteMaintenanceTestCase extends DrupalWebTestCase {
       'name' => $this->user->name,
       'pass' => $this->user->pass_raw,
     );
-    $this->drupalPost(NULL, $edit, t('Log in'));
+    $this->drupalPost(NULL, $edit, 'Log in');
     $this->assertText($user_message);
 
     // Log in administrative user and configure a custom site offline message.
     $this->drupalLogout();
     $this->drupalLogin($this->admin_user);
     $this->drupalGet('admin/config/development/maintenance');
-    $this->assertNoRaw($admin_message, t('Site maintenance mode message not displayed.'));
+    $this->assertNoRaw($admin_message, 'Site maintenance mode message not displayed.');
 
     $offline_message = 'Sorry, not online.';
     $edit = array(
       'maintenance_mode_message' => $offline_message,
     );
-    $this->drupalPost(NULL, $edit, t('Save configuration'));
+    $this->drupalPost(NULL, $edit, 'Save configuration');
 
     // Logout and verify that custom site offline message is displayed.
     $this->drupalLogout();
     $this->drupalGet('');
-    $this->assertRaw($offline_message, t('Found the site offline message.'));
+    $this->assertRaw($offline_message, 'Found the site offline message.');
 
     // Verify that custom site offline message is not displayed on user/password.
     $this->drupalGet('user/password');
-    $this->assertText(t('Username or e-mail address'), t('Anonymous users can access user/password'));
+    $this->assertText('Username or e-mail address', 'Anonymous users can access user/password');
 
     // Submit password reset form.
     $edit = array(
       'name' => $this->user->name,
     );
-    $this->drupalPost('user/password', $edit, t('E-mail new password'));
+    $this->drupalPost('user/password', $edit, 'E-mail new password');
     $mails = $this->drupalGetMails();
     $start = strpos($mails[0]['body'], 'user/reset/'. $this->user->uid);
     $path = substr($mails[0]['body'], $start, 66 + strlen($this->user->uid));
 
     // Log in with temporary login link.
-    $this->drupalPost($path, array(), t('Log in'));
+    $this->drupalPost($path, array(), 'Log in');
     $this->assertText($user_message);
+    $this->drupalLogout();
+
+    // Disable maintenance mode.
+    $this->drupalLogin($this->admin_user);
+    $edit = array(
+      'maintenance_mode' => FALSE,
+    );
+    $this->drupalPost('admin/config/development/maintenance', $edit, 'Save configuration');
+    $this->assertRaw('The site is no longer in maintenance mode.');
   }
 }
 

--- a/core/modules/update/update.authorize.inc
+++ b/core/modules/update/update.authorize.inc
@@ -175,7 +175,7 @@ function update_authorize_update_batch_finished($success, $results) {
       $success = FALSE;
     }
   }
-  $offline = variable_get('maintenance_mode', FALSE);
+  $offline = state_get('maintenance_mode', FALSE);
   if ($success) {
     // Now that the update completed, we need to clear the cache of available
     // update data and recompute our status, so prevent show bogus results.
@@ -183,7 +183,7 @@ function update_authorize_update_batch_finished($success, $results) {
 
     // Take the site out of maintenance mode if it was previously that way.
     if ($offline && isset($_SESSION['maintenance_mode']) && $_SESSION['maintenance_mode'] == FALSE) {
-      variable_set('maintenance_mode', FALSE);
+      state_set('maintenance_mode', FALSE);
       $page_message = array(
         'message' => t('Update was completed successfully. Your site has been taken out of maintenance mode.'),
         'type' => 'status',
@@ -237,11 +237,11 @@ function update_authorize_install_batch_finished($success, $results) {
       $success = FALSE;
     }
   }
-  $offline = variable_get('maintenance_mode', FALSE);
+  $offline = state_get('maintenance_mode', FALSE);
   if ($success) {
     // Take the site out of maintenance mode if it was previously that way.
     if ($offline && isset($_SESSION['maintenance_mode']) && $_SESSION['maintenance_mode'] == FALSE) {
-      variable_set('maintenance_mode', FALSE);
+      state_set('maintenance_mode', FALSE);
       $page_message = array(
         'message' => t('Installation was completed successfully. Your site has been taken out of maintenance mode.'),
         'type' => 'status',

--- a/core/modules/update/update.manager.inc
+++ b/core/modules/update/update.manager.inc
@@ -405,7 +405,7 @@ function update_manager_update_ready_form_submit($form, &$form_state) {
   // Store maintenance_mode setting so we can restore it when done.
   $_SESSION['maintenance_mode'] = variable_get('maintenance_mode', FALSE);
   if ($form_state['values']['maintenance_mode'] == TRUE) {
-    variable_set('maintenance_mode', TRUE);
+    state_set('maintenance_mode', TRUE);
   }
 
   if (!empty($_SESSION['update_manager_update_projects'])) {


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/141.

This PR includes conversion of the following variables to the state system:
- cron_key
- cron_last
- css_js_query_string
- install_task
- install_time
- maintenance_mode

Overall, this matches the basic functionality of D8 but with a different approach (simple procedural code instead of a "service" with a class hierarchy). However this currently means 2 additional SQL queries per page (for maintenance_mode and css_js_query_string).
