### PR TITLE
Issue #783: restore default for second parameter to cache_get()

### DIFF
--- a/core/includes/cache.inc
+++ b/core/includes/cache.inc
@@ -56,7 +56,7 @@ function cache($bin = 'cache') {
  * @return
  *   The cache or FALSE on failure.
  */
-function cache_get($cid, $bin) {
+function cache_get($cid, $bin = 'cache') {
   return cache($bin)->get($cid);
 }
 


### PR DESCRIPTION
Missing default parameter added back to cache_get() to procedural wrappers, to maintain maximum compatibility with Drupal 7. 
