### PR TITLE
Issue #1109: file_scan_directory() ignores all files that start with a period.

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -2063,7 +2063,8 @@ function file_download_access($uri) {
  * @param $options
  *   An associative array of additional options, with the following elements:
  *   - 'nomask': The preg_match() regular expression of the files to ignore.
- *     Defaults to '/(\.\.?|CVS)$/'.
+ *     Defaults to '/^(\..*)|(CVS)$/'. This default ignores all hidden files
+ *     (those that start with a period) and items named "CVS".
  *   - 'callback': The callback function to call for each match. There is no
  *     default callback.
  *   - 'recurse': When TRUE, the directory scan will recurse the entire tree
@@ -2085,7 +2086,7 @@ function file_download_access($uri) {
 function file_scan_directory($dir, $mask, $options = array(), $depth = 0) {
   // Merge in defaults.
   $options += array(
-    'nomask' => '/(\.\.?|CVS)$/',
+    'nomask' => '/^(\..*)|(CVS)$/',
     'callback' => 0,
     'recurse' => TRUE,
     'key' => 'uri',
@@ -2096,7 +2097,7 @@ function file_scan_directory($dir, $mask, $options = array(), $depth = 0) {
   $files = array();
   if (is_dir($dir) && $handle = opendir($dir)) {
     while (FALSE !== ($filename = readdir($handle))) {
-      if (!preg_match($options['nomask'], $filename) && $filename[0] != '.') {
+      if (!preg_match($options['nomask'], $filename) && $filename !== '.' && $filename !== '..') {
         $uri = "$dir/$filename";
         $uri = file_stream_wrapper_uri_normalize($uri);
         if (is_dir($uri) && $options['recurse']) {

--- a/core/modules/simpletest/files/.hidden
+++ b/core/modules/simpletest/files/.hidden
@@ -1,0 +1,2 @@
+This file is used to test file_scan_directory() includes hidden files.
+See FileScanDirectoryTest::testOptionNoMask().

--- a/core/modules/simpletest/tests/file.test
+++ b/core/modules/simpletest/tests/file.test
@@ -1030,12 +1030,19 @@ class FileScanDirectoryTest extends FileTestCase {
    */
   function testOptionNoMask() {
     // Grab a listing of all the JavaSscript files.
-    $all_files = file_scan_directory($this->path, '/^javascript-/');
+    $all_files = file_scan_directory($this->path, '/^javascript-/', array('recurse' => FALSE));
     $this->assertEqual(2, count($all_files), 'Found two, expected javascript files.');
 
-    // Now use the nomast parameter to filter out the .script file.
-    $filtered_files = file_scan_directory($this->path, '/^javascript-/', array('nomask' => '/.script$/'));
+    // Set the nomask parameter be empty to include the .script file.
+    $filtered_files = file_scan_directory($this->path, '/^javascript-/', array('nomask' => '/.script$/', 'recurse' => FALSE));
     $this->assertEqual(1, count($filtered_files), 'Filtered correctly.');
+
+    // List all hidden files with the default nomask, and again with a custom
+    // nomask that permits hidden files.
+    $no_hidden_files = file_scan_directory($this->path, '/^\..*$/', array('recurse' => FALSE));
+    $hidden_files = file_scan_directory($this->path, '/^\..*$/', array('nomask' => '/^$/', 'recurse' => FALSE));
+    $this->assertEqual(0, count($no_hidden_files), 'Hidden files not included by default.');
+    $this->assertEqual(1, count($hidden_files), 'Hidden files included when custom nomask used.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1109.
