### PR TITLE
Issue #728: [UX] page titles on user login page and forgot password page are stupid.

### DIFF
--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -1314,7 +1314,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
 
     // Verify breadcrumb on user pages (without menu link) for anonymous user.
     $trail = $home;
-    $this->assertBreadcrumb('user', $trail, t('User account'));
+    $this->assertBreadcrumb('user', $trail, t('Log in'));
     $this->assertBreadcrumb('user/' . $this->admin_user->uid, $trail, $this->admin_user->name);
 
     // Verify breadcrumb on user pages (without menu link) for registered users.
@@ -1357,7 +1357,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
     // functions, there's a lot that can go wrong in doing so.
     $this->backdropLogin($this->admin_user);
     $edit = array(
-      'link_title' => 'User',
+      'link_title' => 'Log in',
       'link_path' => 'user',
     );
     $this->backdropPost("admin/structure/menu/manage/$menu/add", $edit, t('Save'));

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1471,6 +1471,8 @@ function user_login($form, &$form_state) {
     backdrop_goto('user/' . $user->uid);
   }
 
+  backdrop_set_title(t('Log in'));
+
   // Display login form:
   $form['name'] = array('#type' => 'textfield',
     '#title' => t('Username'),
@@ -1479,10 +1481,8 @@ function user_login($form, &$form_state) {
     '#required' => TRUE,
   );
 
-  $form['name']['#description'] = t('Enter your @s username.', array('@s' => config_get('system.core', 'site_name')));
   $form['pass'] = array('#type' => 'password',
     '#title' => t('Password'),
-    '#description' => t('Enter the password that accompanies your username.'),
     '#required' => TRUE,
   );
   $form['#validate'] = user_login_default_validators();

--- a/core/modules/user/user.pages.inc
+++ b/core/modules/user/user.pages.inc
@@ -31,6 +31,8 @@ function user_autocomplete($string = '') {
 function user_pass() {
   global $user;
 
+  backdrop_set_title(t('Reset password'));
+
   $form['name'] = array(
     '#type' => 'textfield',
     '#title' => t('Username or e-mail address'),


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/728
Replacement for https://github.com/backdrop/backdrop/pull/753
