### PR TITLE
Issue #738 element styles

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -13,16 +13,6 @@
 /**
  * Menus and lists.
  */
-.block ul,
-.item-list ul {
-  list-style-type: disc;
-  list-style-image: none;
-  margin: 0.25em 0 0.25em 1.5em; /* LTR */
-}
-[dir="rtl"] .block ul,
-[dir="rtl"] .item-list ul {
-  margin: 0.25em 1.5em 0.25em 0;
-}
 .item-list ul li,
 li.leaf,
 ul.menu li {


### PR DESCRIPTION
Removed .block ul and .item-list ul stlyes which are now in seven.base.css
https://github.com/backdrop/backdrop-issues/issues/738
