### PR TITLE
Issue #593: update install module from URL help text

### DIFF
--- a/core/modules/update/update.manager.inc
+++ b/core/modules/update/update.manager.inc
@@ -507,7 +507,7 @@ function update_manager_install_form($form, &$form_state, $context) {
   $form['project_url'] = array(
     '#type' => 'url',
     '#title' => t('Install from a URL'),
-    '#description' => t('For example: %url', array('%url' => 'https://github.com/backdrop-contrib/module/archive/v1.2.3.zip')),
+    '#description' => t('For example: %url', array('%url' => 'https://github.com/backdrop-contrib/module/archive/1.x-1.2.3.zip')),
   );
 
   $form['information'] = array(

--- a/core/modules/update/update.manager.inc
+++ b/core/modules/update/update.manager.inc
@@ -507,7 +507,7 @@ function update_manager_install_form($form, &$form_state, $context) {
   $form['project_url'] = array(
     '#type' => 'url',
     '#title' => t('Install from a URL'),
-    '#description' => t('For example: %url', array('%url' => 'http://ftp.drupal.org/files/projects/name.tar.gz')),
+    '#description' => t('For example: %url', array('%url' => 'https://github.com/backdrop-contrib/module/archive/v1.2.3.zip')),
   );
 
   $form['information'] = array(


### PR DESCRIPTION
Updated the help text to reflect the new pattern for installing modules from a Backdrop-contrib URL.
