### PR TITLE
Issue #444: Cache the translate_english option in t().

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1675,7 +1675,14 @@ function backdrop_unpack($obj, $field = 'data') {
  */
 function t($string, array $args = array(), array $options = array()) {
   global $language_interface;
-  //static $custom_strings;
+
+  // Use the advanced backdrop_static() pattern, since this is called very often.
+  static $backdrop_static_fast;
+  if (!isset($backdrop_static_fast)) {
+    $backdrop_static_fast['t'] = &backdrop_static(__FUNCTION__, array());
+  }
+  $custom_strings = &$backdrop_static_fast['t']['custom_strings'];
+  $translate_english = &$backdrop_static_fast['t']['translate_english'];
 
   // Merge in default.
   if (empty($options['langcode'])) {
@@ -1683,6 +1690,12 @@ function t($string, array $args = array(), array $options = array()) {
   }
   if (empty($options['context'])) {
     $options['context'] = '';
+  }
+
+  // Locale module may not have been enabled, so we check for NULL value here
+  // and statically cache the result for performance.
+  if (!isset($translate_english)) {
+    $translate_english = config_get('locale.settings', 'translate_english') ? TRUE : FALSE;
   }
 
   // First, check for an array of customized strings. If present, use the array
@@ -1697,7 +1710,7 @@ function t($string, array $args = array(), array $options = array()) {
     $string = $custom_strings[$options['langcode']][$options['context']][$string];
   }
   // Translate with locale module if enabled.
-  elseif ($options['langcode'] != LANGUAGE_SYSTEM && ($options['langcode'] != 'en' || config_get('locale.settings', 'translate_english')) && function_exists('locale')) {
+  elseif ($options['langcode'] != LANGUAGE_SYSTEM && ($options['langcode'] != 'en' || $translate_english) && function_exists('locale')) {
     $string = locale($string, $options['context'], $options['langcode']);
   }
   if (empty($args)) {

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -629,6 +629,7 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
  * Reset static variables used by locale().
  */
 function locale_reset() {
+  backdrop_static_reset('t');
   backdrop_static_reset('locale');
 }
 

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -122,6 +122,8 @@ class MenuWebTestCase extends BackdropWebTestCase {
 }
 
 class MenuRouterTestCase extends BackdropWebTestCase {
+  protected $profile = 'minimal';
+
   function setUp() {
     // Enable dummy module that implements hook_menu.
     parent::setUp('menu_test');

--- a/core/modules/simpletest/tests/menu_test.module
+++ b/core/modules/simpletest/tests/menu_test.module
@@ -398,6 +398,7 @@ function menu_test_init() {
     'Example title' => 'Alternative example title',
   );
   $GLOBALS['settings']['locale_custom_strings_en'] = array('' => $string_overrides);
+  backdrop_static_reset('t');
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/444.
