### PR TITLE
Issue #2457743 by skein: translation_remove_from_set() runs unnecessary queries to fetch and update every single node with tnid 0.

### DIFF
--- a/core/modules/translation/translation.module
+++ b/core/modules/translation/translation.module
@@ -440,7 +440,7 @@ function translation_node_predelete(Node $node) {
  *   A node entity.
  */
 function translation_remove_from_set($node) {
-  if (isset($node->tnid)) {
+  if (isset($node->tnid) && $node->tnid) {
     $query = db_update('node')
       ->fields(array(
         'tnid' => 0,


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/918
