### PR TITLE
Issue #1606110 by greenrover33, nod_: Fixed Exception thrown in collapse.js by .after(' ') breaks CKEditor display in term edit pages.

### DIFF
--- a/core/misc/collapse.js
+++ b/core/misc/collapse.js
@@ -79,7 +79,7 @@ Backdrop.behaviors.collapse = {
       $('<span class="fieldset-legend-prefix element-invisible"></span>')
         .append($fieldset.hasClass('collapsed') ? Backdrop.t('Show') : Backdrop.t('Hide'))
         .prependTo($legend)
-        .after(' ');
+        .after(document.createTextNode(' '));
 
       // .wrapInner() does not retain bound events.
       var $link = $('<a class="fieldset-title" href="#"></a>')


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/211
