### PR TITLE
Issue #323: Followup. Fixing misnamed function to be admin_menu instead of admin_bar.

### DIFF
--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -511,7 +511,7 @@ function admin_bar_links_menu($tree) {
     }
 
     // Handle links pointing to category/overview pages.
-    if ($data['link']['page_callback'] == 'system_admin_bar_block_page' || $data['link']['page_callback'] == 'system_admin_config_page') {
+    if ($data['link']['page_callback'] == 'system_admin_menu_block_page' || $data['link']['page_callback'] == 'system_admin_config_page') {
       // Apply a marker for others to consume.
       $links[$data['link']['href']]['#is_category'] = TRUE;
       // Automatically hide empty categories.


### PR DESCRIPTION
Followup to the PR at https://github.com/backdrop/backdrop/pull/474.

Fixes https://github.com/backdrop/backdrop-issues/issues/323.

This just addresses a typo where we renamed "system_admin_menu_block_page" to "system_admin_bar_block_page" accidentally.
