### PR TITLE
Issue #552: [UX] 'Find user accounts' / 'Administer users' should be 'Manage user accounts'.

### DIFF
--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -622,7 +622,7 @@ function admin_bar_links_users() {
     '#description' => t('Current anonymous / authenticated users'),
     '#weight' => 20,
     '#attributes' => array('class' => array('admin-bar-action', 'admin-bar-users')),
-    '#href' => (user_access('administer users') ? 'admin/people/list' : 'user'),
+    '#href' => (user_access('manage user accounts') ? 'admin/people/list' : 'user'),
   );
   return $links;
 }

--- a/core/modules/admin_bar/tests/admin_bar.test
+++ b/core/modules/admin_bar/tests/admin_bar.test
@@ -168,7 +168,7 @@ class AdminBarPermissionsTestCase extends AdminBarWebTestCase {
 
     // Create a user with access to one configuration category.
     $permissions = $this->basePermissions + array(
-      'administer users',
+      'manage user accounts',
       'administer account settings',
     );
     $admin_user = $this->backdropCreateUser($permissions);

--- a/core/modules/contact/contact.module
+++ b/core/modules/contact/contact.module
@@ -119,7 +119,7 @@ function _contact_personal_tab_access($account) {
   }
 
   // User administrators should always have access to personal contact forms.
-  if (user_access('administer users')) {
+  if (user_access('manage user accounts')) {
     return TRUE;
   }
 

--- a/core/modules/contact/contact.pages.inc
+++ b/core/modules/contact/contact.pages.inc
@@ -189,7 +189,7 @@ function contact_personal_form($form, &$form_state, $recipient) {
   $config = config('contact.settings');
   $limit = $config->get('contact_threshold_limit');
   $window = $config->get('contact_threshold_window');
-  if (!flood_is_allowed('contact', $limit, $window) && !user_access('administer contact forms') && !user_access('administer users')) {
+  if (!flood_is_allowed('contact', $limit, $window) && !user_access('administer contact forms') && !user_access('manage user accounts')) {
     backdrop_set_message(t("You cannot send more than %limit messages in @interval. Try again later.", array('%limit' => $limit, '@interval' => format_interval($window))), 'error');
     return array();
   }

--- a/core/modules/contact/tests/contact.test
+++ b/core/modules/contact/tests/contact.test
@@ -158,7 +158,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
   */
   function testAutoReply() {
     // Create and login administrative user.
-    $admin_user = $this->backdropCreateUser(array('access site-wide contact form', 'administer contact forms', 'administer permissions', 'administer users'));
+    $admin_user = $this->backdropCreateUser(array('access site-wide contact form', 'administer contact forms', 'administer permissions', 'manage user accounts'));
     $this->backdropLogin($admin_user);
 
     // Set up three categories, 2 with an auto-reply and one without.
@@ -305,7 +305,7 @@ class ContactPersonalTestCase extends BackdropWebTestCase {
     parent::setUp('contact');
 
     // Create an admin user.
-    $this->admin_user = $this->backdropCreateUser(array('administer contact forms', 'administer users', 'administer account settings'));
+    $this->admin_user = $this->backdropCreateUser(array('administer contact forms', 'manage user accounts', 'administer account settings'));
 
     // Create some normal users with their contact forms enabled by default.
     $config = config('contact.settings');

--- a/core/modules/dblog/tests/dblog.test
+++ b/core/modules/dblog/tests/dblog.test
@@ -30,7 +30,7 @@ class DBLogTestCase extends BackdropWebTestCase {
   function setUp() {
     parent::setUp('dblog', 'book');
     // Create users.
-    $this->big_user = $this->backdropCreateUser(array('administer site configuration', 'access administration pages', 'access site reports', 'administer users'));
+    $this->big_user = $this->backdropCreateUser(array('administer site configuration', 'access administration pages', 'access site reports', 'manage user accounts'));
     $this->any_user = $this->backdropCreateUser(array());
   }
 

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -700,7 +700,7 @@ class FieldUIAlterTestCase extends BackdropWebTestCase {
     parent::setUp(array('field_test'));
 
     // Create test user.
-    $admin_user = $this->backdropCreateUser(array('access content', 'administer content types', 'administer users', 'administer account settings'));
+    $admin_user = $this->backdropCreateUser(array('access content', 'administer content types', 'manage user accounts', 'administer account settings'));
     $this->backdropLogin($admin_user);
   }
 

--- a/core/modules/file/tests/file.test
+++ b/core/modules/file/tests/file.test
@@ -23,7 +23,7 @@ class FileFieldTestCase extends BackdropWebTestCase {
     $modules[] = 'path';
     $modules[] = 'file_module_test';
     parent::setUp($modules);
-    $this->admin_user = $this->backdropCreateUser(array('access content', 'access administration pages', 'administer site configuration', 'administer users', 'administer permissions', 'administer content types', 'administer nodes', 'bypass node access', 'create url aliases'));
+    $this->admin_user = $this->backdropCreateUser(array('access content', 'access administration pages', 'administer site configuration', 'manage user accounts', 'administer permissions', 'administer content types', 'administer nodes', 'bypass node access', 'create url aliases'));
     $this->backdropLogin($this->admin_user);
   }
 

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -207,7 +207,7 @@ function locale_form_alter(&$form, &$form_state, $form_id) {
     if ($form_id == 'user_register_form' || $form_id == 'user_profile_form') {
       $selector = locale_language_selector_form($form['#user']);
       if ($form_id == 'user_register_form') {
-        $selector['locale']['#access'] = user_access('administer users');
+        $selector['locale']['#access'] = user_access('manage user accounts');
       }
       $form += $selector;
     }

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -1611,7 +1611,7 @@ class LocaleUserCreationTest extends BackdropWebTestCase {
    */
   function testLocalUserCreation() {
     // User to add and remove language and create new users.
-    $admin_user = $this->backdropCreateUser(array('administer languages', 'access administration pages', 'administer users'));
+    $admin_user = $this->backdropCreateUser(array('administer languages', 'access administration pages', 'manage user accounts'));
     $this->backdropLogin($admin_user);
 
     // Add predefined language.

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -393,7 +393,7 @@ class PathPatternFunctionalTestHelper extends PathPatternTestHelper {
       'bypass node access',
       'access content overview',
       'administer taxonomy',
-      'administer users',
+      'manage user accounts',
     );
     $args = func_get_args();
     if (isset($args[1]) && is_array($args[1])) {

--- a/core/modules/search/tests/search.test
+++ b/core/modules/search/tests/search.test
@@ -1311,7 +1311,7 @@ class SearchConfigSettingsForm extends BackdropWebTestCase {
     parent::setUp('search', 'search_extra_type');
 
     // Login as a user that can create and search content.
-    $this->search_user = $this->backdropCreateUser(array('search content', 'administer search', 'administer nodes', 'bypass node access', 'access user profiles', 'administer users', 'administer blocks'));
+    $this->search_user = $this->backdropCreateUser(array('search content', 'administer search', 'administer nodes', 'bypass node access', 'access user profiles', 'manage user accounts', 'administer blocks'));
     $this->backdropLogin($this->search_user);
 
     // Add a single piece of content and index it.

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -1303,7 +1303,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
 
     // Verify breadcrumbs on user and user/%.
     // We need to log back in and out below, and cannot simply grant the
-    // 'administer users' permission, since user_page() makes your head explode.
+    // 'manage user accounts' permission, since user_page() makes your head explode.
     user_role_grant_permissions(BACKDROP_ANONYMOUS_ROLE, array(
       'access user profiles',
     ));
@@ -1329,7 +1329,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
 
     // Create a second user to verify breadcrumb on user pages again.
     $this->web_user = $this->backdropCreateUser(array(
-      'administer users',
+      'manage user accounts',
       'access user profiles',
     ));
     $this->backdropLogin($this->web_user);

--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -736,7 +736,7 @@ class TokenUserTestCase extends TokenTestHelper {
       $this->fail('Could not create directory ' . $picture_path . '.');
     }
 
-    $this->account = $this->backdropCreateUser(array('administer users', 'administer account settings'));
+    $this->account = $this->backdropCreateUser(array('manage user accounts', 'administer account settings'));
     $this->backdropLogin($this->account);
   }
 

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -2236,7 +2236,7 @@ class ConfirmFormTest extends BackdropWebTestCase {
   function setUp() {
     parent::setUp();
 
-    $this->admin_user = $this->backdropCreateUser(array('administer users'));
+    $this->admin_user = $this->backdropCreateUser(array('manage user accounts'));
     $this->backdropLogin($this->admin_user);
   }
 

--- a/core/modules/user/config/views.view.user_admin.json
+++ b/core/modules/user/config/views.view.user_admin.json
@@ -7,7 +7,7 @@
     "tag": "default",
     "disabled": false,
     "base_table": "users",
-    "human_name": "Administer users",
+    "human_name": "Manage user accounts",
     "core": "1.0-dev",
     "display": {
         "default": {
@@ -20,7 +20,7 @@
                 },
                 "access": {
                     "type": "perm",
-                    "perm": "administer users"
+                    "perm": "manage user accounts"
                 },
                 "cache": {
                     "type": "none"
@@ -840,7 +840,7 @@
                 "path": "admin/people/list",
                 "menu": {
                     "type": "default tab",
-                    "title": "Find user accounts",
+                    "title": "Manage user accounts",
                     "description": "",
                     "name": "management",
                     "weight": "0",

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -92,7 +92,7 @@ class UserRegistrationTestCase extends BackdropWebTestCase {
     // Activate the new account.
     $accounts = user_load_multiple(array(), array('name' => $name, 'mail' => $mail));
     $new_user = reset($accounts);
-    $admin_user = $this->backdropCreateUser(array('administer users'));
+    $admin_user = $this->backdropCreateUser(array('manage user accounts'));
     $this->backdropLogin($admin_user);
     $edit = array(
       'status' => 1,
@@ -509,7 +509,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
     $user1->pass_raw = $password;
 
     // Try to cancel uid 1's account with a different user.
-    $this->admin_user = $this->backdropCreateUser(array('administer users'));
+    $this->admin_user = $this->backdropCreateUser(array('manage user accounts'));
     $this->backdropLogin($this->admin_user);
     $edit = array(
       'action' => 'user_cancel_user_action',
@@ -771,7 +771,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
     $account = $this->backdropCreateUser(array());
 
     // Create administrative user.
-    $admin_user = $this->backdropCreateUser(array('administer users'));
+    $admin_user = $this->backdropCreateUser(array('manage user accounts'));
     $this->backdropLogin($admin_user);
 
     // Delete regular user.
@@ -795,7 +795,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
     config_set('system.core', 'user_mail_status_canceled_notify', TRUE);
 
     // Create administrative user.
-    $admin_user = $this->backdropCreateUser(array('administer users'));
+    $admin_user = $this->backdropCreateUser(array('manage user accounts'));
     $this->backdropLogin($admin_user);
 
     // Create some users.
@@ -1278,7 +1278,7 @@ class UserAdminTestCase extends BackdropWebTestCase {
     $user_c = $this->backdropCreateUser(array('administer taxonomy'));
 
     // Create admin user to delete registered user.
-    $admin_user = $this->backdropCreateUser(array('administer users', 'access user profiles'));
+    $admin_user = $this->backdropCreateUser(array('manage user accounts', 'access user profiles'));
     $this->backdropLogin($admin_user);
     $this->backdropGet('admin/people');
     $this->assertText($user_a->name, 'Found user A on admin users page');
@@ -1682,7 +1682,7 @@ class UserCreateTestCase extends BackdropWebTestCase {
    * displays in the user list.
    */
   protected function testUserAdd() {
-    $user = $this->backdropCreateUser(array('administer users'));
+    $user = $this->backdropCreateUser(array('manage user accounts'));
     $this->backdropLogin($user);
 
     // Test user creation page for valid fields.
@@ -1904,7 +1904,7 @@ class UserEditedOwnAccountTestCase extends BackdropWebTestCase {
 class UserRoleAdminTestCase extends BackdropWebTestCase {
   function setUp() {
     parent::setUp();
-    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'administer users'));
+    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'manage user accounts'));
   }
 
   /**
@@ -2046,7 +2046,7 @@ class UserUserSearchTestCase extends BackdropWebTestCase {
     $this->assertNoText($keys);
     $this->backdropLogout();
 
-    $user2 = $this->backdropCreateUser(array('administer users', 'access user profiles', 'search content', 'use advanced search'));
+    $user2 = $this->backdropCreateUser(array('manage user accounts', 'access user profiles', 'search content', 'use advanced search'));
     $this->backdropLogin($user2);
     $keys = $user2->mail;
     $edit = array('keys' => $keys);
@@ -2058,13 +2058,13 @@ class UserUserSearchTestCase extends BackdropWebTestCase {
     $blocked_user->status = 0;
     $blocked_user->save();
 
-    // Verify that users with "administer users" permissions can see blocked
+    // Verify that users with "manage user accounts" permissions can see blocked
     // accounts in search results.
     $edit = array('keys' => $blocked_user->name);
     $this->backdropPost('search/user', $edit, t('Search'));
-    $this->assertText($blocked_user->name, 'Blocked users are listed on the user search results for users with the "administer users" permission.');
+    $this->assertText($blocked_user->name, 'Blocked users are listed on the user search results for users with the "manage user accounts" permission.');
 
-    // Verify that users without "administer users" permissions do not see
+    // Verify that users without "manage user accounts" permissions do not see
     // blocked accounts in search results.
     $this->backdropLogin($user1);
     $edit = array('keys' => $blocked_user->name);
@@ -2083,7 +2083,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
 
   function setUp() {
     parent::setUp();
-    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'administer users'));
+    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'manage user accounts'));
     $this->backdropLogin($this->admin_user);
   }
 
@@ -2166,7 +2166,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
   protected $accessUser;
 
   /**
-   * User permission to administer users.
+   * User permission to manage user accounts.
    */
   protected $adminUser;
 
@@ -2174,7 +2174,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
     parent::setUp('user_form_test');
     // Create two users
     $this->accessUser = $this->backdropCreateUser(array('access content'));
-    $this->adminUser = $this->backdropCreateUser(array('administer users'));
+    $this->adminUser = $this->backdropCreateUser(array('manage user accounts'));
   }
 
   /**

--- a/core/modules/user/tests/user_form_test/user_form_test.module
+++ b/core/modules/user/tests/user_form_test/user_form_test.module
@@ -16,7 +16,7 @@ function user_form_test_menu() {
     'title' => 'User form test for current password validation',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('user_form_test_current_password',1),
-    'access arguments' => array('administer users'),
+    'access arguments' => array('manage user accounts'),
     'type' => MENU_SUGGESTED_ITEM,
   );
   return $items;

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -181,7 +181,7 @@ function user_admin_settings($form, &$form_state) {
   $form['registration_cancellation']['user_cancel_method'] = array(
     '#type' => 'item',
     '#title' => t('When cancelling a user account'),
-    '#description' => t('Users with the %select-cancel-method or %administer-users <a href="@permissions-url">permissions</a> can override this default method.', array('%select-cancel-method' => t('Select method for cancelling account'), '%administer-users' => t('Administer users'), '@permissions-url' => url('admin/config/people/permissions'))),
+    '#description' => t('Users with the %select-cancel-method or %administer-users <a href="@permissions-url">permissions</a> can override this default method.', array('%select-cancel-method' => t('Select method for cancelling account'), '%administer-users' => t('Manage user accounts'), '@permissions-url' => url('admin/config/people/permissions'))),
   );
   $form['registration_cancellation']['user_cancel_method'] += user_cancel_methods();
   foreach (element_children($form['registration_cancellation']['user_cancel_method']) as $element) {

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -216,10 +216,10 @@ function user_update_1000() {
 }
 
 /**
- * Grant "administer account settings" to roles with "administer users."
+ * Grant "administer account settings" to roles with "manage user accounts."
  */
 function user_update_1001() {
-  $rids = db_query("SELECT rid FROM {role_permission} WHERE permission = :perm", array(':perm' => 'administer users'))->fetchCol();
+  $rids = db_query("SELECT rid FROM {role_permission} WHERE permission = :perm", array(':perm' => 'manage user accounts'))->fetchCol();
   // None found.
   if (empty($rids)) {
     return;
@@ -492,7 +492,7 @@ function user_update_1009() {
     'tag' => 'default',
     'disabled' => FALSE,
     'base_table' => 'users',
-    'human_name' => 'Administer users',
+    'human_name' => 'Manage user accounts',
     'core' => '1.0-dev',
     'display' => array(
       'default' => array(
@@ -505,7 +505,7 @@ function user_update_1009() {
           ),
           'access' => array(
             'type' => 'perm',
-            'perm' => 'administer users',
+            'perm' => 'manage user accounts',
           ),
           'cache' => array(
             'type' => 'none',
@@ -1073,7 +1073,7 @@ function user_update_1009() {
           'path' => 'admin/people/list',
           'menu' => array(
             'type' => 'default tab',
-            'title' => 'Find user accounts',
+            'title' => 'Manage user accounts',
             'description' => '',
             'name' => 'management',
             'weight' => '0',

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -106,7 +106,7 @@ function user_entity_info() {
           'label' => t('User'),
           'admin' => array(
             'path' => 'admin/config/people/manage',
-            'access arguments' => array('administer users'),
+            'access arguments' => array('manage user accounts'),
           ),
         ),
       ),
@@ -478,8 +478,8 @@ function user_permission() {
       'title' => t('Administer permissions'),
       'restrict access' => TRUE,
     ),
-    'administer users' => array(
-      'title' => t('Administer users'),
+    'manage user accounts' => array(
+      'title' => t('Manage user accounts'),
       'restrict access' => TRUE,
     ),
     'administer account settings' => array(
@@ -598,7 +598,7 @@ function user_search_execute($keys = NULL, $conditions = NULL) {
   $keys = preg_replace('!\*+!', '%', $keys);
   $query = db_select('users')->extend('PagerDefault');
   $query->fields('users', array('uid'));
-  if (user_access('administer users')) {
+  if (user_access('manage user accounts')) {
     // Administrators can also search in the otherwise private email field,
     // and they don't need to be restricted to only active users.
     $query->fields('users', array('mail'));
@@ -624,7 +624,7 @@ function user_search_execute($keys = NULL, $conditions = NULL) {
       'title' => user_format_name($account),
       'link' => url('user/' . $account->uid, array('absolute' => TRUE)),
     );
-    if (user_access('administer users')) {
+    if (user_access('manage user accounts')) {
       $result['title'] .= ' (' . $account->mail . ')';
     }
     $results[] = $result;
@@ -663,7 +663,7 @@ function user_account_form(&$form, &$form_state) {
   $account = $form['#user'];
   $register = ($form['#user']->uid > 0 ? FALSE : TRUE);
 
-  $admin = user_access('administer users');
+  $admin = user_access('manage user accounts');
 
   $form['#validate'][] = 'user_account_form_validate';
 
@@ -1069,7 +1069,7 @@ function user_view_access($account) {
   // Never allow access to view the anonymous user account.
   if ($uid) {
     // Admins can view all, users can view own profiles at all times.
-    if ($GLOBALS['user']->uid == $uid || user_access('administer users')) {
+    if ($GLOBALS['user']->uid == $uid || user_access('manage user accounts')) {
       return TRUE;
     }
     elseif (user_access('access user profiles')) {
@@ -1087,7 +1087,7 @@ function user_view_access($account) {
  * Access callback for user account editing.
  */
 function user_edit_access($account) {
-  return (($GLOBALS['user']->uid == $account->uid) || user_access('administer users')) && $account->uid > 0;
+  return (($GLOBALS['user']->uid == $account->uid) || user_access('manage user accounts')) && $account->uid > 0;
 }
 
 /**
@@ -1097,7 +1097,7 @@ function user_edit_access($account) {
  * users, and prevent the anonymous user from cancelling the account.
  */
 function user_cancel_access($account) {
-  return ((($GLOBALS['user']->uid == $account->uid) && user_access('cancel account')) || user_access('administer users')) && $account->uid > 0;
+  return ((($GLOBALS['user']->uid == $account->uid) && user_access('cancel account')) || user_access('manage user accounts')) && $account->uid > 0;
 }
 
 /**
@@ -1168,14 +1168,14 @@ function user_menu() {
     'title' => 'Add user account',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('user_register_form'),
-    'access arguments' => array('administer users'),
+    'access arguments' => array('manage user accounts'),
     'type' => MENU_LOCAL_ACTION,
   );
   $items['admin/people/cancel'] = array(
     'title' => 'Cancel user accounts',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('user_multiple_cancel_confirm'),
-    'access arguments' => array('administer users'),
+    'access arguments' => array('manage user accounts'),
     'file' => 'user.admin.inc',
     'type' => MENU_CALLBACK,
   );
@@ -2882,7 +2882,7 @@ function user_form_field_ui_field_edit_form_submit($form, &$form_state) {
 function user_register_form($form, &$form_state) {
   global $user;
 
-  $admin = user_access('administer users');
+  $admin = user_access('manage user accounts');
 
   // Pass access information to the submit handler. Running an access check
   // inside the submit function interferes with form processing and breaks
@@ -2927,7 +2927,7 @@ function user_register_form($form, &$form_state) {
   elseif (isset($_SERVER['HTTP_REFERER'])) {
     $path = urldecode($_SERVER['HTTP_REFERER']);
   }
-  elseif (user_access('administer users')) {
+  elseif (user_access('manage user accounts')) {
     $path = 'admin/people';
   }
   else {

--- a/core/modules/user/user.pages.inc
+++ b/core/modules/user/user.pages.inc
@@ -270,7 +270,7 @@ function user_profile_form($form, &$form_state, $account) {
     '#type' => 'submit',
     '#value' => t('Cancel account'),
     '#submit' => array('user_edit_cancel_submit'),
-    '#access' => $account->uid > 1 && (($account->uid == $user->uid && user_access('cancel account')) || user_access('administer users')),
+    '#access' => $account->uid > 1 && (($account->uid == $user->uid && user_access('cancel account')) || user_access('manage user accounts')),
   );
   $form['actions']['cancel_form'] = array(
     '#type' => 'link',
@@ -343,7 +343,7 @@ function user_cancel_confirm_form($form, &$form_state, $account) {
   $form['_account'] = array('#type' => 'value', '#value' => $account);
 
   // Display account cancellation method selection, if allowed.
-  $admin_access = user_access('administer users');
+  $admin_access = user_access('manage user accounts');
   $can_select_method = $admin_access || user_access('select account cancellation method');
   $form['user_cancel_method'] = array(
     '#type' => 'item',
@@ -419,7 +419,7 @@ function user_cancel_confirm_form_submit($form, &$form_state) {
   // Cancel account immediately, if the current user has administrative
   // privileges, no confirmation mail shall be sent, and the user does not
   // attempt to cancel the own account.
-  if (user_access('administer users') && empty($form_state['values']['user_cancel_confirm']) && $account->uid != $user->uid) {
+  if (user_access('manage user accounts') && empty($form_state['values']['user_cancel_confirm']) && $account->uid != $user->uid) {
     user_cancel($form_state['values'], $account->uid, $form_state['values']['user_cancel_method']);
 
     $form_state['redirect'] = 'admin/people';
@@ -467,7 +467,7 @@ function user_cancel_methods() {
     'user_cancel_delete' => array(
       'title' => t('Delete the account and its content.'),
       'description' => t('Your account will be removed and all account information deleted. All of your content will also be deleted.'),
-      'access' => user_access('administer users'),
+      'access' => user_access('manage user accounts'),
     ),
   );
   // Allow modules to customize account cancellation methods.


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/552
