### PR TITLE
Issue #304: Rename the 'main menu' menu to 'primary navigation'.

### DIFF
--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -1791,7 +1791,7 @@ function menu_set_custom_theme() {
  */
 function menu_list_system_menus() {
   return array(
-    'main-menu' => 'Main menu',
+    'main-menu' => 'Primary navigation',
     'management' => 'Management',
     'user-menu' => 'User menu',
   );

--- a/core/modules/menu/menu.install
+++ b/core/modules/menu/menu.install
@@ -10,7 +10,7 @@
  */
 function menu_schema() {
   $schema['menu_custom'] = array(
-    'description' => 'Holds definitions for top-level custom menus (for example, Main menu).',
+    'description' => 'Holds definitions for top-level custom menus (for example, Primary navigation).',
     'fields' => array(
       'menu_name' => array(
         'type' => 'varchar',
@@ -47,7 +47,7 @@ function menu_install() {
   $system_menus = menu_list_system_menus();
   $t = get_t();
   $descriptions = array(
-    'main-menu' => $t('The <em>Main</em> menu is used on many sites to show the major sections of the site, often in a top navigation bar.'),
+    'main-menu' => $t('The <em>Primary navigation</em> menu is used on many sites to show the major sections of the site, often in a top navigation bar.'),
     'management' => $t('The <em>Management</em> menu contains links for administrative tasks.'),
     'user-menu' => $t("The <em>User</em> menu contains links related to the user's account, as well as the 'Log out' link."),
   );

--- a/core/modules/menu/menu.test
+++ b/core/modules/menu/menu.test
@@ -545,7 +545,7 @@ class MenuTestCase extends BackdropWebTestCase {
     $this->backdropGet('admin/structure/menu/manage/main-menu');
         $this->assertResponse($response);
     if ($response == 200) {
-      $this->assertText(t('Main menu'), 'Main menu menu node was displayed');
+      $this->assertText(t('Primary navigation'), 'Primary navigation menu node was displayed');
     }
 
     // View menu edit node.

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -1044,7 +1044,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
     );
     $this->assertBreadcrumb('admin/structure/menu/manage/main-menu', $trail);
     $trail += array(
-      'admin/structure/menu/manage/main-menu' => t('Main menu'),
+      'admin/structure/menu/manage/main-menu' => t('Primary navigation'),
     );
     $this->assertBreadcrumb('admin/structure/menu/manage/main-menu/edit', $trail);
     $this->assertBreadcrumb('admin/structure/menu/manage/main-menu/add', $trail);

--- a/core/modules/views/tests/views_ui.test
+++ b/core/modules/views/tests/views_ui.test
@@ -556,7 +556,7 @@ class ViewsUIWizardMenuTestCase extends ViewsUIWizardHelper {
         break;
       }
     }
-    $this->assertTrue($found, t('Found a link to %path in the main menu', array('%path' => $view['page[path]'])));
+    $this->assertTrue($found, t('Found a link to %path in the primary navigation', array('%path' => $view['page[path]'])));
   }
 }
 


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/304.
