### PR TITLE
Issue #686: Improve performance/memory usage of backdrop_parse_info_format().

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -7785,7 +7785,6 @@ function backdrop_parse_info_file($filename, $process_sections = FALSE) {
  */
 function backdrop_parse_info_format($data, $process_sections = FALSE) {
   $info = array();
-  $constants = get_defined_constants();
 
   // Separate by sections and parse individually if requested.
   if ($process_sections) {
@@ -7845,8 +7844,8 @@ function backdrop_parse_info_format($data, $process_sections = FALSE) {
       }
 
       // Handle PHP constants.
-      if (isset($constants[$value])) {
-        $value = $constants[$value];
+      if (preg_match('/^\w+$/', $value) && defined($value)) {
+        $value = constant($value);
       }
 
       // Insert actual value.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/686.
