### PR TITLE
Issue #2364047 by JvE, dcam: Fix missing file definitions in hook_theme() in the Update Manager module.

### DIFF
--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -243,13 +243,16 @@ function update_theme() {
     ) + $base,
     'update_report' => array(
       'variables' => array('data' => NULL),
-    ) + $base,
+      'file' => 'update.report.inc',
+    ),
     'update_version' => array(
       'variables' => array('version' => NULL, 'tag' => NULL, 'class' => array()),
-    ) + $base,
+      'file' => 'update.report.inc',
+    ),
     'update_status_label' => array(
       'variables' => array('status' => NULL),
-    ) + $base,
+      'file' => 'update.report.inc',
+    ),
   );
 }
 


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/918
