### PR TITLE
Issue #311: Changed admin menu search form element #type to 'search'.

### DIFF
--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -641,7 +641,7 @@ function admin_bar_links_search() {
     ),
   );
   $search['search']['search'] = array(
-    '#type' => 'textfield',
+    '#type' => 'search',
     '#title' => t('Admin search'),
     '#title_display' => 'attribute',
     '#attributes' => array(


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/310. Was this issue trying to accomplish more than this? I'd be happy to flesh it out more.
