### PR TITLE
Issue #1476810 by Spleshka, David_Rothstein, franz | Heine: Drupal_serve_page_from_cache can serve uncompressed data with Content-Encoding gzip header with page_cache_without_database = 1.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1463,7 +1463,7 @@ function backdrop_page_header() {
  */
 function backdrop_serve_page_from_cache(stdClass $cache) {
   // Negotiate whether to use compression.
-  $page_compression = config_get('system.performance', 'page_compression') && extension_loaded('zlib');
+  $page_compression = !empty($cache->data['page_compressed']);
   $return_compressed = $page_compression && isset($_SERVER['HTTP_ACCEPT_ENCODING']) && strpos($_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip') !== FALSE;
 
   // Get headers set in hook_boot(). Keys are lower-case.

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5444,6 +5444,10 @@ function backdrop_page_set_cache() {
   global $base_root;
 
   if (backdrop_page_is_cacheable()) {
+
+    // Check whether the current page might be compressed.
+    $page_compressed = config_get('system.performance', 'page_compression') && extension_loaded('zlib');
+
     $cache = (object) array(
       'cid' => $base_root . request_uri(),
       'data' => array(
@@ -5451,6 +5455,9 @@ function backdrop_page_set_cache() {
         'body' => ob_get_clean(),
         'title' => backdrop_get_title(),
         'headers' => array(),
+        // We need to store whether page was compressed or not,
+        // because by the time it is read, the configuration might change.
+        'page_compressed' => $page_compressed,
       ),
       'expire' => CACHE_TEMPORARY,
       'created' => REQUEST_TIME,
@@ -5468,7 +5475,7 @@ function backdrop_page_set_cache() {
     }
 
     if ($cache->data['body']) {
-      if (config_get('system.performance', 'page_compression') && extension_loaded('zlib')) {
+      if ($page_compressed) {
         $cache->data['body'] = gzencode($cache->data['body'], 9, FORCE_GZIP);
       }
       cache('page')->set($cache->cid, $cache->data, $cache->expire);

--- a/core/modules/simpletest/tests/bootstrap.test
+++ b/core/modules/simpletest/tests/bootstrap.test
@@ -201,6 +201,18 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
     $this->assertFalse($this->backdropGetHeader('Content-Encoding'), 'A Content-Encoding header was not sent.');
     $this->assertTitle(t('Welcome to @site-name | @site-name', array('@site-name' => config_get('system.site', 'site_name'))), 'Site title matches.');
     $this->assertRaw('</html>', 'Page was not compressed.');
+
+    // Disable compression mode.
+    config_set('system.performance', 'page_compression', FALSE);
+
+    // Verify if cached page is still available for a client with compression support.
+    $this->backdropGet('', array(), array('Accept-Encoding: gzip,deflate'));
+    $this->backdropSetContent(gzinflate(substr($this->backdropGetContent(), 10, -8)));
+    $this->assertRaw('</html>', 'Page was delivered after compression mode is changed (compression support enabled).');
+
+    // Verify if cached page is still available for a client without compression support.
+    $this->backdropGet('');
+    $this->assertRaw('</html>', 'Page was delivered after compression mode is changed (compression support disabled).');
   }
 }
 


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/222
