### PR TITLE
Issue #493: Do not call hook_boot() or hook_exit() on page cache hits.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -2632,15 +2632,15 @@ function _backdrop_bootstrap_page_cache() {
       $_GET['q'] = $cache->data['path'];
       backdrop_set_title($cache->data['title'], PASS_THROUGH);
       date_default_timezone_set(backdrop_get_user_timezone());
-      // If the skipping of the bootstrap hooks is not enforced, call
-      // hook_boot.
-      if (settings_get('page_cache_invoke_hooks', TRUE)) {
+      // Calls to hook_boot() on page cache requests is deprecated, though they
+      // can still be enabled via settings.php
+      if (settings_get('page_cache_invoke_hooks', FALSE)) {
         bootstrap_invoke_all('boot');
       }
       backdrop_serve_page_from_cache($cache);
-      // If the skipping of the bootstrap hooks is not enforced, call
-      // hook_exit.
-      if (settings_get('page_cache_invoke_hooks', TRUE)) {
+      // Like hook_boot(), hook_exit() is no longer called on page cache
+      // requests unless enabled via settings.php.
+      if (settings_get('page_cache_invoke_hooks', FALSE)) {
         bootstrap_invoke_all('exit');
       }
       // We are done.

--- a/core/modules/simpletest/tests/session_test.module
+++ b/core/modules/simpletest/tests/session_test.module
@@ -1,5 +1,9 @@
 <?php
 
+// Set this header as soon as this module is included. We need this header
+// to be set on all page requests, even those served by the internal page cache.
+header('X-Session-Empty: ' . intval(empty($_SESSION)));
+
 /**
  * Implements hook_menu().
  */
@@ -62,6 +66,8 @@ function session_test_menu() {
  * Implements hook_boot().
  */
 function session_test_boot() {
+  // Although set at the top of this module for cached pages, replace this
+  // header during hook_boot() in the event that the session has been destroyed.
   header('X-Session-Empty: ' . intval(empty($_SESSION)));
 
   // Enable HTTPS for this request if set in state.

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -267,12 +267,9 @@ function hook_element_info_alter(&$type) {
  * anything because by the time it runs the response is already sent to
  * the browser.
  *
- * Only use this hook if your code must run even for cached page views.
- * If you have code which must run once on all non-cached pages, use
- * hook_init() instead. That is the usual case. If you implement this hook
- * and see an error like 'Call to undefined function', it is likely that
- * you are depending on the presence of a module which has not been loaded yet.
- * It is not loaded because Backdrop is still in bootstrap mode.
+ * This hook by default is not called on pages served by the default page cache,
+ * but can be enabled through the $settings['invoke_page_cache_hooks'] option in
+ * settings.php.
  *
  * @param $destination
  *   If this hook is invoked as part of a backdrop_goto() call, then this argument
@@ -1313,9 +1310,11 @@ function hook_forms($form_id, $args) {
  * This hook is run at the beginning of the page request. It is typically
  * used to set up global parameters that are needed later in the request.
  *
- * Only use this hook if your code must run even for cached page views. This
- * hook is called before the theme, modules, or most include files are loaded
- * into memory. It happens while Backdrop is still in bootstrap mode.
+ * If needing to execute code early in the page request, consider using
+ * hook_init() instead. In hook_boot(), only the most basic APIs are available
+ * and not all modules have been loaded. This hook by default is not called on
+ * pages served by the default page cache, but can be enabled through the
+ * $settings['invoke_page_cache_hooks'] option in settings.php.
  *
  * @see hook_init()
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/493.
