### PR TITLE
Issue #670: Remove horizontal scroll from seven theme last active tab.

### DIFF
--- a/core/modules/system/css/system.css
+++ b/core/modules/system/css/system.css
@@ -274,6 +274,7 @@ tr .ajax-progress-throbber .throbber {
   clip: rect(1px, 1px, 1px, 1px);
   overflow: hidden;
   height: 1px;
+  width: 1px;
 }
 
 /**


### PR DESCRIPTION
This fixes: https://github.com/backdrop/backdrop-issues/issues/670
