### PR TITLE
Issue #1993728 by johnmcc, pfrenssen: TestMenuTreeData() assert message confuses dashes and underscores.

### DIFF
--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -946,8 +946,8 @@ class MenuTreeOutputTestCase extends BackdropWebTestCase {
     $output = menu_tree_output($this->tree_data);
 
     // Validate that the - in main-menu is changed into an underscore
-    $this->assertEqual( $output['1']['#theme'], 'menu_link__main_menu', t('Hyphen is changed to a dash on menu_link'));
-    $this->assertEqual( $output['#theme_wrappers'][0], 'menu_tree__main_menu', t('Hyphen is changed to a dash on menu_tree wrapper'));
+    $this->assertEqual($output['1']['#theme'], 'menu_link__main_menu', t('Hyphen is changed to a underscore on menu_link'));
+    $this->assertEqual($output['#theme_wrappers'][0], 'menu_tree__main_menu', t('Hyphen is changed to a underscore on menu_tree wrapper'));
     // Looking for child items in the data
     $this->assertEqual( $output['1']['#below']['2']['#href'], 'a/b', t('Checking the href on a child item'));
     $this->assertTrue( in_array('active-trail',$output['1']['#below']['2']['#attributes']['class']) , t('Checking the active trail class'));


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/222
