### PR TITLE
Issue #674:  cache_clear_all() clear expired items

### DIFF
--- a/core/includes/cache.inc
+++ b/core/includes/cache.inc
@@ -173,7 +173,12 @@ function cache_clear_all($cid = NULL, $bin = NULL, $wildcard = FALSE) {
   }
 
   if (!$wildcard) {
-    cache($bin)->delete($cid);
+    if (is_null($cid)) {
+      cache($bin)->garbageCollection();
+    }
+    else {
+      cache($bin)->delete($cid);
+    }
   }
   else {
     if ($cid === '*') {


### PR DESCRIPTION
Restore cache_clear_all() clear expired items when $bin is set but $cid
is null. https://github.com/backdrop/backdrop-issues/issues/674
