### PR TITLE
Issue #920: Path JS does not properly reflect Auto/Manual state in summary on taxonomy term form.

### DIFF
--- a/core/modules/path/js/path.js
+++ b/core/modules/path/js/path.js
@@ -2,23 +2,25 @@
  * @file
  * Attaches behaviors for the Path module.
  */
-
 (function ($) {
+
+"use strict";
 
 Backdrop.behaviors.pathFieldsetSummaries = {
   attach: function (context) {
-    $('fieldset.path-form', context).backdropSetSummary(function (context) {
-      var path = $('.form-item-path-alias input').val();
-      var automatic = $('.form-item-path-auto input').attr('checked');
+    $(context).find('fieldset.path-form').backdropSetSummary(function (element) {
+      var $element = $(element);
+      var path = $element.find('[name="path[alias]"]').val();
+      var automatic = $element.find('[name="path[auto]"]').prop('checked');
 
       if (automatic) {
-          return Backdrop.t('Automatic alias');
+        return Backdrop.t('Automatic alias');
       }
       if (path) {
-          return Backdrop.t('Alias: @alias', { '@alias': path });
+        return Backdrop.t('Alias: @alias', { '@alias': path });
       }
       else {
-          return Backdrop.t('No alias');
+        return Backdrop.t('No alias');
       }
     });
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/920.
