### PR TITLE
Issue #999: [UX] Improve the vocabulary and view creation forms buttons and make them consistent with the content type creation form.

### DIFF
--- a/core/modules/taxonomy/taxonomy.admin.inc
+++ b/core/modules/taxonomy/taxonomy.admin.inc
@@ -88,7 +88,7 @@ function taxonomy_form_vocabulary($form, &$form_state, TaxonomyVocabulary $vocab
   // During initial form build, add the entity to the form state for use
   // during form building and processing. During a rebuild, use what is in the
   // form state.
- if (!isset($form_state['vocabulary'])) {
+  if (!isset($form_state['vocabulary'])) {
     // Create a new TaxonomyVocabulary entity for the add form.
     if (!isset($vocabulary)) {
       $vocabulary = new TaxonomyVocabulary();
@@ -128,11 +128,21 @@ function taxonomy_form_vocabulary($form, &$form_state, TaxonomyVocabulary $vocab
     '#type' => 'value',
     '#value' => '0',
   );
-
   $form['actions'] = array('#type' => 'actions');
-  $form['actions']['submit'] = array(
+  if ($vocabulary->machine_name == NULL)  {
+    // Only show 'Save and add terms' button when creating new vocabulary.
+    $form['actions']['continue'] = array(
+      '#type' => 'submit',
+      '#value' => t('Save and add terms'),
+      '#validate' => array('taxonomy_form_vocabulary_validate'),
+      '#submit' => array('taxonomy_form_vocabulary_store_edit_submit'),
+    );
+  }
+  $form['actions']['save'] = array(
     '#type' => 'submit',
-    '#value' => t('Save'),
+    '#value' => t('Save vocabulary'),
+    '#validate' => array('taxonomy_form_vocabulary_validate'),
+    '#submit' => array('taxonomy_form_vocabulary_submit'),
   );
 
   return $form;
@@ -161,7 +171,42 @@ function taxonomy_form_vocabulary_validate($form, &$form_state) {
 }
 
 /**
- * Form submission handler for taxonomy_form_vocabulary().
+ * Process the add vocabulary form, 'continue'.
+ *
+ * @see taxonomy_form_vocabulary()
+ * @see taxonomy_form_vocabulary_validate()
+ */
+function taxonomy_form_vocabulary_store_edit_submit($form, &$form_state) {
+  if ($form_state['triggering_element']['#value'] == t('Delete')) {
+    // Rebuild the form to confirm vocabulary deletion.
+    $form_state['rebuild'] = TRUE;
+    $form_state['confirm_delete'] = TRUE;
+    return;
+  }
+
+  $vocabulary = $form_state['vocabulary'];
+  entity_form_submit_build_entity('taxonomy_vocabulary', $vocabulary, $form, $form_state);
+
+  // Prevent leading and trailing spaces in vocabulary names.
+  $vocabulary->name = trim($vocabulary->name);
+
+  switch (taxonomy_vocabulary_save($vocabulary)) {
+    case SAVED_NEW:
+      backdrop_set_message(t('Created new vocabulary %name.', array('%name' => $vocabulary->name)));
+      watchdog('taxonomy', 'Created new vocabulary %name.', array('%name' => $vocabulary->name), WATCHDOG_NOTICE, l(t('edit'), 'admin/structure/taxonomy/' . $vocabulary->machine_name . '/edit'));
+      $form_state['redirect'] = 'admin/structure/taxonomy/' . $vocabulary->machine_name . '/add';
+      break;
+
+    case SAVED_UPDATED:
+      backdrop_set_message(t('Updated vocabulary %name.', array('%name' => $vocabulary->name)));
+      watchdog('taxonomy', 'Updated vocabulary %name.', array('%name' => $vocabulary->name), WATCHDOG_NOTICE, l(t('edit'), 'admin/structure/taxonomy/' . $vocabulary->machine_name . '/edit'));
+      $form_state['redirect'] = 'admin/structure/taxonomy/' . $vocabulary->machine_name . '/add';
+      break;
+  }
+}
+
+/**
+ * Process the add view form, 'save'.
  *
  * @see taxonomy_form_vocabulary()
  * @see taxonomy_form_vocabulary_validate()
@@ -639,6 +684,7 @@ function taxonomy_form_term($form, &$form_state, TaxonomyTerm $term = NULL, Taxo
     $path = '<front>';
   }
   $options = backdrop_parse_url($path);
+  $options['path'] = !strpos($options['path'], 'taxonomy/add') ? $options['path'] : 'admin/structure/taxonomy/';
   $options['attributes']['class'][] = 'form-cancel';
 
   $form['actions'] = array('#type' => 'actions');

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -59,14 +59,25 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     // Visit the main taxonomy administration page.
     $this->backdropGet('admin/structure/taxonomy');
 
-    // Create a new vocabulary.
+    // Create a new vocabulary and then add terms.
     $this->clickLink(t('Add vocabulary'));
     $edit = array();
     $machine_name = backdrop_strtolower($this->randomName());
     $edit['name'] = $this->randomName();
     $edit['description'] = $this->randomName();
     $edit['machine_name'] = $machine_name;
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->backdropPost(NULL, $edit, t('Save and add terms'));
+    $this->assertRaw(t('Created new vocabulary %name.', array('%name' => $edit['name'])));
+
+    // Create a new vocabulary.
+    $this->backdropGet('admin/structure/taxonomy');
+    $this->clickLink(t('Add vocabulary'));
+    $edit = array();
+    $machine_name = backdrop_strtolower($this->randomName());
+    $edit['name'] = $this->randomName();
+    $edit['description'] = $this->randomName();
+    $edit['machine_name'] = $machine_name;
+    $this->backdropPost(NULL, $edit, t('Save vocabulary'));
     $this->assertRaw(t('Created new vocabulary %name.', array('%name' => $edit['name'])), 'Vocabulary created successfully.');
 
     // Edit the vocabulary.
@@ -75,18 +86,18 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     $this->clickLink(t('Edit vocabulary'));
     $edit = array();
     $edit['name'] = $this->randomName();
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->backdropPost(NULL, $edit, t('Save vocabulary'));
     $this->backdropGet('admin/structure/taxonomy');
     $this->assertText($edit['name'], 'Vocabulary found in the vocabulary overview listing.');
 
     // Try to submit a vocabulary with a duplicate machine name.
     $edit['machine_name'] = $machine_name;
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
     $this->assertText(t('The machine-readable name is already in use. It must be unique.'));
 
     // Try to submit an invalid machine name.
     $edit['machine_name'] = '!&^%';
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
     $this->assertText(t('The machine-readable name must contain only lowercase letters, numbers, and underscores.'));
 
     // Ensure that vocabulary titles are escaped properly.
@@ -94,7 +105,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     $edit['name'] = 'Don\'t Panic';
     $edit['description'] = $this->randomName();
     $edit['machine_name'] = 'don_t_panic';
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
 
     $site_name = config_get('system.core', 'site_name');
     $this->backdropGet('admin/structure/taxonomy/don_t_panic');
@@ -155,7 +166,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
       'name' => $this->randomName(),
       'machine_name' => $vocabulary_name,
     );
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
     $this->assertText(t('Created new vocabulary'), 'New vocabulary was created.');
 
     // Check the created vocabulary.

--- a/core/modules/views/tests/views_ui.test
+++ b/core/modules/views/tests/views_ui.test
@@ -34,7 +34,7 @@ class ViewsUIWizardBasicTestCase extends ViewsUIWizardHelper {
     $view1['name'] = strtolower($this->randomName(16));
     $view1['description'] = $this->randomName(16);
     $view1['page[create]'] = FALSE;
-    $this->backdropPost('admin/structure/views/add', $view1, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view1, t('Save view'));
     $this->assertText(t('Your view was saved. You may edit it from the list below.'));
     $this->assertText($view1['human_name']);
     $this->assertText($view1['description']);
@@ -60,7 +60,7 @@ class ViewsUIWizardBasicTestCase extends ViewsUIWizardHelper {
     $view2['page[path]'] = $this->randomName(16);
     $view2['page[feed]'] = 1;
     $view2['page[feed_properties][path]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view2, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view2, t('Save view'));
 
     // Since the view has a page, we expect to be automatically redirected to
     // it.
@@ -105,7 +105,7 @@ class ViewsUIWizardBasicTestCase extends ViewsUIWizardHelper {
     $view3['page[path]'] = $this->randomName(16);
     $view3['block[create]'] = 1;
     $view3['block[title]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view3, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view3, t('Save view'));
 
     // Make sure the view only displays the node we expect.
     $this->assertUrl($view3['page[path]']);
@@ -321,7 +321,7 @@ class ViewsUIWizardTaggedWithTestCase extends ViewsUIWizardHelper {
     $view1['page[create]'] = 1;
     $view1['page[title]'] = $this->randomName(16);
     $view1['page[path]'] = $this->randomName(16);
-    $this->backdropPost(NULL, $view1, t('Save & exit'));
+    $this->backdropPost(NULL, $view1, t('Save view'));
     // Visit the page and check that the nodes we expect are present and the
     // ones we don't expect are absent.
     $this->backdropGet($view1['page[path]']);
@@ -341,7 +341,7 @@ class ViewsUIWizardTaggedWithTestCase extends ViewsUIWizardHelper {
     $view2['page[create]'] = 1;
     $view2['page[title]'] = $this->randomName(16);
     $view2['page[path]'] = $this->randomName(16);
-    $this->backdropPost(NULL, $view2, t('Save & exit'));
+    $this->backdropPost(NULL, $view2, t('Save view'));
     $this->backdropGet($view2['page[path]']);
     $this->assertNoText($node_tag1_title);
     $this->assertText($node_tag1_tag2_title);
@@ -404,7 +404,7 @@ class ViewsUIWizardSortingTestCase extends ViewsUIWizardHelper {
     $view1['page[create]'] = 1;
     $view1['page[title]'] = $this->randomName(16);
     $view1['page[path]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view1, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view1, t('Save view'));
 
     // Make sure the view shows the nodes in the expected order.
     $this->assertUrl($view1['page[path]']);
@@ -427,7 +427,7 @@ class ViewsUIWizardSortingTestCase extends ViewsUIWizardHelper {
     $view2['page[create]'] = 1;
     $view2['page[title]'] = $this->randomName(16);
     $view2['page[path]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view2, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view2, t('Save view'));
 
     // Make sure the view shows the nodes in the expected order.
     $this->assertUrl($view2['page[path]']);
@@ -478,7 +478,7 @@ class ViewsUIWizardItemsPerPageTestCase extends ViewsUIWizardHelper {
     $view['block[create]'] = 1;
     $view['block[title]'] = $this->randomName(16);
     $view['block[items_per_page]'] = 3;
-    $this->backdropPost('admin/structure/views/add', $view, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view, t('Save view'));
 
     // Make sure the page display shows the nodes we expect, and that they
     // appear in the expected order.
@@ -539,7 +539,7 @@ class ViewsUIWizardMenuTestCase extends ViewsUIWizardHelper {
     $view['page[link]'] = 1;
     $view['page[link_properties][menu_name]'] = 'main-menu';
     $view['page[link_properties][title]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view, t('Save view'));
 
     // Make sure there is a link to the view from the front page (where we
     // expect the main menu to display).
@@ -604,7 +604,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
       $view['page[path]'] = $this->randomName(16);
       $view['page[style][style_plugin]'] = 'jump_menu';
       $view['page[style][row_plugin]'] = 'fields';
-      $this->backdropPost('admin/structure/views/add', $view, t('Save & exit'));
+      $this->backdropPost('admin/structure/views/add', $view, t('Save view'));
       $this->backdropGet($view['page[path]']);
 
       // Submit the jump menu form, and check that we are redirected to the
@@ -732,7 +732,7 @@ class ViewsUIWizardOverrideDisplaysTestCase extends ViewsUIWizardHelper {
     $view['page[path]'] = $this->randomName(16);
     $view['block[create]'] = 1;
     $view_path = $view['page[path]'];
-    $this->backdropPost('admin/structure/views/add', $view, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view, t('Save view'));
 
     // Configure its title. Since the page and block both started off with the
     // same (empty) title in the views wizard, we expect the wizard to have set
@@ -800,7 +800,7 @@ class ViewsUIWizardOverrideDisplaysTestCase extends ViewsUIWizardHelper {
     $view['page[feed_properties][path]'] = $this->randomName(16);
     $view['block[create]'] = 1;
     $view['block[title]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view, t('Save & exit'));
+    $this->backdropPost('admin/structure/views/add', $view, t('Save view'));
 
     // Put the block into the first sidebar region, and make sure it will not
     // display on the view's page display (since we will be searching for the
@@ -882,7 +882,7 @@ class ViewsUIWizardOverrideDisplaysTestCase extends ViewsUIWizardHelper {
     $view['page[path]'] = $this->randomName(16);
     $view['block[create]'] = 1;
     $view['block[title]'] = $this->randomName(16);
-    $this->backdropPost('admin/structure/views/add', $view, t('Continue & edit'));
+    $this->backdropPost('admin/structure/views/add', $view, t('Save and edit'));
 
     // Revert the title of the block back to the default ones, but submit some
     // new values to be sure that the new value is not stored.

--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -431,14 +431,14 @@ function views_ui_add_form($form, &$form_state) {
   $form['actions']['#type'] = 'actions';
   $form['actions']['continue'] = array(
     '#type' => 'submit',
-    '#value' => t('Continue & edit'),
+    '#value' => t('Save and edit'),
     '#validate' => array('views_ui_wizard_form_validate'),
     '#submit' => array('views_ui_add_form_store_edit_submit'),
     '#process' => array_merge(array('views_ui_default_button'), element_info_property('submit', '#process', array())),
   );
   $form['actions']['save'] = array(
     '#type' => 'submit',
-    '#value' => t('Save & exit'),
+    '#value' => t('Save view'),
     '#validate' => array('views_ui_wizard_form_validate'),
     '#submit' => array('views_ui_add_form_save_submit'),
   );


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/999

This is working as far as I can tell, but I'm not sure if we want more thorough testing than I've added so far. Also, some of the things I did here are kind of hack-y (modifying the 'Cancel' button path, only showing 'Save and add terms' button when making a new vocabulary) just because I wasn't sure what the best way to do them was.
