### PR TITLE
Issue #186: Update run-tests.sh for easier usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - chmod a+w sites/default
   - ./core/scripts/install.sh --db-url=mysql://travis:@localhost/backdrop
   - chmod go-w sites/default
-script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url 'http://localhost' --color --verbose --force --all
+script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --concurrency 12 --url 'http://localhost' --color --verbose --force --all
 after_failure:
   - echo "Failures detected. Outputing additional logs:"
   - sudo cat /var/log/apache2/error.log

--- a/core/scripts/password-hash.sh
+++ b/core/scripts/password-hash.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 /**

--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /**
  * @file
@@ -276,6 +277,9 @@ function simpletest_script_init($server_software) {
     // 'SUDO_COMMAND' is an environment variable set by the sudo program.
     // Extract only the PHP interpreter, not the rest of the command.
     list($php, ) = explode(' ', $sudo, 2);
+  }
+  elseif ($php_exec = exec('which php')) {
+    $php = $php_exec;
   }
   else {
     simpletest_script_print_error('Unable to automatically determine the path to the PHP interpreter. Supply the --php command line argument.');
@@ -612,7 +616,7 @@ function simpletest_script_reporter_display_results() {
     echo "Detailed test results\n";
     echo "---------------------\n";
 
-    $results = db_query("SELECT * FROM {simpletest} WHERE test_id = :test_id AND status = 'fail' ORDER BY test_class, message_id", array(':test_id' => $test_id));
+    $results = db_query("SELECT * FROM {simpletest} WHERE test_id = :test_id AND (status = 'exception' OR status = 'fail') ORDER BY test_class, message_id", array(':test_id' => $test_id));
     $test_class = '';
     foreach ($results as $result) {
       if (isset($results_map[$result->status])) {


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/186.

This makes working with the run-tests.sh script easier. It implements all the suggestions from the issue as well as allowing a more liberal interpretation of input options. For example options like --color can come after the list of tests, and any option can be specified with an "=" to set the value, or a space like before. Now both of these work: `--url http://localhost` or `--url=http://localhost`. Quotes are also allowed in either approach.
