### PR TITLE
Issue #767: Add hooks for Layout presave/insert/update

### DIFF
--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -240,12 +240,25 @@ class Layout {
       }
     }
 
+    // Allow modules to act on layout data before saving.
+    foreach (module_implements('layout_presave') as $module) {
+      $function = $module . '_layout_presave';
+      $function($this->name, $data);
+    }
+
     if (isset($this->original_name) && $this->original_name != $this->name) {
       config('layout.layout.' . $this->original_name)->delete();
     }
     config('layout.layout.' . $this->name)
       ->setData($data)
       ->save();
+
+    if (!empty($this->is_new)) {
+      $this->invokeHook('insert');
+    }
+    else {
+      $this->invokeHook('update');
+    }
 
     // If this layout overrides an existing module path, reassign or delete
     // the layout menu item.
@@ -290,6 +303,7 @@ class Layout {
       if ($this->menu_item && $this->menu_item->name === $this->name) {
         $this->menu_item->reassign();
       }
+      $this->invokeHook('delete');
       layout_reset_caches();
     }
     else {
@@ -312,6 +326,7 @@ class Layout {
         $this->menu_item->revert();
       }
       layout_reset_caches();
+      $this->invokeHook('revert');
     }
   }
 
@@ -326,6 +341,7 @@ class Layout {
     if ($this->menu_item && $this->menu_item->name === $this->name) {
       $this->menu_item->reassign();
     }
+    $this->invokeHook('disable');
   }
 
   /**
@@ -336,9 +352,20 @@ class Layout {
     $this->save();
 
     // Check if the menu item needs to be assigned to this layout.
-    if ($this->menu_item->name === $this->name) {
+    if ($this->menu_item && $this->menu_item->name === $this->name) {
       $this->menu_item->reassign();
     }
+    $this->invokeHook('enable');
+  }
+
+  /**
+   * Invokes a hook on behalf of the layout.
+   *
+   * @param $hook
+   *   One of 'insert', 'update', 'enable', 'disable', 'revert', or 'delete'.
+   */
+   protected function invokeHook($hook) {
+    module_invoke_all('layout_' . $hook, $this);
   }
 
   /**
@@ -425,6 +452,7 @@ class Layout {
    *   The UUID of the block being removed.
    */
   function removeBlock($block_uuid) {
+    $block = $this->content[$block_uuid];
     unset($this->content[$block_uuid]);
     foreach ($this->positions as $region => $positions) {
       $key = array_search($block_uuid, $positions);
@@ -433,6 +461,7 @@ class Layout {
         unset($this->content[$block_uuid]);
       }
     }
+
   }
 
   /**
@@ -624,6 +653,7 @@ class Layout {
 
     $this->layout = $layout_name;
     $this->positions = $new_positions;
+    module_invoke_all('layout_template_change', $this, $old_layout_info['name']);
   }
 
   /**

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -1549,12 +1549,12 @@ function layout_enable_layout($status, Layout $layout) {
     return MENU_ACCESS_DENIED;
   }
 
-  $layout->disabled = !$status;
-  $layout->save();
   if ($status) {
+    $layout->enable();
     backdrop_set_message(t('Layout "@title" enabled.', array('@title' => $layout->title)));
   }
   else {
+    $layout->disable();
     backdrop_set_message(t('Layout "@title" disabled.', array('@title' => $layout->title)));
   }
   backdrop_goto('admin/structure/layouts');

--- a/core/modules/layout/layout.api.php
+++ b/core/modules/layout/layout.api.php
@@ -196,6 +196,143 @@ function hook_layout_renderer_info() {
 }
 
 /**
+ * Respond to a layout being reverted.
+ *
+ * Layouts can be reverted only if the configuration is provided
+ * by a module. Layouts created in the Layout Builder User Interface
+ * cannot be reverted. 
+ * A layout revert operation results in deletion of the existing
+ * layout configuration and replacement with the default configuration
+ * from the providing module. 
+ * This hook is invoked from Layout::revert() after a layout has been 
+ * reverted and the new configuration has been inserted into the live
+ * config directory and the layout cache has been cleared.
+ *
+ * @param Layout $layout
+ *   The old layout object that has just been deleted.
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_revert(Layout $old_layout) {
+  if ($old_layout->name == 'my_layout') {
+    my_custom_function();
+  }
+  // Get the new (reverted) configuration.
+  $new_config = config_get('layout.layout.' . $old_layout->name);
+}
+
+/**
+ * Respond to a layout being deleted.
+ *
+ * This hook is invoked from Layout::delete() after a layout has been 
+ * deleted.
+ *
+ * @param Layout $layout
+ *   The layout object that was deleted.
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_delete(Layout $layout) {
+  if ($layout->path == 'my_path') {
+    my_custom_function();
+  }
+}
+
+/**
+ * Respond to a layout being enabled.
+ *
+ * This hook is invoked from Layout::enable() after a layout has been 
+ * enabled.
+ *
+ * @param Layout $layout
+ *   The layout object that was enabled.
+ *
+ * @see hook_layout_disable()
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_enable(Layout $layout) {
+  if ($layout->path == 'my_path') {
+    my_custom_function();
+  }
+}
+
+/**
+ * Respond to a layout being disabled.
+ *
+ * This hook is invoked from Layout::disable() after a layout has been 
+ * disabled.
+ * A layout configuration may be disabled by a user from the administrative 
+ * list of layouts. A disabled layout will not affect pages at its configured 
+ * path, but will retain its configuration so that it may be enabled later.
+ *
+ * @param Layout $layout
+ *   The layout object that was disabled.
+ *
+ * @see hook_layout_enable()
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_disable(Layout $layout) {
+  if ($layout->path == 'my_path') {
+    my_custom_function();
+  }
+}
+
+/**
+ * Respond to updates to a layout.
+ *
+ * This hook is invoked from Layout::save() after a layout has been saved
+ * to configuration.
+ *
+ * @param Layout $layout
+ *   The layout object that was saved.
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_update(Layout $layout) {
+  if ($layout->path == 'my_path') {
+    my_custom_function();
+  }
+}
+
+/**
+ * Respond to initial creation of a layout.
+ *
+ * This hook is invoked from Layout::save() after a layout has been saved
+ * to configuration.
+ *
+ * @param Layout $layout
+ *   The layout object that was saved.
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_insert(Layout $layout) {
+  if ($layout->path == 'my_path') {
+    my_custom_function();
+  }
+}
+
+/**
+ * Act on a layout being inserted or updated.
+ *
+ * This hook is invoked from Layout::save() before the layout is saved to
+ * configuration.
+ *
+ * @param Layout $layout
+ *   The layout that is being inserted or updated.
+ *
+ * @ingroup layout_api_hooks
+ */
+function hook_layout_presave(Layout $layout) {
+  if ($layout->name == 'default') {
+    $my_block_uuid = get_my_uuid();
+    $my_block = $layout->content[$uuid];
+    $my_block->data['settings']['title'] = 'New Title';
+  }
+}
+
+/**
  * Defines to Backdrop what blocks are provided by your module.
  *
  * In hook_block_info(), each block your module provides is given a unique

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -1190,3 +1190,150 @@ class LayoutUpgradePathTest extends UpgradePathTestCase {
     return $this->assertBlocks($blocks, TRUE);
   }
 }
+
+/**
+ * Tests invocation of hooks when performing an action.
+ *
+ * Tested hooks are:
+ * - hook_layout_presave
+ * - hook_layout_insert
+ * - hook_layout_update
+ * - hook_layout_disable
+ * - hook_layout_enable
+ * - hook_layout_delete
+ * - hook_layout_template_change
+ * - hook_layout_revert
+ */
+class LayoutHookTestCase extends BackdropWebTestCase {
+  protected $admin_user;
+  protected $profile = 'testing';
+
+  function setUp() {
+    parent::setUp('layout', 'layout_test');
+
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'administer layouts',
+    ));
+    $this->backdropLogin($this->admin_user);
+
+  }
+
+  /**
+   * Checks the order of CRUD hook execution messages.
+   *
+   * layout_test.module implements all core layout CRUD hooks and
+   * stores a message for each in state_get('layout_test').
+   *
+   * @param $messages
+   *   An array of plain-text messages in the order they should appear.
+   */
+  protected function assertHookMessageOrder($messages) {
+    $positions = array();
+    $state_get = state_get('layout_test');
+    foreach ($messages as $message) {
+      // Verify that each message is found and record its position.
+      $position = array_search($message, $state_get);
+      if ($this->assertTrue($position !== FALSE, $message)) {
+        $positions[] = $position;
+      }
+    }
+    // Sort the positions and ensure they remain in the same order.
+    $sorted = $positions;
+    sort($sorted);
+    $this->assertTrue($sorted == $positions, 'The hook messages appear in the correct order.');
+  }
+
+  /**
+   * Tests hook invocations for operations on layouts.
+   */
+  public function testLayoutHooks() {
+    state_set('layout_test', array());
+    
+    $this->backdropGet('admin/structure/layouts');
+    $this->clickLink(t('Add layout'));
+
+    // Create a new layout at a new path.
+    $layout_name = strtolower($this->randomName());
+    $layout_title = $this->randomString();
+    $layout_url = 'layout-test-path';
+    $edit = array(
+      'title' => $layout_title,
+      'name' => $layout_name,
+      'layout' => 'two_column',
+      'path' => $layout_url,
+    );
+    $this->backdropPost(NULL, $edit, t('Create layout'));
+
+    // We should be taken to the layout content page next.
+    $this->assertText(t('Layout created. Blocks may now be added to this layout.'));
+    
+    // Save the layout.
+    $this->backdropPost(NULL, array(), t('Save layout'));
+    
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_presave called',
+      'layout_test_layout_insert called',
+    ));
+
+    state_set('layout_test', array());
+
+    // Return to the layout edit page and save it again.
+    $this->backdropGet('admin/structure/layouts/manage/' . $layout_name);
+    $this->backdropPost(NULL, array(), t('Save layout'));
+
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_presave called',
+      'layout_test_layout_update called',
+    ));
+
+    // Disable the layout via the dropbutton link.
+    state_set('layout_test', array());
+    $disable_link = $this->xpath('//*[contains(@class, "disable")]//a');
+    $disable_url_parts = backdrop_parse_url($disable_link[0]['href']);
+    $this->backdropGet($disable_url_parts['path'], $disable_url_parts);
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_disable called',
+    ));
+
+    state_set('layout_test', array());
+
+    // Re-enable the layout.
+    $this->backdropGet('admin/structure/layouts/manage');
+    $enable_link = $this->xpath('//li[contains(@class, "enable")]//a');
+    $enable_url_parts = backdrop_parse_url($enable_link[0]['href']);
+    $this->backdropGet($enable_url_parts['path'], $enable_url_parts);
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_enable called',
+    ));
+
+    // Delete the layout.
+    state_set('layout_test', array());
+    $this->backdropPost('admin/structure/layouts/manage/' . $layout_name . '/delete', array(), t('Delete layout'));
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_delete called',
+    ));
+
+    // Go to the Default layout's edit page and change the layout to the 
+    // one_column layout.
+    state_set('layout_test', array());
+    $edit = array(
+      'layout' => 'one_column',
+    );
+    $this->backdropPost('admin/structure/layouts/manage/default/settings', $edit, t('Save layout'));
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_template_change called',
+    ));
+
+    // Save the layout.
+    $this->backdropPost(NULL, array(), t('Save layout'));
+
+    // Revert the Default layout.
+    state_set('layout_test', array());
+    $this->backdropPost('admin/structure/layouts/manage/default/delete', array(), t('Revert layout'));
+    $this->assertHookMessageOrder(array(
+      'layout_test_layout_revert called',
+    ));
+
+  }
+}

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -15,3 +15,9 @@ name = Layout Upgrade Test
 description = Tests the upgrade path from block-based regions to layouts.
 group = Layout
 file = layout.test
+
+[LayoutHookTestCase]
+name = Layout Hook Test
+description = Tests the upgrade path from block-based regions to layouts.
+group = Layout
+file = layout.test

--- a/core/modules/layout/tests/layout_test/layout_test.module
+++ b/core/modules/layout/tests/layout_test/layout_test.module
@@ -113,3 +113,75 @@ function layout_test_block_configure($delta = '', $settings = array()) {
 function layout_test_path() {
   return '<div id="layout-test-page-content">This is the layout test page.</div>';
 }
+
+/**
+ * Implements hook_layout_presave().
+ */
+function layout_test_layout_presave($layout_name, $layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_insert().
+ */
+function layout_test_layout_insert($layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_update().
+ */
+function layout_test_layout_update($layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_disable().
+ */
+function layout_test_layout_disable($layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_enable().
+ */
+function layout_test_layout_enable($layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_delete().
+ */
+function layout_test_layout_delete($layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_template_change().
+ */
+function layout_test_layout_template_change($layout, $old_template) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}
+
+/**
+ * Implements hook_layout_revert().
+ */
+function layout_test_layout_revert($layout) {
+  $return = state_get('layout_test');
+  $return[] = (__FUNCTION__ . ' called');
+  state_set('layout_test', $return);
+}


### PR DESCRIPTION
- Also added hooks for disable, enable and revert.
- Modified `layout.admin.inc` to actually use layout class functions for
  disabling and enabling.

Fix for: https://github.com/backdrop/backdrop-issues/issues/767
