### PR TITLE
Issue #423: Upgrade path does not save any effects to default image styles.

### DIFF
--- a/core/modules/image/image.install
+++ b/core/modules/image/image.install
@@ -135,13 +135,15 @@ function image_update_1000() {
     'label' => 'Thumbnail (100x100)',
     'name' => 'thumbnail',
     'effects' => array(
-      'name' => 'image_scale',
-      'data' => array(
-        'width' => 100,
-        'height' => 100,
-        'upscale' => 1,
+      array(
+        'name' => 'image_scale',
+        'data' => array(
+          'width' => 100,
+          'height' => 100,
+          'upscale' => 1,
+        ),
+        'weight' => 1,
       ),
-      'weight' => 1,
     ),
   );
   $config = config('image.styles.thumbnail');
@@ -154,13 +156,15 @@ function image_update_1000() {
     'label' => 'Medium (220x220)',
     'name' => 'medium',
     'effects' => array(
-      'name' => 'image_scale',
-      'data' => array(
-        'width' => 220,
-        'height' => 220,
-        'upscale' => 1,
+      array(
+        'name' => 'image_scale',
+        'data' => array(
+          'width' => 220,
+          'height' => 220,
+          'upscale' => 1,
+        ),
+        'weight' => 1,
       ),
-      'weight' => 1,
     ),
   );
   $config = config('image.styles.medium');
@@ -173,13 +177,15 @@ function image_update_1000() {
     'label' => 'Large (480x480)',
     'name' => 'large',
     'effects' => array(
-      'name' => 'image_scale',
-      'data' => array(
-        'width' => 480,
-        'height' => 480,
-        'upscale' => 1,
+      array(
+        'name' => 'image_scale',
+        'data' => array(
+          'width' => 480,
+          'height' => 480,
+          'upscale' => 1,
+        ),
+        'weight' => 1,
       ),
-      'weight' => 1,
     ),
   );
   $config = config('image.styles.large');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/423.
