### PR TITLE
Issue #302: Rename the Management menu to Administration menu.

### DIFF
--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -1792,7 +1792,7 @@ function menu_set_custom_theme() {
 function menu_list_system_menus() {
   return array(
     'main-menu' => 'Main menu',
-    'management' => 'Management',
+    'management' => 'Administration menu',
     'user-menu' => 'User menu',
   );
 }

--- a/core/modules/menu/menu.install
+++ b/core/modules/menu/menu.install
@@ -48,7 +48,7 @@ function menu_install() {
   $t = get_t();
   $descriptions = array(
     'main-menu' => $t('The <em>Main</em> menu is used on many sites to show the major sections of the site, often in a top navigation bar.'),
-    'management' => $t('The <em>Management</em> menu contains links for administrative tasks.'),
+    'management' => $t('The <em>Administration</em> menu contains links for administrative tasks and content entry.'),
     'user-menu' => $t("The <em>User</em> menu contains links related to the user's account, as well as the 'Log out' link."),
   );
   foreach ($system_menus as $menu_name => $title) {

--- a/core/modules/menu/menu.test
+++ b/core/modules/menu/menu.test
@@ -651,7 +651,7 @@ class MenuNodeTestCase extends BackdropWebTestCase {
     $this->backdropGet('');
     $this->assertNoLink($node_title);
 
-    // Add a menu link to the Management menu.
+    // Add a menu link to the Administration menu.
     $item = array(
       'link_path' => 'node/' . $node->nid,
       'link_title' => $this->randomName(16),
@@ -659,10 +659,10 @@ class MenuNodeTestCase extends BackdropWebTestCase {
     );
     menu_link_save($item);
 
-    // Assert that disabled Management menu is not shown on the node/$nid/edit page.
+    // Assert that disabled Administration menu is not shown on the node/$nid/edit page.
     $this->backdropGet('node/' . $node->nid . '/edit');
     $this->assertText('Provide a menu link', 'Link in not allowed menu not shown in node edit form');
-    // Assert that the link is still in the management menu after save.
+    // Assert that the link is still in the Administration menu after save.
     $this->backdropPost('node/' . $node->nid . '/edit', $edit, t('Save'));
     $link = menu_link_load($item['mlid']);
     $this->assertTrue($link, 'Link in not allowed menu still exists after saving node');

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -1495,8 +1495,8 @@ class MenuTrailTestCase extends MenuWebTestCase {
     variable_del('menu_test_menu_tree_set_path');
     $this->assertBreadcrumb('menu-test/menu-trail', $breadcrumb, t('Menu trail - Case 1'), $tree);
 
-    // Override the active trail for the Management tree; it should not affect
-    // the Main tree.
+    // Override the active trail for the Administration tree; it should not
+    // affect the Main tree.
     variable_set('menu_test_menu_tree_set_path', $test_menu_path);
     $this->assertBreadcrumb('menu-test/menu-trail', $breadcrumb, t('Menu trail - Case 1'), $tree);
 
@@ -1517,12 +1517,12 @@ class MenuTrailTestCase extends MenuWebTestCase {
       'admin/config/system/site-information' => t('Site information'),
     );
 
-    // Test the tree generation for the Management menu.
+    // Test the tree generation for the Administration menu.
     variable_del('menu_test_menu_tree_set_path');
     $this->assertBreadcrumb('admin/config/development/menu-trail', $breadcrumb, t('Menu trail - Case 2'), $tree);
 
-    // Override the active trail for the Management tree; it should affect the
-    // breadcrumbs and Management tree.
+    // Override the active trail for the Administration tree; it should affect
+    // both the breadcrumbs and Administration menu tree.
     variable_set('menu_test_menu_tree_set_path', $test_menu_path);
     $this->assertBreadcrumb('admin/config/development/menu-trail', $override_breadcrumb, t('Menu trail - Case 2'), $override_tree);
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/302.

Replacement PR for https://github.com/backdrop/backdrop/pull/446.
