### PR TITLE
Issue #2356983 by bzrudi71, Dave Reid, jaredsmith: SystemQueue::claimItem() sometimes returns items in the wrong order (resolves locale test failures on PostgreSQL).

### DIFF
--- a/core/modules/system/system.queue.inc
+++ b/core/modules/system/system.queue.inc
@@ -230,7 +230,7 @@ class SystemQueue implements BackdropReliableQueueInterface {
     // until an item is successfully claimed or we are reasonably sure there
     // are no unclaimed items left.
     while (TRUE) {
-      $item = db_query_range('SELECT data, item_id FROM {queue} q WHERE expire = 0 AND name = :name ORDER BY created ASC', 0, 1, array(':name' => $this->name))->fetchObject();
+      $item = db_query_range('SELECT data, item_id FROM {queue} q WHERE expire = 0 AND name = :name ORDER BY created, item_id ASC', 0, 1, array(':name' => $this->name))->fetchObject();
       if ($item) {
         // Try to update the item. Only one thread can succeed in UPDATEing the
         // same row. We cannot rely on REQUEST_TIME because items might be


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/918
