### PR TITLE
Issue #893: Switch MySQL to use TCP/IP to avoid Travis errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
   # Install Backdrop with the installation script.
   - chmod a+w . settings.php
-  - ./core/scripts/install.sh --db-url=mysql://travis:@localhost/backdrop
+  - ./core/scripts/install.sh --db-url=mysql://travis:@127.0.0.1/backdrop
   - chmod go-w . settings.php
 script: php -d display_errors="stderr" ./core/scripts/run-tests.sh --concurrency 12 --url 'http://localhost' --color --verbose --force --all
 after_failure:


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/893.
