### PR TITLE
Issue #85: Avoid long cache lifetime on the maintenance page.

### DIFF
--- a/core/includes/cache.inc
+++ b/core/includes/cache.inc
@@ -308,7 +308,7 @@ class BackdropDatabaseCache implements BackdropCacheInterface {
       // is used here only due to the performance overhead we would incur
       // otherwise. When serving an uncached page, the overhead of using
       // db_select() is a much smaller proportion of the request.
-      $result = db_query('SELECT cid, data, created, expire, serialized FROM {' . db_escape_table($this->bin) . '} WHERE cid IN (:cids)', array(':cids' => $cids));
+      $result = db_query('SELECT cid, data, created, expire, serialized FROM {' . db_escape_table($this->bin) . '} WHERE cid IN (:cids) AND (expire <= 0 OR expire > :time)', array(':cids' => $cids, ':time' => REQUEST_TIME));
       $cache = array();
       foreach ($result as $item) {
         $item = $this->prepareItem($item);

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5519,6 +5519,11 @@ function backdrop_page_set_cache() {
       }
     }
 
+    if (state_get('maintenance_mode', FALSE)) {
+      // Cache maintenance pages for 10 seconds.
+      $cache->expire = time() + config_get('system.core', 'maintenance_page_lifetime');
+    }
+
     if ($cache->data['body']) {
       if ($page_compressed) {
         $cache->data['body'] = gzencode($cache->data['body'], 9, FORCE_GZIP);

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -30,6 +30,7 @@
     "log_facility": "",
     "log_format": "!base_url|!timestamp|!type|!ip|!request_uri|!referer|!uid|!link|!message",
     "maintenance_mode_message": "@site is currently under maintenance. We should be back shortly. Thank you for your patience.",
+    "maintenance_page_lifetime": "10",
     "menu_route_handler": null,
     "node_admin_theme": "",
     "page_cache_maximum_age": 0,

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2409,6 +2409,15 @@ function system_update_1031() {
 }
 
 /**
+ * Provide a default value for maintenance_page_lifetime.
+ */
+function system_update_1032() {
+  $config = config('system.core');
+  $config->set('maintenance_page_lifetime', 10);
+  $config->save();
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1015,14 +1015,24 @@ class SiteMaintenanceTestCase extends BackdropWebTestCase {
     $this->backdropGet('');
     $this->assertRaw($admin_message, 'Found the site maintenance mode message.');
 
-    // Logout and verify that offline message is displayed.
+    // Logout and verify that offline message is displayed and maintenance page
+    // will not be cached by external caches like varnish.
     $this->backdropLogout();
+
     $this->backdropGet('');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
+
     $this->backdropGet('node');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
+
     $this->backdropGet('user/register');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
 
     // Verify that user is able to log in.
     $this->backdropGet('user');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/85
