### PR TITLE
Issue #631: Add file_create_htaccess() compatibility wrapper.

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -606,6 +606,9 @@ function drupal_rmdir($uri, $context = NULL) {
 function drupal_tempnam($directory, $prefix) {
   return backdrop_tempnam($directory, $prefix);
 }
+function file_create_htaccess($directory, $private = TRUE, $force_overwrite = FALSE) {
+  return file_save_htaccess($directory, $private, $force_overwrite);
+}
 // Functions from form.inc.
 function drupal_get_form() {
   $args = func_get_args(); // pass $args to form function


### PR DESCRIPTION
This fixes https://github.com/backdrop/backdrop-issues/issues/631 by adding a wrapper function to file_save_htaccess() in drupal.inc.
