### PR TITLE
Issue #902: Prevent jumping page content as the admin bar is loaded.

### DIFF
--- a/core/modules/admin_bar/css/admin_bar.css
+++ b/core/modules/admin_bar/css/admin_bar.css
@@ -35,12 +35,12 @@
   overflow: hidden;
 }
 /* When body is a contextual links region. */
-.contextual-links-region #admin-menu {
-  top: -30px;
+.contextual-links-region #admin-bar {
+  top: -33px;
 }
 
-body.admin-bar {
-  margin-top: 30px !important;
+.admin-bar body {
+  border-top: 33px solid #2D2D2D !important;
 }
 
 /* Top level items. */

--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -2,7 +2,6 @@
 
 Backdrop.adminBar = Backdrop.adminBar || {};
 Backdrop.adminBar.behaviors = Backdrop.adminBar.behaviors || {};
-Backdrop.adminBar.hashes = Backdrop.adminBar.hashes || {};
 
 /**
  * Core behavior for Administration bar.
@@ -26,7 +25,7 @@ Backdrop.behaviors.adminBar = {
     if (settings.admin_bar.suppress) {
       return;
     }
-    var $adminBar = $('#admin-bar:not(.admin-bar-processed)', context);
+    var $adminBar = $('#admin-bar', context);
     // Client-side caching; if administration bar is not in the output, it is
     // fetched from the server and cached in the browser.
     if (!$adminBar.length && settings.admin_bar.hash) {
@@ -45,7 +44,7 @@ Backdrop.behaviors.adminBar = {
       });
     }
     // If the menu is in the output already, this means there is a new version.
-    else {
+    else if (!$adminBar.hasClass('admin-bar-processed')) {
       // Apply our behaviors.
       Backdrop.adminBar.attachBehaviors(context, settings, $adminBar);
     }
@@ -85,21 +84,34 @@ Backdrop.adminBar.behaviors.adminBarMarginTop(document, Backdrop.settings);
  *   A callback function invoked when the cache request was successful.
  */
 Backdrop.adminBar.getCache = function (hash, onSuccess) {
-  if (Backdrop.adminBar.hashes.hash !== undefined) {
-    return Backdrop.adminBar.hashes.hash;
+  // Send an AJAX request for the admin bar content, only if we’re not already
+  // waiting on a response from a previous request.
+  if (!Backdrop.adminBar.ajaxRequest) {
+    Backdrop.adminBar.ajaxRequest = $.ajax({
+      cache: true,
+      type: 'GET',
+      dataType: 'text', // Prevent auto-evaluation of response.
+      global: false, // Do not trigger global AJAX events.
+      url: Backdrop.settings.admin_bar.basePath.replace(/admin_bar/, 'js/admin_bar/cache/' + hash),
+      success: onSuccess,
+      complete: function () {
+        Backdrop.adminBar.ajaxRequest = false;
+      }
+    });
   }
-  $.ajax({
-    cache: true,
-    type: 'GET',
-    dataType: 'text', // Prevent auto-evaluation of response.
-    global: false, // Do not trigger global AJAX events.
-    url: Backdrop.settings.admin_bar.basePath.replace(/admin_bar/, 'js/admin_bar/cache/' + hash),
-    success: onSuccess,
-    complete: function (XMLHttpRequest, status) {
-      Backdrop.adminBar.hashes.hash = status;
-    }
-  });
+  else {
+    // Invoke our callback when the AJAX request is complete.
+    Backdrop.adminBar.ajaxRequest.done(onSuccess);
+  }
 };
+
+/**
+ * If we have a hash, send the AJAX request right away, in an effort to have it
+ * complete as early as possible.
+ */
+if (Backdrop.settings.admin_bar.hash && Backdrop.settings.admin_bar.basePath) {
+  Backdrop.adminBar.getCache(Backdrop.settings.admin_bar.hash);
+}
 
 /**
  * @defgroup admin_behaviors Administration behaviors.

--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -52,30 +52,6 @@ Backdrop.behaviors.adminBar = {
 };
 
 /**
- * Apply active trail highlighting based on current path.
- */
-Backdrop.adminBar.behaviors.adminBarActiveTrail = function (context, settings, $adminBar) {
-  if (settings.admin_bar.activeTrail) {
-    $adminBar.find('#admin-bar-menu > li > ul > li > a[href="' + settings.admin_bar.activeTrail + '"]').addClass('active-trail');
-  }
-};
-
-/**
- * Apply margin to page.
- *
- * We apply the class to the HTML element, since it’s the only element that’s
- * guaranteed to exist at execution time.
- */
-Backdrop.adminBar.behaviors.adminBarMarginTop = function (context, settings) {
-  if (!settings.admin_bar.suppress && settings.admin_bar.margin_top) {
-    $('html:not(.admin-bar)', context).addClass('admin-bar');
-  }
-};
-// Don’t wait until the DOM is ready, run this immediately to prevent flickering
-// or jumping page content.
-Backdrop.adminBar.behaviors.adminBarMarginTop(document, Backdrop.settings);
-
-/**
  * Retrieve content from client-side cache.
  *
  * @param hash
@@ -129,6 +105,30 @@ Backdrop.adminBar.attachBehaviors = function (context, settings, $adminBar) {
     });
   }
 };
+
+/**
+ * Apply active trail highlighting based on current path.
+ */
+Backdrop.adminBar.behaviors.adminBarActiveTrail = function (context, settings, $adminBar) {
+  if (settings.admin_bar.activeTrail) {
+    $adminBar.find('#admin-bar-menu > li > ul > li > a[href="' + settings.admin_bar.activeTrail + '"]').addClass('active-trail');
+  }
+};
+
+/**
+ * Apply margin to page.
+ *
+ * We apply the class to the HTML element, since it’s the only element that’s
+ * guaranteed to exist at execution time.
+ */
+Backdrop.adminBar.behaviors.adminBarMarginTop = function (context, settings) {
+  if (!settings.admin_bar.suppress && settings.admin_bar.margin_top) {
+    $('html:not(.admin-bar)', context).addClass('admin-bar');
+  }
+};
+// Don’t wait until the DOM is ready, run this immediately to prevent flickering
+// or jumping page content.
+Backdrop.adminBar.behaviors.adminBarMarginTop(document, Backdrop.settings);
 
 /**
  * Apply 'position: fixed'.

--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -64,17 +64,17 @@ Backdrop.adminBar.behaviors.adminBarActiveTrail = function (context, settings, $
 /**
  * Apply margin to page.
  *
- * Note that directly applying marginTop does not work in IE. To prevent
- * flickering/jumping page content with client-side caching, this is a regular
- * Backdrop behavior.
+ * We apply the class to the HTML element, since it’s the only element that’s
+ * guaranteed to exist at execution time.
  */
-Backdrop.behaviors.adminBarMarginTop = {
-  attach: function (context, settings) {
-    if (!settings.admin_bar.suppress && settings.admin_bar.margin_top) {
-      $('body:not(.admin-bar)', context).addClass('admin-bar');
-    }
+Backdrop.adminBar.behaviors.adminBarMarginTop = function (context, settings) {
+  if (!settings.admin_bar.suppress && settings.admin_bar.margin_top) {
+    $('html:not(.admin-bar)', context).addClass('admin-bar');
   }
 };
+// Don’t wait until the DOM is ready, run this immediately to prevent flickering
+// or jumping page content.
+Backdrop.adminBar.behaviors.adminBarMarginTop(document, Backdrop.settings);
 
 /**
  * Retrieve content from client-side cache.

--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -2,6 +2,7 @@
 
 Backdrop.adminBar = Backdrop.adminBar || {};
 Backdrop.adminBar.behaviors = Backdrop.adminBar.behaviors || {};
+Backdrop.adminBar.cache = Backdrop.adminBar.cache || {};
 
 /**
  * Core behavior for Administration bar.
@@ -60,6 +61,13 @@ Backdrop.behaviors.adminBar = {
  *   A callback function invoked when the cache request was successful.
  */
 Backdrop.adminBar.getCache = function (hash, onSuccess) {
+  // Check for locally cached content.
+  if (Backdrop.adminBar.cache.hash) {
+    if (typeof onSuccess === 'function') {
+      onSuccess(Backdrop.adminBar.cache.hash);
+    }
+    return;
+  }
   // Send an AJAX request for the admin bar content, only if we’re not already
   // waiting on a response from a previous request.
   if (!Backdrop.adminBar.ajaxRequest) {
@@ -69,7 +77,10 @@ Backdrop.adminBar.getCache = function (hash, onSuccess) {
       dataType: 'text', // Prevent auto-evaluation of response.
       global: false, // Do not trigger global AJAX events.
       url: Backdrop.settings.admin_bar.basePath.replace(/admin_bar/, 'js/admin_bar/cache/' + hash),
-      success: onSuccess,
+      success: [function (response) {
+        // Cache the response data in a variable.
+        Backdrop.adminBar.cache.hash = response;
+      }, onSuccess],
       complete: function () {
         Backdrop.adminBar.ajaxRequest = false;
       }

--- a/core/themes/bartik/css/style.css
+++ b/core/themes/bartik/css/style.css
@@ -307,9 +307,9 @@ ul.tips {
   -ms-flex-direction: column;
   flex-direction: column;
 }
-body.admin-bar .layout {
-  padding-top: 30px;
-  margin-top: -30px;
+.admin-bar body .layout {
+  padding-top: 33px;
+  margin-top: -33px;
 }
 .l-container,
 .l-triptych {


### PR DESCRIPTION
As a second follow-up to https://github.com/backdrop/backdrop-issues/issues/902:
- Prevents the page content from jumping down as the admin bar is loaded, by adding a class before the DOM is loaded.
- Since the body element is not guaranteed to be available when the script is executed, it adds the class to the HTML element instead. Note that this could affect themes which currently rely on the class being added to the body.
- Uses a black top border on the body element for spacing, instead of a margin. The border acts as a mock toolbar while the content is loaded, improving the flicker effect.

I’m pretty happy with the effect this has on perceived page load, feels much more stable now.
