### PR TITLE
Issue #163: Convert test variables to state system.

### DIFF
--- a/core/modules/simpletest/drupal_web_test_case.php
+++ b/core/modules/simpletest/drupal_web_test_case.php
@@ -1527,8 +1527,8 @@ class DrupalWebTestCase extends DrupalTestCase {
   }
 
   /**
-   * Refresh the in-memory set of variables. Useful after a page request is made
-   * that changes a variable in a different thread.
+   * Refresh the in-memory set of variables and state values. Useful after a
+   * page request is made that changes a variable in a different thread.
    *
    * In other words calling a settings page with $this->drupalPost() with a changed
    * value would update a variable to reflect that change, but in the thread that
@@ -1542,6 +1542,7 @@ class DrupalWebTestCase extends DrupalTestCase {
     global $conf;
     cache('bootstrap')->delete('variables');
     $conf = variable_initialize();
+    drupal_static_reset('states');
   }
 
   /**
@@ -2745,9 +2746,6 @@ class DrupalWebTestCase extends DrupalTestCase {
    *   An array containing e-mail messages captured during the current test.
    */
   protected function drupalGetMails($filter = array()) {
-    // Ensure this value is always up-to-date.
-    drupal_static_reset('states');
-
     $captured_emails = state_get('test_email_collector', array());
     $filtered_emails = array();
 

--- a/core/modules/simpletest/drupal_web_test_case.php
+++ b/core/modules/simpletest/drupal_web_test_case.php
@@ -2745,6 +2745,9 @@ class DrupalWebTestCase extends DrupalTestCase {
    *   An array containing e-mail messages captured during the current test.
    */
   protected function drupalGetMails($filter = array()) {
+    // Ensure this value is always up-to-date.
+    drupal_static_reset('states');
+
     $captured_emails = state_get('test_email_collector', array());
     $filtered_emails = array();
 

--- a/core/modules/simpletest/drupal_web_test_case.php
+++ b/core/modules/simpletest/drupal_web_test_case.php
@@ -1555,7 +1555,7 @@ class DrupalWebTestCase extends DrupalTestCase {
     // log to pick up any fatal errors.
     simpletest_log_read($this->testId, $this->databasePrefix, get_class($this), TRUE);
 
-    $emailCount = count(variable_get('drupal_test_email_collector', array()));
+    $emailCount = count(state_get('test_email_collector', array()));
     if ($emailCount) {
       $message = format_plural($emailCount, '1 e-mail was sent during this test.', '@count e-mails were sent during this test.');
       $this->pass($message, t('E-mail'));
@@ -2745,7 +2745,7 @@ class DrupalWebTestCase extends DrupalTestCase {
    *   An array containing e-mail messages captured during the current test.
    */
   protected function drupalGetMails($filter = array()) {
-    $captured_emails = variable_get('drupal_test_email_collector', array());
+    $captured_emails = state_get('test_email_collector', array());
     $filtered_emails = array();
 
     foreach ($captured_emails as $message) {
@@ -3490,7 +3490,7 @@ class DrupalWebTestCase extends DrupalTestCase {
    *   TRUE on pass, FALSE on fail.
    */
   protected function assertMail($name, $value = '', $message = '') {
-    $captured_emails = variable_get('drupal_test_email_collector', array());
+    $captured_emails = state_get('test_email_collector', array());
     $email = end($captured_emails);
     return $this->assertTrue($email && isset($email[$name]) && $email[$name] == $value, $message, t('E-mail'));
   }

--- a/core/modules/system/system.mail.inc
+++ b/core/modules/system/system.mail.inc
@@ -124,9 +124,9 @@ class TestingMailSystem extends DefaultMailSystem implements MailSystemInterface
    *   An e-mail message.
    */
   public function mail(array $message) {
-    $captured_emails = variable_get('drupal_test_email_collector', array());
+    $captured_emails = state_get('test_email_collector', array());
     $captured_emails[] = $message;
-    variable_set('drupal_test_email_collector', $captured_emails);
+    state_set('test_email_collector', $captured_emails);
     return TRUE;
   }
 }

--- a/core/modules/system/system.test
+++ b/core/modules/system/system.test
@@ -596,7 +596,6 @@ class CronRunTestCase extends DrupalWebTestCase {
     state_set('cron_last', $cron_last);
     variable_set('cron_safe_threshold', $cron_safe_threshold);
     $this->drupalGet('');
-    drupal_static_reset('states');
     $this->assertTrue($cron_last == state_get('cron_last'), t('Cron does not run when the cron threshold is not passed.'));
 
     // Test if cron runs when the cron threshold was passed.
@@ -604,7 +603,6 @@ class CronRunTestCase extends DrupalWebTestCase {
     state_set('cron_last', $cron_last);
     $this->drupalGet('');
     sleep(1);
-    drupal_static_reset('states');
     $this->assertTrue($cron_last < state_get('cron_last'), t('Cron runs when the cron threshold is passed.'));
 
     // Disable the cron threshold through the interface.
@@ -618,7 +616,6 @@ class CronRunTestCase extends DrupalWebTestCase {
     $cron_last = time() - 200;
     state_set('cron_last', $cron_last);
     $this->drupalGet('');
-    drupal_static_reset('states');
     $this->assertTrue($cron_last == state_get('cron_last'), t('Cron does not run when the cron threshold is disabled.'));
   }
 


### PR DESCRIPTION
This converts the "drupal_test_email_collector" variable to the state system, preventing problems with e-mails that are sent containing entity-objects (blocks https://github.com/backdrop/backdrop-issues/issues/155).
