### PR TITLE
Issue #607 ; remove mysterious right borders on menu tabs sub-items

### DIFF
--- a/core/modules/system/css/system.theme.css
+++ b/core/modules/system/css/system.theme.css
@@ -402,12 +402,10 @@ ul.secondary {
   margin: 5px;
 }
 ul.secondary li {
-  border-right: 1px solid #ccc; /* LTR */
   display: inline;
   padding: 0 1em;
 }
 [dir="rtl"] ul.secondary li {
-  border-left: 1px solid #ccc;
   border-right: none;
   display: inline;
   padding: 0 1em;


### PR DESCRIPTION
This solves: https://github.com/backdrop/backdrop-issues/issues/607
