### PR TITLE
Issue #2077003 by Wim Leers: Fixed tableselect.js uses Drupal object, but does not include it in its closure.

### DIFF
--- a/core/misc/tableselect.js
+++ b/core/misc/tableselect.js
@@ -1,4 +1,4 @@
-(function ($) {
+(function ($, Drupal) {
 
 Drupal.behaviors.tableSelect = {
   attach: function (context, settings) {
@@ -87,4 +87,4 @@ Drupal.tableSelectRange = function (from, to, state) {
   }
 };
 
-})(jQuery);
+})(jQuery, Drupal);


### PR DESCRIPTION
PR for https://drupal.org/node/2077003
