### PR TITLE
Issue #197: Replace theme_checkboxes and theme_radios with theme_container

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -7250,9 +7250,6 @@ function drupal_common_theme() {
     'radio' => array(
       'render element' => 'element',
     ),
-    'radios' => array(
-      'render element' => 'element',
-    ),
     'date' => array(
       'render element' => 'element',
     ),
@@ -7260,9 +7257,6 @@ function drupal_common_theme() {
       'render element' => 'form',
     ),
     'checkbox' => array(
-      'render element' => 'element',
-    ),
-    'checkboxes' => array(
       'render element' => 'element',
     ),
     'button' => array(

--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -2825,33 +2825,6 @@ function theme_radio($variables) {
 }
 
 /**
- * Returns HTML for a set of radio button form elements.
- *
- * @param $variables
- *   An associative array containing:
- *   - element: An associative array containing the properties of the element.
- *     Properties used: #title, #value, #options, #description, #required,
- *     #attributes, #children.
- *
- * @ingroup themeable
- */
-function theme_radios($variables) {
-  $element = $variables['element'];
-  $attributes = array();
-  if (isset($element['#id'])) {
-    $attributes['id'] = $element['#id'];
-  }
-  $attributes['class'] = 'form-radios';
-  if (!empty($element['#attributes']['class'])) {
-    $attributes['class'] .= ' ' . implode(' ', $element['#attributes']['class']);
-  }
-  if (isset($element['#attributes']['title'])) {
-    $attributes['title'] = $element['#attributes']['title'];
-  }
-  return '<div' . drupal_attributes($attributes) . '>' . (!empty($element['#children']) ? $element['#children'] : '') . '</div>';
-}
-
-/**
  * Expand a password_confirm field into two text boxes.
  */
 function form_process_password_confirm($element) {
@@ -3259,6 +3232,9 @@ function form_process_container($element, &$form_state) {
 function theme_container($variables) {
   $element = $variables['element'];
 
+  // Disabled attribute is handled on children
+  unset($element['#attributes']['disabled']);
+
   // Special handling for form elements.
   if (isset($element['#array_parents'])) {
     // Assign an html ID.
@@ -3267,6 +3243,9 @@ function theme_container($variables) {
     }
     // Add the 'form-wrapper' class.
     $element['#attributes']['class'][] = 'form-wrapper';
+    if(isset($variables['element']['#type'])) {
+      $element['#attributes']['class'][] = 'form-' . $variables['element']['#type'];
+    }
   }
 
   return '<div' . drupal_attributes($element['#attributes']) . '>' . $element['#children'] . '</div>';

--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -3065,32 +3065,6 @@ function theme_checkbox($variables) {
 }
 
 /**
- * Returns HTML for a set of checkbox form elements.
- *
- * @param $variables
- *   An associative array containing:
- *   - element: An associative array containing the properties of the element.
- *     Properties used: #children, #attributes.
- *
- * @ingroup themeable
- */
-function theme_checkboxes($variables) {
-  $element = $variables['element'];
-  $attributes = array();
-  if (isset($element['#id'])) {
-    $attributes['id'] = $element['#id'];
-  }
-  $attributes['class'][] = 'form-checkboxes';
-  if (!empty($element['#attributes']['class'])) {
-    $attributes['class'] = array_merge($attributes['class'], $element['#attributes']['class']);
-  }
-  if (isset($element['#attributes']['title'])) {
-    $attributes['title'] = $element['#attributes']['title'];
-  }
-  return '<div' . drupal_attributes($attributes) . '>' . (!empty($element['#children']) ? $element['#children'] : '') . '</div>';
-}
-
-/**
  * Adds form element theming to an element if its title or description is set.
  *
  * This is used as a pre render function for checkboxes and radios.
@@ -3102,13 +3076,24 @@ function form_pre_render_conditional_form_element($element) {
     $element['#attributes']['title'] = $element['#title'];
     if (!empty($element['#required'])) {
       // Append an indication that this field is required.
-      $element['#attributes']['title'] .= ' (' . t('Required') . ')';
+      $element['#attributes']['title'] .= ' (' . $t('Required') . ')';
     }
+  }
+
+  // Add the element type to the wrapping container.
+  if (isset($element['#type'])) {
+    $element['#attributes']['class'][] = 'form-' . $element['#type'];
+  }
+
+  // The disabled attribute is only shown on the children, not on the wrapper.
+  if (isset($element['#attributes']['disabled'])) {
+    unset($element['#attributes']['disabled']);
   }
 
   if (isset($element['#title']) || isset($element['#description'])) {
     $element['#theme_wrappers'][] = 'form_element';
   }
+
   return $element;
 }
 
@@ -3232,9 +3217,6 @@ function form_process_container($element, &$form_state) {
 function theme_container($variables) {
   $element = $variables['element'];
 
-  // Disabled attribute is handled on children
-  unset($element['#attributes']['disabled']);
-
   // Special handling for form elements.
   if (isset($element['#array_parents'])) {
     // Assign an html ID.
@@ -3243,9 +3225,6 @@ function theme_container($variables) {
     }
     // Add the 'form-wrapper' class.
     $element['#attributes']['class'][] = 'form-wrapper';
-    if(isset($variables['element']['#type'])) {
-      $element['#attributes']['class'][] = 'form-' . $variables['element']['#type'];
-    }
   }
 
   return '<div' . drupal_attributes($element['#attributes']) . '>' . $element['#children'] . '</div>';

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -370,7 +370,7 @@ function system_element_info() {
   $types['radios'] = array(
     '#input' => TRUE,
     '#process' => array('form_process_radios'),
-    '#theme_wrappers' => array('radios'),
+    '#theme_wrappers' => array('container'),
     '#pre_render' => array('form_pre_render_conditional_form_element'),
   );
   $types['radio'] = array(

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -370,7 +370,7 @@ function system_element_info() {
   $types['radios'] = array(
     '#input' => TRUE,
     '#process' => array('form_process_radios'),
-    '#theme_wrappers' => array('container'),
+    '#theme_wrappers' => array('container__radios'),
     '#pre_render' => array('form_pre_render_conditional_form_element'),
   );
   $types['radio'] = array(
@@ -384,7 +384,7 @@ function system_element_info() {
   $types['checkboxes'] = array(
     '#input' => TRUE,
     '#process' => array('form_process_checkboxes'),
-    '#theme_wrappers' => array('checkboxes'),
+    '#theme_wrappers' => array('container__checkboxes'),
     '#pre_render' => array('form_pre_render_conditional_form_element'),
   );
   $types['checkbox'] = array(


### PR DESCRIPTION
This PR for https://github.com/backdrop/backdrop-issues/issues/197 combines both of the issues for replacing checkboxes and radios into a single PR. Considering they both have identical implementations and depend on the same changes, I've combined them into a single issue.

This PR replaces both the previous PRs: https://github.com/backdrop/backdrop/pull/266 and https://github.com/backdrop/backdrop/pull/319.
