### PR TITLE
Issue #939: Node types without patterns cannot save aliases at all.

### DIFF
--- a/core/modules/path/path.module
+++ b/core/modules/path/path.module
@@ -212,12 +212,15 @@ function path_entity_insert(Entity $entity) {
     $path = $entity->path;
     $path['source'] = $uri['path'];
   }
+
+  // If no pattern exists for this entity type, default to a manual alias.
+  $pattern = path_get_pattern_by_entity_type($entity->entityType(), $entity->bundle(), $langcode);
   $path += array(
     'pid' => NULL,
     'alias' => '',
     'source' => $uri['path'],
     'langcode' => $langcode,
-    'auto' => TRUE,
+    'auto' => strlen($pattern) === 0 ? FALSE : TRUE,
   );
 
   // Trim whitespace and slashes from path alias start and end.
@@ -248,18 +251,21 @@ function path_entity_update(Entity $entity) {
     $uri = $entity->uri();
     $path = $entity->path;
     $path['source'] = $uri['path'];
+
+    // If no pattern exists for this entity type, default to a manual alias.
+    $pattern = path_get_pattern_by_entity_type($entity->entityType(), $entity->bundle(), $langcode);
     $path += array(
       'pid' => NULL,
       'alias' => '',
       'langcode' => $langcode,
-      'auto' => TRUE,
+      'auto' => strlen($pattern) === 0 ? FALSE : TRUE,
     );
 
     // Trim whitespace and slashes from path alias start and end.
     $path['alias'] = trim($path['alias'], " \t\n\r\0\x0B/");
 
     // Save an automatic alias if specified.
-    if (!empty($path['auto'])) {
+    if ($path['auto']) {
       module_load_include('inc', 'path');
       $path = path_save_automatic_entity_alias($entity);
 

--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -12,7 +12,7 @@ class PathTestCase extends BackdropWebTestCase {
     parent::setUp('path');
 
     // Create test user and login.
-    $web_user = $this->backdropCreateUser(array('create page content', 'edit own page content', 'administer url aliases', 'create url aliases'));
+    $web_user = $this->backdropCreateUser(array('create page content', 'edit own page content', 'create article content', 'edit own article content', 'administer url aliases', 'create url aliases'));
     $this->backdropLogin($web_user);
   }
 
@@ -105,12 +105,13 @@ class PathTestCase extends BackdropWebTestCase {
    */
   function testNodeAlias() {
     // Create test node.
-    $node1 = $this->backdropCreateNode();
+    $node1 = $this->backdropCreateNode(array(
+      'type' => 'article',
+    ));
 
     // Create alias.
     $edit = array();
     $edit['path[alias]'] = $this->randomName(8);
-    $edit['path[auto]'] = FALSE;
     $this->backdropPost('node/' . $node1->nid . '/edit', $edit, t('Save'));
 
     // Confirm that the alias works.

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -427,7 +427,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
     $this->backdropGet('node/add/page');
     $this->assertFieldChecked('edit-path-auto');
 
-    // Create node for testing by previewing and saving the node form.
+    // Create node for testing by saving the node form.
     $title = ' Testing: node title [';
     $automatic_alias = 'content/testing-node-title';
     $this->backdropPost(NULL, array('title' => $title), 'Save');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/939.
