### PR TITLE
Issue #602: Fixing message overlap with breadcrumb in Chrome.

### DIFF
--- a/core/themes/bartik/css/style.css
+++ b/core/themes/bartik/css/style.css
@@ -318,6 +318,7 @@ body.admin-bar .layout {
   flex: 1 0 auto;
 }
 .l-header,
+.l-top,
 .l-messages,
 .l-footer-wrapper,
 .l-footer {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/602
