### PR TITLE
Issue #85: Avoid long cache lifetime on the maintenance page.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5591,6 +5591,11 @@ function backdrop_page_set_cache() {
       }
     }
 
+    if (state_get('maintenance_mode', FALSE)) {
+      // Cache maintenance pages for 10 seconds.
+      $cache->expire = REQUEST_TIME + config_get('system.core', 'maintenance_page_lifetime');
+    }
+
     if ($cache->data['body']) {
       if ($page_compressed) {
         $cache->data['body'] = gzencode($cache->data['body'], 9, FORCE_GZIP);

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -32,6 +32,7 @@
     "log_facility": "",
     "log_format": "!base_url|!timestamp|!type|!ip|!request_uri|!referer|!uid|!link|!message",
     "maintenance_mode_message": "@site is currently under maintenance. We should be back shortly. Thank you for your patience.",
+    "maintenance_page_lifetime": "10",
     "menu_route_handler": null,
     "node_admin_theme": "",
     "page_cache_maximum_age": 300,

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2526,6 +2526,13 @@ function system_update_1039() {
 }
 
 /**
+ * Provide a default value for maintenance_page_lifetime.
+ */
+function system_update_1040() {
+  config_set('system.core', 'maintenance_page_lifetime', 10);
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1043,14 +1043,24 @@ class SiteMaintenanceTestCase extends BackdropWebTestCase {
     $this->backdropGet('');
     $this->assertRaw($admin_message, 'Found the site maintenance mode message.');
 
-    // Logout and verify that offline message is displayed.
+    // Logout and verify that offline message is displayed and maintenance page
+    // will not be cached by external caches like varnish.
     $this->backdropLogout();
+
     $this->backdropGet('');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
+
     $this->backdropGet('node');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
+
     $this->backdropGet('user/register');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
 
     // Verify that user is able to log in.
     $this->backdropGet('user');


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/85
Replaces https://github.com/backdrop/backdrop/pull/594
