### PR TITLE
Issue #313: Add role assignment permissions to backdrop core.

### DIFF
--- a/core/modules/admin_bar/tests/admin_bar.test
+++ b/core/modules/admin_bar/tests/admin_bar.test
@@ -218,9 +218,10 @@ class AdminBarPermissionsTestCase extends AdminBarWebTestCase {
     );
     $this->backdropPost('admin/config/people/roles', $edit, t('Add role'));
 
-    // Grant the 'administer content types' permission for the role.
+    // Grant the 'administer content types' and 'assign all roles' permissions for the role.
     $edit = array(
       'test[administer content types]' => TRUE,
+      'test[assign all roles]' => TRUE,
     );
     $this->backdropPost('admin/config/people/permissions/test', $edit, t('Save permissions'));
     // Verify that Structure » Content types does not appear.

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -710,7 +710,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
     $node_type = node_type_get_type('page');
     $node_type->settings['comment_subject_field'] = TRUE;
     node_type_save($node_type);
-    
+
     // Create a simple node.
     $node = $this->backdropCreateNode(array('uid' => $account->uid));
 
@@ -1824,7 +1824,7 @@ class UserSignatureTestCase extends BackdropWebTestCase {
     $node_type = node_type_get_type('page');
     $node_type->settings['comment_subject_field'] = TRUE;
     node_type_save($node_type);
-    
+
     // Create a new node with comments on.
     $node = $this->backdropCreateNode(array('comment' => COMMENT_NODE_OPEN));
 
@@ -2092,7 +2092,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
    * again.
    */
   function testAssignAndRemoveRole()  {
-    $role_name = $this->backdropCreateRole(array('administer content types'));
+    $role_name = $this->backdropCreateRole(array('administer content types', 'assign all roles'));
     $account = $this->backdropCreateUser();
 
     // Assign the role to the user.
@@ -2113,7 +2113,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
    * be removed again.
    */
   function testCreateUserWithRole() {
-    $role_name = $this->backdropCreateRole(array('administer content types'));
+    $role_name = $this->backdropCreateRole(array('administer content types', 'assign all roles'));
     // Create a new user and add the role at the same time.
     $edit = array(
       'name' => $this->randomName(),

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -473,7 +473,7 @@ function user_has_role($rid, $account = NULL) {
  * Implements hook_permission().
  */
 function user_permission() {
-  return array(
+  $perms = array(
     'administer permissions' =>  array(
       'title' => t('Administer permissions'),
       'restrict access' => TRUE,
@@ -501,7 +501,23 @@ function user_permission() {
       'title' => t('Select method for cancelling own account'),
       'restrict access' => TRUE,
     ),
+    'assign all roles' => array(
+      'title' => t('Assign any role to users'),
+      'restrict access' => TRUE,
+    ),
   );
+
+  // Generate role assign permissions for all applicable roles.
+  foreach (user_roles(TRUE) as $role_name => $label) {
+    if ($role_name != BACKDROP_AUTHENTICATED_ROLE) {
+      $perms["assign $role_name role"] = array(
+        'title' => t('Assign %label role to users', array('%label' => $label)),
+        'restrict access' => ($role_name == config_get('system.core', 'user_admin_role')),
+      );
+    }
+  }
+
+  return $perms;
 }
 
 /**
@@ -755,13 +771,19 @@ function user_account_form(&$form, &$form_state) {
     '#access' => $admin,
   );
 
-  $roles = array_map('check_plain', user_roles(TRUE));
+  $roles = array();
+  $current_roles = !$register && isset($account->roles) ? $account->roles : array();
+  foreach (user_roles(TRUE) as $role_name => $label) {
+    if (user_access('assign all roles') || user_access("assign $role_name role")) {
+      $roles[$role_name] = check_plain($label);
+    }
+  }
   $form['account']['roles'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Roles'),
-    '#default_value' => (!$register && isset($account->roles) ? $account->roles : array()),
+    '#default_value' => array_intersect($current_roles, array_keys($roles)),
     '#options' => $roles,
-    '#access' => $roles && user_access('administer permissions'),
+    '#access' => !empty($roles),
   );
   $form['account']['roles'][BACKDROP_AUTHENTICATED_ROLE] = array(
     '#disabled' => TRUE,
@@ -905,6 +927,16 @@ function user_account_form_validate($form, &$form_state) {
     $user_schema = backdrop_get_schema('users');
     if (backdrop_strlen($form_state['values']['signature']) > $user_schema['fields']['signature']['length']) {
       form_set_error('signature', t('The signature is too long: it must be %max characters or less.', array('%max' => $user_schema['fields']['signature']['length'])));
+    }
+  }
+
+  // Add all previous roles the account had before saving if he has no right to
+  // assign them.
+  if (isset($form_state['values']['roles'])) {
+    foreach ($account->roles as $role_name) {
+      if (!user_access('assign all roles') && !user_access("assign $role_name role")) {
+        $form_state['values']['roles'][$role_name] = $role_name;
+      }
     }
   }
 }
@@ -2796,7 +2828,7 @@ function user_action_info() {
   $roles = user_roles(TRUE);
   $index = 0;
   foreach ($roles as $role_name => $role_label) {
-    if ($role_name === BACKDROP_AUTHENTICATED_ROLE) {
+    if ($role_name === BACKDROP_AUTHENTICATED_ROLE || (!user_access("assign all roles") && !user_access("assign $role_name role"))) {
       continue;
     }
     $index++;


### PR DESCRIPTION
This fixes https://github.com/backdrop/backdrop-issues/issues/313 by adding permissions to assign roles, and modifying the user edit form, and the VBO for adding roles.
