### PR TITLE
Issue #205: Add a warning to the 'Administer user account settings' permission.

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -498,6 +498,7 @@ function user_permission() {
     'administer account settings' => array(
       'title' => t('Administer user account settings'),
       'description' => t('Manage settings that apply to all user accounts.'),
+      'restrict access' => TRUE,
     ),
     'access user profiles' => array(
       'title' => t('View user profiles'),


### PR DESCRIPTION
Followup to https://github.com/backdrop/backdrop-issues/issues/205
