### PR TITLE
Issue #843: Drupal 7.36 meta #2439287 by jmsv23, jonathan_hunt: Fix typo in inline docs for field_sql_storage_field_storage_write().

### DIFF
--- a/core/modules/field/field.api.php
+++ b/core/modules/field/field.api.php
@@ -1872,7 +1872,7 @@ function hook_field_storage_write($entity_type, $entity, $op, $fields) {
       $items = (array) $entity->{$field_name}[$langcode];
       $delta_count = 0;
       foreach ($items as $delta => $item) {
-        // We now know we have someting to insert.
+        // We now know we have something to insert.
         $do_insert = TRUE;
         $record = array(
           'entity_type' => $entity_type,

--- a/core/modules/field/modules/field_sql_storage/field_sql_storage.module
+++ b/core/modules/field/modules/field_sql_storage/field_sql_storage.module
@@ -406,7 +406,7 @@ function field_sql_storage_field_storage_write($entity_type, $entity, $op, $fiel
       $items = (array) $entity->{$field_name}[$langcode];
       $delta_count = 0;
       foreach ($items as $delta => $item) {
-        // We now know we have someting to insert.
+        // We now know we have something to insert.
         $do_insert = TRUE;
         $record = array(
           'entity_type' => $entity_type,


### PR DESCRIPTION
This fixes: backdrop/backdrop-issues#843 / #2439287.
