### PR TITLE
Issue #349: Hide Stark from the themes page.

### DIFF
--- a/core/modules/simpletest/tests/theme_test.module
+++ b/core/modules/simpletest/tests/theme_test.module
@@ -152,3 +152,12 @@ function theme_test_preprocess_page(&$variables) {
 function theme_theme_test_foo($variables) {
   return $variables['foo'];
 }
+
+/**
+ * Implements hook_system_info_alter().
+ */
+function theme_test_system_info_alter(&$info, $file, $type) {
+  if ($type === 'theme' && $file->name === 'stark') {
+    unset($info['hidden']);
+  }
+}

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -114,7 +114,10 @@ function system_themes_page() {
   uasort($themes, 'system_sort_modules_by_info_name');
 
   $theme_default = config_get('system.core', 'theme_default');
-  $theme_groups  = array();
+  $theme_groups  = array(
+    'enabled' => array(),
+    'disabled' => array(),
+  );
 
   foreach ($themes as &$theme) {
     if (!empty($theme->info['hidden'])) {
@@ -211,10 +214,10 @@ function system_themes_page() {
 
   // There are two possible theme groups.
   $theme_group_titles = array(
-    'enabled' => format_plural(count($theme_groups['enabled']), 'Enabled theme', 'Enabled themes'),
+    'enabled' => t('Enabled themes'),
   );
   if (!empty($theme_groups['disabled'])) {
-    $theme_group_titles['disabled'] = format_plural(count($theme_groups['disabled']), 'Disabled theme', 'Disabled themes');
+    $theme_group_titles['disabled'] = t('Disabled themes');
   }
 
   uasort($theme_groups['enabled'], 'system_sort_themes');

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1501,6 +1501,15 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
 
     $this->backdropGet('node/add');
     $this->assertRaw('core/themes/bartik', 'Site default theme used on the add content page.');
+
+    // Check that Stark does not show up on the Appearance page.
+    $this->backdropGet('admin/appearance');
+    $this->assertNoText('Stark', 'Stark theme not shown on appearance page.');
+
+    // Turn on the theme test module, which makes Stark unhidden.
+    module_enable(array('theme_test'));
+    $this->backdropGet('admin/appearance');
+    $this->assertText('Stark', 'Stark theme now shown when hook_system_info_alter() unhides the theme.');
   }
 
   /**
@@ -1513,10 +1522,10 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
     $this->clickLink(t('Set default'));
     $this->assertEqual(config_get('system.core', 'theme_default'), 'bartik');
 
-    // Switch back to Stark and test again.
+    // Switch back to Seven and test again.
     $this->backdropGet('admin/appearance');
-    $this->clickLink(t('Set default'), 0);
-    $this->assertEqual(config_get('system.core', 'theme_default'), 'stark');
+    $this->clickLink(t('Enable and set default'), 0);
+    $this->assertEqual(config_get('system.core', 'theme_default'), 'seven');
   }
 }
 

--- a/core/themes/stark/stark.info
+++ b/core/themes/stark/stark.info
@@ -4,3 +4,4 @@ package = Core
 version = BACKDROP_VERSION
 backdrop = 1.x
 stylesheets[all][] = layout.css
+hidden = TRUE


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/349.
