### PR TITLE
Issue #912: remove button-danger class from enable module confirmatio…

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -817,6 +817,8 @@ function system_modules_confirm_form($modules, $storage) {
       t('Would you like to continue with the above?'),
       t('Continue'),
       t('Cancel'));
+    // Removing the button-danger class so that button-primary will be added automatically for us.
+    unset($form['actions']['submit']['#attributes']['class']);
     return $form;
   }
 }


### PR DESCRIPTION
…n continue button.
this fixes: https://github.com/backdrop/backdrop-issues/issues/912
