### PR TITLE
Issue #581: Clear caches before starting updates.

### DIFF
--- a/core/includes/update.inc
+++ b/core/includes/update.inc
@@ -322,6 +322,10 @@ function update_fix_requirements() {
       update_module_enable(array('views'));
     }
 
+    // Empty a few basic caches.
+    db_query('TRUNCATE {cache}');
+    db_query('TRUNCATE {cache_bootstrap}');
+
     state_set('update_backdrop_requirements', TRUE);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/581.
