### PR TITLE
Issue #988: Converted layouts admin to flexbox with fallbacks

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -13,16 +13,61 @@
 }
 
 /* Individual layout settings form. */
-.layout-settings-form .layout-options {
+.layout-settings-form .form-type-radios {
   width: 100%;
 }
+.layout-settings-form .layout-options .form-radios {
+  display: block\9; /* IE 9 and down fallback */
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-wrap: wrap; /* Required for current Safari */
+  flex-wrap: wrap;
+  line-height: 1.3;
+}
 .layout-settings-form .layout-options .form-type-radio {
-  float: left;
+  width: 100px;
+  margin: 0 5px 5px 0;
+  padding: 0;
   text-align: center;
+  float: left\9; /* IE 9 and down fallback */
+}
+/**
+ * Pretty block radios, `div:not(#foo) >` rules out browsers that can't support this
+ */
+main:not(#foo) > .layout-settings-form .layout-options .form-type-radio input {
+  display: none;
+}
+.layout-settings-form .layout-options .form-type-radio label {
+  position: relative;
+  z-index: 2; /* Fix IE issue clicking on image doesn't trigger radio */
+  display: block;
+  min-height: 144px;
+  padding: .6em;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  -webkit-transition: border-color 0.25s ease-in-out;
+  -moz-transition: border-color 0.25s ease-in-out;
+  -ms-transition: border-color 0.25s ease-in-out;
+  -o-transition: border-color 0.25s ease-in-out;
+  will-change: border-color;
+}
+.layout-settings-form .layout-options .form-type-radio:hover label {
+  border-color: #d0d0d0;
+}
+.layout-settings-form .layout-options .form-type-radio input:checked + label {
+  border-color: #CFDE56;
+  background: #E9EEBC;
 }
 .layout-settings-form .layout-icon .caption {
-  width: 90px;
-  margin-bottom: 1em;
+}
+.layout-settings-form .layout-options .form-type-radio img {
+  position: relative;
+  z-index: -1; /* Fix IE issue clicking on image doesn't trigger radio */
+  padding: 4px;
+  border-radius: 4px;
+  background: #ffffff;
 }
 
 /* Menu item argument settings. */


### PR DESCRIPTION
**Dependent on Issue PR #955 to work right**

The proper layout works in IE10+, FF22+, Chrome 21+, Safari on OSX Mt Lion+, Safari on iOS7+, Android 2.1+
The fallback works on IE 9 and down
We're leaving Safari on iOS 6 and down and Safari 6 and down in an awkward spot
If we add modernizr the fallback works on everything
Also added prettier radios, hid the radio element and instead the image/text selects using the radio element (the lable triggers the radio)
![backdrop-988](https://cloud.githubusercontent.com/assets/5607236/8146523/695bb898-120a-11e5-9e8a-b12574ef5c44.gif)
