### PR TITLE
Issue #806: Fix url path to message-16-error.png icon

### DIFF
--- a/core/modules/dblog/css/dblog.css
+++ b/core/modules/dblog/css/dblog.css
@@ -70,5 +70,5 @@
 .admin-dblog .dblog-critical .icon,
 .admin-dblog .dblog-alert .icon,
 .admin-dblog .dblog-emergency .icon {
-  background-image: url(../../misc/message-16-error.png);
+  background-image: url(../../../misc/message-16-error.png);
 }


### PR DESCRIPTION
This solves https://github.com/backdrop/backdrop-issues/issues/806
