### PR TITLE
Issue #2010636 by mcjim, Wim Leers, typhonius: Remove backdrop_add_css() and backdrop_add_js() from color.module — use #attached.

### DIFF
--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -222,16 +222,17 @@ function color_scheme_form($complete_form, &$form_state, $theme) {
  * @ingroup themeable
  */
 function theme_color_scheme_form($variables) {
-  $form = $variables['form'];
+  $form = &$variables['form'];
 
   $theme = $form['theme']['#value'];
   $info = $form['info']['#value'];
   $path = backdrop_get_path('theme', $theme) . '/';
-  backdrop_add_css($path . $info['preview_css']);
 
+  $preview_css_path = $path . $info['preview_css'];
   $preview_js_path = isset($info['preview_js']) ? $path . $info['preview_js'] : backdrop_get_path('module', 'color') . '/' . 'preview.js';
+  $preview_css_path = $path . $info['preview_css'];
   // Add the JS at a weight below color.js.
-  backdrop_add_js($preview_js_path, array('weight' => -1));
+  $form['scheme']['#attached']['js'][$preview_js_path] = array('weight' => -1);
 
   $output  = '';
   $output .= '<div class="color-form clearfix">';


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/207
