### PR TITLE
Issue #830: Initialize element array for number formatter

### DIFF
--- a/core/modules/field/modules/number/number.module
+++ b/core/modules/field/modules/number/number.module
@@ -198,6 +198,7 @@ function number_field_formatter_info() {
 function number_field_formatter_settings_form($field, $instance, $view_mode, $form, &$form_state) {
   $display = $instance['display'][$view_mode];
   $settings = $display['settings'];
+  $element = array();
 
   if ($display['type'] == 'number_decimal' || $display['type'] == 'number_integer') {
     $options = array(


### PR DESCRIPTION
This removes a PHP notice, causing Views to not display modal options for the field.
