### PR TITLE
Issue #958: Update manager not configured for layouts

### DIFF
--- a/core/modules/admin_bar/admin_bar.map.inc
+++ b/core/modules/admin_bar/admin_bar.map.inc
@@ -120,10 +120,10 @@ function taxonomy_admin_bar_map() {
   if (!user_access('administer taxonomy')) {
     return;
   }
-  $map['admin/structure/taxonomy/%taxonomy_vocabulary_machine_name'] = array(
+  $map['admin/structure/taxonomy/%taxonomy_vocabulary'] = array(
     'parent' => 'admin/structure/taxonomy',
     'arguments' => array(
-      array('%taxonomy_vocabulary_machine_name' => array_keys(taxonomy_vocabulary_get_names())),
+      array('%taxonomy_vocabulary' => array_keys(taxonomy_vocabulary_load_multiple(FALSE))),
     ),
   );
   return $map;

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2004,6 +2004,11 @@ function system_updater_info() {
       'name' => t('Update themes'),
       'weight' => 0,
     ),
+    'layout' => array(
+      'class' => 'LayoutUpdater',
+      'name' => t('Update layouts'),
+      'weight' => 0,
+    ),
   );
 }
 
@@ -3581,6 +3586,7 @@ function system_autoload_info() {
     'Archive_Tar' => 'system.tar.inc',
     'ModuleUpdater' => 'system.updater.inc',
     'ThemeUpdater' => 'system.updater.inc',
+    'LayoutUpdater' => 'system.updater.inc',
 
     // @todo: Move file entities to File module.
     // https://github.com/backdrop/backdrop-issues/issues/213

--- a/core/modules/system/system.updater.inc
+++ b/core/modules/system/system.updater.inc
@@ -3,7 +3,7 @@
 /**
  * @file
  * Subclasses of the Updater class to update Backdrop core knows how to update.
- * At this time, only modules and themes are supported.
+ * At this time, only modules, themes and layouts are supported.
  */
 
 /**
@@ -124,10 +124,15 @@ class ThemeUpdater extends Updater implements BackdropUpdaterInterface {
 
   static function canUpdateDirectory($directory) {
     // This is a lousy test, but don't know how else to confirm it is a theme.
-    if (file_scan_directory($directory, '/.*\.module$/')) {
+    // Check for a filename prefixed with 'layout--' or '.module' (bad) or 
+    // a file named 'template.php' (good).
+    if (file_scan_directory($directory, '/(?=.*layout--)|(?=.*\.module$)/')) {
       return FALSE;
     }
-    return TRUE;
+    elseif (file_scan_directory($directory, '/.*template.php$/')) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
   public static function canUpdate($project_name) {
@@ -144,6 +149,67 @@ class ThemeUpdater extends Updater implements BackdropUpdaterInterface {
   public function postInstallTasks() {
     return array(
       l(t('Enable newly added themes'), 'admin/appearance'),
+      l(t('Administration pages'), 'admin'),
+    );
+  }
+}
+
+/**
+ * Class for updating layouts using FileTransfer classes via authorize.php.
+ */
+class LayoutUpdater extends Updater implements BackdropUpdaterInterface {
+
+  /**
+   * Return the directory where a theme should be installed.
+   *
+   * If the layout is already installed, backdrop_get_path() will return
+   * a valid path and we should install it there (although we need to use an
+   * absolute path, so we prepend BACKDROP_ROOT). If we're installing a new
+   * layout, we always want it to go into /layouts, since that's
+   * where all the documentation recommends users install their layouts, and
+   * there's no way that can conflict on a multi-site installation, since
+   * the Update manager won't let you install a new layout if it's already
+   * found on your system, and if there was a copy in top-level, we'd see it.
+   */
+  public function getInstallDirectory() {
+    if ($relative_path = backdrop_get_path('layout', $this->name)) {
+      $relative_path = dirname($relative_path);
+    }
+    else {
+      $relative_path = 'layouts';
+    }
+    return BACKDROP_ROOT . '/' . $relative_path;
+  }
+
+  public function isInstalled() {
+    return (bool) backdrop_get_path('layout', $this->name);
+  }
+
+  static function canUpdateDirectory($directory) {
+    // This is a lousy test, but don't know how else to confirm it is a layout.
+    if (file_scan_directory($directory, '/(?=.*template\.php$)|(?=.*\.module$)/')) {
+      return FALSE;
+    }
+    elseif (file_scan_directory($directory, '/.*layout--.*/')) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  public static function canUpdate($project_name) {
+    return (bool) backdrop_get_path('layout', $project_name);
+  }
+
+  public function postInstall() {
+    // Update the system table.
+    clearstatcache();
+    // system_rebuild_layout_data(); todo
+
+  }
+
+  public function postInstallTasks() {
+    return array(
+      l(t('Enable newly added layouts'), 'admin/structure/layouts'),
       l(t('Administration pages'), 'admin'),
     );
   }

--- a/core/modules/update/tests/update.test
+++ b/core/modules/update/tests/update.test
@@ -5,7 +5,7 @@
  * This file contains tests for the Update Manager module.
  *
  * The overarching methodology of these tests is we need to compare a given
- * state of installed modules and themes (e.g., version, project grouping,
+ * state of installed modules, themes and layouts (e.g., version, project grouping,
  * timestamps, etc) against a current state of what the release history XML
  * files we fetch say is available. We have dummy XML files (in the
  * modules/update/tests directory) that describe various scenarios of what's

--- a/core/modules/update/tests/update.tests.info
+++ b/core/modules/update/tests/update.tests.info
@@ -6,7 +6,7 @@ file = update.test
 
 [UpdateTestContribCase]
 name = Update contrib functionality
-description = Tests how the update module handles contributed modules and themes in a series of functional tests using mock XML data.
+description = Tests how the update module handles contributed modules, themes and layouts in a series of functional tests using mock XML data.
 group = Update
 file = update.test
 

--- a/core/modules/update/tests/update_test/update_test.module
+++ b/core/modules/update/tests/update_test/update_test.module
@@ -45,7 +45,7 @@ function update_test_menu() {
  * defined, its subarray will include .info keys and values for all modules and
  * themes on the system. Otherwise, the settings array is keyed by the module or
  * theme short name ($file->name) and the subarrays contain settings just for
- * that module or theme.
+ * that module, theme or layout.
  */
 function update_test_system_info_alter(&$info, $file) {
   $setting = config_get('update.settings', 'update_system_info');
@@ -66,8 +66,8 @@ function update_test_system_info_alter(&$info, $file) {
  * The setting is expected to be a nested associative array. If the key '#all'
  * is defined, its subarray will include .info keys and values for all modules
  * and themes on the system. Otherwise, the settings array is keyed by the
- * module or theme short name and the subarrays contain settings just for that
- * module or theme.
+ * module, theme or layout short name and the subarrays contain settings just for that
+ * module, theme or layout.
  */
 function update_test_update_status_alter(&$projects) {
   $setting = config_get('update.settings', 'update_status');

--- a/core/modules/update/update.admin.inc
+++ b/core/modules/update/update.admin.inc
@@ -21,12 +21,12 @@ function update_settings($form, &$form_state) {
       '1' => t('Daily'),
       '7' => t('Weekly'),
     ),
-    '#description' => t('Select how frequently you want to automatically check for new releases of your currently installed modules and themes.'),
+    '#description' => t('Select how frequently you want to automatically check for new releases of your currently installed modules, themes and layouts.'),
   );
 
   $form['update_check_disabled'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Check for updates of disabled modules and themes'),
+    '#title' => t('Check for updates of disabled modules, themes and layouts'),
     '#default_value' => $config->get('update_disabled_extensions'),
   );
 
@@ -50,7 +50,7 @@ function update_settings($form, &$form_state) {
       'all' => t('All newer versions'),
       'security' => t('Only security updates'),
     ),
-    '#description' => t('You can choose to send e-mail only if a security update is available, or to be notified about all newer versions. If there are updates available of Backdrop CMS or any of your installed modules and themes, your site will always print a message on the <a href="@status_report">status report</a> page, and will also display an error message on administration pages if there is a security update.', array('@status_report' => url('admin/reports/status')))
+    '#description' => t('You can choose to send e-mail only if a security update is available, or to be notified about all newer versions. If there are updates available of Backdrop CMS or any of your installed modules, themes and layouts, your site will always print a message on the <a href="@status_report">status report</a> page, and will also display an error message on administration pages if there is a security update.', array('@status_report' => url('admin/reports/status')))
   );
 
   // Custom validation callback for the email notification setting.
@@ -104,7 +104,7 @@ function update_settings_validate($form, &$form_state) {
  * Form submission handler for update_settings().
  *
  * Also invalidates the cache of available updates if the "Check for updates of
- * disabled modules and themes" setting is being changed. The available updates
+ * disabled modules, themes and layouts" setting is being changed. The available updates
  * report needs to refetch available update data after this setting changes or
  * it would show misleading things (e.g., listing the disabled projects on the
  * site with the "No available releases found" warning).

--- a/core/modules/update/update.api.php
+++ b/core/modules/update/update.api.php
@@ -16,7 +16,7 @@
  * Most modules will never need to implement this hook. It is for advanced
  * interaction with the Update Manager module. The primary use-case for this
  * hook is to add projects to the list; for example, to provide update status
- * data on disabled modules and themes. A contributed module might want to hide
+ * data on disabled modules, themes and layouts. A contributed module might want to hide
  * projects from the list; for example, if there is a site-specific module that
  * doesn't have any official releases, that module could remove itself from this
  * list to avoid "No available releases found" warnings on the available updates
@@ -26,7 +26,7 @@
  * @param $projects
  *   Reference to an array of the projects installed on the system. This
  *   includes all the metadata documented in the comments below for each project
- *   (either module or theme) that is currently enabled. The array is initially
+ *   (either module, theme or layout) that is currently enabled. The array is initially
  *   populated inside update_get_projects() with the help of
  *   _update_process_info_list(), so look there for examples of how to populate
  *   the array with real values.

--- a/core/modules/update/update.authorize.inc
+++ b/core/modules/update/update.authorize.inc
@@ -220,7 +220,7 @@ function update_authorize_update_batch_finished($success, $results) {
   }
   // Since we're doing an update of existing code, always add a task for
   // running update.php.
-  $results['tasks'][] = t('Your modules have been downloaded and updated.');
+  $results['tasks'][] = t('Your projects have been downloaded and updated.');
   $results['tasks'][] = t('<a href="@update">Run database updates</a>', array('@update' => base_path() . 'core/update.php'));
 
   // Unset the variable since it is no longer needed.

--- a/core/modules/update/update.compare.inc
+++ b/core/modules/update/update.compare.inc
@@ -9,7 +9,7 @@
  * Fetches an array of installed and enabled projects.
  *
  * This is only responsible for generating an array of projects (taking into
- * account projects that include more than one module, theme or layout). Other
+ * account projects that include more than one module or theme). Other
  * information like the specific version and install type (official release,
  * dev snapshot, etc) is handled later in update_process_project_info() since
  * that logic is only required when preparing the status report, not for
@@ -21,7 +21,7 @@
  * available updates fetched from the network, it is acceptable to invalidate it
  * somewhat quickly. If we keep this data for very long, site administrators are
  * more likely to see incorrect results if they upgrade to a newer version of a
- * module, theme or layout but do not visit certain pages that automatically clear this
+ * module or theme but do not visit certain pages that automatically clear this
  * cache.
  *
  * @return
@@ -62,11 +62,14 @@ function update_get_projects() {
       // Still empty, so we have to rebuild the cache.
       $module_data = system_rebuild_module_data();
       $theme_data = system_rebuild_theme_data();
+      $layout_data = layout_get_layout_info();
       _update_process_info_list($projects, $module_data, 'module', TRUE);
       _update_process_info_list($projects, $theme_data, 'theme', TRUE);
+      _update_process_info_list($projects, $layout_data, 'layout', TRUE);
       if (config_get('update.settings', 'update_disabled_extensions')) {
         _update_process_info_list($projects, $module_data, 'module', FALSE);
         _update_process_info_list($projects, $theme_data, 'theme', FALSE);
+        _update_process_info_list($projects, $layout_data, 'layout', FALSE); //todo
       }
       // Allow other modules to alter projects before fetching and comparing.
       backdrop_alter('update_projects', $projects);
@@ -96,7 +99,7 @@ function update_get_projects() {
  * @param $list
  *   Array of data to process to add the relevant info to the $projects array.
  * @param $project_type
- *   The kind of data in the list. Can be 'module' or 'theme'.
+ *   The kind of data in the list. Can be 'module' or 'theme' or 'layout'.
  * @param $status
  *   Boolean that controls what status (enabled or disabled) to process out of
  *   the $list and add to the $projects array.
@@ -794,6 +797,7 @@ function update_project_cache($cid) {
     'admin/modules/update',
     'admin/appearance',
     'admin/appearance/update',
+    'admin/structure/layouts',
     'admin/reports',
     'admin/reports/updates',
     'admin/reports/updates/update',

--- a/core/modules/update/update.compare.inc
+++ b/core/modules/update/update.compare.inc
@@ -9,7 +9,7 @@
  * Fetches an array of installed and enabled projects.
  *
  * This is only responsible for generating an array of projects (taking into
- * account projects that include more than one module or theme). Other
+ * account projects that include more than one module, theme or layout). Other
  * information like the specific version and install type (official release,
  * dev snapshot, etc) is handled later in update_process_project_info() since
  * that logic is only required when preparing the status report, not for
@@ -21,7 +21,7 @@
  * available updates fetched from the network, it is acceptable to invalidate it
  * somewhat quickly. If we keep this data for very long, site administrators are
  * more likely to see incorrect results if they upgrade to a newer version of a
- * module or theme but do not visit certain pages that automatically clear this
+ * module, theme or layout but do not visit certain pages that automatically clear this
  * cache.
  *
  * @return
@@ -82,13 +82,13 @@ function update_get_projects() {
  *
  * This iterates over a list of the installed modules or themes and groups them
  * by project and status. A few parts of this function assume that enabled
- * modules and themes are always processed first, and if disabled modules or
+ * modules, themes and layouts are always processed first, and if disabled modules or
  * themes are being processed (there is a setting to control if disabled code
  * should be included or not in the 'Available updates' report), those are only
  * processed after $projects has been populated with information about the
- * enabled code. Modules and themes set as hidden are always ignored. This
+ * enabled code. modules, themes and layouts set as hidden are always ignored. This
  * function also records the latest change time on the .info files for each
- * module or theme, which is important data which is used when deciding if the
+ * module, theme or layout, which is important data which is used when deciding if the
  * cached available update data should be invalidated.
  *
  * @param $projects
@@ -131,7 +131,7 @@ function _update_process_info_list(&$projects, $list, $project_type, $status) {
       continue;
     }
 
-    // Skip if it's a hidden module or theme.
+    // Skip if it's a hidden module, theme or layout.
     if (!empty($file->info['hidden'])) {
       continue;
     }
@@ -227,7 +227,7 @@ function _update_process_info_list(&$projects, $list, $project_type, $status) {
     }
     elseif (empty($status)) {
       // If we have a project_name that matches, but the project_display_type
-      // does not, it means we're processing a disabled module or theme that
+      // does not, it means we're processing a disabled module, theme or layout that
       // belongs to a project that has some enabled code. In this case, we add
       // the disabled thing into a separate array for separate display.
       $projects[$project_name]['disabled'][$file->name] = $file->info['name'];
@@ -318,7 +318,7 @@ function update_process_project_info(&$projects) {
  * the data about available updates fetched from the network, it is ok to
  * invalidate it somewhat quickly. If we keep this data for very long, site
  * administrators are more likely to see incorrect results if they upgrade to a
- * newer version of a module or theme but do not visit certain pages that
+ * newer version of a module, theme or layout but do not visit certain pages that
  * automatically clear this cache.
  *
  * @param array $available
@@ -759,11 +759,11 @@ function update_calculate_project_update_status(&$project_data, $available) {
  * Retrieves data from {cache_update} or empties the cache when necessary.
  *
  * Two very expensive arrays computed by this module are the list of all
- * installed modules and themes (and .info data, project associations, etc), and
+ * installed modules, themes and layouts (and .info data, project associations, etc), and
  * the current status of the site relative to the currently available releases.
  * These two arrays are cached in the {cache_update} table and used whenever
  * possible. The cache is cleared whenever the administrator visits the status
- * report, available updates report, or the module or theme administration
+ * report, available updates report, or the module, theme or layout administration
  * pages, since we should always recompute the most current values on any of
  * those pages.
  *

--- a/core/modules/update/update.compare.inc
+++ b/core/modules/update/update.compare.inc
@@ -62,7 +62,7 @@ function update_get_projects() {
       // Still empty, so we have to rebuild the cache.
       $module_data = system_rebuild_module_data();
       $theme_data = system_rebuild_theme_data();
-      $layout_data = layout_get_layout_info();
+      $layout_data = _system_rebuild_layout_data();
       _update_process_info_list($projects, $module_data, 'module', TRUE);
       _update_process_info_list($projects, $theme_data, 'theme', TRUE);
       _update_process_info_list($projects, $layout_data, 'layout', TRUE);
@@ -78,6 +78,22 @@ function update_get_projects() {
     }
   }
   return $projects;
+}
+
+//temp todo
+function _system_rebuild_layout_data() {
+  // Find modules
+  $layout_data = layout_get_layout_info();
+  foreach($layout_data as $layout) {
+    $name = $layout['name'];
+    $layouts[$name] = new stdClass();
+    $layouts[$name]->name = $name;
+    $layouts[$name]->uri = $layout['path'] . '/' . $name . '.info';
+    $layouts[$name]->info = $layout;
+    $layouts[$name]->status = 1;
+  }
+
+  return $layouts;
 }
 
 /**
@@ -128,7 +144,6 @@ function _update_process_info_list(&$projects, $list, $project_type, $status) {
     elseif ($file->status != $status) {
       continue;
     }
-
     // Skip if the .info file is broken.
     if (empty($file->info)) {
       continue;

--- a/core/modules/update/update.fetch.inc
+++ b/core/modules/update/update.fetch.inc
@@ -299,7 +299,7 @@ function _update_build_fetch_url($project, $site_key = '') {
   // Only append usage information if we have a site key and the project is
   // enabled. We do not want to record usage statistics for disabled projects.
   // Only append a site_key and the version information if we have a site_key
-  // in the first place, and if this is not a disabled module or theme. We do
+  // in the first place, and if this is not a disabled module, theme or layout. We do
   // not want to record usage statistics for disabled code.
   if (!empty($site_key) && (strpos($project['project_type'], 'disabled') === FALSE)) {
     // Append the site key.

--- a/core/modules/update/update.info
+++ b/core/modules/update/update.info
@@ -1,5 +1,5 @@
 name = Update Manager
-description = Checks for available updates, and can securely install or update modules and themes via a web interface.
+description = Checks for available updates, and can securely install or update modules, themes and layouts via a web interface.
 version = BACKDROP_VERSION
 package = Development
 backdrop = 1.x

--- a/core/modules/update/update.install
+++ b/core/modules/update/update.install
@@ -110,7 +110,7 @@ function _update_requirement_check($project, $type) {
     $requirement['title'] = t('Backdrop CMS update status');
   }
   else {
-    $requirement['title'] = t('Module and theme update status');
+    $requirement['title'] = t('Module, theme and layout update status');
   }
   $status = $project['status'];
   if ($status != UPDATE_CURRENT) {

--- a/core/modules/update/update.manager.inc
+++ b/core/modules/update/update.manager.inc
@@ -67,8 +67,11 @@ function update_manager_update_form($form, $form_state = array(), $context) {
     case 'theme':
       backdrop_set_title('Update themes');
       break;
+    case 'layout':
+      backdrop_set_title('Update layouts');
+      break;
     case 'report':
-      backdrop_set_title('Update modules & themes');
+      backdrop_set_title('Update projects');
       break;
   }
 
@@ -204,11 +207,13 @@ function update_manager_update_form($form, $form_state = array(), $context) {
 
       case 'module':
       case 'theme':
+      case 'layout':
         $projects['enabled'][$name] = $entry;
         break;
 
       case 'module-disabled':
       case 'theme-disabled':
+      case 'layout-disabled':
         $projects['disabled'][$name] = $entry;
         break;
     }
@@ -481,7 +486,7 @@ function update_manager_update_ready_form_submit($form, &$form_state) {
  *
  * @param $context
  *   String representing the context from which we're trying to install.
- *   Allowed values are 'module', 'theme', and 'report'.
+ *   Allowed values are 'module', 'theme', 'layout', and 'report'.
  *
  * @see update_manager_install_form_validate()
  * @see update_manager_install_form_submit()
@@ -493,7 +498,7 @@ function update_manager_install_form($form, &$form_state, $context) {
     return $form;
   }
 
-  backdrop_set_title('Install a module');
+  backdrop_set_title('Install a project');
 
   $form['help_text'] = array(
     '#prefix' => '<p>',
@@ -706,7 +711,6 @@ function update_manager_install_form_submit($form, &$form_state) {
     form_set_error($field, t('%project is already installed.', array('%project' => $project_title)));
     return;
   }
-
   $project_real_location = backdrop_realpath($project_location);
   $arguments = array(
     'project' => $project,

--- a/core/modules/update/update.manager.inc
+++ b/core/modules/update/update.manager.inc
@@ -477,7 +477,7 @@ function update_manager_update_ready_form_submit($form, &$form_state) {
  * Form constructor for the install form of the Update Manager module.
  *
  * This presents a place to enter a URL or upload an archive file to use to
- * install a new module or theme.
+ * install a new module, theme or layout.
  *
  * @param $context
  *   String representing the context from which we're trying to install.
@@ -497,7 +497,7 @@ function update_manager_install_form($form, &$form_state, $context) {
 
   $form['help_text'] = array(
     '#prefix' => '<p>',
-    '#markup' => t('You can find modules and themes on <a href="@url">backdropcms.org</a>. The following file extensions are supported: %extensions.', array(
+    '#markup' => t('You can find modules, themes and layouts on <a href="@url">backdropcms.org</a>. The following file extensions are supported: %extensions.', array(
       '@url' => 'http://backdropcms.org',
       '%extensions' => archiver_get_extensions(),
     )),
@@ -518,7 +518,7 @@ function update_manager_install_form($form, &$form_state, $context) {
 
   $form['project_upload'] = array(
     '#type' => 'file',
-    '#title' => t('Upload a module or theme archive to install'),
+    '#title' => t('Upload a module, theme or layout archive to install'),
     '#description' => t('For example: %filename from your local computer', array('%filename' => 'name.tar.gz')),
   );
 
@@ -563,10 +563,10 @@ function _update_manager_check_backends(&$form, $operation) {
   $available_backends = backdrop_get_filetransfer_info();
   if (empty($available_backends)) {
     if ($operation == 'update') {
-      $form['available_backends']['#markup'] = t('Your server does not support updating modules and themes from this interface. Instead, update modules and themes by uploading the new versions directly to the server, as described in the <a href="@handbook_url">handbook</a>.', array('@handbook_url' => 'http://backdropcms.org/guide/modules'));
+      $form['available_backends']['#markup'] = t('Your server does not support updating modules, themes and layouts from this interface. Instead, update modules, themes and layouts by uploading the new versions directly to the server, as described in the <a href="@handbook_url">handbook</a>.', array('@handbook_url' => 'http://backdropcms.org/guide/modules'));
     }
     else {
-      $form['available_backends']['#markup'] = t('Your server does not support installing modules and themes from this interface. Instead, install modules and themes by uploading them directly to the server, as described in the <a href="@handbook_url">handbook</a>.', array('@handbook_url' => 'http://backdropcms.org/guide/modules'));
+      $form['available_backends']['#markup'] = t('Your server does not support installing modules, themes and layouts from this interface. Instead, install modules, themes and layouts by uploading them directly to the server, as described in the <a href="@handbook_url">handbook</a>.', array('@handbook_url' => 'http://backdropcms.org/guide/modules'));
     }
     return FALSE;
   }
@@ -578,8 +578,8 @@ function _update_manager_check_backends(&$form, $operation) {
   if ($operation == 'update') {
     $form['available_backends']['#markup'] = format_plural(
       count($available_backends),
-      'Updating modules and themes requires <strong>@backends access</strong> to your server. See the <a href="@handbook_url">handbook</a> for other update methods.',
-      'Updating modules and themes requires access to your server via one of the following methods: <strong>@backends</strong>. See the <a href="@handbook_url">handbook</a> for other update methods.',
+      'Updating modules, themes and layouts requires <strong>@backends access</strong> to your server. See the <a href="@handbook_url">handbook</a> for other update methods.',
+      'Updating modules, themes and layouts requires access to your server via one of the following methods: <strong>@backends</strong>. See the <a href="@handbook_url">handbook</a> for other update methods.',
       array(
         '@backends' => implode(', ', $backend_names),
         '@handbook_url' => 'http://drupal.org/getting-started/install-contrib',
@@ -588,8 +588,8 @@ function _update_manager_check_backends(&$form, $operation) {
   else {
     $form['available_backends']['#markup'] = format_plural(
       count($available_backends),
-      'Installing modules and themes requires <strong>@backends access</strong> to your server. See the <a href="@handbook_url">handbook</a> for other installation methods.',
-      'Installing modules and themes requires access to your server via one of the following methods: <strong>@backends</strong>. See the <a href="@handbook_url">handbook</a> for other installation methods.',
+      'Installing modules, themes and layouts requires <strong>@backends access</strong> to your server. See the <a href="@handbook_url">handbook</a> for other installation methods.',
+      'Installing modules, themes and layouts requires access to your server via one of the following methods: <strong>@backends</strong>. See the <a href="@handbook_url">handbook</a> for other installation methods.',
       array(
         '@backends' => implode(', ', $backend_names),
         '@handbook_url' => 'http://drupal.org/getting-started/install-contrib',

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -4,10 +4,10 @@
  * Handles updates of Backdrop core and contributed projects.
  *
  * The module checks for available updates of Backdrop core and any installed
- * contributed modules and themes. It warns site administrators if newer
+ * contributed modules, themes and layouts. It warns site administrators if newer
  * releases are available via the system status report (admin/reports/status),
- * the module and theme pages, and optionally via e-mail. It also provides the
- * ability to install contributed modules and themes via an user interface.
+ * the module, theme and layout pages, and optionally via e-mail. It also provides the
+ * ability to install contributed modules, themes and layouts via an user interface.
  */
 
 /**
@@ -129,7 +129,7 @@ function update_menu() {
 
   $items['admin/reports/updates'] = array(
     'title' => 'Available updates',
-    'description' => 'Get a status report about available updates for your installed modules and themes.',
+    'description' => 'Get a status report about available updates for your installed modules, themes and layouts.',
     'page callback' => 'update_status',
     'access arguments' => array('administer site configuration'),
     'weight' => -50,
@@ -158,7 +158,7 @@ function update_menu() {
   );
 
   // We want action links for updating projects at a few different locations:
-  // both the module and theme administration pages, and on the available
+  // on the Module, theme and layout administration pages, and on the available
   // updates report itself. The menu items will be mostly identical, except the
   // paths and titles, so we just define them in a loop. We pass in a string
   // indicating what context we're entering the action from, so that can
@@ -191,7 +191,7 @@ function update_menu() {
   }
   // Customize the titles of the action links depending on where they appear.
   // We use += array() to let the translation extractor find these menu titles.
-  $items['admin/reports/updates/install'] += array('title' => 'Install module or theme');
+  $items['admin/reports/updates/install'] += array('title' => 'Install module, theme or layout');
   $items['admin/modules/install'] += array('title' => 'Install module');
   $items['admin/appearance/install'] += array('title' => 'Install theme');
 
@@ -644,10 +644,10 @@ function update_verify_update_archive($project, $archive_file, $directory) {
   $incompatible = array();
   $files = file_scan_directory("$directory/$project", '/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.info$/', array('key' => 'name', 'min_depth' => 0));
   foreach ($files as $key => $file) {
-    // Get the .info file for the module or theme this file belongs to.
+    // Get the .info file for the module, theme or layout this file belongs to.
     $info = backdrop_parse_info_file($file->uri);
 
-    // If the module or theme is incompatible with Backdrop core, set an error.
+    // If the module, theme or layout is incompatible with Backdrop core, set an error.
     if (empty($info['backdrop']) || $info['backdrop'] != BACKDROP_CORE_COMPATIBILITY) {
       $incompatible[] = !empty($info['name']) ? $info['name'] : t('Unknown');
     }

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -90,6 +90,7 @@ function update_init() {
       // of the update status.
       case 'admin/appearance':
       case 'admin/modules':
+      case 'admin/structure/layouts':
         $verbose = TRUE;
         break;
 
@@ -167,6 +168,7 @@ function update_menu() {
     'report' => 'admin/reports/updates',
     'module' => 'admin/modules',
     'theme' => 'admin/appearance',
+    'layout' => 'admin/structure/layouts',
   );
   foreach ($paths as $context => $path) {
     $items[$path . '/install'] = array(
@@ -194,6 +196,7 @@ function update_menu() {
   $items['admin/reports/updates/install'] += array('title' => 'Install module, theme or layout');
   $items['admin/modules/install'] += array('title' => 'Install module');
   $items['admin/appearance/install'] += array('title' => 'Install theme');
+  $items['admin/structure/layouts/install'] += array('title' => 'Install layout');
 
   // Menu callback used for the confirmation page after all the releases
   // have been downloaded, asking you to backup before installing updates.

--- a/core/modules/update/update.theme.inc
+++ b/core/modules/update/update.theme.inc
@@ -70,7 +70,7 @@ function theme_update_report($variables) {
 
   $notification_level = config_get('update.settings', 'update_threshold');
 
-  // Create an array of status values keyed by module or theme name, since
+  // Create an array of status values keyed by module, theme or layout name, since
   // we'll need this while generating the report if we have to cross reference
   // anything (e.g. subthemes which have base themes missing an update).
   foreach ($data as $project) {

--- a/core/modules/update/update.theme.inc
+++ b/core/modules/update/update.theme.inc
@@ -261,8 +261,10 @@ function theme_update_report($variables) {
     'core' => t('Backdrop CMS'),
     'module' => t('Modules'),
     'theme' => t('Themes'),
+    'layout' => t('Layouts'),
     'module-disabled' => t('Disabled modules'),
     'theme-disabled' => t('Disabled themes'),
+    'layout-disabled' => t('Disabled layouts'),
   );
   foreach ($project_types as $type_name => $type_label) {
     if (!empty($rows[$type_name])) {


### PR DESCRIPTION
First pass at fixing https://github.com/backdrop/backdrop-issues/issues/958.
Issues with this patch: 
`system.updater.inc has a new`LayoutUpdater` class with the following which is a bit shaky:

```
  static function canUpdateDirectory($directory) {
    // This is a lousy test, but don't know how else to confirm it is a layout.
    if (file_scan_directory($directory, '/(?=.*template\.php$)|(?=.*\.module$)/')) {
      return FALSE;
    }
    elseif (file_scan_directory($directory, '/.*layout--.*/')) {
      return TRUE;
    }
    return FALSE;
  }
```

This would be easier if we got in https://github.com/backdrop/backdrop-issues/issues/960.

Also, in `update.compare.inc` theres a temporary function 

```
//temp todo
function _system_rebuild_layout_data() {
  // Find modules
  $layout_data = layout_get_layout_info();
  foreach($layout_data as $layout) {
    $name = $layout['name'];
    $layouts[$name] = new stdClass();
    $layouts[$name]->name = $name;
    $layouts[$name]->uri = $layout['path'] . '/' . $name . '.info';
    $layouts[$name]->info = $layout;
    $layouts[$name]->status = 1;
  }

  return $layouts;
}
```

for compatibility with `system_rebuild_theme_data()` and the module one. There may be a pre-existing function which I cant find. If not do we need to create this function? will just a stub like this (renamed to `_update__rebuild_layout_data()` maybe?) do for now?
