### PR TITLE
Issue #961: Remove list image on available updates page.

### DIFF
--- a/core/modules/update/css/update.css
+++ b/core/modules/update/css/update.css
@@ -120,7 +120,8 @@ table.update,
   direction: ltr;
 }
 
-.update table.version .version-links {
+.update table.version .version-links ul {
+  list-style-type: none;
   text-align: right; /* LTR */
   padding-right: 1em; /* LTR */
 }


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/961
