### PR TITLE
Issue #445: Revert the name of the 'language' variable back from 'language_interface'.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -195,7 +195,7 @@ const LANGUAGE_TYPE_CONTENT = 'language_content';
 /**
  * The type of language used to select the user interface.
  */
-const LANGUAGE_TYPE_INTERFACE = 'language_interface';
+const LANGUAGE_TYPE_INTERFACE = 'language';
 
 /**
  * The type of language used for URLs.
@@ -1704,7 +1704,7 @@ function backdrop_unpack($obj, $field = 'data') {
  * @ingroup sanitization
  */
 function t($string, array $args = array(), array $options = array()) {
-  global $language_interface;
+  global $language;
 
   // Use the advanced backdrop_static() pattern, since this is called very often.
   static $backdrop_static_fast;
@@ -1716,7 +1716,7 @@ function t($string, array $args = array(), array $options = array()) {
 
   // Merge in default.
   if (empty($options['langcode'])) {
-    $options['langcode'] = isset($language_interface->langcode) ? $language_interface->langcode : LANGUAGE_SYSTEM;
+    $options['langcode'] = isset($language->langcode) ? $language->langcode : LANGUAGE_SYSTEM;
   }
   if (empty($options['context'])) {
     $options['context'] = '';

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -2189,9 +2189,9 @@ function format_date($timestamp, $date_format_name = 'medium', $pattern = '', $t
   }
 
   // Use the interface langcode if none is set.
-  global $language_interface;
+  global $language;
   if (empty($langcode)) {
-    $langcode = isset($language_interface->langcode) ? $language_interface->langcode : LANGUAGE_SYSTEM;
+    $langcode = isset($language->langcode) ? $language->langcode : LANGUAGE_SYSTEM;
   }
 
   // Create a DateTime object from the timestamp.
@@ -2745,8 +2745,8 @@ function backdrop_deliver_html_page($page_callback_result) {
   }
 
   // Send appropriate HTTP-Header for browsers and search engines.
-  global $language_interface;
-  backdrop_add_http_header('Content-Language', $language_interface->langcode);
+  global $language;
+  backdrop_add_http_header('Content-Language', $language->langcode);
 
   // Menu status constants are integers; page content is a string or array.
   if (is_int($page_callback_result)) {

--- a/core/includes/language.inc
+++ b/core/includes/language.inc
@@ -105,7 +105,7 @@ const LANGUAGE_NEGOTIATION_DEFAULT = 'language-default';
  *   The type of language to retrieve as provided by hook_language_types_info().
  *   In Backdrop core, the available language types will be one of the
  *   following:
- *   - language_interface
+ *   - language
  *   - language_content
  *   - language_url
  *

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -112,8 +112,8 @@ const LANGUAGE_NEGOTIATION_URL_DOMAIN = 'domain';
  *   The current interface language code.
  */
 function locale_language_from_interface() {
-  global $language_interface;
-  return isset($language_interface->langcode) ? $language_interface->langcode : FALSE;
+  global $language;
+  return isset($language->langcode) ? $language->langcode : FALSE;
 }
 
 /**
@@ -717,8 +717,8 @@ function _locale_invalidate_js($langcode = NULL) {
  */
 function _locale_rebuild_js($langcode = NULL) {
   if (!isset($langcode)) {
-    global $language_interface;
-    $language = $language_interface;
+    global $language;
+    $language = $language;
   }
   else {
     // Get information about the locale.

--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -1143,7 +1143,7 @@ function menu_tree_all_data($menu_name, $link = NULL, $max_depth = NULL) {
   // Use $mlid as a flag for whether the data being loaded is for the whole tree.
   $mlid = isset($link['mlid']) ? $link['mlid'] : 0;
   // Generate a cache ID (cid) specific for this $menu_name, $link, $language, and depth.
-  $cid = 'links:' . $menu_name . ':all:' . $mlid . ':' . $GLOBALS['language_interface']->langcode . ':' . (int) $max_depth;
+  $cid = 'links:' . $menu_name . ':all:' . $mlid . ':' . $GLOBALS['language']->langcode . ':' . (int) $max_depth;
 
   if (!isset($tree[$cid])) {
     // If the static variable doesn't have the data, check {cache_menu}.
@@ -1257,7 +1257,7 @@ function menu_tree_page_data($menu_name, $max_depth = NULL, $only_active_trail =
       $max_depth = min($max_depth, MENU_MAX_DEPTH);
     }
     // Generate a cache ID (cid) specific for this page.
-    $cid = 'links:' . $menu_name . ':page:' . $item['href'] . ':' . $GLOBALS['language_interface']->langcode . ':' . (int) $item['access'] . ':' . (int) $max_depth;
+    $cid = 'links:' . $menu_name . ':page:' . $item['href'] . ':' . $GLOBALS['language']->langcode . ':' . (int) $item['access'] . ':' . (int) $max_depth;
     // In order to not build a giant menu tree that needs to be checked for
     // access on all levels, we simply check whether we have the menu already
     // in cache, or otherwise, build a minimum tree containing the
@@ -1406,7 +1406,7 @@ function _menu_build_tree($menu_name, array $parameters = array()) {
   if (isset($parameters['expanded'])) {
     sort($parameters['expanded']);
   }
-  $tree_cid = 'links:' . $menu_name . ':tree-data:' . $GLOBALS['language_interface']->langcode . ':' . hash('sha256', serialize($parameters));
+  $tree_cid = 'links:' . $menu_name . ':tree-data:' . $GLOBALS['language']->langcode . ':' . hash('sha256', serialize($parameters));
 
   // If we do not have this tree in the static cache, check {cache_menu}.
   if (!isset($trees[$tree_cid])) {

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2513,8 +2513,8 @@ function template_preprocess_page(&$variables) {
 
   // Initialize attributes which are specific to the html and body elements.
   $variables['html_attributes'] = array();
-  $variables['html_attributes']['lang'] = $GLOBALS['language_interface']->langcode;
-  $variables['html_attributes']['dir'] = $GLOBALS['language_interface']->direction ? 'rtl' : 'ltr';
+  $variables['html_attributes']['lang'] = $GLOBALS['language']->langcode;
+  $variables['html_attributes']['dir'] = $GLOBALS['language']->direction ? 'rtl' : 'ltr';
   $variables['body_attributes'] = array();
 
   // Add favicon.
@@ -2674,12 +2674,12 @@ function template_preprocess_maintenance_page(&$variables) {
   }
 
   // set the default language if necessary
-  $language = isset($GLOBALS['language_interface']) ? $GLOBALS['language_interface'] : language_default();
+  $language = isset($GLOBALS['language']) ? $GLOBALS['language'] : language_default();
 
   // Initialize attributes which are specific to the html element.
   $variables['html_attributes'] = array();
-  $variables['html_attributes']['lang'] = $GLOBALS['language_interface']->langcode;
-  $variables['html_attributes']['dir'] = $GLOBALS['language_interface']->direction ? 'rtl' : 'ltr';
+  $variables['html_attributes']['lang'] = $GLOBALS['language']->langcode;
+  $variables['html_attributes']['dir'] = $GLOBALS['language']->direction ? 'rtl' : 'ltr';
 
   $variables['head_title_array']  = $head_title;
   $variables['head_title']        = implode(' | ', $head_title);

--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -14,11 +14,11 @@
  *   page.
  */
 function admin_bar_output($complete = FALSE) {
-  global $user, $language_interface;
+  global $user, $language;
   $config = config('admin_bar.settings');
 
   $cache_server_enabled = !$complete;
-  $cid = 'admin_bar:' . $user->uid . ':' . session_id() . ':' . $language_interface->langcode;
+  $cid = 'admin_bar:' . $user->uid . ':' . session_id() . ':' . $language->langcode;
 
   // Try to load and output administration bar from server-side cache. The
   // cache is only valid if a hash key exists, otherwise it needs to be

--- a/core/modules/admin_bar/admin_bar.module
+++ b/core/modules/admin_bar/admin_bar.module
@@ -137,7 +137,7 @@ function admin_bar_preprocess_page(&$variables) {
     return;
   }
 
-  global $user, $language_interface;
+  global $user, $language;
   $path = backdrop_get_path('module', 'admin_bar');
 
   $options = array('every_page' => TRUE);
@@ -165,7 +165,7 @@ function admin_bar_preprocess_page(&$variables) {
 
   // If we have a cached menu for the current user, only output the hash for the
   // client-side HTTP cache callback URL.
-  $cid = 'admin_bar:' . $user->uid . ':' . session_id() . ':' . $language_interface->langcode;
+  $cid = 'admin_bar:' . $user->uid . ':' . session_id() . ':' . $language->langcode;
   if (!$complete && ($hash = admin_bar_cache_get($cid))) {
     $settings['hash'] = $hash;
 
@@ -325,8 +325,8 @@ function admin_bar_deliver($page_callback_result) {
   backdrop_add_http_header('Content-Type', 'text/html; charset=utf-8');
 
   // Send appropriate language header for browsers.
-  global $language_interface;
-  backdrop_add_http_header('Content-Language', $language_interface->langcode);
+  global $language;
+  backdrop_add_http_header('Content-Language', $language->langcode);
 
   // The page callback is always admin_bar_js_cache(), which always returns a
   // string, and is only accessed when the user actually has access to it.

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -1791,10 +1791,10 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
    * Creates a comment, then tests the tokens generated from it.
    */
   function testCommentTokenReplacement() {
-    global $language_interface;
+    global $language;
     $url_options = array(
       'absolute' => TRUE,
-      'language' => $language_interface,
+      'language' => $language,
     );
 
     $this->backdropLogin($this->admin_user);
@@ -1827,8 +1827,8 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
     $tests['[comment:body]'] = _text_sanitize($instance, LANGUAGE_NONE, $comment->comment_body[LANGUAGE_NONE][0], 'value');
     $tests['[comment:url]'] = url('comment/' . $comment->cid, $url_options + array('fragment' => 'comment-' . $comment->cid));
     $tests['[comment:edit-url]'] = url('comment/' . $comment->cid . '/edit', $url_options);
-    $tests['[comment:created:since]'] = format_interval(REQUEST_TIME - $comment->created, 2, $language_interface->langcode);
-    $tests['[comment:changed:since]'] = format_interval(REQUEST_TIME - $comment->changed, 2, $language_interface->langcode);
+    $tests['[comment:created:since]'] = format_interval(REQUEST_TIME - $comment->created, 2, $language->langcode);
+    $tests['[comment:changed:since]'] = format_interval(REQUEST_TIME - $comment->changed, 2, $language->langcode);
     $tests['[comment:parent:cid]'] = $comment->pid;
     $tests['[comment:parent:title]'] = check_plain($parent_comment->subject);
     $tests['[comment:node:nid]'] = $comment->nid;
@@ -1840,7 +1840,7 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('comment' => $comment), array('language' => $language_interface));
+      $output = token_replace($input, array('comment' => $comment), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized comment token %token replaced.', array('%token' => $input)));
     }
 
@@ -1856,7 +1856,7 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
     $tests['[comment:author:name]'] = $this->admin_user->name;
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('comment' => $comment), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('comment' => $comment), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized comment token %token replaced.', array('%token' => $input)));
     }
 
@@ -1869,7 +1869,7 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
     $tests['[node:comment-count-new]'] = 2;
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('node' => $node), array('language' => $language_interface));
+      $output = token_replace($input, array('node' => $node), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Node comment token %token replaced.', array('%token' => $input)));
     }
   }

--- a/core/modules/contact/contact.pages.inc
+++ b/core/modules/contact/contact.pages.inc
@@ -129,7 +129,7 @@ function contact_site_form_validate($form, &$form_state) {
  * @see contact_site_form_validate()
  */
 function contact_site_form_submit($form, &$form_state) {
-  global $user, $language_interface;
+  global $user, $language;
 
   $values = $form_state['values'];
   $values['sender'] = $user;
@@ -151,12 +151,12 @@ function contact_site_form_submit($form, &$form_state) {
 
   // If the user requests it, send a copy using the current language.
   if ($values['copy']) {
-    backdrop_mail('contact', 'page_copy', $from, $language_interface, $values, $from);
+    backdrop_mail('contact', 'page_copy', $from, $language, $values, $from);
   }
 
   // Send an auto-reply if necessary using the current language.
   if ($values['category']['reply']) {
-    backdrop_mail('contact', 'page_autoreply', $from, $language_interface, $values, $to);
+    backdrop_mail('contact', 'page_autoreply', $from, $language, $values, $to);
   }
 
   $config = config('contact.settings');
@@ -257,7 +257,7 @@ function contact_personal_form($form, &$form_state, $recipient) {
  * @see contact_personal_form_validate()
  */
 function contact_personal_form_submit($form, &$form_state) {
-  global $user, $language_interface;
+  global $user, $language;
 
   $values = $form_state['values'];
   $values['sender'] = $user;
@@ -278,7 +278,7 @@ function contact_personal_form_submit($form, &$form_state) {
 
   // Send a copy if requested, using current page language.
   if ($values['copy']) {
-    backdrop_mail('contact', 'user_copy', $from, $language_interface, $values, $from);
+    backdrop_mail('contact', 'user_copy', $from, $language, $values, $from);
   }
 
   $config = config('contact.settings');

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -30,7 +30,7 @@ function entity_modules_disabled() {
  * @see hook_entity_info_alter()
  */
 function entity_get_info($entity_type = NULL) {
-  global $language_interface;
+  global $language;
 
   // Use the advanced backdrop_static() pattern, since this is called very often.
   static $backdrop_static_fast;
@@ -41,7 +41,7 @@ function entity_get_info($entity_type = NULL) {
 
   // hook_entity_info() includes translated strings, so each language is cached
   // separately.
-  $langcode = $language_interface->langcode;
+  $langcode = $language->langcode;
 
   if (empty($entity_info)) {
     if ($cache = cache()->get("entity_info:$langcode")) {

--- a/core/modules/field/field.info.inc
+++ b/core/modules/field/field.info.inc
@@ -67,7 +67,7 @@ function field_info_cache_clear() {
  * @see _field_info_collate_types_reset()
  */
 function _field_info_collate_types() {
-  global $language_interface;
+  global $language;
 
   // Use the advanced backdrop_static() pattern, since this is called very often.
   static $backdrop_static_fast;
@@ -79,7 +79,7 @@ function _field_info_collate_types() {
 
   // The _info() hooks invoked below include translated strings, so each
   // language is cached separately.
-  $langcode = $language_interface->langcode;
+  $langcode = $language->langcode;
 
   if (!isset($info)) {
     if ($cached = cache('field')->get("field_info_types:$langcode")) {

--- a/core/modules/file/tests/file.test
+++ b/core/modules/file/tests/file.test
@@ -1023,10 +1023,10 @@ class FileTokenReplaceTestCase extends FileFieldTestCase {
    * Creates a file, then tests the tokens generated from it.
    */
   function testFileTokenReplacement() {
-    global $language_interface;
+    global $language;
     $url_options = array(
       'absolute' => TRUE,
-      'language' => $language_interface,
+      'language' => $language,
     );
 
     // Create file field.
@@ -1056,8 +1056,8 @@ class FileTokenReplaceTestCase extends FileFieldTestCase {
     $tests['[file:mime]'] = check_plain($file->filemime);
     $tests['[file:size]'] = format_size($file->filesize);
     $tests['[file:url]'] = check_plain(file_create_url($file->uri));
-    $tests['[file:timestamp]'] = format_date($file->timestamp, 'medium', '', NULL, $language_interface->langcode);
-    $tests['[file:timestamp:short]'] = format_date($file->timestamp, 'short', '', NULL, $language_interface->langcode);
+    $tests['[file:timestamp]'] = format_date($file->timestamp, 'medium', '', NULL, $language->langcode);
+    $tests['[file:timestamp:short]'] = format_date($file->timestamp, 'short', '', NULL, $language->langcode);
     $tests['[file:owner]'] = check_plain(user_format_name($this->admin_user));
     $tests['[file:owner:uid]'] = $file->uid;
 
@@ -1065,7 +1065,7 @@ class FileTokenReplaceTestCase extends FileFieldTestCase {
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('file' => $file), array('language' => $language_interface));
+      $output = token_replace($input, array('file' => $file), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized file token %token replaced.', array('%token' => $input)));
     }
 
@@ -1076,7 +1076,7 @@ class FileTokenReplaceTestCase extends FileFieldTestCase {
     $tests['[file:size]'] = format_size($file->filesize);
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('file' => $file), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('file' => $file), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized file token %token replaced.', array('%token' => $input)));
     }
   }

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -418,12 +418,12 @@ function filter_modules_disabled($modules) {
  * @see filter_formats_reset()
  */
 function filter_formats($account = NULL) {
-  global $language_interface;
+  global $language;
   $formats = &backdrop_static(__FUNCTION__, array());
 
   // All available formats are cached for performance.
   if (!isset($formats['all'])) {
-    if ($cache = cache()->get("filter_formats:{$language_interface->langcode}")) {
+    if ($cache = cache()->get("filter_formats:{$language->langcode}")) {
       $formats['all'] = $cache->data;
     }
     else {
@@ -465,7 +465,7 @@ function filter_formats($account = NULL) {
         $formats['all'][$filter_format->format] = $filter_format;
       }
 
-      cache()->set("filter_formats:{$language_interface->langcode}", $formats['all']);
+      cache()->set("filter_formats:{$language->langcode}", $formats['all']);
     }
   }
 

--- a/core/modules/image/image.module
+++ b/core/modules/image/image.module
@@ -912,11 +912,11 @@ function image_default_style_revert($style) {
  * @see image_effect_definition_load()
  */
 function image_effect_definitions() {
-  global $language_interface;
+  global $language;
 
   // hook_image_effect_info() includes translated strings, so each language is
   // cached separately.
-  $langcode = $language_interface->langcode;
+  $langcode = $language->langcode;
 
   $effects = &backdrop_static(__FUNCTION__);
 

--- a/core/modules/language/language.install
+++ b/core/modules/language/language.install
@@ -137,7 +137,7 @@ function language_update_1001() {
   // hook_language_negotiation_info() as a cache, now we just store the order.
   $negotiation = array(
     'language_content' => array(),
-    'language_interface' => array(),
+    'language' => array(),
     'language_url' => array(),
   );
   foreach ($negotiation as $language_type => $negotiation_data) {
@@ -153,7 +153,7 @@ function language_update_1001() {
   update_variable_del('language_default');
   update_variable_del('language_count');
   update_variable_del('language_negotiation_language_content');
-  update_variable_del('language_negotiation_language_interface');
+  update_variable_del('language_negotiation_language');
   update_variable_del('language_negotiation_language_url');
 
   // The language_types variable is no longer used in Backdrop.

--- a/core/modules/layout/plugins/access/language_layout_access.inc
+++ b/core/modules/layout/plugins/access/language_layout_access.inc
@@ -39,18 +39,18 @@ class LanguageLayoutAccess extends LayoutAccess {
    * {@inheritdoc}
    */
   function checkAccess() {
-    global $language_interface;
+    global $language;
 
     // Specialcase: If 'default' is checked, return TRUE if the default site
     // language matches the current interface language.
     if (in_array('default', $this->settings['language'])) {
       $default = language_default();
-      if ($language_interface->langcode == $default->langcode) {
+      if ($language->langcode == $default->langcode) {
         return TRUE;
       }
     }
 
-    return in_array($language_interface->langcode, $this->settings['language']);
+    return in_array($language->langcode, $this->settings['language']);
   }
 
   /**

--- a/core/modules/locale/config/locale.settings.json
+++ b/core/modules/locale/config/locale.settings.json
@@ -7,10 +7,10 @@
   "language_negotiation_url_prefixes": {
     "en": ""
   },
-  "language_negotiation_url_type": "language_interface",
+  "language_negotiation_url_type": "language",
   "language_negotiation_url_domains": {
     "en": ""
   },
-  "language_providers_weight_language_interface": [],
+  "language_providers_weight_language": [],
   "translate_english": false
 }

--- a/core/modules/locale/locale.install
+++ b/core/modules/locale/locale.install
@@ -222,44 +222,7 @@ function locale_update_1000() {
  * Language type 'language' renamed to 'language_interface'.
  */
 function locale_update_1001() {
-  // Rename language_negotiation_language setting if exists.
-  $setting = update_variable_get('language_negotiation_language', NULL);
-  if ($setting !== NULL) {
-    update_variable_set('language_negotiation_language_interface', $setting);
-    update_variable_del('language_negotiation_language');
-  }
-
-  // Rename locale_language_providers_weight_language setting if exists.
-  $weight = update_variable_get('locale_language_providers_weight_language', NULL);
-  if ($weight !== NULL) {
-    update_variable_set('locale_language_providers_weight_language_interface', $weight);
-    update_variable_del('locale_language_providers_weight_language');
-  }
-
-  // Update block data in all core block related tables. Contributed modules
-  // storing data for blocks will need to update for themselves.
-  $block_tables = array('block', 'block_node_type', 'block_role');
-  foreach ($block_tables as $table) {
-    // Perform the update only if the language switcher block data is available.
-    $block_data = db_query_range('SELECT 1 FROM {' . $table . '} WHERE delta = :delta AND module = :module', 0, 1, array(':delta' => 'language', ':module' => 'locale'))
-      ->fetchField();
-    if ($block_data) {
-      // If block information is rebuilt before performing the update, we might
-      // already have data for the new delta. In this case we need to remove it
-      // to avoid integrity constraint violation errors.
-      db_delete($table)
-        ->condition('delta', 'language_interface')
-        ->condition('module', 'locale')
-        ->execute();
-      db_update($table)
-        ->fields(array(
-          'delta' => 'language_interface',
-        ))
-        ->condition('delta', 'language')
-        ->condition('module', 'locale')
-        ->execute();
-    }
-  }
+  // Update removed. See https://github.com/backdrop/backdrop-issues/issues/445.
 }
 
 /**
@@ -351,8 +314,8 @@ function locale_update_1004() {
     $old_config->delete();
   }
 
-  $config->set('language_negotiation_url_type', update_variable_get('locale_language_negotiation_url_type', 'language_interface'));
-  $config->set('language_providers_weight_language_interface', update_variable_get('locale_language_providers_weight_language_interface'));
+  $config->set('language_negotiation_url_type', update_variable_get('locale_language_negotiation_url_type', 'language'));
+  $config->set('language_providers_weight_language', update_variable_get('locale_language_providers_weight_language'));
   $config->set('cache_length', update_variable_get('locale_cache_length', 75));
   $config->set('field_language_fallback', update_variable_get('locale_field_language_fallback', TRUE));
   $config->set('translate_english', update_variable_get('locale_translate_english', FALSE));
@@ -363,7 +326,7 @@ function locale_update_1004() {
 
   // Moved to config:
   update_variable_del('locale_language_negotiation_url_type');
-  update_variable_del('locale_language_providers_weight_language_interface');
+  update_variable_del('locale_language_providers_weight_language');
   update_variable_del('locale_cache_length');
   update_variable_del('locale_field_language_fallback');
   update_variable_del('locale_translate_english');

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -166,12 +166,12 @@ function locale_config_info() {
  * @see locale_form_alter()
  */
 function locale_language_selector_form($user) {
-  global $language_interface;
+  global $language;
   // Get list of enabled languages only.
   $languages = language_list(TRUE);
 
   // If the user is being created, we set the user language to the page language.
-  $user_preferred_language = $user->uid ? user_preferred_language($user) : $language_interface;
+  $user_preferred_language = $user->uid ? user_preferred_language($user) : $language;
 
   $names = array();
   foreach ($languages as $langcode => $item) {
@@ -528,7 +528,7 @@ function locale_language_delete($language) {
  *   Language code to use for the lookup.
  */
 function locale($string = NULL, $context = NULL, $langcode = NULL) {
-  global $language_interface;
+  global $language;
 
   // Use the advanced backdrop_static() pattern, since this is called very often.
   static $backdrop_static_fast;
@@ -543,12 +543,12 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
     return $locale_t;
   }
 
-  $langcode = isset($langcode) ? $langcode : $language_interface->langcode;
+  $langcode = isset($langcode) ? $langcode : $language->langcode;
 
   // Store database cached translations in a static variable. Only build the
-  // cache after $language_interface has been set to avoid an unnecessary cache
+  // cache after $language has been set to avoid an unnecessary cache
   // rebuild.
-  if (!isset($locale_t[$langcode]) && isset($language_interface)) {
+  if (!isset($locale_t[$langcode]) && isset($language)) {
     $locale_t[$langcode] = array();
     // Disabling the usage of string caching allows a module to watch for
     // the exact list of strings used on a page. From a performance
@@ -649,7 +649,7 @@ function locale_reset() {
  *   plural formula.
  */
 function locale_get_plural($count, $langcode = NULL) {
-  global $language_interface;
+  global $language;
 
   // Used to locally cache the plural formulas for all languages.
   $plural_formulas = &backdrop_static(__FUNCTION__, array());
@@ -657,7 +657,7 @@ function locale_get_plural($count, $langcode = NULL) {
   // individually for each language.
   $plural_indexes = &backdrop_static(__FUNCTION__ . ':plurals', array());
 
-  $langcode = $langcode ? $langcode : $language_interface->langcode;
+  $langcode = $langcode ? $langcode : $language->langcode;
 
   if (!isset($plural_indexes[$langcode][$count])) {
     // Retrieve and statically cache the plural formulas for all languages.
@@ -735,7 +735,7 @@ function locale_system_update($components) {
  * file if necessary, and adds it to the page.
  */
 function locale_js_alter(&$javascript) {
-  global $language_interface;
+  global $language;
 
   $dir = 'public://' . settings_get('locale_js_directory', 'languages');
   $parsed = state_get('locale_javascript_parsed', array());
@@ -767,11 +767,11 @@ function locale_js_alter(&$javascript) {
   }
 
   // If necessary, rebuild the translation file for the current language.
-  if (!empty($parsed['refresh:' . $language_interface->langcode])) {
+  if (!empty($parsed['refresh:' . $language->langcode])) {
     // Don't clear the refresh flag on failure, so that another try will
     // be performed later.
     if (_locale_rebuild_js()) {
-      unset($parsed['refresh:' . $language_interface->langcode]);
+      unset($parsed['refresh:' . $language->langcode]);
     }
     // Store any changes after refresh was attempted.
     state_set('locale_javascript_parsed', $parsed);
@@ -784,9 +784,9 @@ function locale_js_alter(&$javascript) {
 
   // Add the translation JavaScript file to the page.
   $locale_javascripts = state_get('locale_translation_javascript', array());
-  if ($files && !empty($locale_javascripts[$language_interface->langcode])) {
+  if ($files && !empty($locale_javascripts[$language->langcode])) {
     // Add the translation JavaScript file to the page.
-    $file = $dir . '/' . $language_interface->langcode . '_' . $locale_javascripts[$language_interface->langcode] . '.js';
+    $file = $dir . '/' . $language->langcode . '_' . $locale_javascripts[$language->langcode] . '.js';
     $javascript[$file] = backdrop_js_defaults($file);
   }
 }
@@ -798,7 +798,7 @@ function locale_js_alter(&$javascript) {
  */
 function locale_library_info_alter(&$libraries, $module) {
   if ($module == 'system' && isset($libraries['ui.datepicker'])) {
-    global $language_interface;
+    global $language;
     // locale.datepicker.js should be added in the JS_LIBRARY group, so that
     // this attach behavior will execute early. JS_LIBRARY is the default for
     // hook_library_info_alter(), thus does not have to be specified explicitly.
@@ -809,7 +809,7 @@ function locale_library_info_alter(&$libraries, $module) {
         'jquery' => array(
           'ui' => array(
             'datepicker' => array(
-              'isRTL' => $language_interface->direction == LANGUAGE_RTL,
+              'isRTL' => $language->direction == LANGUAGE_RTL,
               'firstDay' => config_get('system.date', 'first_day'),
             ),
           ),
@@ -1039,15 +1039,15 @@ function locale_form_system_file_system_settings_alter(&$form, $form_state) {
  */
 function locale_preprocess_node(&$variables) {
   if ($variables['langcode'] != LANGUAGE_NONE) {
-    global $language_interface;
+    global $language;
 
     $node_language = language_load($variables['langcode']);
-    if ($node_language->langcode != $language_interface->langcode) {
+    if ($node_language->langcode != $language->langcode) {
       // If the node language was different from the page language, we should
       // add markup to identify the language. Otherwise the page language is
       // inherited.
       $variables['attributes']['lang'] = $variables['langcode'];
-      if ($node_language->direction != $language_interface->direction) {
+      if ($node_language->direction != $language->direction) {
         // If text direction is different form the page's text direction, add
         // direction information as well.
         $dir = array('ltr', 'rtl');

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -1243,7 +1243,7 @@ class LocaleUninstallFunctionalTest extends BackdropWebTestCase {
 
     // Check the UI language.
     backdrop_language_initialize();
-    $this->assertEqual($GLOBALS['language_interface']->langcode, $this->langcode, format_string('Current language: %lang', array('%lang' => $GLOBALS['language_interface']->langcode)));
+    $this->assertEqual($GLOBALS['language']->langcode, $this->langcode, format_string('Current language: %lang', array('%lang' => $GLOBALS['language']->langcode)));
 
     // Enable multilingual workflow option for articles.
     $node_type = node_type_load('article');
@@ -1290,7 +1290,7 @@ class LocaleUninstallFunctionalTest extends BackdropWebTestCase {
 
     // Check the init language logic.
     backdrop_language_initialize();
-    $this->assertEqual($GLOBALS['language_interface']->langcode, 'en', format_string('Language after uninstall: %lang', array('%lang' => $GLOBALS['language_interface']->langcode)));
+    $this->assertEqual($GLOBALS['language']->langcode, 'en', format_string('Language after uninstall: %lang', array('%lang' => $GLOBALS['language']->langcode)));
 
     // Check JavaScript files deletion.
     $this->assertTrue($result = !file_exists($js_file), format_string('JavaScript file deleted: %file', array('%file' => $result ? $js_file : 'found')));
@@ -1370,7 +1370,7 @@ class LocaleLanguageSwitchingFunctionalTest extends BackdropWebTestCase {
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add language'));
 
     // Enable URL language detection and selection.
-    $edit = array('language_interface[locale-url][enabled]' => '1');
+    $edit = array('language[locale-url][enabled]' => '1');
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     // Assert that the language switching block is displayed on the frontpage.
@@ -1625,7 +1625,7 @@ class LocaleUserCreationTest extends BackdropWebTestCase {
 
     // Set language negotiation.
     $edit = array(
-      'language_interface[locale-url][enabled]' => TRUE,
+      'language[locale-url][enabled]' => TRUE,
     );
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
     $this->assertText(t('Language negotiation configuration saved.'), 'Set language negotiation.');
@@ -2258,17 +2258,17 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
 
     // Enable browser and URL language detection.
     $edit = array(
-      'language_interface[locale-browser][enabled]' => TRUE,
-      'language_interface[locale-browser][weight]' => -8,
-      'language_interface[locale-url][enabled]' => TRUE,
-      'language_interface[locale-url][weight]' => -10,
+      'language[locale-browser][enabled]' => TRUE,
+      'language[locale-browser][weight]' => -8,
+      'language[locale-url][enabled]' => TRUE,
+      'language[locale-url][weight]' => -10,
     );
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
     $this->backdropGet('admin/config/regional/language/detection');
 
     // Enable the language switcher block.
     $layout = layout_load('default');
-    $layout->addBlock('locale', 'language_interface', 'sidebar');
+    $layout->addBlock('locale', 'language', 'sidebar');
     $layout->save();
 
     // Access the front page without specifying any valid URL language prefix
@@ -2280,7 +2280,7 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
     // Check that the language switcher active link matches the given browser
     // language.
     $args = array(':url' => base_path() . (config_get('system.core', 'clean_url') ? $langcode_browser_fallback : "?q=$langcode_browser_fallback"));
-    $fields = $this->xpath('//*[contains(@class,"block-locale-language-interface")]//a[@class="language-link active" and @href=:url]', $args);
+    $fields = $this->xpath('//*[contains(@class,"block-locale-language")]//a[@class="language-link active" and @href=:url]', $args);
     $this->assertTrue($fields[0] == $languages[$langcode_browser_fallback]->name, 'The browser language is the URL active language');
 
     // Check that URLs are rewritten using the given browser language.
@@ -2302,8 +2302,8 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
 
     // Enable browser and URL language detection.
     $edit = array(
-      'language_interface[locale-url][enabled]' => TRUE,
-      'language_interface[locale-url][weight]' => -10,
+      'language[locale-url][enabled]' => TRUE,
+      'language[locale-url][weight]' => -10,
     );
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
@@ -2369,7 +2369,7 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
     $this->backdropPost('admin/config/regional/language', $edit, t('Save configuration'));
 
     // Enable URL language detection and selection.
-    $edit = array('language_interface[locale-url][enabled]' => 1);
+    $edit = array('language[locale-url][enabled]' => 1);
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     // Reset static caching.
@@ -2446,7 +2446,7 @@ class LocaleMultilingualFieldsFunctionalTest extends BackdropWebTestCase {
     language_save($language);
 
     // Enable URL language detection and selection.
-    $edit = array('language_interface[locale-url][enabled]' => '1');
+    $edit = array('language[locale-url][enabled]' => '1');
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     // Set "Basic page" content type to use multilingual support.
@@ -2567,7 +2567,7 @@ class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
     // language will fall back to the default language if no URL language can be
     // detected.
     $edit = array(
-      'language_interface[locale-user][enabled]' => TRUE,
+      'language[locale-user][enabled]' => TRUE,
       'language_content[locale-url][enabled]' => TRUE,
       'language_content[locale-interface][enabled]' => FALSE,
     );

--- a/core/modules/locale/tests/locale_test/locale_test.module
+++ b/core/modules/locale/tests/locale_test/locale_test.module
@@ -22,8 +22,8 @@ function locale_test_boot() {
  */
 function locale_test_init() {
   locale_test_store_language_negotiation();
-  if (isset($GLOBALS['language_interface']) && isset($GLOBALS['language_interface']->provider)) {
-    backdrop_set_message(t('Language negotiation provider: @name', array('@name' => $GLOBALS['language_interface']->provider)));
+  if (isset($GLOBALS['language']) && isset($GLOBALS['language']->provider)) {
+    backdrop_set_message(t('Language negotiation provider: @name', array('@name' => $GLOBALS['language']->provider)));
   }
 }
 

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -641,7 +641,7 @@ function node_type_update_nodes($old_type, $type) {
  *   type object by $type->disabled being set to TRUE.
  */
 function _node_types_build() {
-  $cid = 'node_types:' . $GLOBALS['language_interface']->langcode;
+  $cid = 'node_types:' . $GLOBALS['language']->langcode;
 
   $_node_types = &backdrop_static(__FUNCTION__);
   if (isset($_node_types)) {

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -2150,10 +2150,10 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
    * Creates a node, then tests the tokens generated from it.
    */
   function testNodeTokenReplacement() {
-    global $language_interface;
+    global $language;
     $url_options = array(
       'absolute' => TRUE,
-      'language' => $language_interface,
+      'language' => $language,
     );
 
     // Create a user and a node.
@@ -2186,14 +2186,14 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[node:author]'] = check_plain(user_format_name($account));
     $tests['[node:author:uid]'] = $node->uid;
     $tests['[node:author:name]'] = check_plain(user_format_name($account));
-    $tests['[node:created:since]'] = format_interval(REQUEST_TIME - $node->created, 2, $language_interface->langcode);
-    $tests['[node:changed:since]'] = format_interval(REQUEST_TIME - $node->changed, 2, $language_interface->langcode);
+    $tests['[node:created:since]'] = format_interval(REQUEST_TIME - $node->created, 2, $language->langcode);
+    $tests['[node:changed:since]'] = format_interval(REQUEST_TIME - $node->changed, 2, $language->langcode);
 
     // Test to make sure that we generated something for each token.
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), t('No empty tokens generated.'));
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('node' => $node), array('language' => $language_interface));
+      $output = token_replace($input, array('node' => $node), array('language' => $language));
       $this->assertEqual($output, $expected, t('Sanitized node token %token replaced.', array('%token' => $input)));
     }
 
@@ -2205,7 +2205,7 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[node:author:name]'] = user_format_name($account);
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('node' => $node), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('node' => $node), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, t('Unsanitized node token %token replaced.', array('%token' => $input)));
     }
 
@@ -2226,7 +2226,7 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated for node without a summary.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('node' => $node), array('language' => $language_interface));
+      $output = token_replace($input, array('node' => $node), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized node token %token replaced for node without a summary.', array('%token' => $input)));
     }
 
@@ -2234,7 +2234,7 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[node:summary]'] = $node->body[$node->langcode][0]['value'];
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('node' => $node), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('node' => $node), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized node token %token replaced for node without a summary.', array('%token' => $input)));
     }    
   }

--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -259,7 +259,7 @@ class PathLanguageTestCase extends BackdropWebTestCase {
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add language'));
 
     // Enable URL language detection and selection.
-    $edit = array('language_interface[locale-url][enabled]' => 1);
+    $edit = array('language[locale-url][enabled]' => 1);
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
   }
 
@@ -319,10 +319,10 @@ class PathLanguageTestCase extends BackdropWebTestCase {
     // Confirm that the alias works even when changing language negotiation
     // options. Enable User language detection and selection over URL one.
     $edit = array(
-      'language_interface[locale-user][enabled]' => 1,
-      'language_interface[locale-user][weight]' => -9,
-      'language_interface[locale-url][enabled]' => 1,
-      'language_interface[locale-url][weight]' => -8,
+      'language[locale-user][enabled]' => 1,
+      'language[locale-user][weight]' => -9,
+      'language[locale-url][enabled]' => 1,
+      'language[locale-url][weight]' => -8,
     );
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
@@ -346,7 +346,7 @@ class PathLanguageTestCase extends BackdropWebTestCase {
     $this->assertText($french_node->title, 'Alias for French translation works.');
 
     // Disable URL language negotiation.
-    $edit = array('language_interface[locale-url][enabled]' => FALSE);
+    $edit = array('language[locale-url][enabled]' => FALSE);
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     // Check that the English alias still works.
@@ -396,7 +396,7 @@ class PathLanguageUITestCase extends BackdropWebTestCase {
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add language'));
 
     // Enable URL language detection and selection.
-    $edit = array('language_interface[locale-url][enabled]' => 1);
+    $edit = array('language[locale-url][enabled]' => 1);
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
   }
 
@@ -477,7 +477,7 @@ class PathMonolingualTestCase extends BackdropWebTestCase {
     $this->assertEqual(language_default()->langcode, 'fr', 'French is the default language');
 
     // Set language detection to URL.
-    $edit = array('language_interface[locale-url][enabled]' => TRUE);
+    $edit = array('language[locale-url][enabled]' => TRUE);
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
 
     // Force languages to be initialized.

--- a/core/modules/search/search.pages.inc
+++ b/core/modules/search/search.pages.inc
@@ -79,7 +79,7 @@ function search_view($module = NULL, $keys = '') {
  * @see search-results.tpl.php
  */
 function template_preprocess_search_results(&$variables) {
-  global $language_interface;
+  global $language;
   $variables['search_results'] = array();
   if (!empty($variables['module'])) {
     $variables['module'] = check_plain($variables['module']);
@@ -116,7 +116,7 @@ function template_preprocess_search_results(&$variables) {
       'attributes' => $attributes,
     );
     
-    if (isset($result['language']) && $result['language'] != $language_interface->langcode && $result['language'] != LANGUAGE_NONE) {
+    if (isset($result['language']) && $result['language'] != $language->langcode && $result['language'] != LANGUAGE_NONE) {
       $variables['content_attributes']['lang'] = $result['language'];
     }
   }

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1408,10 +1408,10 @@ class BackdropWebTestCase extends BackdropTestCase {
    * @see BackdropWebTestCase::tearDown()
    */
   protected function prepareEnvironment() {
-    global $user, $language_interface, $settings, $config_directories;
+    global $user, $language, $settings, $config_directories;
 
     // Store necessary current values before switching to prefixed database.
-    $this->originalLanguage = $language_interface;
+    $this->originalLanguage = $language;
     $this->originalLanguageDefault = config_get('system.core', 'language_default');
     $this->originalConfigDirectories = $config_directories;
     $this->originalFileDirectory = config_get('system.core', 'file_public_path', 'files');
@@ -1423,7 +1423,7 @@ class BackdropWebTestCase extends BackdropTestCase {
     // Set to English to prevent exceptions from utf8_truncate() from t()
     // during install if the current language is not 'en'.
     // The following array/object conversion is copied from language_default().
-    $language_interface = (object) array(
+    $language = (object) array(
       'langcode' => 'en',
       'name' => 'English',
       'direction' => 0,
@@ -1500,7 +1500,7 @@ class BackdropWebTestCase extends BackdropTestCase {
    * @see BackdropWebTestCase::prepareEnvironment()
    */
   protected function setUp() {
-    global $user, $language_interface, $conf;
+    global $user, $language, $conf;
 
     // Create the database prefix for this test.
     $this->prepareDatabasePrefix();
@@ -1602,7 +1602,7 @@ class BackdropWebTestCase extends BackdropTestCase {
 
     // Set up English language.
     unset($conf['language_default']);
-    $language_interface = language_default();
+    $language = language_default();
 
     // Use the test mail class instead of the default mail handler class.
     config_set('system.mail', 'default-system', 'TestingMailSystem');
@@ -1662,7 +1662,7 @@ class BackdropWebTestCase extends BackdropTestCase {
    * and reset the database prefix.
    */
   protected function tearDown() {
-    global $user, $language_interface, $settings, $config_directories;
+    global $user, $language, $settings, $config_directories;
 
     // In case a fatal error occurred that was not in the test process read the
     // log to pick up any fatal errors.
@@ -1737,7 +1737,7 @@ class BackdropWebTestCase extends BackdropTestCase {
     $GLOBALS['conf']['file_public_path'] = $this->originalFileDirectory;
 
     // Reset language.
-    $language_interface = $this->originalLanguage;
+    $language = $this->originalLanguage;
     if ($this->originalLanguageDefault) {
       $GLOBALS['conf']['language_default'] = $this->originalLanguageDefault;
     }

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -2342,7 +2342,7 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
    * Tests for the format_date() function.
    */
   function testFormatDate() {
-    global $user, $language_interface;
+    global $user, $language;
 
     $timestamp = strtotime('2007-03-26T00:00:00+00:00');
     $this->assertIdentical(format_date($timestamp, 'custom', 'l, d-M-y H:i:s T', 'America/Los_Angeles', 'en'), 'Sunday, 25-Mar-07 17:00:00 PDT', 'Test all parameters.');
@@ -2378,8 +2378,8 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
     // Save the original user and language and then replace it with the test user and language.
     $real_user = $user;
     $user = user_load($test_user->uid, TRUE);
-    $real_language = $language_interface->langcode;
-    $language_interface->langcode = $user->language;
+    $real_language = $language->langcode;
+    $language->langcode = $user->language;
     // Simulate a Backdrop bootstrap with the logged-in user.
     date_default_timezone_set(backdrop_get_user_timezone());
 
@@ -2401,7 +2401,7 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
 
     // Restore the original user and language, and enable session saving.
     $user = $real_user;
-    $language_interface->langcode = $real_language;
+    $language->langcode = $real_language;
     // Restore default time zone.
     date_default_timezone_set(backdrop_get_user_timezone());
     backdrop_save_session(TRUE);

--- a/core/modules/simpletest/tests/mail.test
+++ b/core/modules/simpletest/tests/mail.test
@@ -24,10 +24,10 @@ class MailTestCase extends BackdropWebTestCase implements MailSystemInterface {
    * Assert that the pluggable mail system is functional.
    */
   function testPluggableFramework() {
-    global $language_interface;
+    global $language;
 
     // Use MailTestCase for sending a message.
-    $message = backdrop_mail('simpletest', 'mail_test', 'testing@example.com', $language_interface);
+    $message = backdrop_mail('simpletest', 'mail_test', 'testing@example.com', $language);
 
     // Assert whether the message was sent through the send function.
     $this->assertEqual(self::$sent_message['to'], 'testing@example.com', 'Pluggable mail system is extendable.');

--- a/core/modules/simpletest/tests/upgrade/upgrade.language.test
+++ b/core/modules/simpletest/tests/upgrade/upgrade.language.test
@@ -61,7 +61,7 @@ class LanguageUpgradePathTestCase extends UpgradePathTestCase {
     // assert the expected HTML id because the block might appear even if the
     // language negotiation settings are not properly upgraded.
     $elements = $this->xpath('//*[contains(@class, :block)]', array(
-      ':block' => 'block-locale-language-interface',
+      ':block' => 'block-locale-language',
     ));
     $this->assertTrue($elements, t('The language switcher block is being correctly showed.'));
 

--- a/core/modules/simpletest/tests/upgrade/upgrade.test
+++ b/core/modules/simpletest/tests/upgrade/upgrade.test
@@ -47,7 +47,7 @@ abstract class UpgradePathTestCase extends BackdropWebTestCase {
    * @see BackdropWebTestCase::prepareEnvironment()
    */
   protected function setUp() {
-    global $user, $language_interface, $conf;
+    global $user, $language, $conf;
 
     // Load the Update API.
     require_once BACKDROP_ROOT . '/core/includes/update.inc';

--- a/core/modules/system/language.api.php
+++ b/core/modules/system/language.api.php
@@ -24,9 +24,9 @@
  * did not happen yet and thus they cannot rely on translated variables.
  */
 function hook_language_init() {
-  global $language_interface, $settings;
+  global $language, $settings;
 
-  switch ($language_interface->language) {
+  switch ($language->language) {
     case 'it':
       $settings['locale_custom_strings_en']['site_name'] = 'Il mio sito Backdrop';
       break;

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -1799,7 +1799,7 @@ function hook_custom_theme() {
  *     the message is not possible to translate.
  */
 function hook_watchdog(array $log_entry) {
-  global $base_url, $language_interface;
+  global $base_url, $language;
 
   $severity_list = array(
     WATCHDOG_EMERGENCY     => t('Emergency'),
@@ -1845,7 +1845,7 @@ function hook_watchdog(array $log_entry) {
     '@message'       => strip_tags($log_entry['message']),
   ));
 
-  backdrop_mail('emaillog', 'entry', $to, $language_interface, $params);
+  backdrop_mail('emaillog', 'entry', $to, $language, $params);
 }
 
 /**

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1625,7 +1625,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
     $account = $this->backdropCreateUser();
     $node = $this->backdropCreateNode(array('uid' => $account->uid));
     $node->title = '<blink>Blinking Text</blink>';
-    global $user, $language_interface;
+    global $user, $language;
 
     $source  = '[node:title]';         // Title of the node we passed in
     $source .= '[node:author:name]';   // Node author's name
@@ -1637,18 +1637,18 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
 
     $target  = check_plain($node->title);
     $target .= check_plain($account->name);
-    $target .= format_interval(REQUEST_TIME - $node->created, 2, $language_interface->langcode);
+    $target .= format_interval(REQUEST_TIME - $node->created, 2, $language->langcode);
     $target .= check_plain($user->name);
-    $target .= format_date(REQUEST_TIME, 'short', '', NULL, $language_interface->langcode);
+    $target .= format_date(REQUEST_TIME, 'short', '', NULL, $language->langcode);
 
     // Test that the clear parameter cleans out non-existent tokens.
-    $result = token_replace($source, array('node' => $node), array('language' => $language_interface, 'clear' => TRUE));
+    $result = token_replace($source, array('node' => $node), array('language' => $language, 'clear' => TRUE));
     $result = $this->assertEqual($target, $result, 'Valid tokens replaced while invalid tokens cleared out.');
 
     // Test without using the clear parameter (non-existent token untouched).
     $target .= '[user:name]';
     $target .= '[bogus:token]';
-    $result = token_replace($source, array('node' => $node), array('language' => $language_interface));
+    $result = token_replace($source, array('node' => $node), array('language' => $language));
     $this->assertEqual($target, $result, 'Valid tokens replaced while invalid tokens ignored.');
 
     // Check that the results of token_generate are sanitized properly. This does NOT
@@ -1670,7 +1670,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
    * Test whether token-replacement works in various contexts.
    */
   function testSystemTokenRecognition() {
-    global $language_interface;
+    global $language;
 
     // Generate prefixes and suffixes for the token context.
     $tests = array(
@@ -1690,7 +1690,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
     foreach ($tests as $test) {
       $input = $test['prefix'] . '[site:name]' . $test['suffix'];
       $expected = $test['prefix'] . 'Backdrop' . $test['suffix'];
-      $output = token_replace($input, array(), array('language' => $language_interface));
+      $output = token_replace($input, array(), array('language' => $language));
       $this->assertTrue($output == $expected, format_string('Token recognized in string %string', array('%string' => $input)));
     }
   }
@@ -1699,10 +1699,10 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
    * Tests the generation of all system site information tokens.
    */
   function testSystemSiteTokenReplacement() {
-    global $language_interface;
+    global $language;
     $url_options = array(
       'absolute' => TRUE,
-      'language' => $language_interface,
+      'language' => $language,
     );
 
     // Set a few site variables.
@@ -1724,7 +1724,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array(), array('language' => $language_interface));
+      $output = token_replace($input, array(), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized system site information token %token replaced.', array('%token' => $input)));
     }
 
@@ -1733,7 +1733,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[site:slogan]'] = config_get('system.core', 'site_slogan');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array(), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array(), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized system site information token %token replaced.', array('%token' => $input)));
     }
   }
@@ -1742,25 +1742,25 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
    * Tests the generation of all system date tokens.
    */
   function testSystemDateTokenReplacement() {
-    global $language_interface;
+    global $language;
 
     // Set time to one hour before request.
     $date = REQUEST_TIME - 3600;
 
     // Generate and test tokens.
     $tests = array();
-    $tests['[date:short]'] = format_date($date, 'short', '', NULL, $language_interface->langcode);
-    $tests['[date:medium]'] = format_date($date, 'medium', '', NULL, $language_interface->langcode);
-    $tests['[date:long]'] = format_date($date, 'long', '', NULL, $language_interface->langcode);
-    $tests['[date:custom:m/j/Y]'] = format_date($date, 'custom', 'm/j/Y', NULL, $language_interface->langcode);
-    $tests['[date:since]'] = format_interval((REQUEST_TIME - $date), 2, $language_interface->langcode);
+    $tests['[date:short]'] = format_date($date, 'short', '', NULL, $language->langcode);
+    $tests['[date:medium]'] = format_date($date, 'medium', '', NULL, $language->langcode);
+    $tests['[date:long]'] = format_date($date, 'long', '', NULL, $language->langcode);
+    $tests['[date:custom:m/j/Y]'] = format_date($date, 'custom', 'm/j/Y', NULL, $language->langcode);
+    $tests['[date:since]'] = format_interval((REQUEST_TIME - $date), 2, $language->langcode);
     $tests['[date:raw]'] = filter_xss($date);
 
     // Test to make sure that we generated something for each token.
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('date' => $date), array('language' => $language_interface));
+      $output = token_replace($input, array('date' => $date), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Date token %token replaced.', array('%token' => $input)));
     }
   }

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -1515,7 +1515,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
    * Creates some terms and a node, then tests the tokens generated from them.
    */
   function testTaxonomyTokenReplacement() {
-    global $language_interface;
+    global $language;
 
     // Create two taxonomy terms.
     $term1 = $this->createTerm($this->vocabulary);
@@ -1544,7 +1544,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
     $tests['[term:vocabulary:name]'] = check_plain($this->vocabulary->name);
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('term' => $term1), array('language' => $language_interface));
+      $output = token_replace($input, array('term' => $term1), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized taxonomy term token %token replaced.', array('%token' => $input)));
     }
 
@@ -1564,7 +1564,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('term' => $term2), array('language' => $language_interface));
+      $output = token_replace($input, array('term' => $term2), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized taxonomy term token %token replaced.', array('%token' => $input)));
     }
 
@@ -1575,7 +1575,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
     $tests['[term:vocabulary:name]'] = $this->vocabulary->name;
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('term' => $term2), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('term' => $term2), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized taxonomy term token %token replaced.', array('%token' => $input)));
     }
 
@@ -1591,7 +1591,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('vocabulary' => $this->vocabulary), array('language' => $language_interface));
+      $output = token_replace($input, array('vocabulary' => $this->vocabulary), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized taxonomy vocabulary token %token replaced.', array('%token' => $input)));
     }
 
@@ -1600,7 +1600,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
     $tests['[vocabulary:description]'] = $this->vocabulary->description;
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('vocabulary' => $this->vocabulary), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('vocabulary' => $this->vocabulary), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized taxonomy vocabulary token %token replaced.', array('%token' => $input)));
     }
   }

--- a/core/modules/translation/config/translation.settings.json
+++ b/core/modules/translation/config/translation.settings.json
@@ -1,4 +1,4 @@
 {
   "_config_name": "translation.settings",
-  "language_type": "language_interface"
+  "language_type": "language"
 }

--- a/core/modules/translation/tests/translation.test
+++ b/core/modules/translation/tests/translation.test
@@ -173,7 +173,7 @@ class TranslationTestCase extends BackdropWebTestCase {
     // Check that content translation links are shown even when no language
     // negotiation is configured.
     $this->backdropLogin($this->admin_user);
-    $edit = array('language_interface[locale-url][enabled]' => FALSE);
+    $edit = array('language[locale-url][enabled]' => FALSE);
     $this->backdropPost('admin/config/regional/language/detection', $edit, t('Save settings'));
     $this->resetCaches();
     $edit = array('status' => TRUE);

--- a/core/modules/translation/translation.install
+++ b/core/modules/translation/translation.install
@@ -15,7 +15,7 @@
 function translation_update_1000() {
   // Create the new config file.
   $config = config('translation.settings');
-  $config->set('language_type', update_variable_get('translation_language_type', 'language_interface'));
+  $config->set('language_type', update_variable_get('translation_language_type', 'language'));
   $config->save();
 
   update_variable_del('translation_language_type');

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1990,10 +1990,10 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
    * Creates a user, then tests the tokens generated from it.
    */
   function testUserTokenReplacement() {
-    global $language_interface;
+    global $language;
     $url_options = array(
       'absolute' => TRUE,
-      'language' => $language_interface,
+      'language' => $language,
     );
 
     // Create two users and log them in one after another.
@@ -2013,17 +2013,17 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[user:mail]'] = check_plain($account->mail);
     $tests['[user:url]'] = url("user/$account->uid", $url_options);
     $tests['[user:edit-url]'] = url("user/$account->uid/edit", $url_options);
-    $tests['[user:last-login]'] = format_date($account->login, 'medium', '', NULL, $language_interface->langcode);
-    $tests['[user:last-login:short]'] = format_date($account->login, 'short', '', NULL, $language_interface->langcode);
-    $tests['[user:created]'] = format_date($account->created, 'medium', '', NULL, $language_interface->langcode);
-    $tests['[user:created:short]'] = format_date($account->created, 'short', '', NULL, $language_interface->langcode);
+    $tests['[user:last-login]'] = format_date($account->login, 'medium', '', NULL, $language->langcode);
+    $tests['[user:last-login:short]'] = format_date($account->login, 'short', '', NULL, $language->langcode);
+    $tests['[user:created]'] = format_date($account->created, 'medium', '', NULL, $language->langcode);
+    $tests['[user:created:short]'] = format_date($account->created, 'short', '', NULL, $language->langcode);
     $tests['[current-user:name]'] = check_plain(user_format_name($global_account));
 
     // Test to make sure that we generated something for each token.
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('user' => $account), array('language' => $language_interface));
+      $output = token_replace($input, array('user' => $account), array('language' => $language));
       $this->assertEqual($output, $expected, format_string('Sanitized user token %token replaced.', array('%token' => $input)));
     }
 
@@ -2033,7 +2033,7 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[current-user:name]'] = user_format_name($global_account);
 
     foreach ($tests as $input => $expected) {
-      $output = token_replace($input, array('user' => $account), array('language' => $language_interface, 'sanitize' => FALSE));
+      $output = token_replace($input, array('user' => $account), array('language' => $language, 'sanitize' => FALSE));
       $this->assertEqual($output, $expected, format_string('Unsanitized user token %token replaced.', array('%token' => $input)));
     }
   }

--- a/core/modules/user/user.pages.inc
+++ b/core/modules/user/user.pages.inc
@@ -80,11 +80,11 @@ function user_pass_validate($form, &$form_state) {
  * Submit handler for user_pass().
  */
 function user_pass_submit($form, &$form_state) {
-  global $language_interface;
+  global $language;
 
   $account = $form_state['values']['account'];
   // Mail one time login URL and instructions using current language.
-  $mail = _user_mail_notify('password_reset', $account, $language_interface);
+  $mail = _user_mail_notify('password_reset', $account, $language);
   if (!empty($mail)) {
     watchdog('user', 'Password reset instructions mailed to %name at %email.', array('%name' => $account->name, '%email' => $account->mail));
     backdrop_set_message(t('Further instructions have been sent to your e-mail address.'));

--- a/core/modules/views/plugins/views_plugin_cache.inc
+++ b/core/modules/views/plugins/views_plugin_cache.inc
@@ -277,7 +277,7 @@ class views_plugin_cache extends views_plugin {
         'build_info' => $build_info,
         'roles' => array_keys($user->roles),
         'super-user' => $user->uid == 1, // special caching for super user.
-        'language' => $GLOBALS['language_interface']->langcode,
+        'language' => $GLOBALS['language']->langcode,
         'base_url' => $GLOBALS['base_url'],
       );
       foreach (array('exposed_info', 'page', 'sort', 'order', 'items_per_page', 'offset') as $key) {
@@ -300,7 +300,7 @@ class views_plugin_cache extends views_plugin {
         'roles' => array_keys($user->roles),
         'super-user' => $user->uid == 1, // special caching for super user.
         'theme' => $GLOBALS['theme'],
-        'language' => $GLOBALS['language_interface']->langcode,
+        'language' => $GLOBALS['language']->langcode,
         'base_url' => $GLOBALS['base_url'],
       );
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/445.
