### PR TITLE
#126: [DX] Rename the .gitignore file and (optionally) ignore it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore this file so it can be changed 
-.gitignore
+#.gitignore
 
 # Ignore configuration files that may contain sensitive information.
 settings.php


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/126

@jenlampton I may have misunderstood the issue, but it seems like `example.gitignore` is already gone and the `.gitignore` documentation is already pretty cleaned up.
