### PR TITLE
Added datetime to the supported field types for fields schemas

### DIFF
--- a/core/includes/database/mysql/schema.inc
+++ b/core/includes/database/mysql/schema.inc
@@ -242,6 +242,8 @@ class DatabaseSchema_mysql extends DatabaseSchema {
 
       'blob:big'        => 'LONGBLOB',
       'blob:normal'     => 'BLOB',
+
+      'datetime:normal' => 'DATETIME',
     );
     return $map;
   }


### PR DESCRIPTION
I could have reverted some changes in _processField_ to get the _mysql_type_ index into account, but I thing this is more future-proof (in case of Date merging into core :-) ).
This fixes https://github.com/backdrop-contrib/date/issues/1 and https://github.com/backdrop-ops/contrib/issues/76
