### PR TITLE
Issue #983: ensure all [entity]_save() functions return SAVED_NEW or SAVED_UPDATED with proper docs.

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -604,15 +604,14 @@ function file_load($fid) {
 }
 
 /**
- * Saves a file entity to the database.
- *
- * If the $file->fid is not set a new record will be added.
+ * Saves a new or updated file.
  *
  * @param File $file
- *   A file object returned by file_load().
+ *   A file object returned by file_load(). If the $file->fid is not set a new
+ *   record will be added.
  *
- * @return
- *   Either SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
+ * @return int
+ *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
  *
  * @see hook_file_insert()
  * @see hook_file_update()

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1485,13 +1485,16 @@ function comment_access($op, $comment) {
 }
 
 /**
- * Accepts a submission of new or changed comment content.
+ * Saves a new or updated comment.
  *
  * @param Comment $comment
  *   A comment entity.
+ *
+ * @return int
+ *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
  */
 function comment_save(Comment $comment) {
-  $comment->save();
+  return $comment->save();
 }
 
 /**

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -445,9 +445,8 @@ interface EntityStorageControllerInterface extends EntityControllerInterface {
    * @param EntityInterface $entity
    *   The entity to save.
    *
-   * @return
-   *   SAVED_NEW or SAVED_UPDATED is returned depending on the operation
-   *   performed.
+   * @return int
+   *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
    *
    * @throws EntityStorageException
    *   In case of failures, an exception is thrown.

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -940,14 +940,17 @@ function node_submit($node) {
 }
 
 /**
- * Saves changes to a node or adds a new node.
+ * Saves a new or updated node.
  *
  * @param Node $node
- *   The $node entity to be saved. If $node->nid is
- *   omitted (or $node->is_new is TRUE), a new node will be added.
+ *   The $node entity to be saved. If $node->nid is omitted (or $node->is_new
+ *   is TRUE), a new node will be added.
+ *
+ * @return int
+ *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
  */
 function node_save(Node $node) {
-  $node->save();
+  return $node->save();
 }
 
 /**

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -383,14 +383,13 @@ function taxonomy_vocabulary_title(TaxonomyVocabulary $vocabulary) {
 }
 
 /**
- * Saves a vocabulary.
+ * Saves a new or updated taxonomy vocabulary.
  *
  * @param TaxonomyVocabulary $vocabulary
  *   The taxonomy vocabulary entity to be saved.
  *
- * @return
- *   Status constant indicating whether the vocabulary was inserted (SAVED_NEW)
- *   or updated (SAVED_UPDATED).
+ * @return int
+ *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
  */
 function taxonomy_vocabulary_save(TaxonomyVocabulary $vocabulary) {
   return $vocabulary->save();
@@ -492,15 +491,13 @@ function taxonomy_check_vocabulary_hierarchy(TaxonomyVocabulary $vocabulary, $ch
 }
 
 /**
- * Saves a term object to the database.
+ * Saves a new or updated taxonomy term.
  *
  * @param TaxonomyTerm $term
  *   The taxonomy term entity to be saved.
  *
- * @return
- *   Status constant indicating whether term was inserted (SAVED_NEW) or updated
- *   (SAVED_UPDATED). When inserting a new term, $term->tid will contain the
- *   term ID of the newly created term.
+ * @return int
+ *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
  */
 function taxonomy_term_save(TaxonomyTerm $term) {
   return $term->save();

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -258,18 +258,17 @@ function user_load_by_name($name) {
 }
 
 /**
- * Save changes to a user account or add a new user.
+ * Save a new or updated user.
  *
  * @param $account
- *   The user object to modify or add. If you want to modify
- *   an existing user account, you will need to ensure that (a) $account
- *   is an object, and (b) you have set $account->uid to the numeric
- *   user ID of the user account you wish to modify. If you
- *   want to create a new user account, you can set $account->is_new to
- *   TRUE or omit the $account->uid field.
+ *   The user object to modify or add. If you want to modify an existing user
+ *   account, you need to ensure that (a) $account is an object, and (b) you
+ *   have set $account->uid to the numeric user ID of the user account you wish
+ *   to modify. If you want to create a new user account, you can set
+ *   $account->is_new to TRUE or omit the $account->uid field.
  *
- * @return
- *   The saved $user object upon successful save or FALSE if the save failed.
+ * @return int
+ *   Either SAVED_NEW or SAVED_UPDATED depending on the operation performed.
  */
 function user_save($account) {
   return $account->save();


### PR DESCRIPTION
Addresses the documentation issue surfaced in: https://github.com/backdrop/backdrop-issues/issues/983

I didn't update the $account parameter documentation on user_save() to include the entity class name as the other functions, because I wasn't sure if there was code saving accounts with stdClass objects. (That said, I don't even see any place in core calling the function except a single test.)
