### PR TITLE
Issue #1800304 by dawehner: Fixed The css for responsive tables on bartik contains old class names.

### DIFF
--- a/core/themes/bartik/css/style.css
+++ b/core/themes/bartik/css/style.css
@@ -1671,16 +1671,16 @@ div.admin-panel .description {
  * Responsive tables.
  */
 @media screen and (max-width:450px) {
-  th.helpful,
-  td.helpful,
+  th.priority-low,
+  td.priority-low,
   th.priority-medium,
   td.priority-medium {
     display: none;
   }
 }
 @media screen and (max-width:720px) {
-  th.helpful,
-  td.helpful {
+  th.priority-low,
+  td.priority-low {
     display: none;
   }
 }


### PR DESCRIPTION
Replacement PR for https://github.com/backdrop/backdrop/pull/320.

Sub issue of https://github.com/backdrop/backdrop-issues/issues/207.
