### PR TITLE
Issue #968: add the convenience function entity_load_single().

### DIFF
--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -221,6 +221,22 @@ function entity_load($entity_type, $ids = FALSE, $conditions = array(), $reset =
 }
 
 /**
+ * Loads a single entity from the database.
+ *
+ * @param string $entity_type
+ *   The entity type to load, e.g. node or user.
+ * @param int $id
+ *   The ID of the entity to load.
+ *
+ * @return EntityInterface|bool
+ *   The fully loaded entity or FALSE if not found.
+ */
+function entity_load_single($entity_type, $id) {
+  $result = entity_load($entity_type, array($id));
+  return reset($result);
+}
+
+/**
  * Loads the unchanged, i.e. not modified, entity from the database.
  *
  * Unlike entity_load() this function ensures the entity is directly loaded from


### PR DESCRIPTION
My gut says entity_load() and entity_load_multiple() are better, given the singular nature of entity_load_unchanged(), but in case that's logistically impossible for some time, here's a pull request.
