### PR TITLE
Issue #755: Styled fieldsets as per Darius's updates

### DIFF
--- a/core/modules/system/css/system.css
+++ b/core/modules/system/css/system.css
@@ -60,12 +60,6 @@
  *
  * @see collapse.js
  */
-.js fieldset.collapsed {
-  border-bottom-width: 0;
-  border-left-width: 0;
-  border-right-width: 0;
-  height: 1em;
-}
 .js fieldset.collapsed .fieldset-wrapper {
   display: none;
 }

--- a/core/modules/system/css/system.theme.css
+++ b/core/modules/system/css/system.theme.css
@@ -8,8 +8,14 @@
  * HTML elements.
  */
 fieldset {
+  min-width: 0; /* Webkit/Blink fix for mobile */
   margin-bottom: 1em;
   padding: 0.5em;
+}
+@-moz-document url-prefix() {
+  fieldset {
+    display: table-cell; /* Firefox mobile fix */
+  }
 }
 form {
   margin: 0;
@@ -203,20 +209,20 @@ abbr.form-required, abbr.tabledrag-changed, abbr.ajax-changed {
  *
  * @see collapse.js
  */
-.js fieldset.collapsible .fieldset-legend a {
+.js fieldset.collapsible .fieldset-title {
   background: url(../../../misc/menu-expanded.png) 5px 65% no-repeat; /* LTR */
   padding-left: 15px; /* LTR */
 }
-.js[dir="rtl"] fieldset.collapsible .fieldset-legend a {
+.js[dir="rtl"] fieldset.collapsible .fieldset-title {
   background-position: 98% 75%;
   padding-left: 0;
   padding-right: 15px;
 }
-.js fieldset.collapsed .fieldset-legend a {
+.js fieldset.collapsed .fieldset-title {
   background-image: url(../../../misc/menu-collapsed.png); /* LTR */
   background-position: 5px 50%; /* LTR */
 }
-.js[dir="rtl"] fieldset.collapsed .fieldset-legend a {
+.js[dir="rtl"] fieldset.collapsed .fieldset-title {
   background-image: url(../../../misc/menu-collapsed-rtl.png);
   background-position: 98% 50%;
 }

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -623,25 +623,47 @@ tr.selected td {
  *   to apply all padding to the inner .fieldset-wrapper instead.
  */
 fieldset {
-  border: 1px solid #ccc;
-  padding: 2.5em 0 0 0; /* LTR */
   position: relative;
+  max-width: 100%;
   margin: 1em 0;
+  padding: 3em 0 0 0; /* LTR */
+  border-radius: 4px;
+  background-color:#fff;
+  border:solid 2px #EAEAEA;
+  min-width: 0;
 }
 [dir="rtl"] fieldset {
-  padding: 2.5em 0 0 0;
+  padding: 2.5em 0 0;
 }
 fieldset .fieldset-legend {
-  margin-top: 0.5em;
-  padding-left: 15px; /* LTR */
+  position: absolute;
   left: 0; /* LTR */
   top: 0;
-  position: absolute;
+  width: 100%;
+  margin-top: .35em;
+  padding-left: 15px; /* LTR */
   text-transform: uppercase;
 }
 [dir="rtl"] fieldset .fieldset-legend {
-  padding-right: 15px;
   right: 0;
+  padding-right: 15px;
+  padding-left: 0;
+}
+legend {
+  font-size: 120%;
+  font-weight: normal;
+}
+fieldset fieldset {
+  background-color: #fff;
+}
+fieldset fieldset fieldset {
+  background-color: #f8f8f8;
+}
+/**
+ * Collapsible Fieldsets
+ */
+.js fieldset.collapsible {
+  position: relative;
 }
 fieldset .fieldset-wrapper {
   padding: 0 13px 13px 15px; /* LTR */
@@ -649,18 +671,49 @@ fieldset .fieldset-wrapper {
 [dir="rtl"] fieldset .fieldset-wrapper {
   padding: 0 15px 13px 13px;
 }
-fieldset.collapsed {
-  background-color: transparent;
+.js fieldset.collapsible .fieldset-title {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 94%; /* IE8 fallback */
+  width: calc(100% - 4em);
+  padding: .3em .3em .3em 1.8em;
+  margin: 0 -.5em;
+  border-radius: 4px;
+  background: transparent;
 }
+.js fieldset.collapsible .fieldset-legend a:before {
+  content: "";
+  position: absolute;
+  left: .6em;
+  top: .8em;
+  width: 0;
+  height: 0;
+  border: .32em solid transparent;
+  border-top-color: #000;
+  border-bottom: 0;
+}
+
+.fieldset-legend span.summary {
+  position: absolute;
+  top: .4em;
+  right: 2em;
+  display: none;
+}
+@media (min-width: 450px) {
+  .fieldset-legend span.summary {
+    display: block;
+  }
+}
+/* Collapsed state styles */
 .js fieldset.collapsed {
-  border-width: 1px;
-  height: auto;
+  padding: 1.6em 0;
 }
-fieldset fieldset {
-  background-color: #fff;
-}
-fieldset fieldset fieldset {
-  background-color: #f8f8f8;
+.js fieldset.collapsed .fieldset-legend a:before {
+  left: .8em;
+  top: .7em;
+  border: .32em solid transparent;
+  border-left-color: black;
 }
 
 /**
@@ -692,6 +745,9 @@ div.teaser-checkbox .form-item,
 .form-item label {
   margin: 0;
   padding: 0 0 10px;
+}
+fieldset label {
+  font-weight: normal;
 }
 .form-item label.option {
   font-size: 0.923em;
@@ -902,6 +958,13 @@ textarea.form-textarea {
   -moz-transition: all 0.25s ease-in-out;
   -ms-transition: all 0.25s ease-in-out;
   -o-transition: all 0.25s ease-in-out;
+}
+input.form-text,
+input.form-email,
+input.form-url,
+input.form-search,
+textarea.form-textarea {
+  max-width: 100%;
 }
 select.form-select {
   font-weight: 400;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/755

Darius's design: http://codepen.io/dariusgarza/pen/qdjxbe
Made fields responsive so they can't be any wider than their container
Fixed an issue with Safari, Blink, and Firefox where fields inside of fieldsets would not respect max-width
- Safari/Blink has a hidden property min-content, setting min-width to 0 fixes that
- Firefox needs fieldsets to be set to display: table-cell, which can cause issues on other browsers, so that's set in a moz-document query
  Also simplified some of the core styles to make theming fieldsets a little easier with little change to default
