### PR TITLE
Issue: #336: Split "Administer comments"

### DIFF
--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -379,6 +379,9 @@ function comment_permission() {
     'administer comments' => array(
       'title' => t('Administer comments and comment settings'),
     ),
+    'administer comment settings' => array(
+      'title' => t('Administer comment settings'),
+    ),
     'access comments' => array(
       'title' => t('View comments'),
     ),
@@ -1205,7 +1208,7 @@ function comment_form_node_form_alter(&$form, $form_state) {
   $node = $form['#node'];
   $form['comment_settings'] = array(
     '#type' => 'fieldset',
-    '#access' => user_access('administer comments'),
+    '#access' => user_access('administer comment settings') || user_access('administer comments'),
     '#title' => t('Comment settings'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,


### PR DESCRIPTION
Fixes issue #336. Assumes persons with "administer comments" permission should also be able to "administer comment settings" but not the reverse.
