### PR TITLE
support for additional suport and documentation .info values defined in #119

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -607,6 +607,24 @@ function system_modules($form, $form_state = array()) {
         );
       }
     }
+  
+    // Generate link for module's support page, if provided.
+    if ($module->status && isset($module->info['support']) && valid_url($module->info['support'])) {
+      $extra['links']['support'] = array(
+        'title' => t('Support'),
+        'href' => $module->info['support'],
+        'attributes' => array('class' => array('module-link', 'module-link-support'), 'title' => t('Go to Support')),
+      );
+    }
+    
+    // Generate link for module's documentation page, if provided.
+    if ($module->status && isset($module->info['documentation']) && valid_url($module->info['documentation'])) {
+      $extra['links']['documentation'] = array(
+        'title' => t('Documentation'),
+        'href' => $module->info['documentation'],
+        'attributes' => array('class' => array('module-link', 'module-link-documentation'), 'title' => t('Go to Documentation')),
+      );
+    }
 
     // If this module is required by other modules, list those, and then make it
     // impossible to disable this one.
@@ -749,7 +767,7 @@ function _system_modules_build_row($info, $extra) {
 
   // Build dropbutton links.
   $links = array();
-  foreach (array('configure', 'permissions') as $key) {
+  foreach (array('configure', 'permissions', 'support', 'documentation') as $key) {
     if (isset($extra['links'][$key])) {
       $links[$key] =  $extra['links'][$key];
     }

--- a/settings.php
+++ b/settings.php
@@ -11,7 +11,7 @@
  * below. If using master/slave or multiple connections, see the advanced
  * database settings.
  */
-$database = 'mysql://user:pass@localhost/database_name';
+$database = 'mysql://root:root@localhost/backdrop';
 $database_prefix = '';
 
 /**
@@ -191,8 +191,8 @@ $database_prefix = '';
  * $config_directories['staging'] = '/home/myusername/config/active';
  * @endcode
  */
-$config_directories['active'] = 'files/config_' . md5($database) . '/active';
-$config_directories['staging'] = 'files/config_' . md5($database) . '/staging';
+$config_directories['active'] = 'files/config_3beb91deb0d9e97370adbf642bf74e75/active';
+$config_directories['staging'] = 'files/config_3beb91deb0d9e97370adbf642bf74e75/staging';
 
 /**
  * Access control for update.php script.
@@ -224,7 +224,7 @@ $settings['update_free_access'] = FALSE;
  *   $settings['hash_salt'] = file_get_contents('/home/example/salt.txt');
  *
  */
-$settings['hash_salt'] = '';
+$settings['hash_salt'] = 'JmKY-n6KxZPUYauC9LofZeB2C3CO9gbrfYQK4JZq87M';
 
 /**
  * Base URL (optional).
@@ -486,3 +486,7 @@ $settings['404_fast_html'] = '<!DOCTYPE html><html><head><title>404 Not Found</t
  * built for Backdrop.
  */
 $settings['backdrop_drupal_compatibility'] = TRUE;
+$settings['hash_salt'] = 'JmKY-n6KxZPUYauC9LofZeB2C3CO9gbrfYQK4JZq87M';
+$database = 'mysql://root:root@localhost/backdrop';
+$config_directories['active'] = 'files/config_3beb91deb0d9e97370adbf642bf74e75/active';
+$config_directories['staging'] = 'files/config_3beb91deb0d9e97370adbf642bf74e75/staging';


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/119

In token.info I added...

```
support = https://github.com/backdrop-contrib/token/issues
documentation = https://github.com/backdrop-contrib/token/blob/1.x-1.x/README.md
```

This does not address an alternate url to check for updates, just a simple way to point users the location for support and documentation a module's maintainer prefers.

![extended_info_file_support](https://cloud.githubusercontent.com/assets/385234/6086379/54010518-adfe-11e4-910a-ac7475486a73.png)
