### PR TITLE
279 drop postgres doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ Backdrop aims to provide:
 Requirements
 ------------
 - PHP 5.3.2 or higher
-- MySQL 5.0.15 or PostgreSQL 8.3 or higher with PDO enabled
+- MySQL 5.0.15 or higher with PDO enabled
 
 Installation
 ------------
 
-1. Create a new database, username, and password for Backdrop to use in MySQL
-   or PostgreSQL.
+1. Create a new database, username, and password for Backdrop to use in MySQL.
 
 2. Point your browser at the URL of your Backdrop installation. On Apache web
    servers, you will be directed to the install screen. If you're not

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -7565,8 +7565,8 @@ function backdrop_write_record($table, &$record, $primary_keys = array()) {
     // column allows this.
     //
     // MySQL PDO silently casts e.g. FALSE and '' to 0 when inserting the value
-    // into an integer column, but PostgreSQL PDO does not. Also type cast NULL
-    // when the column does not allow this.
+    // into an integer column. Also type cast NULL when the column does not
+    // allow this.
     if (isset($object->$field) || !empty($info['not null'])) {
       if ($info['type'] == 'int' || $info['type'] == 'serial') {
         $fields[$field] = (int) $fields[$field];

--- a/core/includes/database/database.inc
+++ b/core/includes/database/database.inc
@@ -1298,9 +1298,8 @@ abstract class DatabaseConnection extends PDO {
    * Retrieves an unique id from a given sequence.
    *
    * Use this function if for some reason you can't use a serial field. For
-   * example, MySQL has no ways of reading of the current value of a sequence
-   * and PostgreSQL can not advance the sequence to be larger than a given
-   * value. Or sometimes you just need a unique integer.
+   * example, MySQL has no ways of reading of the current value of a sequence.
+   * Or sometimes you just need a unique integer.
    *
    * @param $existing_id
    *   After a database import, it might be that the sequences table is behind,
@@ -2988,12 +2987,6 @@ function db_drop_index($table, $name) {
  *   array('type' => 'serial', 'not null' => TRUE),
  *   array('primary key' => array('bar')));
  * @endcode
- *
- * The reasons for this are due to the different database engines:
- *
- * On PostgreSQL, changing a field definition involves adding a new field and
- * dropping an old one which causes any indices, primary keys and sequences
- * (from serial-type fields) that use the changed field to be dropped.
  *
  * On MySQL, all type 'serial' fields must be part of at least one key or index
  * as soon as they are created. You cannot use

--- a/core/includes/database/query.inc
+++ b/core/includes/database/query.inc
@@ -946,8 +946,6 @@ class TruncateQuery extends Query {
     // In most cases, TRUNCATE is not a transaction safe statement as it is a
     // DDL statement which results in an implicit COMMIT. When we are in a
     // transaction, fallback to the slower, but transactional, DELETE.
-    // PostgreSQL also locks the entire table for a TRUNCATE strongly reducing
-    // the concurrency with other transactions.
     if ($this->connection->inTransaction()) {
       return $comments . 'DELETE FROM {' . $this->connection->escapeTable($this->table) . '}';
     }
@@ -1227,9 +1225,9 @@ class UpdateQuery extends Query implements QueryConditionInterface {
  *   INSERT (column1 [, column2 ...]) VALUES (value1 [, value2 ...
  * @endcode
  *
- * Thus far, many databases (most notably MySQL, PostgreSQL or SQLite) do not
- * directly implement MERGE queries and will emulate this statement by running
- * an UPDATE, and if that does not match any rows, then an INSERT.
+ * MySQL does not directly implement MERGE queries and will emulate this
+ * statement by running an UPDATE, and if that does not match any rows, then
+ * an INSERT.
  *
  * The condition is built exactly like SelectQuery or UpdateQuery conditions,
  * the UPDATE query part is built similarly like an UpdateQuery and finally the

--- a/core/includes/database/schema.inc
+++ b/core/includes/database/schema.inc
@@ -598,12 +598,6 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
    *   array('primary key' => array('bar')));
    * @endcode
    *
-   * The reasons for this are due to the different database engines:
-   *
-   * On PostgreSQL, changing a field definition involves adding a new field
-   * and dropping an old one which* causes any indices, primary keys and
-   * sequences (from serial-type fields) that use the changed field to be dropped.
-   *
    * On MySQL, all type 'serial' fields must be part of at least one key
    * or index as soon as they are created. You cannot use
    * db_add_{primary_key,unique_key,index}() for this purpose because

--- a/core/includes/database/select.inc
+++ b/core/includes/database/select.inc
@@ -368,11 +368,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    * order this method is called.
    *
    * If the query uses DISTINCT or GROUP BY conditions, fields or expressions
-   * that are used for the order must be selected to be compatible with some
-   * databases like PostgreSQL. The PostgreSQL driver can handle simple cases
-   * automatically but it is suggested to explicitly specify them. Additionally,
-   * when ordering on an alias, the alias must be added before orderBy() is
-   * called.
+   * that are used for the order must be selected. Additionally, when ordering
+   * on an alias, the alias must be added before orderBy() is called.
    *
    * @param $field
    *   The field on which to order.
@@ -1502,8 +1499,7 @@ class SelectQuery extends Query implements SelectQueryInterface {
       }
     }
     foreach ($this->fields as $alias => $field) {
-      // Always use the AS keyword for field aliases, as some
-      // databases require it (e.g., PostgreSQL).
+      // Always use the AS keyword for field aliases
       $fields[] = (isset($field['table']) ? $this->connection->escapeTable($field['table']) . '.' : '') . $this->connection->escapeField($field['field']) . ' AS ' . $this->connection->escapeAlias($field['alias']);
     }
     foreach ($this->expressions as $alias => $expression) {

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -1470,10 +1470,6 @@ class CommentPagerTest extends CommentHelperCase {
 
 /**
  * Tests comments with node access.
- *
- * See http://drupal.org/node/886752 -- verify there is no PostgreSQL error when
- * viewing a node with threaded comments (a comment and a reply), if a node
- * access module is in use.
  */
 class CommentNodeAccessTest extends CommentHelperCase {
   function setUp() {

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -558,7 +558,7 @@ function user_search_access() {
  */
 function user_search_execute($keys = NULL, $conditions = NULL) {
   $find = array();
-  // Replace wildcards with MySQL/PostgreSQL wildcards.
+  // Replace wildcards with MySQL wildcards.
   $keys = preg_replace('!\*+!', '%', $keys);
   $query = db_select('users')->extend('PagerDefault');
   $query->fields('users', array('uid'));

--- a/core/modules/views/handlers/views_handler_argument_string.inc
+++ b/core/modules/views/handlers/views_handler_argument_string.inc
@@ -29,7 +29,6 @@ class views_handler_argument_string extends views_handler_argument {
     $options['glossary'] = array('default' => FALSE, 'bool' => TRUE);
     $options['limit'] = array('default' => 0);
     $options['case'] = array('default' => 'none');
-    $options['path_case'] = array('default' => 'none');
     $options['transform_dash'] = array('default' => FALSE, 'bool' => TRUE);
     $options['break_phrase'] = array('default' => FALSE, 'bool' => TRUE);
 
@@ -77,21 +76,6 @@ class views_handler_argument_string extends views_handler_argument {
         'ucwords' => t('Capitalize each word'),
       ),
       '#default_value' => $this->options['case'],
-      '#fieldset' => 'more',
-    );
-
-    $form['path_case'] = array(
-      '#type' => 'select',
-      '#title' => t('Case in path'),
-      '#description' => t('When printing url paths, how to transform the case of the filter value. Do not use this unless with Postgres as it uses case sensitive comparisons.'),
-      '#options' => array(
-        'none' => t('No transform'),
-        'upper' => t('Upper case'),
-        'lower' => t('Lower case'),
-        'ucfirst' => t('Capitalize first letter'),
-        'ucwords' => t('Capitalize each word'),
-      ),
-      '#default_value' => $this->options['path_case'],
       '#fieldset' => 'more',
     );
 
@@ -228,7 +212,7 @@ class views_handler_argument_string extends views_handler_argument {
   }
 
   function summary_argument($data) {
-    $value = $this->case_transform($data->{$this->base_alias}, $this->options['path_case']);
+    $value = $data->{$this->base_alias};
     if (!empty($this->options['transform_dash'])) {
       $value = strtr($value, ' ', '-');
     }

--- a/core/modules/views/plugins/views_plugin_query_default.inc
+++ b/core/modules/views/plugins/views_plugin_query_default.inc
@@ -796,8 +796,6 @@ class views_plugin_query_default extends views_plugin_query {
     // Make sure an alias is assigned
     $alias = $alias ? $alias : $field;
 
-    // PostgreSQL truncates aliases to 63 characters: http://drupal.org/node/571548
-
     // We limit the length of the original alias up to 60 characters
     // to get a unique alias later if its have duplicates
     $alias = strtolower(substr($alias, 0, 60));


### PR DESCRIPTION
I noticed backdrop has dropped psql, but there were still references to psql in the README, in some code doc blocks and a psql specific option in a views handler. This PR removes those.
