### PR TITLE
Issue #2012526 by mcjim: Remove drupal_add_css() from book.module and use #attached.

### DIFF
--- a/core/modules/book/book.info
+++ b/core/modules/book/book.info
@@ -5,4 +5,3 @@ version = BACKDROP_VERSION
 backdrop = 1.x
 dependencies[] = node
 configure = admin/content/book/settings
-stylesheets[all][] = book.theme.css

--- a/core/modules/book/book.module
+++ b/core/modules/book/book.module
@@ -872,6 +872,11 @@ function book_node_view(Node $node, $view_mode) {
       $node->content['book_navigation'] = array(
         '#markup' => theme('book_navigation', array('book_link' => $node->book)),
         '#weight' => 100,
+        '#attached' => array(
+          'css' => array(
+            drupal_get_path('module', 'book') . '/css/book.theme.css',
+          ),
+        ),
       );
     }
   }


### PR DESCRIPTION
Replacement PR for https://github.com/backdrop/backdrop/pull/295

Backdrop issue https://github.com/backdrop/backdrop-issues/issues/207
Drupal issue http://drupal.org/node/2012526
