### PR TITLE
Issue #577: Removing node delete operations from admin nav.

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -1632,6 +1632,7 @@ function node_menu() {
     'title' => 'Delete',
     'page arguments' => array('node_type_delete_confirm', 4),
     'access arguments' => array('administer content types'),
+    'type' => MENU_VISIBLE_IN_BREADCRUMB,
     'file' => 'node.types.inc',
   );
 


### PR DESCRIPTION
This fixes: https://github.com/backdrop/backdrop-issues/issues/577
