### PR TITLE
Issue #287: Add a link to the status report on the page when updates are completed.

### DIFF
--- a/core/update.php
+++ b/core/update.php
@@ -174,6 +174,12 @@ function update_helpful_links() {
       'href' => 'admin',
     );
   }
+  if (user_access('administer site configuration')) {
+    $links['status-report'] = array(
+      'title' => t('Status report'),
+      'href' => 'admin/reports/status',
+    );
+  }
   return $links;
 }
 


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/287
