### PR TITLE
Issue #843: Drupal 7.36 meta #495930 by fietserwin: Translated strings not correctly marked in the administrative interface when the default language is not English

### DIFF
--- a/core/modules/locale/locale.pages.inc
+++ b/core/modules/locale/locale.pages.inc
@@ -110,7 +110,7 @@ function _locale_translate_seek() {
     $rows[] = array(
       array('data' => check_plain(truncate_utf8($string['source'], 150, FALSE, TRUE)) . '<br /><small>' . $string['location'] . '</small>'),
       $string['context'],
-      array('data' => _locale_translate_language_list($string['languages'], $limit_language), 'align' => 'center'),
+      array('data' => _locale_translate_language_list($string, $limit_language), 'align' => 'center'),
       array('data' => array('#type' => 'operations', '#links' => $links)),
     );
   }
@@ -124,18 +124,23 @@ function _locale_translate_seek() {
 /**
  * List languages in search result table
  */
-function _locale_translate_language_list($translation, $limit_language) {
+function _locale_translate_language_list($string, $limit_language) {
   // Add CSS.
   backdrop_add_css(backdrop_get_path('module', 'locale') . '/css/locale.css');
 
+  // Include both translated and not yet translated target languages in the
+  // list. The source language is English for built-in strings and the default
+  // language for other strings.
   $languages = language_list();
   if (!locale_translate_english()) {
-    unset($languages['en']);
+    $default = language_default();
+    $omit = $string['group'] == 'default' ? 'en' : $default->language;
+    unset($languages[$omit]);
   }
   $output = '';
   foreach ($languages as $langcode => $language) {
     if (!$limit_language || $limit_language == $langcode) {
-      $output .= (!empty($translation[$langcode])) ? $langcode . ' ' : "<em class=\"locale-untranslated\">$langcode</em> ";
+      $output .= (!empty($string['languages'][$langcode])) ? $langcode . ' ' : "<em class=\"locale-untranslated\">$langcode</em> ";
     }
   }
 
@@ -318,11 +323,14 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
     '#value' => $source->location
   );
 
-  // Include default form controls with empty values for all languages.
-  // This ensures that the languages are always in the same order in forms.
+  // Include both translated and not yet translated target languages in the
+  // list. The source language is English for built-in strings and the default
+  // language for other strings.
   $languages = language_list();
   if (!locale_translate_english()) {
-    unset($languages['en']);
+    $default = language_default();
+    $omit = $source->textgroup == 'default' ? 'en' : $default->language;
+    unset($languages[($omit)]);
   }
   $form['translations'] = array('#tree' => TRUE);
   // Approximate the number of rows to use in the default textarea.


### PR DESCRIPTION
Fix for: backdrop/backdrop-issues#843 / #495930.
