### PR TITLE
Issue #701: Allow admins to customize the login failed message.

### DIFF
--- a/core/modules/user/config/user.mail.json
+++ b/core/modules/user/config/user.mail.json
@@ -15,5 +15,6 @@
     "status_blocked_body": "[user:name],\n\nYour account on [site:name] has been blocked.\n\n--  [site:name] team",
     "status_blocked_subject": "Account details for [user:name] at [site:name] (blocked)",
     "status_canceled_body": "[user:name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team",
-    "status_canceled_subject": "Account details for [user:name] at [site:name] (canceled)"
+    "status_canceled_subject": "Account details for [user:name] at [site:name] (canceled)",
+    "user_login_error_customized": "[user:name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team"
 }

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -503,6 +503,32 @@ function user_admin_settings($form, &$form_state) {
     '#rows' => 3,
   );
 
+  /**
+   *  attempt to make customizable user login message
+   */
+  $form['user_login_error'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Customize login error message'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#description' => t('Customize the error message a user sees if their login fails.') . ' ' . $email_token_help,
+    '#group' => 'email',
+  );
+//$config = config('user.mail.json');
+  $form['user_login_error']['user_login_error_customized'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Message'),
+    '#default_value' => $mail_config->get('user_login_error_customized'),
+    /*'#default_value' => variable_get(
+      'user_login_error_customized',
+      t('Sorry, unrecognized username or password.
+          <a href="@password">Have you forgotten your password?</a>',
+        array('@password' => url('user/password', array('query' => array('name' => 'my name'))))
+      )
+    ),*/
+    '#rows' => 3,
+  );
+
   $form['actions']['#type'] = 'actions';
   $form['actions']['submit'] = array(
     '#type' => 'submit',
@@ -551,6 +577,7 @@ function user_admin_settings_submit($form, &$form_state) {
     ->set('status_blocked_subject', $form_state['values']['user_mail_status_blocked_subject'])
     ->set('status_canceled_body', $form_state['values']['user_mail_status_canceled_body'])
     ->set('status_canceled_subject', $form_state['values']['user_mail_status_canceled_subject'])
+    ->set('user_login_error_customized', $form_state['values']['user_login_error_customized'])
     ->save();
 
     backdrop_set_message(t('The configuration options have been saved.'));

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -324,6 +324,7 @@ function user_update_1005() {
   $config->set('cancel_confirm_body', update_variable_get('cancel_confirm_body', '[user:name],\n\nA request to cancel your account has been made at [site:name].\n\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\n\n[user:cancel-url]\n\nNOTE: The cancellation of your account is not reversible.\n\nThis link expires in one day and nothing will happen if it is not used.\n\n--  [site:name] team'));
   $config->set('status_canceled_subject', update_variable_get('status_canceled_subject', 'Account details for [user:name] at [site:name] (canceled)'));
   $config->set('status_canceled_body', update_variable_get('status_canceled_body', '[user:name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team'));
+  $config->set('user_login_error_customized', update_variable_get('user_login_error_customized', '[user:name],\n\nYour account on [site:name] has been canceled.\n\n--  [site:name] team'));
   $config->save();
 
   // Delete variables.

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1580,7 +1580,8 @@ function user_login_final_validate($form, &$form_state) {
       }
     }
     else {
-      form_set_error('name', t('Sorry, unrecognized username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
+      $mail_config = config('user.mail');
+      form_set_error('name', $mail_config->get('user_login_error_customized'));//t('Sorry, unrecognized username or password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
       watchdog('user', 'Login attempt failed for %user.', array('%user' => $form_state['values']['name']));
     }
   }


### PR DESCRIPTION
This fixes: https://github.com/backdrop/backdrop-issues/issues/701
