### PR TITLE
Issue #1047: Fixing wrapping issues on disabled themes

### DIFF
--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -191,6 +191,16 @@ table.screenshot {
   border-top: 1px solid #cdcdcd;
   padding-top: 20px;
 }
+.system-themes-list-disabled-wrapper.flexbox {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
+  width: calc(100vw - 60px); /* Fix flex-wrap issue with some browsers */
+}
 .system-themes-list h2 {
   margin: 0;
 }
@@ -242,12 +252,16 @@ table.screenshot {
 }
 .system-themes-list-disabled .theme-selector {
   width: 300px;
-  float: left; /* LTR */
   padding: 20px 20px 20px 0; /* LTR */
 }
 [dir="rtl"] .system-themes-list-disabled .theme-selector {
-  float: right;
   padding: 20px 0 20px 20px;
+}
+.system-themes-list-disabled.no-flexbox .theme-selector {
+  float: left; /* LTR */
+}
+[dir="rtl"] .system-themes-list-disabled.no-flexbox .theme-selector {
+  float: right;
 }
 .system-themes-list-enabled .theme-info {
   max-width: 940px;

--- a/core/modules/system/js/system.admin.themes.js
+++ b/core/modules/system/js/system.admin.themes.js
@@ -1,0 +1,50 @@
+/**
+ * @file system.admin.themes.js
+ *
+ * Behaviors for themes admin
+ */
+
+(function ($) {
+
+"use strict";
+
+/**
+ * Behavior for theme list
+ *
+ * Detect flexbox support for displaying our list of disabled themes
+ */
+Backdrop.behaviors.layoutDisplayEditor = {
+  attach: function(context) {
+    var $element = $(context).find('.system-themes-list-disabled');
+    if ($element.length) {
+      if ($element.css('flex-wrap')) {
+        $element.addClass('flexbox');
+      }
+      else {
+        $element.addClass('no-flexbox');
+      }
+    }
+  }
+};
+
+/**
+ * Behavior for showing a list of disabled themes.
+ *
+ * Detect flexbox support for displaying our list of themes with vertical
+ * height matching for each row of layout template icons.
+ */
+Backdrop.behaviors.disabledThemesListing = {
+  attach: function(context) {
+    var $element = $(context).find('.system-themes-list-disabled-wrapper');
+    if ($element.length) {
+      if ($element.css('flex-wrap')) {
+        $element.addClass('flexbox');
+      }
+      else {
+        $element.addClass('no-flexbox');
+      }
+    }
+  }
+};
+
+})(jQuery);

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -84,6 +84,9 @@ function theme_exposed_filters($variables) {
  * @ingroup themeable
  */
 function theme_system_themes_page($variables) {
+  $module_path = backdrop_get_path('module', 'system');
+  backdrop_add_js($module_path . '/js/system.admin.themes.js');
+
   $theme_groups = $variables['theme_groups'];
 
   $output = '<div id="system-themes-page">';
@@ -94,7 +97,7 @@ function theme_system_themes_page($variables) {
       continue;
     }
     // Start new theme group.
-    $output .= '<div class="system-themes-list system-themes-list-'. $state .' clearfix"><h2>'. $title .'</h2>';
+    $output .= '<div class="system-themes-list system-themes-list-'. $state .' clearfix"><h2>'. $title .'</h2><div class="system-themes-list-'. $state .'-wrapper">';
 
     foreach ($theme_groups[$state] as $theme) {
 
@@ -125,7 +128,7 @@ function theme_system_themes_page($variables) {
       }
       $output .= '</div></div>';
     }
-    $output .= '</div>';
+    $output .= '</div></div>';
   }
   $output .= '</div>';
 


### PR DESCRIPTION
Unfortunately there's only a reasonable fix if the browser supports flexbox
Added extra div so flexbox doesn't treat h2 as a grid element
Added JS to detect if we have flexbox or not
