### PR TITLE
Issue #1030: Add the word 'permission' to block permission conditions list in dialog.

### DIFF
--- a/core/modules/layout/plugins/access/user_permission_layout_access.inc
+++ b/core/modules/layout/plugins/access/user_permission_layout_access.inc
@@ -23,8 +23,7 @@ class UserPermissionLayoutAccess extends LayoutAccess {
     }
 
     $permissions = module_invoke_all('permission');
-    return t('User has "@permission"', array('@permission' => $permissions[$this->settings['permission']]['title']));
-
+    return t('User has "@permission" permission.', array('@permission' => $permissions[$this->settings['permission']]['title']));
   }
 
   /**


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/1030
