### PR TITLE
Issue #197: Remove theme_checkboxes (call theme_container instead).

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -3092,32 +3092,6 @@ function theme_checkbox($variables) {
 }
 
 /**
- * Returns HTML for a set of checkbox form elements.
- *
- * @param $variables
- *   An associative array containing:
- *   - element: An associative array containing the properties of the element.
- *     Properties used: #children, #attributes.
- *
- * @ingroup themeable
- */
-function theme_checkboxes($variables) {
-  $element = $variables['element'];
-  $attributes = array();
-  if (isset($element['#id'])) {
-    $attributes['id'] = $element['#id'];
-  }
-  $attributes['class'][] = 'form-checkboxes';
-  if (!empty($element['#attributes']['class'])) {
-    $attributes['class'] = array_merge($attributes['class'], $element['#attributes']['class']);
-  }
-  if (isset($element['#attributes']['title'])) {
-    $attributes['title'] = $element['#attributes']['title'];
-  }
-  return '<div' . drupal_attributes($attributes) . '>' . (!empty($element['#children']) ? $element['#children'] : '') . '</div>';
-}
-
-/**
  * Adds form element theming to an element if its title or description is set.
  *
  * This is used as a pre render function for checkboxes and radios.
@@ -3259,6 +3233,9 @@ function form_process_container($element, &$form_state) {
 function theme_container($variables) {
   $element = $variables['element'];
 
+  // Disabled attribute is handled on children
+  unset($element['#attributes']['disabled']);
+
   // Special handling for form elements.
   if (isset($element['#array_parents'])) {
     // Assign an html ID.
@@ -3267,8 +3244,10 @@ function theme_container($variables) {
     }
     // Add the 'form-wrapper' class.
     $element['#attributes']['class'][] = 'form-wrapper';
+    if(isset($variables['element']['#type'])) {
+      $element['#attributes']['class'][] = 'form-' . $variables['element']['#type'];
+    }
   }
-
   return '<div' . drupal_attributes($element['#attributes']) . '>' . $element['#children'] . '</div>';
 }
 

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -384,7 +384,7 @@ function system_element_info() {
   $types['checkboxes'] = array(
     '#input' => TRUE,
     '#process' => array('form_process_checkboxes'),
-    '#theme_wrappers' => array('checkboxes'),
+    '#theme_wrappers' => array('container'),
     '#pre_render' => array('form_pre_render_conditional_form_element'),
   );
   $types['checkbox'] = array(


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/197
