### PR TITLE
Issue #560: Human-readable name of a layout is a 'title', not 'name' in hook_layout_info().

### DIFF
--- a/core/modules/layout/layout.api.php
+++ b/core/modules/layout/layout.api.php
@@ -20,7 +20,7 @@
  *
  * @return array
  *   Each item in the returned array of info should have the following keys:
- *   - name: The human-readable name of the layout.
+ *   - title: The human-readable name of the layout.
  *   - path: A local path within the providing module to files needed by this
  *     layout, such as associated CSS, the icon image, and template file.
  *   - regions: A list of regions this layout provides, keyed by a machine name


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/560.
