### PR TITLE
issue #450 Remove regions defaults from _system_rebuild_theme_data()

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2594,15 +2594,6 @@ function _system_rebuild_theme_data() {
   // Set defaults for theme info.
   $defaults = array(
     'engine' => 'phptemplate',
-    'regions' => array(
-      'sidebar_first' => 'Left sidebar',
-      'sidebar_second' => 'Right sidebar',
-      'content' => 'Content',
-      'header' => 'Header',
-      'footer' => 'Footer',
-      'highlighted' => 'Highlighted',
-      'page_bottom' => 'Page bottom',
-    ),
     'description' => '',
     'screenshot' => 'screenshot.png',
     'php' => BACKDROP_MINIMUM_PHP,


### PR DESCRIPTION
simply removed the 'regions' index in its entirety.

https://github.com/backdrop/backdrop-issues/issues/450
