### PR TITLE
Issue #843: Drupal 7.36 meta #2383491 by er.pushpinderrana, Sweetchuck: Inaccurate documentation - hook_image_toolkits()

### DIFF
--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -1350,9 +1350,8 @@ function hook_init() {
 /**
  * Define image toolkits provided by this module.
  *
- * The file which includes each toolkit's functions must be declared as part of
- * the files array in the module .info file so that the registry will find and
- * parse it.
+ * The file which includes each toolkit's functions must be included in this
+ * hook.
  *
  * The toolkit's functions must be named image_toolkitname_operation().
  * where the operation may be:


### PR DESCRIPTION
This fixes: backdrop/backdrop-issues#843 / #2383491.
