### PR TITLE
Issue #130: Remove the global theme settings page

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -268,6 +268,85 @@ function backdrop_get_breadcrumb() {
 }
 
 /**
+ * Gets the site logo.
+ *
+ * Falls back to none (empty string) if not defined or theme provided.
+ *
+ * @return (string) $logo
+ *   URL to the logo file to use for the site.
+ */
+function backdrop_get_logo() {
+  $logo = '';
+
+  // The logo may be needed on pages prior to config being ready, e.g. during
+  // installer or on maintenance pages. Default to an empty string if unable to
+  // load the configuration.
+  try {
+    $site_config = config('system.site');
+
+    if ($site_config->get('site_default_logo')) {
+      global $theme;
+      $theme_data = list_themes();
+      $theme_object = $theme_data[$theme];
+      if (file_exists($logo = dirname($theme_object->filename) . '/logo.png')) {
+        $logo = file_create_url($logo);
+      }
+    }
+    elseif ($site_config->get('site_logo_path')) {
+      $logo = file_create_url($site_config->get('site_logo_path'));
+    }
+  }
+  catch (ConfigException $e) {
+    // Use the default empty logo.
+  }
+
+  return $logo;
+}
+
+/**
+ * Gets the file location and mime type for site favicon.
+ *
+ * Falls back to the Backdrop favicon if not defined or theme provided.
+ *
+ * @return (array) $favicon
+ *   Information about the favicon to use for the site.  Keys include:
+ *   - path: Relative path to the file to be used.
+ *   - type: mime type for the icon being used.
+ */
+function backdrop_get_favicon() {
+  $favicon = array(
+    'path' => file_create_url('core/misc/favicon.ico'),
+    'type' => 'image/vnd.microsoft.icon',
+  );
+
+  // Load the config and update, if we can.
+  try {
+    $site_config = config('system.site');
+
+    if ($site_config->get('site_default_favicon')) {
+      global $theme;
+      $theme_data = list_themes();
+      $theme_object = $theme_data[$theme];
+      if (file_exists($favicon = dirname($theme_object->filename) . '/favicon.ico')) {
+        $favicon['path'] = file_create_url($favicon);
+      }
+    }
+    elseif ($site_config->get('site_favicon_path')) {
+      $favicon['path'] = file_create_url($site_config->get('site_favicon_path'));
+      $favicon['type'] = $site_config->get('site_favicon_mime');
+    }
+  }
+  catch (ConfigException $e) {
+    // Use the default.
+  }
+
+  // Safety check to prevent user-provided javascript: URLs or the like.
+  $favicon['path'] = backdrop_strip_dangerous_protocols($favicon['path']);
+
+  return $favicon;
+}
+
+/**
  * Adds output to the HEAD tag of the HTML page.
  *
  * This function can be called as long as the headers aren't sent. Pass no

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1429,106 +1429,55 @@ function backdrop_find_theme_templates($cache, $extension, $path) {
  *   The value of the requested setting, NULL if the setting does not exist.
  */
 function theme_get_setting($setting_name, $theme = NULL) {
-  $cache = &backdrop_static(__FUNCTION__, array());
+  $config = &backdrop_static(__FUNCTION__, array());
 
   // If no key is given, use the current theme if we can determine it.
   if (!isset($theme)) {
     $theme = !empty($GLOBALS['theme_key']) ? $GLOBALS['theme_key'] : '';
   }
 
-  if (empty($cache[$theme])) {
-    // Set the default values for each global setting.
-    // To add new global settings, add their default values below, and then
-    // add form elements to system_theme_settings() in system.admin.inc.
-    $cache[$theme] = array(
-      'default_logo'                     =>  1,
-      'logo_path'                        =>  '',
-      'default_favicon'                  =>  1,
-      'favicon_path'                     =>  '',
-      // Use the IANA-registered MIME type for ICO files as default.
-      'favicon_mimetype'                 =>  'image/vnd.microsoft.icon',
-    );
-    // Turn on all default features.
-    $features = _system_default_theme_features();
-    foreach ($features as $feature) {
-      $cache[$theme]['toggle_' . $feature] = 1;
-    }
-
-    // Get the values for the theme-specific settings from the .info files of
-    // the theme and all its base themes.
-    if ($theme) {
-      $themes = list_themes();
-      $theme_object = $themes[$theme];
-
-      // Create a list which includes the current theme and all its base themes.
-      if (isset($theme_object->base_themes)) {
-        $theme_keys = array_keys($theme_object->base_themes);
-        $theme_keys[] = $theme;
-      }
-      else {
-        $theme_keys = array($theme);
-      }
-      foreach ($theme_keys as $theme_key) {
-        if (!empty($themes[$theme_key]->info['settings'])) {
-          $cache[$theme] = array_merge($cache[$theme], $themes[$theme_key]->info['settings']);
-        }
-      }
-    }
-
-    // Get the saved global settings from the database.
-    $cache[$theme] = array_merge($cache[$theme], variable_get('theme_settings', array()));
-
-    if ($theme) {
-      // Get the saved theme-specific settings from the database.
-      $cache[$theme] = array_merge($cache[$theme], variable_get('theme_' . $theme . '_settings', array()));
-
-      // If the theme does not support a particular feature, override the global
-      // setting and set the value to NULL.
-      if (!empty($theme_object->info['features'])) {
-        foreach ($features as $feature) {
-          if (!in_array($feature, $theme_object->info['features'])) {
-            $cache[$theme]['toggle_' . $feature] = NULL;
-          }
-        }
-      }
-
-      // Generate the path to the logo image.
-      if ($cache[$theme]['toggle_logo']) {
-        if ($cache[$theme]['default_logo']) {
-          if (file_exists($logo = dirname($theme_object->filename) . '/logo.png')) {
-            $cache[$theme]['logo'] = file_create_url($logo);
-          }
-          else {
-            $cache[$theme]['logo'] = '';
-            $cache[$theme]['toggle_logo'] = FALSE;
-          }
-        }
-        elseif ($cache[$theme]['logo_path']) {
-          $cache[$theme]['logo'] = file_create_url($cache[$theme]['logo_path']);
-        }
-      }
-
-      // Generate the path to the favicon.
-      if ($cache[$theme]['toggle_favicon']) {
-        if ($cache[$theme]['default_favicon']) {
-          if (file_exists($favicon = dirname($theme_object->filename) . '/favicon.ico')) {
-            $cache[$theme]['favicon'] = file_create_url($favicon);
-          }
-          else {
-            $cache[$theme]['favicon'] = file_create_url('core/misc/favicon.ico');
-          }
-        }
-        elseif ($cache[$theme]['favicon_path']) {
-          $cache[$theme]['favicon'] = file_create_url($cache[$theme]['favicon_path']);
-        }
-        else {
-          $cache[$theme]['toggle_favicon'] = FALSE;
-        }
-      }
-    }
+  if (empty($config)) {
+    $config = config($theme . '.settings');
+    $config->load();
   }
 
-  return isset($cache[$theme][$setting_name]) ? $cache[$theme][$setting_name] : NULL;
+  // If the setting is not found in config, load the default from the theme's
+  // info file.
+  $value = $config->get($setting_name);
+  if (is_null($value)) {
+    $themes = list_themes();
+    $theme_info = $themes[$theme];
+    $value = isset($theme_info->info['settings'][$setting_name]) ? $theme_info->info['settings'][$setting_name] : NULL;
+  }
+
+  // Loop up through any base themes.
+  if (is_null($value) && isset($theme_info->info['base theme'])) {
+    $value = theme_get_setting($setting_name, $theme_info->info['base theme']);
+  }
+
+  return $value;
+}
+
+/**
+ * Detect if a theme has any theme settings.
+ *
+ * This utility function checks a theme's .info file for any settings. If the
+ * theme has a base theme, it loops through the parent themes .info files as
+ * well.
+ *
+ * @param string $theme
+ *   The theme name to be checked for settings.
+ */
+function theme_has_settings($theme) {
+  $themes = list_themes();
+  $theme_info = $themes[$theme];
+  if (!empty($theme_info->info['settings'])) {
+    return TRUE;
+  }
+  if (isset($theme_info->info['base theme'])) {
+    return theme_has_settings($theme_info->info['base theme']);
+  }
+  return FALSE;
 }
 
 /**
@@ -2646,11 +2595,8 @@ function template_preprocess_html(&$variables) {
   $variables['html_attributes_array']['dir'] = $GLOBALS['language_interface']->direction ? 'rtl' : 'ltr';
 
   // Add favicon.
-  if (theme_get_setting('toggle_favicon')) {
-    $favicon = theme_get_setting('favicon');
-    $type = theme_get_setting('favicon_mimetype');
-    backdrop_add_html_head_link(array('rel' => 'shortcut icon', 'href' => backdrop_strip_dangerous_protocols($favicon), 'type' => $type));
-  }
+  $favicon = backdrop_get_favicon();
+  backdrop_add_html_head_link(array('rel' => 'shortcut icon', 'href' => $favicon['path'], 'type' => $favicon['type']));
 
   $site_config = config('system.site');
   // Construct page title.
@@ -2662,9 +2608,7 @@ function template_preprocess_html(&$variables) {
   }
   else {
     $head_title = array('name' => check_plain($site_config->get('site_name')));
-    if ($site_config->get('site_slogan')) {
-      $head_title['slogan'] = filter_xss_admin($site_config->get('site_slogan'));
-    }
+    $head_title['slogan'] = filter_xss_admin($site_config->get('site_slogan'));
   }
   $variables['head_title_array'] = $head_title;
   $variables['head_title'] = implode(' | ', $head_title);
@@ -2717,7 +2661,7 @@ function template_preprocess_page(&$variables) {
   $variables['feed_icons']        = backdrop_get_feeds();
   $variables['language']          = $GLOBALS['language_interface'];
   $variables['language']->dir     = $GLOBALS['language_interface']->direction ? 'rtl' : 'ltr';
-  $variables['logo']              = theme_get_setting('logo');
+  $variables['logo']              = backdrop_get_logo();
   $variables['action_links']      = menu_local_actions();
   $variables['site_name']         = check_plain($site_config->get('site_name'));
   $variables['site_slogan']       = filter_xss_admin($site_config->get('site_slogan'));
@@ -2902,12 +2846,20 @@ function theme_get_suggestions($args, $base, $delimiter = '__') {
  * @see maintenance-page.tpl.php
  */
 function template_preprocess_maintenance_page(&$variables) {
-  // Add favicon
-  if (theme_get_setting('toggle_favicon')) {
-    $favicon = theme_get_setting('favicon');
-    $type = theme_get_setting('favicon_mimetype');
-    backdrop_add_html_head_link(array('rel' => 'shortcut icon', 'href' => backdrop_strip_dangerous_protocols($favicon), 'type' => $type));
+  // Load site config if available, fallback to the default.
+  try {
+    $site_config = config('system.site');
+    $site_name = filter_xss_admin($site_config->get('site_name'));
+    $site_slogan = filter_xss_admin($site_config->get('site_slogan'));
   }
+  catch (ConfigException $e) {
+    $site_name = 'Backdrop CMS';
+    $site_slogan = '';
+  }
+
+  // Add favicon to the page.
+  $favicon = backdrop_get_favicon();
+  backdrop_add_html_head_link(array('rel' => 'shortcut icon', 'href' => $favicon['path'], 'type' => $favicon['type']));
 
   global $theme;
   // Retrieve the theme data to list all available regions.
@@ -2929,10 +2881,6 @@ function template_preprocess_maintenance_page(&$variables) {
   if (!empty($variables['sidebar_second'])) {
     $variables['layout'] = ($variables['layout'] == 'first') ? 'both' : 'second';
   }
-
-  $site_config = config('system.site');
-  $site_name = check_plain($site_config->get('site_name'));
-  $site_slogan = filter_xss_admin($site_config->get('site_slogan'));
 
   // Construct page title
   if (backdrop_get_title()) {
@@ -2960,10 +2908,10 @@ function template_preprocess_maintenance_page(&$variables) {
   $variables['help']              = '';
   $variables['language']          = $language;
   $variables['language']->dir     = $language->direction ? 'rtl' : 'ltr';
-  $variables['logo']              = theme_get_setting('logo');
   $variables['messages']          = $variables['show_messages'] ? theme('status_messages') : '';
   $variables['main_menu']         = array();
   $variables['secondary_menu']    = array();
+  $variables['logo']              = backdrop_get_logo();
   $variables['site_name']         = $site_name;
   $variables['site_slogan']       = $site_slogan;
   $variables['tabs']              = '';

--- a/core/modules/admin_menu/admin_menu.inc
+++ b/core/modules/admin_menu/admin_menu.inc
@@ -856,12 +856,8 @@ function _admin_menu_flush_cache($name = NULL) {
 function template_preprocess_admin_menu_icon(&$variables) {
   // Image source might have been passed in as theme variable.
   if (!isset($variables['src'])) {
-    if (theme_get_setting('toggle_favicon')) {
-      $variables['src'] = theme_get_setting('favicon');
-    }
-    else {
-      $variables['src'] = base_path() . 'misc/favicon.ico';
-    }
+    $favicon = backdrop_get_favicon();
+    $variables['src'] = $favicon['path'];
   }
   // Strip the protocol without delimiters for transient HTTP/HTTPS support.
   // Since the menu is cached on the server-side and client-side, the cached

--- a/core/modules/admin_menu/tests/admin_menu.test
+++ b/core/modules/admin_menu/tests/admin_menu.test
@@ -383,7 +383,6 @@ class AdminMenuLinkTypesTestCase extends AdminMenuWebTestCase {
     ));
 
     // Verify that MENU_LOCAL_TASKs appear.
-    $this->assertLinkTrailByTitle(array(t('Appearance'), t('Settings')));
     $this->assertLinkTrailByTitle(array(t('Functionality'), t('Uninstall')));
 
     // Verify that MENU_LOCAL_ACTIONs appear.

--- a/core/modules/color/color.install
+++ b/core/modules/color/color.install
@@ -40,3 +40,33 @@ function color_requirements($phase) {
 
   return $requirements;
 }
+
+/**
+ * Convert color module settings to config files.
+ */
+function color_update_1000() {
+  $themes = list_themes();
+  foreach ($themes as $theme_key => $theme_info) {
+    if ($palette = variable_get('color_' . $theme_key . '_palette')) {
+      // Copy any existing settings into config.
+      $config = config($theme_key . '.settings');
+      $color_settings = array(
+        'palette' => $palette,
+        'stylesheets' => variable_get('color_' . $theme_key . '_stylesheets', array()),
+        'files' => variable_get('color_' . $theme_key . '_files', array()),
+      );
+      $config->set('color', $color_settings);
+      $config->save();
+
+      // Delete the legacy variables.
+      variable_del('color_' . $theme_key . '_palette');
+      variable_del('color_' . $theme_key . '_stylesheets');
+      variable_del('color_' . $theme_key . '_files');
+
+      // Screenshot and logo support apparently was removed even in Drupal 7,
+      // delete these variables if they still exist.
+      variable_del('color_' . $theme_key . '_logo');
+      variable_del('color_' . $theme_key . '_screenshot');
+    }
+  }
+}

--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -29,7 +29,7 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
     );
     $form['color'] += color_scheme_form($form, $form_state, $theme);
     $form['#validate'][] = 'color_scheme_form_validate';
-    $form['#submit'][] = 'color_scheme_form_submit';
+    array_unshift($form['#submit'], 'color_scheme_form_submit');
   }
 }
 
@@ -47,7 +47,7 @@ function _color_html_alter(&$vars) {
   $themes = list_themes();
 
   // Override stylesheets.
-  $color_paths = variable_get('color_' . $theme_key . '_stylesheets', array());
+  $color_paths = theme_get_setting('color.stylesheets');
   if (!empty($color_paths)) {
 
     foreach ($themes[$theme_key]->stylesheets['all'] as $base_filename => $old_path) {
@@ -81,7 +81,7 @@ function _color_page_alter(&$vars) {
   global $theme_key;
 
   // Override logo.
-  $logo = variable_get('color_' . $theme_key . '_logo');
+  $logo = theme_get_setting('color.logo');
   if ($logo && $vars['logo'] && preg_match('!' . $theme_key . '/logo.png$!', $vars['logo'])) {
     $vars['logo'] = file_create_url($logo);
   }
@@ -114,8 +114,11 @@ function color_get_palette($theme, $default = FALSE) {
   $info = color_get_info($theme);
   $palette = $info['schemes']['default']['colors'];
 
-  // Load variable.
-  return $default ? $palette : variable_get('color_' . $theme . '_palette', $palette);
+  // Load config.
+  if (!$default && ($theme_palette = theme_get_setting('color.palette'))) {
+    $palette = $theme_palette;
+  }
+  return $palette;
 }
 
 /**
@@ -143,7 +146,7 @@ function color_scheme_form($complete_form, &$form_state, $theme) {
 
   // See if we're using a predefined scheme.
   // Note: we use the original theme when the default scheme is chosen.
-  $current_scheme = variable_get('color_' . $theme . '_palette', array());
+  $current_scheme = theme_get_setting('color.palette');
   foreach ($schemes as $key => $scheme) {
     if ($current_scheme == $scheme) {
       $scheme_name = $key;
@@ -328,6 +331,9 @@ function color_scheme_form_submit($form, &$form_state) {
   $theme = $form_state['values']['theme'];
   $info = $form_state['values']['info'];
 
+  // Remove color info so it doesn't get saved in config.
+  unset($form_state['values']['info']);
+
   // Resolve palette.
   $palette = $form_state['values']['palette'];
   if ($form_state['values']['scheme'] != '') {
@@ -362,8 +368,11 @@ function color_scheme_form_submit($form, &$form_state) {
   }
 
   // Delete old files.
-  foreach (variable_get('color_' . $theme . '_files', array()) as $file) {
-    @backdrop_unlink($file);
+  $files = theme_get_setting('color.files');
+  if ($files) {
+    foreach ($files as $file) {
+      @backdrop_unlink($file);
+    }
   }
   if (isset($file) && $file = dirname($file)) {
     @backdrop_rmdir($file);
@@ -371,11 +380,9 @@ function color_scheme_form_submit($form, &$form_state) {
 
   // Don't render the default colorscheme, use the standard theme instead.
   if (implode(',', color_get_palette($theme, TRUE)) == implode(',', $palette)) {
-    variable_del('color_' . $theme . '_palette');
-    variable_del('color_' . $theme . '_stylesheets');
-    variable_del('color_' . $theme . '_logo');
-    variable_del('color_' . $theme . '_files');
-    variable_del('color_' . $theme . '_screenshot');
+    unset($form_state['values']['scheme']);
+    unset($form_state['values']['palette']);
+    $form_state['values']['color'] = NULL;
     return;
   }
 
@@ -390,10 +397,6 @@ function color_scheme_form_submit($form, &$form_state) {
   $paths['id'] = $id;
   $paths['source'] = backdrop_get_path('theme', $theme) . '/';
   $paths['files'] = $paths['map'] = array();
-
-  // Save palette and logo location.
-  variable_set('color_' . $theme . '_palette', $palette);
-  variable_set('color_' . $theme . '_logo', $paths['target'] . 'logo.png');
 
   // Copy over neutral images.
   foreach ($info['copy'] as $file) {
@@ -440,9 +443,16 @@ function color_scheme_form_submit($form, &$form_state) {
     }
   }
 
-  // Maintain list of files.
-  variable_set('color_' . $theme . '_stylesheets', $css);
-  variable_set('color_' . $theme . '_files', $paths['files']);
+  // Save all the values into form state for saving to config.
+  $form_state['values']['color'] = array(
+    'palette' => $palette,
+    'stylesheets' => $css,
+    'files' => $paths['files'],
+  );
+
+  // Remove color field elements.
+  unset($form_state['values']['scheme']);
+  unset($form_state['values']['palette']);
 }
 
 /**
@@ -578,15 +588,8 @@ function _color_render_images($theme, &$info, &$paths, $palette) {
     $image = backdrop_realpath($paths['target'] . $base);
 
     // Cut out slice.
-    if ($file == 'screenshot.png') {
-      $slice = imagecreatetruecolor(150, 90);
-      imagecopyresampled($slice, $target, 0, 0, $x, $y, 150, 90, $width, $height);
-      variable_set('color_' . $theme . '_screenshot', $image);
-    }
-    else {
-      $slice = imagecreatetruecolor($width, $height);
-      imagecopy($slice, $target, 0, 0, $x, $y, $width, $height);
-    }
+    $slice = imagecreatetruecolor($width, $height);
+    imagecopy($slice, $target, 0, 0, $x, $y, $width, $height);
 
     // Save image.
     imagepng($slice, $image);

--- a/core/modules/color/color.test
+++ b/core/modules/color/color.test
@@ -64,10 +64,10 @@ class ColorTestCase extends BackdropWebTestCase {
     $this->assertResponse(200);
     $edit['scheme'] = '';
     $edit[$test_values['palette_input']] = '#123456';
-    $this->backdropPost($settings_path, $edit, t('Save configuration'));
+    $this->backdropPost($settings_path, $edit, t('Save theme settings'));
 
     $this->backdropGet('<front>');
-    $stylesheets = variable_get('color_' . $theme . '_stylesheets', array());
+    $stylesheets = theme_get_setting('color.stylesheets', $theme);
     $this->assertPattern('|' . file_create_url($stylesheets[0]) . '|', 'Make sure the color stylesheet is included in the content. (' . $theme . ')');
 
     $stylesheet_content = join("\n", file($stylesheets[0]));
@@ -76,10 +76,11 @@ class ColorTestCase extends BackdropWebTestCase {
     $this->backdropGet($settings_path);
     $this->assertResponse(200);
     $edit['scheme'] = $test_values['scheme'];
-    $this->backdropPost($settings_path, $edit, t('Save configuration'));
+    $this->backdropPost($settings_path, $edit, t('Save theme settings'));
 
     $this->backdropGet('<front>');
-    $stylesheets = variable_get('color_' . $theme . '_stylesheets', array());
+    backdrop_static_reset();
+    $stylesheets = theme_get_setting('color.stylesheets', $theme);
     $stylesheet_content = join("\n", file($stylesheets[0]));
     $this->assertTrue(strpos($stylesheet_content, 'color: ' . $test_values['scheme_color']) !== FALSE, 'Make sure the color we changed is in the color stylesheet. (' . $theme . ')');
 
@@ -107,7 +108,7 @@ class ColorTestCase extends BackdropWebTestCase {
 
     foreach ($this->colorTests as $color => $is_valid) {
       $edit['palette[bg]'] = $color;
-      $this->backdropPost($settings_path, $edit, t('Save configuration'));
+      $this->backdropPost($settings_path, $edit, t('Save theme settings'));
 
       if($is_valid) {
         $this->assertText('The configuration options have been saved.');

--- a/core/modules/system/config/system.site.json
+++ b/core/modules/system/config/system.site.json
@@ -5,5 +5,10 @@
     "site_slogan": "",
     "site_403": "",
     "site_404": "",
-    "site_frontpage": "user"
+    "site_frontpage": "user",
+    "site_default_logo": 0,
+    "site_logo_path": "",
+    "site_default_favicon": 0,
+    "site_favicon_path": "core/misc/favicon.ico",
+    "site_favicon_mimetype": "image/vnd.microsoft.icon"
 }

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -158,7 +158,7 @@ function system_themes_page() {
     if (!empty($theme->status) || !$theme->incompatible_core && !$theme->incompatible_php) {
       // Create the operations links.
       $query['theme'] = $theme->name;
-      if (backdrop_theme_access($theme)) {
+      if (backdrop_theme_access($theme) && theme_has_settings($theme->name)) {
         $theme->operations[] = array(
           'title' => t('Settings'),
           'href' => 'admin/appearance/settings/' . $theme->name,
@@ -362,339 +362,69 @@ function system_theme_default() {
  *   A theme name.
  * @return
  *   The form structure.
+ *
  * @ingroup forms
+ *
  * @see system_theme_settings_submit()
  */
-function system_theme_settings($form, &$form_state, $key = '') {
-  // Default settings are defined in theme_get_setting() in includes/theme.inc
-  if ($key) {
-    $var = 'theme_' . $key . '_settings';
-    $themes = list_themes();
-    $features = $themes[$key]->info['features'];
+function system_theme_settings($form, &$form_state, $key) {
+  $themes = list_themes();
+
+  $form['theme'] = array(
+    '#type' => 'value',
+    '#value' => $key,
+  );
+
+  // Create a list which includes the current theme and all its base themes.
+  if (isset($themes[$key]->base_themes)) {
+    $theme_keys = array_keys($themes[$key]->base_themes);
+    $theme_keys[] = $key;
   }
   else {
-    $var = 'theme_settings';
+    $theme_keys = array($key);
   }
 
-  $form['var'] = array('#type' => 'hidden', '#value' => $var);
-
-  // Toggle settings
-  $toggles = array(
-    'logo'                      => t('Logo'),
-    'favicon'                   => t('Shortcut icon'),
-  );
-
-  $form['theme_settings'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Toggle display'),
-    '#description' => t('Enable or disable the display of certain page elements.'),
-  );
-  foreach ($toggles as $name => $title) {
-    if ((!$key) || in_array($name, $features)) {
-      $form['theme_settings']['toggle_' . $name] = array('#type' => 'checkbox', '#title' => $title, '#default_value' => theme_get_setting('toggle_' . $name, $key));
-      // Disable checkboxes for features not supported in the current configuration.
-      if (isset($disabled['toggle_' . $name])) {
-        $form['theme_settings']['toggle_' . $name]['#disabled'] = TRUE;
-      }
+  // Process the theme and all its base themes.
+  foreach ($theme_keys as $theme) {
+    // Include the theme-settings.php file.
+    $filename = BACKDROP_ROOT . '/' . str_replace("/$theme.info", '', $themes[$theme]->filename) . '/theme-settings.php';
+    if (file_exists($filename)) {
+      require_once $filename;
     }
-  }
 
-  if (!element_children($form['theme_settings'])) {
-    // If there is no element in the theme settings fieldset then do not show
-    // it -- but keep it in the form if another module wants to alter.
-    $form['theme_settings']['#access'] = FALSE;
-  }
-
-  // Logo settings
-  if ((!$key) || in_array('logo', $features)) {
-    $form['logo'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Logo image settings'),
-      '#attributes' => array('class' => array('theme-settings-bottom')),
-    );
-    $form['logo']['default_logo'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Use the default logo supplied by the theme'),
-      '#default_value' => theme_get_setting('default_logo', $key),
-      '#tree' => FALSE,
-    );
-    $form['logo']['settings'] = array(
-      '#type' => 'container',
-      '#states' => array(
-        // Hide the logo settings when using the default logo.
-        'invisible' => array(
-          'input[name="default_logo"]' => array('checked' => TRUE),
-        ),
-      ),
-    );
-    $form['logo']['settings']['logo_path'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Path to custom logo'),
-      '#default_value' => theme_get_setting('logo_path', $key),
-    );
-    $form['logo']['settings']['logo_upload'] = array(
-      '#type' => 'file',
-      '#title' => t('Upload logo image'),
-      '#maxlength' => 40,
-      '#description' => t("If you don't have direct file access to the server, use this field to upload your logo.")
-    );
-  }
-
-  if ((!$key) || in_array('favicon', $features)) {
-    $form['favicon'] = array(
-      '#type' => 'fieldset',
-      '#title' => t('Shortcut icon settings'),
-      '#description' => t("Your shortcut icon, or 'favicon', is displayed in the address bar and bookmarks of most browsers."),
-    );
-    $form['favicon']['default_favicon'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Use the default shortcut icon supplied by the theme'),
-      '#default_value' => theme_get_setting('default_favicon', $key),
-    );
-    $form['favicon']['settings'] = array(
-      '#type' => 'container',
-      '#states' => array(
-        // Hide the favicon settings when using the default favicon.
-        'invisible' => array(
-          'input[name="default_favicon"]' => array('checked' => TRUE),
-        ),
-      ),
-    );
-    $form['favicon']['settings']['favicon_path'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Path to custom icon'),
-      '#default_value' => theme_get_setting('favicon_path', $key),
-    );
-    $form['favicon']['settings']['favicon_upload'] = array(
-      '#type' => 'file',
-      '#title' => t('Upload icon image'),
-      '#description' => t("If you don't have direct file access to the server, use this field to upload your shortcut icon.")
-    );
-  }
-
-  // Inject human-friendly values and form element descriptions for logo and
-  // favicon.
-  foreach (array('logo' => 'logo.png', 'favicon' => 'favicon.ico') as $type => $default) {
-    if (isset($form[$type]['settings'][$type . '_path'])) {
-      $element = &$form[$type]['settings'][$type . '_path'];
-
-      // If path is a public:// URI, display the path relative to the files
-      // directory; stream wrappers are not end-user friendly.
-      $original_path = $element['#default_value'];
-      $friendly_path = NULL;
-      if (file_uri_scheme($original_path) == 'public') {
-        $friendly_path = file_uri_target($original_path);
-        $element['#default_value'] = $friendly_path;
-      }
-
-      // Prepare local file path for description.
-      if ($original_path && isset($friendly_path)) {
-        $local_file = strtr($original_path, array('public:/' => variable_get('file_public_path', 'files')));
-      }
-      elseif ($key) {
-        $local_file = backdrop_get_path('theme', $key) . '/' . $default;
-      }
-      else {
-        $local_file = path_to_theme() . '/' . $default;
-      }
-
-      $element['#description'] = t('Examples: <code>@implicit-public-file</code> (for a file in the public filesystem), <code>@explicit-file</code>, or <code>@local-file</code>.', array(
-        '@implicit-public-file' => isset($friendly_path) ? $friendly_path : $default,
-        '@explicit-file' => file_uri_scheme($original_path) !== FALSE ? $original_path : 'public://' . $default,
-        '@local-file' => $local_file,
-      ));
-    }
-  }
-
-  if ($key) {
-    // Call engine-specific settings.
-    $function = $themes[$key]->prefix . '_engine_settings';
+    // Call theme-specific settings.
+    $function = $theme . '_form_system_theme_settings_alter';
     if (function_exists($function)) {
-      $form['engine_specific'] = array(
-        '#type' => 'fieldset',
-        '#title' => t('Theme-engine-specific settings'),
-        '#description' => t('These settings only exist for the themes based on the %engine theme engine.', array('%engine' => $themes[$key]->prefix)),
-      );
       $function($form, $form_state);
     }
-
-    // Create a list which includes the current theme and all its base themes.
-    if (isset($themes[$key]->base_themes)) {
-      $theme_keys = array_keys($themes[$key]->base_themes);
-      $theme_keys[] = $key;
-    }
-    else {
-      $theme_keys = array($key);
-    }
-
-    // Save the name of the current theme (if any), so that we can temporarily
-    // override the current theme and allow theme_get_setting() to work
-    // without having to pass the theme name to it.
-    $default_theme = !empty($GLOBALS['theme_key']) ? $GLOBALS['theme_key'] : NULL;
-    $GLOBALS['theme_key'] = $key;
-
-    // Process the theme and all its base themes.
-    foreach ($theme_keys as $theme) {
-      // Include the theme-settings.php file.
-      $filename = BACKDROP_ROOT . '/' . str_replace("/$theme.info", '', $themes[$theme]->filename) . '/theme-settings.php';
-      if (file_exists($filename)) {
-        require_once $filename;
-      }
-
-      // Call theme-specific settings.
-      $function = $theme . '_form_system_theme_settings_alter';
-      if (function_exists($function)) {
-        $function($form, $form_state);
-      }
-    }
-
-    // Restore the original current theme.
-    if (isset($default_theme)) {
-      $GLOBALS['theme_key'] = $default_theme;
-    }
-    else {
-      unset($GLOBALS['theme_key']);
-    }
   }
 
-  $form = system_settings_form($form);
-  // We don't want to call system_settings_form_submit(), so change #submit.
-  array_pop($form['#submit']);
-  $form['#submit'][] = 'system_theme_settings_submit';
-  $form['#validate'][] = 'system_theme_settings_validate';
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save theme settings'),
+  );
+
   return $form;
-}
-
-/**
- * Validator for the system_theme_settings() form.
- */
-function system_theme_settings_validate($form, &$form_state) {
-  // Handle file uploads.
-  $validators = array('file_validate_is_image' => array());
-
-  // Check for a new uploaded logo.
-  $file = file_save_upload('logo_upload', $validators);
-  if (isset($file)) {
-    // File upload was attempted.
-    if ($file) {
-      // Put the temporary file in form_values so we can save it on submit.
-      $form_state['values']['logo_upload'] = $file;
-    }
-    else {
-      // File upload failed.
-      form_set_error('logo_upload', t('The logo could not be uploaded.'));
-    }
-  }
-
-  $validators = array('file_validate_extensions' => array('ico png gif jpg jpeg apng svg'));
-
-  // Check for a new uploaded favicon.
-  $file = file_save_upload('favicon_upload', $validators);
-  if (isset($file)) {
-    // File upload was attempted.
-    if ($file) {
-      // Put the temporary file in form_values so we can save it on submit.
-      $form_state['values']['favicon_upload'] = $file;
-    }
-    else {
-      // File upload failed.
-      form_set_error('favicon_upload', t('The favicon could not be uploaded.'));
-    }
-  }
-
-  // If the user provided a path for a logo or favicon file, make sure a file
-  // exists at that path.
-  if ($form_state['values']['logo_path']) {
-    $path = _system_theme_settings_validate_path($form_state['values']['logo_path']);
-    if (!$path) {
-      form_set_error('logo_path', t('The custom logo path is invalid.'));
-    }
-  }
-  if ($form_state['values']['favicon_path']) {
-    $path = _system_theme_settings_validate_path($form_state['values']['favicon_path']);
-    if (!$path) {
-      form_set_error('favicon_path', t('The custom favicon path is invalid.'));
-    }
-  }
-}
-
-/**
- * Helper function for the system_theme_settings form.
- *
- * Attempts to validate normal system paths, paths relative to the public files
- * directory, or stream wrapper URIs. If the given path is any of the above,
- * returns a valid path or URI that the theme system can display.
- *
- * @param $path
- *   A path relative to the Backdrop root or to the public files directory, or
- *   a stream wrapper URI.
- * @return mixed
- *   A valid path that can be displayed through the theme system, or FALSE if
- *   the path could not be validated.
- */
-function _system_theme_settings_validate_path($path) {
-  // Absolute local file paths are invalid.
-  if (backdrop_realpath($path) == $path) {
-    return FALSE;
-  }
-  // A path relative to the Backdrop root or a fully qualified URI is valid.
-  if (is_file($path)) {
-    return $path;
-  }
-  // Prepend 'public://' for relative file paths within public filesystem.
-  if (file_uri_scheme($path) === FALSE) {
-    $path = 'public://' . $path;
-  }
-  if (is_file($path)) {
-    return $path;
-  }
-  return FALSE;
 }
 
 /**
  * Process system_theme_settings form submissions.
  */
 function system_theme_settings_submit($form, &$form_state) {
+  $theme = $form_state['values']['theme'];
+
   // Exclude unnecessary elements before saving.
   form_state_values_clean($form_state);
-  $key = $form_state['values']['var'];
-  unset($form_state['values']['var']);
+  unset($form_state['values']['theme']);
 
-  $values = $form_state['values'];
-
-  // If the user uploaded a new logo or favicon, save it to a permanent location
-  // and use it in place of the default theme-provided file.
-  if ($file = $values['logo_upload']) {
-    unset($values['logo_upload']);
-    $filename = file_unmanaged_copy($file->uri);
-    $values['default_logo'] = 0;
-    $values['logo_path'] = $filename;
-    $values['toggle_logo'] = 1;
+  // Save all settings to config.
+  $config = config($theme . '.settings');
+  foreach ($form_state['values'] as $key => $value) {
+    $config->set($key, $value);
   }
-  if ($file = $values['favicon_upload']) {
-    unset($values['favicon_upload']);
-    $filename = file_unmanaged_copy($file->uri);
-    $values['default_favicon'] = 0;
-    $values['favicon_path'] = $filename;
-    $values['toggle_favicon'] = 1;
-  }
-
-  // If the user entered a path relative to the system files directory for
-  // a logo or favicon, store a public:// URI so the theme system can handle it.
-  if (!empty($values['logo_path'])) {
-    $values['logo_path'] = _system_theme_settings_validate_path($values['logo_path']);
-  }
-  if (!empty($values['favicon_path'])) {
-    $values['favicon_path'] = _system_theme_settings_validate_path($values['favicon_path']);
-  }
-
-  if (empty($values['default_favicon']) && !empty($values['favicon_path'])) {
-    $values['favicon_mimetype'] = file_get_mimetype($values['favicon_path']);
-  }
-
-  variable_set($key, $values);
+  $config->save();
   backdrop_set_message(t('The configuration options have been saved.'));
-
   cache_clear_all();
 }
 
@@ -1381,12 +1111,76 @@ function system_site_information_settings($form, &$form_state) {
     '#default_value' => $site_config->get('site_name'),
     '#required' => TRUE
   );
+
+  // Logo settings
+  $form['logo'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Logo settings'),
+    '#attributes' => array('class' => array('theme-settings-bottom')),
+  );
+  $form['logo']['site_default_logo'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use the logo supplied by the active theme'),
+    '#default_value' => $site_config->get('site_default_logo'),
+    '#tree' => FALSE,
+  );
+  $form['logo']['settings'] = array(
+    '#type' => 'container',
+    '#states' => array(
+      // Hide the logo settings when using the default logo.
+      'invisible' => array(
+        'input[name="site_default_logo"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+  $form['logo']['settings']['site_logo_upload'] = array(
+    '#type' => 'file',
+    '#title' => t('Upload logo'),
+    '#maxlength' => 60,
+  );
+  $form['logo']['settings']['site_logo_path'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Path to custom logo'),
+    '#default_value' => $site_config->get('site_logo_path'),
+  );
+
+  $form['favicon'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Shortcut icon settings'),
+    '#description' => t("Your shortcut icon, or 'favicon', is displayed in the address bar and bookmarks of most browsers."),
+  );
+  $form['favicon']['site_default_favicon'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use the shortcut icon supplied by the active theme'),
+    '#default_value' => $site_config->get('site_default_favicon'),
+  );
+  $form['favicon']['settings'] = array(
+    '#type' => 'container',
+    '#states' => array(
+      // Hide the favicon settings when using the default favicon.
+      'invisible' => array(
+        'input[name="site_default_favicon"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+  $form['favicon']['settings']['site_favicon_upload'] = array(
+    '#type' => 'file',
+    '#title' => t('Upload icon'),
+    '#maxlength' => 60,
+  );
+  $form['favicon']['settings']['site_favicon_path'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Path to custom icon'),
+    '#default_value' => $site_config->get('site_favicon_path'),
+  );
+
   $form['site_information']['site_slogan'] = array(
     '#type' => 'textfield',
     '#title' => t('Slogan'),
     '#default_value' => $site_config->get('site_slogan'),
     '#description' => t("How this is used depends on your site's theme."),
   );
+
   $form['site_information']['site_mail'] = array(
     '#type' => 'email',
     '#title' => t('E-mail address'),
@@ -1394,6 +1188,7 @@ function system_site_information_settings($form, &$form_state) {
     '#description' => t("The <em>From</em> address in automated e-mails sent during registration and new password requests, and other notifications. (Use an address ending in your site's domain to help prevent this e-mail being flagged as spam.)"),
     '#required' => TRUE,
   );
+
   $form['front_page'] = array(
     '#type' => 'fieldset',
     '#title' => t('Front page'),
@@ -1441,6 +1236,37 @@ function system_site_information_settings($form, &$form_state) {
     '#type' => 'submit',
     '#value' => t('Save configuration')
   );
+
+  // Inject human-friendly form element descriptions for logo and favicon.
+  foreach (array('logo' => 'logo.png', 'favicon' => 'favicon.ico') as $type => $default) {
+    if (isset($form[$type]['settings']['site_' . $type . '_path'])) {
+      $element = &$form[$type]['settings']['site_' . $type . '_path'];
+
+      // If path is a public:// URI, display the path relative to the files
+      // directory; stream wrappers are not end-user friendly.
+      $original_path = $element['#default_value'];
+      $friendly_path = NULL;
+      if (file_uri_scheme($original_path) == 'public') {
+        $friendly_path = file_uri_target($original_path);
+        $element['#default_value'] = $friendly_path;
+      }
+
+      // Prepare local file path for description.
+      if ($original_path && isset($friendly_path)) {
+        $local_file = strtr($original_path, array('public:/' => variable_get('file_public_path', 'files')));
+      }
+      else {
+        $local_file = path_to_theme() . '/' . $default;
+      }
+
+      $element['#description'] = t('Examples: <code>@implicit-public-file</code> (for a file in the public filesystem), <code>@explicit-file</code>, or <code>@local-file</code>.', array(
+        '@implicit-public-file' => isset($friendly_path) ? $friendly_path : $default,
+        '@explicit-file' => file_uri_scheme($original_path) !== FALSE ? $original_path : 'public://' . $default,
+        '@local-file' => $local_file,
+      ));
+    }
+  }
+
   return $form;
 }
 
@@ -1448,6 +1274,54 @@ function system_site_information_settings($form, &$form_state) {
  * Validates the submitted site-information form.
  */
 function system_site_information_settings_validate($form, &$form_state) {
+  // Handle file uploads.
+  $validators = array('file_validate_is_image' => array());
+
+  // Check for a new uploaded logo.
+  $file = file_save_upload('site_logo_upload', $validators);
+  if (isset($file)) {
+    // File upload was attempted.
+    if ($file) {
+      // Put the temporary file in form_values so we can save it on submit.
+      $form_state['values']['site_logo_upload'] = $file;
+    }
+    else {
+      // File upload failed.
+      form_set_error('site_logo_upload', t('The logo could not be uploaded.'));
+    }
+  }
+
+  $validators = array('file_validate_extensions' => array('ico png gif jpg jpeg apng svg'));
+
+  // Check for a new uploaded favicon.
+  $file = file_save_upload('site_favicon_upload', $validators);
+  if (isset($file)) {
+    // File upload was attempted.
+    if ($file) {
+      // Put the temporary file in form_values so we can save it on submit.
+      $form_state['values']['site_favicon_upload'] = $file;
+    }
+    else {
+      // File upload failed.
+      form_set_error('site_favicon_upload', t('The favicon could not be uploaded.'));
+    }
+  }
+
+  // If the user provided a path for a logo or favicon file, make sure a file
+  // exists at that path.
+  if ($form_state['values']['site_logo_path']) {
+    $path = _system_site_information_settings_validate_path($form_state['values']['site_logo_path']);
+    if (!$path) {
+      form_set_error('site_logo_path', t('The custom logo path is invalid.'));
+    }
+  }
+  if ($form_state['values']['site_favicon_path']) {
+    $path = _system_site_information_settings_validate_path($form_state['values']['site_favicon_path']);
+    if (!$path) {
+      form_set_error('site_favicon_path', t('The custom favicon path is invalid.'));
+    }
+  }
+
   // Check for empty front page path.
   if (empty($form_state['values']['site_frontpage'])) {
     // Set to default "user".
@@ -1479,11 +1353,80 @@ function system_site_information_settings_validate($form, &$form_state) {
 }
 
 /**
+ * Helper function for the system_site_information_settings form.
+ *
+ * Attempts to validate normal system paths, paths relative to the public files
+ * directory, or stream wrapper URIs. If the given path is any of the above,
+ * returns a valid path or URI that the theme system can display.
+ *
+ * @param $path
+ *   A path relative to the Backdrop root or to the public files directory, or
+ *   a stream wrapper URI.
+ * @return mixed
+ *   A valid path that can be displayed through the theme system, or FALSE if
+ *   the path could not be validated.
+ */
+function _system_site_information_settings_validate_path($path) {
+  // Absolute local file paths are invalid.
+  if (backdrop_realpath($path) == $path) {
+    return FALSE;
+  }
+  // A path relative to the Backdrop root or a fully qualified URI is valid.
+  if (is_file($path)) {
+    return $path;
+  }
+  // Prepend 'public://' for relative file paths within public filesystem.
+  if (file_uri_scheme($path) === FALSE) {
+    $path = 'public://' . $path;
+  }
+  if (is_file($path)) {
+    return $path;
+  }
+  return FALSE;
+}
+
+/**
  * Form submission handler for system_site_information_settings().
  */
 function system_site_information_settings_submit($form, &$form_state) {
+  // If the user uploaded a new logo or favicon, save it to a permanent location
+  // and use it in place of the default theme-provided file.
+  if ($file = $form_state['values']['site_logo_upload']) {
+    unset($form_state['values']['site_logo_upload']);
+    $filename = file_unmanaged_copy($file->uri);
+    $form_state['values']['site_default_logo'] = 0;
+    $form_state['values']['site_logo_path'] = $filename;
+  }
+  if ($file = $form_state['values']['site_favicon_upload']) {
+    unset($form_state['values']['site_favicon_upload']);
+    $filename = file_unmanaged_copy($file->uri);
+    $form_state['values']['site_default_favicon'] = 0;
+    $form_state['values']['site_favicon_path'] = $filename;
+  }
+
+  // If the user entered a path relative to the system files directory for
+  // a logo or favicon, store a public:// URI so the theme system can handle it.
+  if (!empty($form_state['values']['site_logo_path'])) {
+    $form_state['values']['site_logo_path'] = _system_site_information_settings_validate_path($form_state['values']['site_logo_path']);
+  }
+  if (!empty($form_state['values']['site_favicon_path'])) {
+    $form_state['values']['site_favicon_path'] = _system_site_information_settings_validate_path($form_state['values']['site_favicon_path']);
+  }
+
+  if (empty($form_state['values']['site_default_favicon']) && !empty($form_state['values']['site_favicon_path'])) {
+    $form_state['values']['site_favicon_mimetype'] = file_get_mimetype($form_state['values']['site_favicon_path']);
+  }
+  else {
+    $form_state['values']['site_favicon_mimetype'] = '';
+  }
+
   config('system.site')
     ->set('site_name', $form_state['values']['site_name'])
+    ->set('site_default_logo', $form_state['values']['site_default_logo'])
+    ->set('site_logo_path', $form_state['values']['site_logo_path'])
+    ->set('site_default_favicon', $form_state['values']['site_default_favicon'])
+    ->set('site_favicon_path', $form_state['values']['site_favicon_path'])
+    ->set('site_favicon_mimetype', $form_state['values']['site_favicon_mimetype'])
     ->set('site_mail', $form_state['values']['site_mail'])
     ->set('site_slogan', $form_state['values']['site_slogan'])
     ->set('site_frontpage', $form_state['values']['site_frontpage'])

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -1782,9 +1782,7 @@ function system_update_1012() {
  * Moves site system settings from variable to config.
  */
 function system_update_1013() {
-  // Copy config file to site config folder.
-  config_install_default_config('module', 'system.site');
-  // Migrate variables if any.
+  // Set the default variables for the system.site config file.
   $config = config('system.site');
   $config->set('site_name', variable_get('site_name', 'Backdrop'));
   $config->set('site_mail', variable_get('site_mail', ''));
@@ -2027,6 +2025,38 @@ function system_update_1020() {
  */
 function system_update_1021() {
   variable_del('js_cache_files');
+}
+
+/**
+ * Converts theme logo and shortcut settings to site-wide config.
+ */
+function system_update_1022() {
+  // Update to set the defaults.
+  $config = config('system.site');
+  $config->set('site_default_logo', 1);
+  $config->set('site_logo_path', '');
+  $config->set('site_default_favicon', 1);
+  $config->set('site_favicon_path', 'core/misc/favicon.ico');
+  $config->set('site_favicon_mimetype', 'image/vnd.microsoft.icon');
+
+  $settings = variable_get('theme_settings');
+
+  // Copy over logo settings.
+  if (!empty($settings['toggle_logo'])) {
+    $config->set('site_default_logo', $settings['default_logo']);
+    if (is_file($settings['logo_path'])) {
+      $config->set('site_favicon_path', $settings['logo_path']);
+      $config->set('site_favicon_mimetype', file_get_mimetype($settings['logo_path']));
+    }
+  }
+
+  // Copy over favicon settings.
+  if (!empty($settings['toggle_favicon'])) {
+    $config->set('site_default_favicon', $settings['default_favicon']);
+    if (is_file($settings['favicon_path'])) {
+      $config->set('site_favicon_path', $settings['favicon_path']);
+    }
+  }
 }
 
 /**

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -614,32 +614,19 @@ function system_menu() {
     'type' => MENU_CALLBACK,
     'file' => 'system.admin.inc',
   );
-  $items['admin/appearance/settings'] = array(
-    'title' => 'Settings',
-    'description' => 'Configure default and theme specific settings.',
-    'page callback' => 'backdrop_get_form',
-    'page arguments' => array('system_theme_settings'),
-    'access arguments' => array('administer themes'),
-    'type' => MENU_LOCAL_TASK,
-    'file' => 'system.admin.inc',
-    'weight' => 20,
-  );
-  // Theme configuration subtabs.
-  $items['admin/appearance/settings/global'] = array(
-    'title' => 'Global settings',
-    'type' => MENU_DEFAULT_LOCAL_TASK,
-    'weight' => -1,
-  );
 
   foreach (list_themes() as $key => $theme) {
-    $items['admin/appearance/settings/' . $theme->name] = array(
-      'title' => $theme->info['name'],
-      'page arguments' => array('system_theme_settings', $theme->name),
-      'type' => MENU_LOCAL_TASK,
-      'access callback' => '_system_themes_access',
-      'access arguments' => array($key),
-      'file' => 'system.admin.inc',
-    );
+    // Only provide pages for themes with settings.
+    if (theme_has_settings($key)) {
+      $items['admin/appearance/settings/' . $theme->name] = array(
+        'title' => $theme->info['name'] . ' settings',
+        'page callback' => 'backdrop_get_form',
+        'page arguments' => array('system_theme_settings', $theme->name),
+        'access callback' => '_system_themes_access',
+        'access arguments' => array($key),
+        'file' => 'system.admin.inc',
+      );
+    }
   }
 
   // Modules.
@@ -924,7 +911,7 @@ function system_menu() {
   );
   $items['admin/config/system/site-information'] = array(
     'title' => 'Site information',
-    'description' => 'Change site name, e-mail address, slogan, default front page, and number of posts per page, error pages.',
+    'description' => 'Change site name, logo, favicon, slogan, e-mail address, default front page, and number of posts per page, error pages.',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('system_site_information_settings'),
     'access arguments' => array('administer site configuration'),
@@ -2582,7 +2569,6 @@ function _system_rebuild_theme_data() {
       'page_bottom' => 'Page bottom',
     ),
     'description' => '',
-    'features' => _system_default_theme_features(),
     'screenshot' => 'screenshot.png',
     'php' => BACKDROP_MINIMUM_PHP,
     'stylesheets' => array(),
@@ -2706,16 +2692,6 @@ function _system_info_add_path($info, $path) {
     }
   }
   return $info;
-}
-
-/**
- * Returns an array of default theme features.
- */
-function _system_default_theme_features() {
-  return array(
-    'logo',
-    'favicon',
-  );
 }
 
 /**

--- a/core/modules/system/system.test
+++ b/core/modules/system/system.test
@@ -828,6 +828,160 @@ class PageNotFoundTestCase extends BackdropWebTestCase {
   }
 }
 
+class CustomLogoTestCase extends BackdropWebTestCase {
+  protected $admin_user;
+
+  /**
+   * Implement setUp().
+   */
+  function setUp() {
+    parent::setUp();
+
+    // Create an administrative user.
+    $this->admin_user = $this->backdropCreateUser(array('administer site configuration'));
+    $this->backdropLogin($this->admin_user);
+
+    theme_enable(array('stark'));
+    variable_set('theme_default', 'stark');
+  }
+
+  /**
+   * Test the use of a custom logo.
+   */
+  function testCustomLogo() {
+    // Specify a filesystem path to be used for the logo.
+    $file = current($this->backdropGetTestFiles('image'));
+    $file_relative = strtr($file->uri, array('public://' => variable_get('file_public_path', 'files') . '/'));
+    $default_theme_path = 'core/themes/stark';
+
+    $supported_paths = array(
+      // Raw stream wrapper URI.
+      $file->uri => array(
+        'form' => file_uri_target($file->uri),
+        'src' => file_create_url($file->uri),
+      ),
+      // Relative path within the public filesystem.
+      file_uri_target($file->uri) => array(
+        'form' => file_uri_target($file->uri),
+        'src' => file_create_url($file->uri),
+      ),
+      // Relative path to a public file.
+      $file_relative => array(
+        'form' => $file_relative,
+        'src' => file_create_url($file->uri),
+      ),
+      // Relative path to an arbitrary file.
+      'core/misc/feed.png' => array(
+        'form' => 'core/misc/feed.png',
+        'src' => $GLOBALS['base_url'] . '/' . 'core/misc/feed.png',
+      ),
+      // Relative path to a file in a theme.
+      $default_theme_path . '/screenshot.png' => array(
+        'form' => $default_theme_path . '/screenshot.png',
+        'src' => $GLOBALS['base_url'] . '/' . $default_theme_path . '/screenshot.png',
+      ),
+    );
+    foreach ($supported_paths as $input => $expected) {
+      $edit = array(
+        'site_default_logo' => FALSE,
+        'site_logo_path' => $input,
+      );
+      $this->backdropPost('admin/config/system/site-information', $edit, t('Save configuration'));
+      $this->assertNoText('The custom logo path is invalid.');
+      $this->assertFieldByName('site_logo_path', $expected['form']);
+
+      // Verify logo path examples.
+      $elements = $this->xpath('//div[contains(@class, :item)]/div[@class=:description]/code', array(
+        ':item' => 'form-item-site-logo-path',
+        ':description' => 'description',
+      ));
+      // Expected default values (if all else fails).
+      $implicit_public_file = 'logo.png';
+      $explicit_file = 'public://logo.png';
+      $local_file = $default_theme_path . '/logo.png';
+      // Adjust for fully qualified stream wrapper URI in public filesystem.
+      if (file_uri_scheme($input) == 'public') {
+        $implicit_public_file = file_uri_target($input);
+        $explicit_file = $input;
+        $local_file = strtr($input, array('public://' => variable_get('file_public_path', 'files') . '/'));
+      }
+      // Adjust for fully qualified stream wrapper URI elsewhere.
+      elseif (file_uri_scheme($input) !== FALSE) {
+        $explicit_file = $input;
+      }
+      // Adjust for relative path within public filesystem.
+      elseif ($input == file_uri_target($file->uri)) {
+        $implicit_public_file = $input;
+        $explicit_file = 'public://' . $input;
+        $local_file = variable_get('file_public_path', 'files') . '/' . $input;
+      }
+      $this->assertEqual((string) $elements[0], $implicit_public_file);
+      $this->assertEqual((string) $elements[1], $explicit_file);
+      $this->assertEqual((string) $elements[2], $local_file);
+
+      // Verify the actual 'src' attribute of the logo being output.
+      $this->backdropGet('');
+      $elements = $this->xpath('//header/a[@rel=:rel]/img', array(
+          ':rel' => 'home',
+        )
+      );
+      $this->assertEqual((string) $elements[0]['src'], $expected['src']);
+    }
+
+    $unsupported_paths = array(
+      // Stream wrapper URI to non-existing file.
+      'public://whatever.png',
+      'private://whatever.png',
+      'temporary://whatever.png',
+      // Bogus stream wrapper URIs.
+      'public:/whatever.png',
+      '://whatever.png',
+      ':whatever.png',
+      'public://',
+      // Relative path within the public filesystem to non-existing file.
+      'whatever.png',
+      // Relative path to non-existing file in public filesystem.
+      variable_get('file_public_path', 'files') . '/whatever.png',
+      // Semi-absolute path to non-existing file in public filesystem.
+      '/' . variable_get('file_public_path', 'files') . '/whatever.png',
+      // Relative path to arbitrary non-existing file.
+      'core/misc/whatever.png',
+      // Semi-absolute path to arbitrary non-existing file.
+      '/core/misc/whatever.png',
+      // Absolute paths to any local file (even if it exists).
+      backdrop_realpath($file->uri),
+    );
+    $this->backdropGet('admin/config/system/site-information');
+    foreach ($unsupported_paths as $path) {
+      $edit = array(
+        'site_default_logo' => FALSE,
+        'site_logo_path' => $path,
+      );
+      $this->backdropPost(NULL, $edit, t('Save configuration'));
+      $this->assertText('The custom logo path is invalid.');
+    }
+
+    // Upload a file to use for the logo.
+    $edit = array(
+      'site_default_logo' => FALSE,
+      'site_logo_path' => '',
+      'files[site_logo_upload]' => backdrop_realpath($file->uri),
+    );
+    $this->backdropPost('admin/config/system/site-information', $edit, t('Save configuration'));
+
+    $fields = $this->xpath($this->constructFieldXpath('name', 'site_logo_path'));
+    $uploaded_filename = 'public://' . $fields[0]['value'];
+
+    $this->backdropGet('');
+    $elements = $this->xpath('//header/a[@rel=:rel]/img', array(
+        ':rel' => 'home',
+      )
+    );
+    $this->assertEqual($elements[0]['src'], file_create_url($uploaded_filename));
+  }
+
+}
+
 /**
  * Tests site maintenance functionality.
  */
@@ -1090,6 +1244,7 @@ class PageTitleFiltering extends BackdropWebTestCase {
     $this->backdropGet("node/" . $node->nid);
     $this->assertText(check_plain($edit["title"]), 'Check to make sure tags in the node title are converted.');
   }
+
   /**
    * Test if the title of the site is XSS proof.
    */
@@ -1300,141 +1455,6 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
     $this->admin_user = $this->backdropCreateUser(array('access administration pages', 'view the administration theme', 'administer themes', 'bypass node access', 'administer blocks'));
     $this->backdropLogin($this->admin_user);
     $this->node = $this->backdropCreateNode();
-  }
-
-  /**
-   * Test the theme settings form.
-   */
-  function testThemeSettings() {
-    // Specify a filesystem path to be used for the logo.
-    $file = current($this->backdropGetTestFiles('image'));
-    $file_relative = strtr($file->uri, array('public://' => variable_get('file_public_path', 'files') . '/'));
-    $default_theme_path = 'core/themes/stark';
-
-    $supported_paths = array(
-      // Raw stream wrapper URI.
-      $file->uri => array(
-        'form' => file_uri_target($file->uri),
-        'src' => file_create_url($file->uri),
-      ),
-      // Relative path within the public filesystem.
-      file_uri_target($file->uri) => array(
-        'form' => file_uri_target($file->uri),
-        'src' => file_create_url($file->uri),
-      ),
-      // Relative path to a public file.
-      $file_relative => array(
-        'form' => $file_relative,
-        'src' => file_create_url($file->uri),
-      ),
-      // Relative path to an arbitrary file.
-      'core/misc/feed.png' => array(
-        'form' => 'core/misc/feed.png',
-        'src' => $GLOBALS['base_url'] . '/' . 'core/misc/feed.png',
-      ),
-      // Relative path to a file in a theme.
-      $default_theme_path . '/screenshot.png' => array(
-        'form' => $default_theme_path . '/screenshot.png',
-        'src' => $GLOBALS['base_url'] . '/' . $default_theme_path . '/screenshot.png',
-      ),
-    );
-    foreach ($supported_paths as $input => $expected) {
-      $edit = array(
-        'default_logo' => FALSE,
-        'logo_path' => $input,
-      );
-      $this->backdropPost('admin/appearance/settings', $edit, t('Save configuration'));
-      $this->assertNoText('The custom logo path is invalid.');
-      $this->assertFieldByName('logo_path', $expected['form']);
-
-      // Verify logo path examples.
-      $elements = $this->xpath('//div[contains(@class, :item)]/div[@class=:description]/code', array(
-        ':item' => 'form-item-logo-path',
-        ':description' => 'description',
-      ));
-      // Expected default values (if all else fails).
-      $implicit_public_file = 'logo.png';
-      $explicit_file = 'public://logo.png';
-      $local_file = $default_theme_path . '/logo.png';
-      // Adjust for fully qualified stream wrapper URI in public filesystem.
-      if (file_uri_scheme($input) == 'public') {
-        $implicit_public_file = file_uri_target($input);
-        $explicit_file = $input;
-        $local_file = strtr($input, array('public://' => variable_get('file_public_path', 'files') . '/'));
-      }
-      // Adjust for fully qualified stream wrapper URI elsewhere.
-      elseif (file_uri_scheme($input) !== FALSE) {
-        $explicit_file = $input;
-      }
-      // Adjust for relative path within public filesystem.
-      elseif ($input == file_uri_target($file->uri)) {
-        $implicit_public_file = $input;
-        $explicit_file = 'public://' . $input;
-        $local_file = variable_get('file_public_path', 'files') . '/' . $input;
-      }
-      $this->assertEqual((string) $elements[0], $implicit_public_file);
-      $this->assertEqual((string) $elements[1], $explicit_file);
-      $this->assertEqual((string) $elements[2], $local_file);
-
-      // Verify the actual 'src' attribute of the logo being output.
-      $this->backdropGet('');
-      $elements = $this->xpath('//header/a[@rel=:rel]/img', array(
-          ':rel' => 'home',
-        )
-      );
-      $this->assertEqual((string) $elements[0]['src'], $expected['src']);
-    }
-
-    $unsupported_paths = array(
-      // Stream wrapper URI to non-existing file.
-      'public://whatever.png',
-      'private://whatever.png',
-      'temporary://whatever.png',
-      // Bogus stream wrapper URIs.
-      'public:/whatever.png',
-      '://whatever.png',
-      ':whatever.png',
-      'public://',
-      // Relative path within the public filesystem to non-existing file.
-      'whatever.png',
-      // Relative path to non-existing file in public filesystem.
-      variable_get('file_public_path', 'files') . '/whatever.png',
-      // Semi-absolute path to non-existing file in public filesystem.
-      '/' . variable_get('file_public_path', 'files') . '/whatever.png',
-      // Relative path to arbitrary non-existing file.
-      'core/misc/whatever.png',
-      // Semi-absolute path to arbitrary non-existing file.
-      '/core/misc/whatever.png',
-      // Absolute paths to any local file (even if it exists).
-      backdrop_realpath($file->uri),
-    );
-    $this->backdropGet('admin/appearance/settings');
-    foreach ($unsupported_paths as $path) {
-      $edit = array(
-        'default_logo' => FALSE,
-        'logo_path' => $path,
-      );
-      $this->backdropPost(NULL, $edit, t('Save configuration'));
-      $this->assertText('The custom logo path is invalid.');
-    }
-
-    // Upload a file to use for the logo.
-    $edit = array(
-      'default_logo' => FALSE,
-      'logo_path' => '',
-      'files[logo_upload]' => backdrop_realpath($file->uri),
-    );
-    $this->backdropPost('admin/appearance/settings', $edit, t('Save configuration'));
-
-    $fields = $this->xpath($this->constructFieldXpath('name', 'logo_path'));
-    $uploaded_filename = 'public://' . $fields[0]['value'];
-
-    $this->backdropGet('');
-    $elements = $this->xpath('//header/a[@rel=:rel]/img', array(
-        ':rel' => 'home',
-      )
-    );
-    $this->assertEqual($elements[0]['src'], file_create_url($uploaded_filename));
   }
 
   /**

--- a/core/modules/system/system.tests.info
+++ b/core/modules/system/system.tests.info
@@ -58,6 +58,12 @@ description = Tests page not found functionality, including custom 404 pages.
 group = System
 file = system.test
 
+[CustomLogoTestCase]
+name = Custom logo
+description = Tests theme based logo and uploaded custom logo functionality.
+group = System
+file = system.test
+
 [SiteMaintenanceTestCase]
 name = Site maintenance mode functionality
 description = Test access to site while in maintenance mode.

--- a/core/themes/bartik/bartik.info
+++ b/core/themes/bartik/bartik.info
@@ -30,5 +30,6 @@ regions[footer_thirdcolumn] = Footer third column
 regions[footer_fourthcolumn] = Footer fourth column
 regions[footer] = Footer
 
-settings[shortcut_module_link] = 0
-
+; We need at least one setting for the theme settings page to appear in the
+; menu. Color module provides our defaults, so we just register a dummy setting.
+settings[color] = true

--- a/core/themes/bartik/color/color.inc
+++ b/core/themes/bartik/color/color.inc
@@ -96,9 +96,7 @@ $info = array(
   ),
 
   // Files to copy.
-  'copy' => array(
-    'logo.png',
-  ),
+  'copy' => array(),
 
   // Gradient definitions.
   'gradients' => array(

--- a/core/themes/bartik/templates/maintenance-page.tpl.php
+++ b/core/themes/bartik/templates/maintenance-page.tpl.php
@@ -38,7 +38,7 @@
             </div>
           <?php endif; ?>
           <?php if ($site_slogan): ?>
-            <div id="site-slogan">>
+            <div id="site-slogan">
               <?php print $site_slogan; ?>
             </div>
           <?php endif; ?>

--- a/core/themes/bartik/theme-settings.php
+++ b/core/themes/bartik/theme-settings.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Theme settings file for Bartik.
+ *
+ * Although Bartik itself does not provide any settings, we use this file to
+ * inform the user that the module supports color schemes if the Color module
+ * is enabled.
+ */
+$form['color'] = array(
+  '#markup' => '<p>' . t('This theme supports custom color palettes if the Color module is enabled on the <a href="!url">modules page</a>. Enable the Color module to customize this theme.', array('!url' => url('admin/modules'))) . '</p>',
+);

--- a/core/themes/seven/seven.info
+++ b/core/themes/seven/seven.info
@@ -5,7 +5,6 @@ version = BACKDROP_VERSION
 backdrop = 1.x
 stylesheets[screen][] = style.css
 stylesheets[screen][] = seven.base.css
-settings[shortcut_module_link] = 1
 regions[content] = Content
 regions[page_top] = Page top
 regions[page_bottom] = Page bottom


### PR DESCRIPTION
Additional PR for https://github.com/backdrop/backdrop-issues/issues/130.

This PR removes the remaining parts of the global theme settings page and removes it entirely. Themes that do not provide any settings do not get a settings page at all.

Because this dealt heavily with saving theme settings into configuration (instead of variables), this PR also converts Color module to read and write from the new config files instead of using the old variables. Upgrade path is provide to convert color settings into the theme config.
