### PR TITLE
Issue #918/254424d: Allow custom HTML tags with a dash in the name to…

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -1746,7 +1746,7 @@ function _filter_xss_split($m, $store = FALSE) {
     return '&lt;';
   }
 
-  if (!preg_match('%^<\s*(/\s*)?([a-zA-Z0-9]+)([^>]*)>?|(<!--.*?-->)$%', $string, $matches)) {
+  if (!preg_match('%^<\s*(/\s*)?([a-zA-Z0-9\-]+)([^>]*)>?|(<!--.*?-->)$%', $string, $matches)) {
     // Seriously malformed.
     return '';
   }

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -1077,7 +1077,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
     // Setup dummy filter object.
     $filter = new stdClass();
     $filter->settings = array(
-      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd>',
+      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <test-element>',
       'filter_html_help' => 1,
       'filter_html_nofollow' => 0,
     );
@@ -1113,6 +1113,10 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
 
     $f = _filter_html('<code onerror>&nbsp;</code>', $filter);
     $this->assertNoNormalized($f, 'onerror', 'HTML filter should remove empty on* attributes on default.');
+
+    // Custom tags are supported and should be allowed through.
+    $f = _filter_html('<test-element></test-element>', $filter);
+    $this->assertNormalized($f, 'test-element', 'HTML filter should allow custom elements.');
   }
 
   /**


### PR DESCRIPTION
… pass through filter_xss() when specified in the list of allowed tags.
this fixes: 918/254424d ; part of https://github.com/backdrop/backdrop-issues/issues/918
