### PR TITLE
Issue #1684812 and #1261002 by quicksketch: Fix tabledrag and add touch support.

### DIFF
--- a/core/modules/system/system.base-rtl.css
+++ b/core/modules/system/system.base-rtl.css
@@ -42,8 +42,8 @@ a.tabledrag-handle .handle {
 }
 div.indentation {
   float: right;
-  margin: -0.4em -0.4em -0.4em 0.2em;
-  padding: 0.42em 0.6em 0.42em 0;
+  margin: -1em -0.4em -1em 0.2em;
+  padding: 1em 0.6em 1em 0;
 }
 div.tree-child,
 div.tree-child-last {

--- a/core/modules/system/system.base.css
+++ b/core/modules/system/system.base.css
@@ -114,8 +114,8 @@ a.tabledrag-handle-hover .handle {
 div.indentation {
   float: left; /* LTR */
   height: 1.7em;
-  margin: -0.4em 0.2em -0.4em -0.4em; /* LTR */
-  padding: 0.42em 0 0.42em 0.6em; /* LTR */
+  margin: -1em 0.2em -1em -0.4em; /* LTR */
+  padding: 1em 0 1em 0.6em; /* LTR */
   width: 20px;
 }
 div.tree-child {


### PR DESCRIPTION
This is a replacement PR for https://github.com/backdrop/backdrop/pull/258.

Due to the difficulties comparing the change independently vs. Drupal 8's final JS, I incorporated both [JSHint tabledrag.js](http://drupal.org/node/1684812) and [Make Tabledrag.js touch-friendly](http://drupal.org/node/1261002).
