### PR TITLE
Issue #633: Admin bar mistakenly reveals disabled node types.

### DIFF
--- a/core/modules/admin_bar/admin_bar.map.inc
+++ b/core/modules/admin_bar/admin_bar.map.inc
@@ -47,10 +47,16 @@ function node_admin_bar_map() {
   if (!user_access('administer content types')) {
     return;
   }
+  $types = node_type_get_types();
+  foreach ($types as $type_name => $type) {
+    if ($type->disabled) {
+      unset($types[$type_name]);
+    }
+  }
   $map['admin/structure/types/manage/%node_type'] = array(
     'parent' => 'admin/structure/types',
     'arguments' => array(
-      array('%node_type' => array_keys(node_type_get_types())),
+      array('%node_type' => array_keys($types)),
     ),
   );
   return $map;

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -655,6 +655,17 @@ function _node_types_build() {
   $config_names = config_get_names_with_prefix('node.type.');
   foreach ($config_names as $config_name) {
     $node_type_data = config($config_name)->get();
+
+    // Check if the node type is disabled or the module is enabled.
+    $module = $node_type_data['module'];
+    $module_disabled = TRUE;
+    if ($module === 'node' || module_exists($module)) {
+      $module_disabled = FALSE;
+    }
+
+    // If the module is enabled, $disabled is forced to TRUE.
+    $node_type_data['disabled'] = !empty($node_type_data['disabled']) || $module_disabled;
+
     $type = str_replace('node.type.', '', $config_name);
     $_node_types->types[$type] = node_type_set_defaults($node_type_data);
     $_node_types->names[$type] = $node_type_data['name'];


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#633

Replaces the PR at https://github.com/backdrop/backdrop/pull/712.
