### PR TITLE
Issue #1076132 by fizk, friesk, foxtrotcharlie, coolestdude1, David_Rothstein, skwashd, alexpott, tstoeckler | adaddinsane: Hook_block_view_MODULE_DELTA_alter fails with blocks that have a hyphen in the block delta.

### DIFF
--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -843,9 +843,11 @@ function _block_get_renderable_block($element) {
   if (!isset($block->content)) {
     $array = module_invoke($block->module, 'block_view', $block->delta);
 
+    // Valid PHP function names cannot contain hyphens.
+    $delta = str_replace('-', '_', $block->delta);
     // Allow modules to modify the block before it is viewed, via either
     // hook_block_view_alter() or hook_block_view_MODULE_DELTA_alter().
-    backdrop_alter(array('block_view', "block_view_{$block->module}_{$block->delta}"), $array, $block);
+    backdrop_alter(array('block_view', "block_view_{$block->module}_{$delta}"), $array, $block);
 
     if (empty($array['content'])) {
       // Blocks without content should emit no markup at all.

--- a/core/modules/block/block.test
+++ b/core/modules/block/block.test
@@ -739,6 +739,39 @@ class BlockTemplateSuggestionsUnitTest extends BackdropUnitTestCase {
 }
 
 /**
+ * Tests for hook_block_view_MODULE_DELTA_alter().
+ */
+class BlockViewModuleDeltaAlterWebTest extends BackdropWebTestCase {
+  public function setUp() {
+    parent::setUp(array('block_test'));
+  }
+
+  /**
+   * Tests that the alter hook is called, even if the delta contains a hyphen.
+   */
+  public function testBlockViewModuleDeltaAlter() {
+    $block = new stdClass;
+    $block->module = 'block_test';
+    $block->delta = 'test_underscore';
+    $block->title = '';
+    $render_array = _block_get_renderable_block(array('region' => $block));
+    $render = array_pop($render_array);
+    $test_underscore = $render->content['#markup'];
+    $this->assertEqual($test_underscore, 'hook_block_view_MODULE_DELTA_alter', 'Found expected altered block content for delta with underscore');
+
+    $block = new stdClass;
+    $block->module = 'block_test';
+    $block->delta = 'test-hyphen';
+    $block->title = '';
+    $render_array = _block_get_renderable_block(array('region' => $block));
+    $render = array_pop($render_array);
+    $test_hyphen = $render->content['#markup'];
+    $this->assertEqual($test_hyphen, 'hook_block_view_MODULE_DELTA_alter', 'Hyphens (-) in block delta were replaced by underscore (_)');
+  }
+
+}
+
+/**
  * Tests that hidden regions do not inherit blocks when a theme is enabled.
  */
 class BlockHiddenRegionTestCase extends BackdropWebTestCase {

--- a/core/modules/block/block.tests.info
+++ b/core/modules/block/block.tests.info
@@ -51,3 +51,9 @@ name = Blocks in invalid regions
 description = Checks that an active block assigned to a non-existing region triggers the warning message and is disabled.
 group = Block
 file = block.test
+
+[BlockViewModuleDeltaAlterWebTest]
+name = Block view module delta alter
+description = Test the hook_block_view_MODULE_DELTA_alter() hook.
+group = Block
+file = block.test

--- a/core/modules/block/tests/block_test.module
+++ b/core/modules/block/tests/block_test.module
@@ -22,6 +22,14 @@ function block_test_block_info() {
     'cache' => variable_get('block_test_caching', BACKDROP_CACHE_PER_ROLE),
   );
 
+  $blocks['test_underscore'] = array(
+    'info' => t('Test underscore'),
+  );
+
+  $blocks['test-hyphen'] = array(
+    'info' => t('Test hyphen'),
+  );
+
   $blocks['test_html_id'] = array(
     'info' => t('Test block html id'),
   );
@@ -33,4 +41,18 @@ function block_test_block_info() {
  */
 function block_test_block_view($delta = 0) {
   return array('content' => state_get('block_test_content', ''));
+}
+
+/**
+ * Implements hook_block_view_MODULE_DELTA_alter().
+ */
+function block_test_block_view_block_test_test_underscore_alter(&$data, $block) {
+  $data['content'] = 'hook_block_view_MODULE_DELTA_alter';
+}
+
+/**
+ * Implements hook_block_view_MODULE_DELTA_alter().
+ */
+function block_test_block_view_block_test_test_hyphen_alter(&$data, $block) {
+  $data['content'] = 'hook_block_view_MODULE_DELTA_alter';
 }


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/222
