### PR TITLE
Issue #132: original issue #1864188 removing permission argument.

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -2969,7 +2969,7 @@ function user_filters() {
   $options = array();
   foreach (module_implements('permission') as $module) {
     $function = $module . '_permission';
-    if ($permissions = $function('permission')) {
+    if ($permissions = $function()) {
       asort($permissions);
       foreach ($permissions as $permission => $description) {
         $options[t('@module module', array('@module' => $module))][$permission] = t($permission);


### PR DESCRIPTION
This solves: https://github.com/backdrop/backdrop-issues/issues/132 5c9c9a6 fixed user_filters invokes
hook_permission() with argument 'permission' ($function('permission')).
