### PR TITLE
Issue #1060: Adding missing backdrop_set_message status messages to admin pages

### DIFF
--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -705,6 +705,8 @@ function admin_bar_theme_settings_submit($form, $form_state) {
   $config->set('position_fixed', $form_state['values']['position_fixed']);
   $config->set('components', array_values(array_filter($form_state['values']['components'])));
   $config->save();
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**

--- a/core/modules/config/config.admin.inc
+++ b/core/modules/config/config.admin.inc
@@ -183,7 +183,7 @@ function config_export_full_form(array $form, array $form_state) {
 /**
  * Submit handler for config_export_full_form().
  */
-function config_export_full_form_submit(array $form, array &$form_state) {
+function config_export_full_form_submit(array $form, array &$form_state) {  
   $form_state['redirect'] = 'admin/config/development/configuration/full/export-download';
 }
 

--- a/core/modules/language/language.admin.inc
+++ b/core/modules/language/language.admin.inc
@@ -105,8 +105,8 @@ function language_admin_overview_form_submit($form, &$form_state) {
 
     language_save($language);
   }
-
-  backdrop_set_message(t('Configuration saved.'));
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**
@@ -314,6 +314,8 @@ function language_admin_edit_form_submit($form, &$form_state) {
   $language->name = $form_state['values']['name'];
   $language->direction = $form_state['values']['direction'];
   language_save($language);
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
   $form_state['redirect'] = 'admin/config/regional/language';
 }
 

--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -664,4 +664,6 @@ function menu_configure_submit($form, &$form_state) {
     ->set('menu_main_links', $form_state['values']['menu_main_links_source'])
     ->set('menu_secondary_links', $form_state['values']['menu_secondary_links_source'])
     ->save();
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1675,6 +1675,8 @@ function system_performance_settings_submit($form, &$form_state) {
   $config->set('preprocess_css', $form_state['values']['preprocess_css']);
   $config->set('preprocess_js', $form_state['values']['preprocess_js']);
   $config->save();
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**
@@ -1759,14 +1761,14 @@ function system_file_system_settings() {
  * Submit handler for system_file_system_settings().
  */
 function system_file_system_settings_submit($form, &$form_state) {
-  backdrop_set_message(t('The configuration options have been saved.'));
   $config = config('system.core');
   $config->set('file_public_path', $form_state['values']['file_public_path']);
   $config->set('file_private_path', $form_state['values']['file_private_path']);
   $config->set('file_temporary_path', $form_state['values']['file_temporary_path']);
   $config->set('file_default_scheme', $form_state['values']['file_default_scheme']);
   $config->save();
-
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**
@@ -1998,6 +2000,8 @@ function system_regional_settings_submit($form, &$form_state) {
     ->set('user_empty_timezone_message', $form_state['values']['empty_timezone_message'])
     ->set('user_default_timezone', $form_state['values']['user_default_timezone'])
     ->save();
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**

--- a/core/modules/update/update.admin.inc
+++ b/core/modules/update/update.admin.inc
@@ -126,4 +126,7 @@ function update_settings_submit($form, $form_state) {
     ->set('update_emails', $form_state['notify_emails'])
     ->set('update_threshold', $form_state['values']['update_notification_threshold'])
     ->save();
+    
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/1060
