### PR TITLE
Issue #662:  Remove uneeded paramter edit in hook_user_update.

### DIFF
--- a/core/modules/user/user.api.php
+++ b/core/modules/user/user.api.php
@@ -245,7 +245,7 @@ function hook_user_insert($account) {
  * @see hook_user_presave()
  * @see hook_user_insert()
  */
-function hook_user_update(&$edit, $account) {
+function hook_user_update($account) {
   db_insert('user_changes')
     ->fields(array(
       'uid' => $account->uid,


### PR DESCRIPTION
This fixes: https://github.com/backdrop/backdrop-issues/issues/662
