### PR TITLE
Issue #1664940 by nod_, jibran, droplet | RobLoach: [Policy, patch] Decide on JSHint configuration.

### DIFF
--- a/core/.jshintignore
+++ b/core/.jshintignore
@@ -1,0 +1,7 @@
+misc/farbtastic
+misc/html5.js
+misc/jquery.cookie.js
+misc/jquery.form.js
+misc/jquery.js
+misc/jquery.once.js
+misc/ui

--- a/core/.jshintrc
+++ b/core/.jshintrc
@@ -1,0 +1,16 @@
+{
+  "browser"   : true,
+  "curly"     : true,
+  "eqeqeq"    : true,
+  "expr"      : true,
+  "forin"     : true,
+  "latedef"   : true,
+  "newcap"    : true,
+  "noarg"     : true,
+  "trailing"  : true,
+  "undef"     : true,
+  "predef"    : [
+    "Drupal",
+    "jQuery"
+  ]
+}


### PR DESCRIPTION
Replacement PR for #318.

Drupal.org issue: https://drupal.org/node/1664940
And part of Backdrop issue: backdrop/backdrop-issues#211

As mentioned in #318, this differs from the D8 version in that we're placing these files within the /core directory, as this is only for linting core JS files and we can't predict which contrib/custom files should be ignored anyway.
