### PR TITLE
Issue #911: Why doesnt backdrop_parse_info_file() list 'settings' as an allowed key?.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -7735,8 +7735,7 @@ function backdrop_write_record($table, &$record, $primary_keys = array()) {
  * - screenshot: Path to screenshot relative to the theme's .info file.
  * - engine: Theme engine; typically phptemplate.
  * - base: Name of a base theme, if applicable; e.g., base = zen.
- * - regions: Listed regions; e.g., region[left] = Left sidebar.
- * - features: Features available; e.g., features[] = logo.
+ * - settings: Theme settings; e.g., settings[color] = true
  * - stylesheets: Theme stylesheets; e.g., stylesheets[all][] = my-style.css.
  * - scripts: Theme scripts; e.g., scripts[] = my-script.js.
  *


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/911
