### PR TITLE
Issue #1473314 by litwol, nod_, tim.plunkett, attiks: Core js still uses -processed instead of context/.once().

### DIFF
--- a/core/misc/ajax.js
+++ b/core/misc/ajax.js
@@ -21,23 +21,18 @@ Drupal.behaviors.AJAX = {
   attach: function (context, settings) {
     // Load all Ajax behaviors specified in the settings.
     for (var base in settings.ajax) {
-      if (!$('#' + base + '.ajax-processed').length) {
-        var element_settings = settings.ajax[base];
-
-        if (typeof element_settings.selector == 'undefined') {
-          element_settings.selector = '#' + base;
-        }
-        $(element_settings.selector).each(function () {
-          element_settings.element = this;
-          Drupal.ajax[base] = new Drupal.ajax(base, this, element_settings);
-        });
-
-        $('#' + base).addClass('ajax-processed');
+      var element_settings = settings.ajax[base];
+      if (typeof element_settings.selector == 'undefined') {
+        element_settings.selector = '#' + base;
       }
+      $(element_settings.selector).once('drupal-ajax', function() {
+        element_settings.element = this;
+        Drupal.ajax[element_settings.selector] = new Drupal.ajax(base, this, element_settings);
+      });
     }
 
     // Bind Ajax behaviors to all items showing the class.
-    $('.use-ajax:not(.ajax-processed)').addClass('ajax-processed').each(function () {
+    $('.use-ajax').once('ajax', function () {
       var element_settings = {};
       // Clicked links look better with the throbber than the progress bar.
       element_settings.progress = { 'type': 'throbber' };
@@ -62,7 +57,7 @@ Drupal.behaviors.AJAX = {
     });
 
     // This class means to submit the form to the action using Ajax.
-    $('.use-ajax-submit:not(.ajax-processed)').addClass('ajax-processed').each(function () {
+    $('.use-ajax-submit').once('ajax', function () {
       var element_settings = {};
 
       // Ajax submits specified in this manner automatically submit to the

--- a/core/modules/color/color.js
+++ b/core/modules/color/color.js
@@ -19,7 +19,7 @@ Drupal.behaviors.color = {
     var focused = null;
 
     // Add Farbtastic.
-    $(form).prepend('<div id="placeholder"></div>').addClass('color-processed');
+    $('<div id="placeholder"></div>').once('color').prependTo(form);
     var farb = $.farbtastic('#placeholder');
 
     // Decode reference colors to HSL.


### PR DESCRIPTION
PR for https://drupal.org/node/1473314
