### PR TITLE
Issue #418: 404 and 403 pages should use admin layout when in admin theme.

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -418,11 +418,21 @@ function layout_route_handler($router_item) {
 
   // If no layout matches at the path, use the default layout.
   if (!$selected_layout) {
-    if (path_is_admin($router_item['path'])) {
+    if (path_is_admin($router_item['path']) && user_access('view the administration theme')) {
       $selected_layout = layout_load('admin_default');
     }
     else {
       $selected_layout = layout_load('default');
+    }
+  }
+
+  // Special handling for 404 and 403 pages to render in admin theme. The
+  // current path will be the 404/403 system path, and we need to check the
+  // original path, which is stored in "destination" by
+  // backdrop_deliver_html_page().
+  if (in_array(backdrop_get_http_header('Status'), array('404 Not Found', '403 Forbidden')) && user_access('view the administration theme')) {
+    if (isset($_GET['destination']) && path_is_admin($_GET['destination'])) {
+      $selected_layout = layout_load('admin_default');
     }
   }
 

--- a/core/modules/layout/layout.tests.info
+++ b/core/modules/layout/layout.tests.info
@@ -4,6 +4,12 @@ description = Tests the interface for adding, removing, and moving blocks.
 group = Layout
 file = tests/layout.test
 
+[LayoutSelectionTest]
+name = Layout Selection Test
+description = Tests that the correct layout is used in various situations.
+group = Layout
+file = tests/layout.test
+
 [LayoutUpgradePathTest]
 name = Layout Upgrade Test
 description = Tests the upgrade path from block-based regions to layouts.

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -944,6 +944,61 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
 }
 
 /**
+ * Tests that the correct layout is used in various situations.
+ */
+class LayoutSelectionTest extends BackdropWebTestCase {
+  /**
+   * Tests the correct layout is used on 404 and 403 pages.
+   */
+  function testErrorPages() {
+    // Create and login admin user.
+    $admin_user = $this->backdropCreateUser(array(
+      'access administration pages',
+      'administer content types',
+      'view the administration theme',
+    ));
+    $this->backdropLogin($admin_user);
+
+    // Check that a known page is using the admin (one-column) layout.
+    $this->backdropGet('admin/config/content/formats/plain_text');
+    $this->assertIsAdminLayout();
+
+    // Check that a 403 page uses the admin layout.
+    $this->backdropGet('admin/appearance');
+    $this->assertIsAdminLayout();
+
+    // Check that a 404 page uses the admin layout.
+    $this->backdropGet('admin/config/content/formats/fake-format');
+    $this->assertIsAdminLayout();
+
+    // Check that the front-end is using the default layout.
+    $this->backdropGet('node');
+    $this->assertIsDefaultLayout();
+
+    // Check that anonymous users get the Default layout for admin paths.
+    $this->backdropLogout();
+
+    // Anonymous 403.
+    $this->backdropGet('admin/config/content/formats/plain_text');
+    $this->assertIsDefaultLayout();
+
+    // Anonymous 404.
+    $this->backdropGet('admin/config/content/formats/fake-format');
+    $this->assertIsDefaultLayout();
+  }
+
+  private function assertIsDefaultLayout($message = '') {
+    $result = $this->xpath('//div[contains(@class, "layout-two-column")]');
+    $this->assertEqual(count($result), 1, $message ? $message : format_string('Admin layout used at @path', array('@path' => $this->getUrl())));
+  }
+
+  private function assertIsAdminLayout($message = '') {
+    $result = $this->xpath('//div[contains(@class, "layout-one-column")]');
+    $this->assertEqual(count($result), 1, $message ? $message : format_string('Admin layout used at @path', array('@path' => $this->getUrl())));
+  }
+}
+
+/**
  * Tests the upgrade path from block-based regions to layouts.
  */
 class LayoutUpgradePathTest extends UpgradePathTestCase {


### PR DESCRIPTION
Fixes issue https://github.com/backdrop/backdrop-issues/issues/418
