### PR TITLE
Issue #2331151 by David_Rothstein, Devin Carlson: Remove leftover code in testFileValidateSize() which runs the tests as a specific user.

### DIFF
--- a/core/modules/simpletest/tests/file.test
+++ b/core/modules/simpletest/tests/file.test
@@ -466,13 +466,6 @@ class FileValidatorTest extends BackdropWebTestCase {
    * Test file_validate_size().
    */
   function testFileValidateSize() {
-    global $user;
-    $original_user = $user;
-    backdrop_save_session(FALSE);
-
-    // Run these tests as a regular user.
-    $user = $this->backdropCreateUser();
-
     // Create a file with a size of 1000 bytes, and quotas of only 1 byte.
     $file = entity_create('file', array('filesize' => 1000));
     $errors = file_validate_size($file, 0, 0);
@@ -483,9 +476,6 @@ class FileValidatorTest extends BackdropWebTestCase {
     $this->assertEqual(count($errors), 1, 'Error for the user being over their limit.', 'File');
     $errors = file_validate_size($file, 1, 1);
     $this->assertEqual(count($errors), 2, 'Errors for both the file and their limit.', 'File');
-
-    $user = $original_user;
-    backdrop_save_session(TRUE);
   }
 }
 


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/918
