### PR TITLE
Issue #981: add h3, h4, h5 and p to the filtered_html allowed tags.

### DIFF
--- a/core/modules/filter/filter.api.php
+++ b/core/modules/filter/filter.api.php
@@ -84,7 +84,7 @@ function hook_filter_info() {
     'process callback' => '_filter_html',
     'settings callback' => '_filter_html_settings',
     'default settings' => array(
-      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd>',
+      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h3> <h4> <h5> <p>',
       'filter_html_help' => 1,
       'filter_html_nofollow' => 0,
     ),

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -1161,7 +1161,7 @@ function filter_filter_info() {
     'process callback' => '_filter_html',
     'settings callback' => '_filter_html_settings',
     'default settings' => array(
-      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd>',
+      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h3> <h4> <h5> <p>',
       'filter_html_help' => 1,
       'filter_html_nofollow' => 0,
     ),

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -1077,7 +1077,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
     // Setup dummy filter object.
     $filter = new stdClass();
     $filter->settings = array(
-      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd>',
+      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h3> <h4> <h5> <p>',
       'filter_html_help' => 1,
       'filter_html_nofollow' => 0,
     );


### PR DESCRIPTION
This solves https://github.com/backdrop/backdrop-issues/issues/981
