### PR TITLE
Issue #252: Disable live preview and make admin bar display the same on all pages.

### DIFF
--- a/core/modules/admin_bar/admin_bar.admin.js
+++ b/core/modules/admin_bar/admin_bar.admin.js
@@ -1,20 +1,6 @@
 (function($) {
 
 /**
- * Live preview of Administration bar components.
- */
-Backdrop.behaviors.adminBarLivePreview = {
-  attach: function (context, settings) {
-    $('input[name^="components"]', context).once('admin-bar-live-preview')
-      .change(function () {
-        var target = $(this).attr('rel');
-        $(target).toggle(this.checked);
-      })
-      .trigger('change');
-  }
-};
-
-/**
  * Automatically enables required permissions on demand.
  *
  * Many users do not understand that two permissions are required for the

--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -686,10 +686,6 @@ function admin_bar_theme_settings() {
     '#description' => t('These features will be enabled/visible in the administration bar. Untick the boxes to disable/hide them.'),
   );
 
-  $process = element_info_property('checkboxes', '#process', array());
-  $form['components']['#process'] = array_merge(array('admin_bar_settings_process_components'), $process);
-  $form['#attached']['js'][] = backdrop_get_path('module', 'admin_bar') . '/admin_bar.admin.js';
-
   $form['actions'] = array(
     '#type' => 'actions',
   );
@@ -699,22 +695,6 @@ function admin_bar_theme_settings() {
   );
 
   return $form;
-}
-
-/**
- * #process callback for component plugin form element in admin_bar_theme_settings().
- */
-function admin_bar_settings_process_components($element) {
-  // Assign 'rel' attributes to all options to achieve a live preview.
-  // Unfortunately, #states relies on wrapping .form-wrapper classes, so it
-  // cannot be used here.
-  foreach ($element['#options'] as $key => $label) {
-    if (!isset($element[$key]['#attributes']['rel'])) {
-      $id = preg_replace('/[^a-z]/', '-', $key);
-      $element[$key]['#attributes']['rel'] = '#' . $id;
-    }
-  }
-  return $element;
 }
 
 /**

--- a/core/modules/admin_bar/admin_bar.module
+++ b/core/modules/admin_bar/admin_bar.module
@@ -159,9 +159,6 @@ function admin_bar_preprocess_page(&$variables) {
 
   // Determine whether we need to show all components and disable all caches.
   $complete = FALSE;
-  if (current_path() == 'admin/config/administration/admin_bar' && $_SERVER['REQUEST_METHOD'] == 'GET') {
-    $complete = TRUE;
-  }
 
   // If we have a cached menu for the current user, only output the hash for the
   // client-side HTTP cache callback URL.
@@ -452,10 +449,12 @@ function admin_bar_admin_bar_output_build(&$content) {
  * Implements hook_admin_bar_output_alter().
  */
 function admin_bar_admin_bar_output_alter(&$content) {
-  foreach ($content['menu']['menu'] as $key => $link) {
-    // Move local tasks on 'admin' into icon menu.
-    if ($key == 'admin/tasks' || $key == 'admin/index') {
-      unset($content['menu']['menu'][$key]);
+  if (isset($content['menu']['menu'])) {
+    foreach ($content['menu']['menu'] as $key => $link) {
+      // Move local tasks on 'admin' into icon menu.
+      if ($key == 'admin/tasks' || $key == 'admin/index') {
+        unset($content['menu']['menu'][$key]);
+      }
     }
   }
 }

--- a/core/modules/admin_bar/tests/admin_bar.test
+++ b/core/modules/admin_bar/tests/admin_bar.test
@@ -266,7 +266,9 @@ class AdminBarDynamicLinksTestCase extends AdminBarWebTestCase {
     $this->backdropLogin($this->admin_user);
 
     // Verify that dynamic links are displayed.
-    $this->backdropGet('admin/config/administration/admin_bar');
+    $cid = 'admin_bar:' . $this->admin_user->uid . ':' . session_id() . ':en';
+    $hash = admin_bar_cache_get($cid);
+    $this->backdropGet('js/admin_bar/cache/' . $hash);
     $this->assertElementByXPath('//div[@id="admin-bar"]', array(), t('Administration bar found.'));
     $this->assertElementByXPath('//div[@id="admin-bar"]//a[contains(@href, :path)]', array(':path' => 'admin/structure/types'), "Structure » Content types link found.");
 
@@ -438,7 +440,9 @@ class AdminBarCustomizedTestCase extends AdminBarWebTestCase {
     $this->backdropPost('admin/structure/menu/manage/management/add', $edit, t('Save'));
 
     // Verify that the link appears in the menu.
-    $this->backdropGet('admin/config/administration/admin_bar');
+    $cid = 'admin_bar:' . $this->admin_user->uid . ':' . session_id() . ':en';
+    $hash = admin_bar_cache_get($cid);
+    $this->backdropGet('js/admin_bar/cache/' . $hash);
     $elements = $this->xpath($xpath);
     $this->assertTrue($elements, 'Custom link found.');
 
@@ -467,7 +471,9 @@ class AdminBarCustomizedTestCase extends AdminBarWebTestCase {
     $this->backdropPost('admin/structure/menu/manage/management/add', $edit, t('Save'));
 
     // Verify that the link appears in the menu.
-    $this->backdropGet('admin/config/administration/admin_bar');
+    $cid = 'admin_bar:' . $this->admin_user->uid . ':' . session_id() . ':en';
+    $hash = admin_bar_cache_get($cid);
+    $this->backdropGet('js/admin_bar/cache/' . $hash);
     $elements = $this->xpath('//div[@id=:id]//a[@href=:href and contains(text(), :text)]', array(
       ':id' => 'admin-bar',
       ':href' => $edit['link_path'],


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/252.
