### PR TITLE
Issue #843/1946240: Remove the hardcoded 0 index in theme_status_message...

### DIFF
--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1704,7 +1704,7 @@ function theme_status_messages($variables) {
       $output .= " </ul>\n";
     }
     else {
-      $output .= $messages[0];
+      $output .= reset($messages);
     }
     $output .= "</div>\n";
   }

--- a/core/modules/simpletest/tests/system_test.module
+++ b/core/modules/simpletest/tests/system_test.module
@@ -78,6 +78,13 @@ function system_test_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['system-test/backdrop-set-message'] = array(
+    'title' => 'Set messages with backdrop_set_message()',
+    'page callback' => 'system_test_backdrop_set_message',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+   );
+
   $items['system-test/main-content-fallback'] = array(
     'title' => 'Test main content fallback',
     'page callback' => 'system_test_main_content_fallback',
@@ -399,6 +406,20 @@ function system_test_authorize_init_page($page_title) {
   $authorize_url = $GLOBALS['base_url'] . '/core/authorize.php';
   system_authorized_init('system_test_authorize_run', backdrop_get_path('module', 'system_test') . '/system_test.module', array(), $page_title);
   backdrop_goto($authorize_url);
+}
+
+/**
+ * Sets two messages and removes the first one before the messages are displayed.
+ */
+function system_test_backdrop_set_message() {
+  // Set two messages.
+  backdrop_set_message('First message (removed).');
+  backdrop_set_message('Second message (not removed).');
+
+  // Remove the first.
+  unset($_SESSION['messages']['status'][0]);
+
+  return '';
 }
 
 /**

--- a/core/modules/system/system.tests.info
+++ b/core/modules/system/system.tests.info
@@ -195,3 +195,9 @@ name = Token scanning
 description = Scan token-like patterns in a dummy text to check token scanning.
 group = System
 file = tests/system.test
+
+[BackdropSetMessageTest]
+name = Messages
+description = Tests that messages can be displayed using backdrop_set_message().
+group = System
+file = tests/system.test

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -2360,6 +2360,27 @@ class SystemValidTokenTest extends BackdropWebTestCase {
 }
 
 /**
+ * Tests backdrop_set_message() and related functions.
+ */
+class BackdropSetMessageTest extends BackdropWebTestCase {
+  protected $profile = 'testing';
+  function setUp() {
+    parent::setUp('system_test');
+  }
+
+  /**
+   * Tests setting messages and removing one before it is displayed.
+   */
+  function testSetRemoveMessages() {
+    // The page at system-test/backdrop-set-message sets two messages and then
+    // removes the first before it is displayed.
+    $this->backdropGet('system-test/backdrop-set-message');
+    $this->assertNoText('First message (removed).');
+    $this->assertText('Second message (not removed).');
+  }
+}
+
+/**
  * Tests confirm form destinations.
  */
 class ConfirmFormTest extends BackdropWebTestCase {


### PR DESCRIPTION
This fixes: #843 / #1946240 Drupal 7.36 update meta issue.
