### PR TITLE
Issue #843: Drupal 7.36 meta #2462223 by helmo: Typo in comment in node_access_test.module

### DIFF
--- a/core/modules/node/tests/node_access_test/node_access_test.module
+++ b/core/modules/node/tests/node_access_test/node_access_test.module
@@ -213,7 +213,7 @@ function node_access_test_node_insert(Node $node) {
 }
 
 /**
- * Implements hook_nodeapi_update().
+ * Implements hook_node_update().
  */
 function node_access_test_node_update(Node $node) {
   _node_access_test_node_write($node);


### PR DESCRIPTION
This fixes: #843 / #2462223.
