### PR TITLE
Issue #729: Add empty() test for $row_classes in views templates

### DIFF
--- a/core/modules/views/templates/views-view-grid.tpl.php
+++ b/core/modules/views/templates/views-view-grid.tpl.php
@@ -26,7 +26,7 @@
 
   <tbody>
     <?php foreach ($rows as $row_number => $columns): ?>
-      <tr <?php if ($row_classes[$row_number]) { print 'class="' . implode(' ', $row_classes[$row_number]) .'"';  } ?>>
+      <tr <?php if (!empty($row_classes[$row_number])) { print 'class="' . implode(' ', $row_classes[$row_number]) .'"';  } ?>>
         <?php foreach ($columns as $column_number => $item): ?>
           <td <?php if ($column_classes[$row_number][$column_number]) { print 'class="' . implode(' ', $column_classes[$row_number][$column_number]) .'"';  } ?>>
             <?php print $item; ?>

--- a/core/modules/views/templates/views-view-list.tpl.php
+++ b/core/modules/views/templates/views-view-list.tpl.php
@@ -14,7 +14,7 @@
   <?php endif; ?>
   <?php print $list_type_prefix; ?>
     <?php foreach ($rows as $id => $row): ?>
-      <li class="<?php print implode(' ', $row_classes[$id]); ?>"><?php print $row; ?></li>
+      <li class="<?php if (!empty($row_classes[$id])) { print implode(' ', $row_classes[$id]); } ?>"><?php print $row; ?></li>
     <?php endforeach; ?>
   <?php print $list_type_suffix; ?>
 <?php print $wrapper_suffix; ?>

--- a/core/modules/views/templates/views-view-table.tpl.php
+++ b/core/modules/views/templates/views-view-table.tpl.php
@@ -38,7 +38,7 @@
   <?php endif; ?>
   <tbody>
     <?php foreach ($rows as $row_count => $row): ?>
-      <tr <?php if ($row_classes[$row_count]) { print 'class="' . implode(' ', $row_classes[$row_count]) .'"';  } ?>>
+      <tr <?php if (!empty($row_classes[$row_count])) { print 'class="' . implode(' ', $row_classes[$row_count]) .'"';  } ?>>
         <?php foreach ($row as $field => $content): ?>
           <td <?php if ($field_classes[$field][$row_count]) { print 'class="'. implode(' ', $field_classes[$field][$row_count]) . '" '; } ?><?php print backdrop_attributes($field_attributes[$field][$row_count]); ?>>
             <?php print $content; ?>

--- a/core/modules/views/templates/views-view-unformatted.tpl.php
+++ b/core/modules/views/templates/views-view-unformatted.tpl.php
@@ -16,7 +16,7 @@
   <h3><?php print $title; ?></h3>
 <?php endif; ?>
 <?php foreach ($rows as $row_count => $row): ?>
-  <div <?php if ($row_classes[$row_count]) { print 'class="' . implode(' ', $row_classes[$row_count]) . '"';  } ?>>
+  <div <?php if (!empty($row_classes[$row_count])) { print 'class="' . implode(' ', $row_classes[$row_count]) . '"';  } ?>>
     <?php print $row; ?>
   </div>
 <?php endforeach; ?>


### PR DESCRIPTION
This fixes https://github.com/backdrop/backdrop-issues/issues/729
