### PR TITLE
Set standard to exclusive in profile

### DIFF
--- a/profiles/standard/standard.info
+++ b/profiles/standard/standard.info
@@ -2,6 +2,7 @@ name = Standard
 description = Install with commonly used features pre-configured.
 version = BACKDROP_VERSION
 backdrop = 1.x
+exclusive = 1
 dependencies[] = node
 dependencies[] = admin_bar
 dependencies[] = block


### PR DESCRIPTION
This setting will allow the installation routine to skip a step and speed it up for the default use-case of most people. Eventual drush support can be used to capture the minimal / testing installation routines.

This stems from https://github.com/backdrop/backdrop-issues/issues/467 which would help speed up initial installation / UX
