### PR TITLE
Issue #334: Set the default comment title disabled

### DIFF
--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1178,7 +1178,7 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
     $form['comment']['comment_subject_field'] = array(
       '#type' => 'checkbox',
       '#title' => t('Allow comment title'),
-      '#default_value' => variable_get('comment_subject_field_' . $form['#node_type']->type, 1),
+      '#default_value' => variable_get('comment_subject_field_' . $form['#node_type']->type, 0),
     );
     $form['comment']['comment_form_location'] = array(
       '#type' => 'checkbox',


### PR DESCRIPTION
Fixes Issue #334 Set the default comment title setting to disabled. https://github.com/backdrop/backdrop-issues/issues/334.
