### PR TITLE
[#515] Made vertical tabs responsive

### DIFF
--- a/core/misc/vertical-tabs.css
+++ b/core/misc/vertical-tabs.css
@@ -1,76 +1,128 @@
-
 .vertical-tabs {
-  margin: 1em 0 1em 15em; /* LTR */
+  margin: 1em 0;
   border: 1px solid #ccc;
 }
-[dir="rtl"] .vertical-tabs {
-   margin-left: 0;
-   margin-right: 15em;
+@media (min-width: 750px) {
+  .vertical-tabs {
+    padding: 0 0 0 15em; /* LTR */
+  }
+  [dir="rtl"] .vertical-tabs {
+     padding-left: 0;
+     padding-right: 15em;
+  }
 }
-.vertical-tabs .vertical-tabs-list {
+.vertical-tabs-list {
+  display: none;
   width: 15em;
-  list-style: none;
   border-top: 1px solid #ccc;
   padding: 0;
-  margin: -1px 0 -1px -15em; /* LTR */
-  float: left; /* LTR */
 }
-[dir="rtl"] .vertical-tabs .vertical-tabs-list {
-  margin-left: 0;
-  margin-right: -15em;
-  float: right;
+@media (min-width: 750px) {
+  .vertical-tabs-list {
+    display:block;
+    float: left; /* LTR */
+    margin: -1px 0 -1px -15em; /* LTR */
+  }
+  [dir="rtl"] .vertical-tabs-list {
+    margin-left: 0;
+    margin-right: -15em;
+    float: right;
+  }
 }
-.vertical-tabs fieldset.vertical-tabs-pane {
-  margin: 0 !important;
-  padding: 0 1em;
+.vertical-tab-item {
+  list-style: none;
+}
+.vertical-tabs-pane {
+  margin: 0;
+  padding: 0;
   border: 0;
+  border-bottom: 1px solid #ccc;
 }
-[dir="rtl"] .vertical-tabs-list {
-  float: right;
-  margin-left: 0;
-  margin-right: -15em;
-}
-fieldset.vertical-tabs-pane > legend {
+.vertical-tabs-pane .fieldset-wrapper {
   display: none;
+  padding: 0 1em;
 }
-
+.vertical-tab-selected .fieldset-wrapper {
+  display: block;
+}
+@media (min-width: 750px) {
+  .vertical-tabs-pane {
+    display: none;
+    border: 0;
+    background: transparent;
+  }
+  /* Show active pane */
+  .vertical-tabs-pane.vertical-tab-selected {
+    display: block;
+    background: transparent;
+  }
+  .vertical-tabs-pane > legend {
+    display: none;
+  }
+  .vertical-tabs-pane .fieldset-wrapper {
+    display: block;
+  }
+}
 /* Layout of each tab */
-.vertical-tabs .vertical-tabs-list li {
+.vertical-tab-item {
   background: #eee;
   border: 1px solid #ccc;
   border-top: 0;
   padding: 0;
   margin: 0;
 }
-.vertical-tabs .vertical-tabs-list a {
+.vertical-tab-link {
   display: block;
   text-decoration: none;
   padding: 0.5em 0.6em;
+  color: blue;
+  cursor: pointer;
 }
-.vertical-tabs .vertical-tabs-list a:focus strong,
-.vertical-tabs .vertical-tabs-list a:active strong,
-.vertical-tabs .vertical-tabs-list a:hover strong {
+.vertical-tab-link span{
+  display: block;
+}
+.vertical-tab-link .fieldset-legend {
+  font-weight: bold;
+}
+.vertical-tab-link:focus strong,
+.vertical-tab-link:active strong,
+.vertical-tab-link:hover strong,
+.vertical-tab-link:focus .fieldset-legend,
+.vertical-tab-link:active .fieldset-legend,
+.vertical-tab-link:hover .fieldset-legend {
   text-decoration: underline;
 }
-.vertical-tabs .vertical-tabs-list a:hover {
+.vertical-tab-link:hover {
   outline: 1px dotted;
 }
-.vertical-tabs .vertical-tabs-list .selected {
+.vertical-tab-selected.vertical-tab-item {
   background-color: #fff;
   border-right-width: 0; /* LTR */
 }
-[dir="rtl"] .vertical-tabs .vertical-tabs-list .selected {
+[dir="rtl"] .vertical-tab-selected.vertical-tab-item {
   border-left-width: 0;
   border-right-width: 1px;
 }
-.vertical-tabs .vertical-tabs-list .selected strong {
+.vertical-tab-selected strong,
+.vertical-tab-selected .fieldset-legend {
   color: #000;
-}
-.vertical-tabs .vertical-tabs-list .summary {
-  display: block;
 }
 .vertical-tabs .vertical-tabs .vertical-tabs-list .summary {
   line-height: normal;
   margin-bottom: 0;
 }
-
+/* Styles for legend at smaller screen sizes */
+.vertical-tabs-pane > .vertical-tab-link {
+  position: relative;
+  width: 100%;
+  padding-left: 1em;
+  padding-right: 1em;
+  background: #eee;
+}
+.vertical-tabs-pane.vertical-tab-selected > .vertical-tab-link {
+  background: transparent;
+  border-bottom: 1px solid #eee;
+}
+.vertical-tabs-pane.vertical-tab-selected > .vertical-tab-link .summary {
+  display: none;
+}

--- a/core/misc/vertical-tabs.js
+++ b/core/misc/vertical-tabs.js
@@ -1,4 +1,3 @@
-
 (function ($) {
 
 /**
@@ -32,7 +31,7 @@ Backdrop.behaviors.verticalTabs = {
       $fieldsets.each(function () {
         var vertical_tab = new Backdrop.verticalTab({
           title: $('> legend', this).text(),
-          fieldset: $(this)
+          fieldset: $(this),
         });
         tab_list.append(vertical_tab.item);
         $(this)
@@ -81,6 +80,11 @@ Backdrop.verticalTab = function (settings) {
     return false;
   });
 
+  this.fieldset.children('legend').click(function () {
+    self.focus();
+    return false;
+  });
+
   // Keyboard events added:
   // Pressing the Enter key will open the tab pane.
   this.link.keydown(function(event) {
@@ -91,6 +95,11 @@ Backdrop.verticalTab = function (settings) {
       return false;
     }
   });
+
+  // Add summary to legend which is seen on smaller breakpoints
+  var $legend = this.fieldset.children('legend');
+  $legend.append(this.legendSummary = $('<span class="summary"></span>'));
+  $legend.addClass('vertical-tab-link');
 
   this.fieldset
     .bind('summaryUpdated', function () {
@@ -104,18 +113,15 @@ Backdrop.verticalTab.prototype = {
    * Displays the tab's content pane.
    */
   focus: function () {
-    this.fieldset
-      .siblings('fieldset.vertical-tabs-pane')
-        .each(function () {
-          var tab = $(this).data('verticalTab');
-          tab.fieldset.hide();
-          tab.item.removeClass('selected');
-        })
-        .end()
-      .show()
+    // Update tab control for desktop
+    this.item.siblings('.vertical-tab-selected').removeClass('vertical-tab-selected');
+    this.item
+      .addClass('vertical-tab-selected')
       .siblings(':hidden.vertical-tabs-active-tab')
         .val(this.fieldset.attr('id'));
-    this.item.addClass('selected');
+    // Update classes on previous active and new active pane
+    this.fieldset.siblings('.vertical-tab-selected').removeClass('vertical-tab-selected');
+    this.fieldset.addClass('vertical-tab-selected');
     // Mark the active tab for screen readers.
     $('#active-vertical-tab').remove();
     this.link.append('<span id="active-vertical-tab" class="element-invisible">' + Backdrop.t('(active tab)') + '</span>');
@@ -125,7 +131,9 @@ Backdrop.verticalTab.prototype = {
    * Updates the tab's summary.
    */
   updateSummary: function () {
-    this.summary.html(this.fieldset.backdropGetSummary());
+    var summaryText = this.fieldset.backdropGetSummary();
+    this.summary.html(summaryText);
+    this.legendSummary.html(summaryText);
   },
 
   /**
@@ -133,14 +141,14 @@ Backdrop.verticalTab.prototype = {
    */
   tabShow: function () {
     // Display the tab.
-    this.item.show();
+    this.focus();
     // Update .first marker for items. We need recurse from parent to retain the
     // actual DOM element order as jQuery implements sortOrder, but not as public
     // method.
-    this.item.parent().children('.vertical-tab-button').removeClass('first')
+    this.item.parent().children('.vertical-tab-item').removeClass('first')
       .filter(':visible:first').addClass('first');
-    // Display the fieldset.
-    this.fieldset.removeClass('vertical-tab-hidden').show();
+    // Remove hidden class, in case tabHide was run on this tab
+    this.fieldset.removeClass('vertical-tab-hidden');
     return this;
   },
 
@@ -148,12 +156,10 @@ Backdrop.verticalTab.prototype = {
    * Hides a vertical tab pane.
    */
   tabHide: function () {
-    // Hide this tab.
-    this.item.hide();
     // Update .first marker for items. We need recurse from parent to retain the
     // actual DOM element order as jQuery implements sortOrder, but not as public
     // method.
-    this.item.parent().children('.vertical-tab-button').removeClass('first')
+    this.item.parent().children('.vertical-tab-item').removeClass('first')
       .filter(':visible:first').addClass('first');
     // Hide the fieldset.
     this.fieldset.addClass('vertical-tab-hidden').hide();
@@ -181,8 +187,9 @@ Backdrop.verticalTab.prototype = {
  */
 Backdrop.theme.prototype.verticalTab = function (settings) {
   var tab = {};
-  tab.item = $('<li class="vertical-tab-button" tabindex="-1"></li>')
-    .append(tab.link = $('<a href="#"></a>')
+  // Calculating height in em so CSS has a chance to update height
+  tab.item = $('<li class="vertical-tab-item" tabindex="-1"></li>')
+    .append(tab.link = $('<a href="#" class="vertical-tab-link"></a>')
       .append(tab.title = $('<strong></strong>').text(settings.title))
       .append(tab.summary = $('<span class="summary"></span>')
     )

--- a/core/modules/system/css/system.theme.css
+++ b/core/modules/system/css/system.theme.css
@@ -8,13 +8,16 @@
  * HTML elements.
  */
 fieldset {
-  min-width: 0; /* Webkit/Blink fix for mobile */
+  /* Webkit/Blink fix for mobile, see stackoverflow.com/questions/17408815 */
+  min-width: 0;
   margin-bottom: 1em;
   padding: 0.5em;
 }
 @-moz-document url-prefix() {
+  /* Firefox fix, see stackoverflow.com/questions/17408815 */
   fieldset {
-    display: table-cell; /* Firefox mobile fix */
+    display: table-cell;
+    vertical-align: top;
   }
 }
 form {

--- a/core/themes/seven/css/vertical-tabs.css
+++ b/core/themes/seven/css/vertical-tabs.css
@@ -1,94 +1,190 @@
-
 /**
  * Override of misc/vertical-tabs.css.
  */
 .vertical-tabs {
-  background: #fff url(../images/fc.png) repeat-y 0 0; /* LTR */
-  border: 1px solid #ccc;
-  margin: 10px 0;
   position: relative;
-}
-[dir="rtl"] .vertical-tabs {
-  background: #fff url(../images/fc-rtl.png) repeat-y right 0;
-}
-fieldset.vertical-tabs-pane {
-  border: 0;
-  padding: 0;
-  margin: 0;
-}
-.vertical-tabs .vertical-tabs-list {
-  border-bottom: 1px solid #ccc;
-  float: left; /* LTR */
-  font-size: 0.923em;
-  line-height: 1.385em;
-  margin: 0 -100% -1px 0; /* LTR */
-  padding: 0;
-  width: 240px;
-}
-[dir="rtl"] .vertical-tabs .vertical-tabs-list {
-  float: right;
-  margin: 0 0 -1px -100%;
-}
-.vertical-tabs .vertical-tab-button {
-  list-style: none;
-  list-style-image: none;
-  margin: 0;
-}
-.vertical-tabs .vertical-tab-button a {
-  border-top: 1px solid #ccc;
-  display: block;
-  padding: 10px;
-}
-.vertical-tabs .first a {
-  border-top: 0;
-}
-.vertical-tabs .vertical-tab-button strong {
-  font-size: 0.923em;
-}
-.vertical-tabs .vertical-tab-button .summary {
-  color: #666;
-  display: block;
-  font-size: 0.846em;
-  padding-top: 0.4em;
-}
-.vertical-tabs .vertical-tab-button a:hover,
-.vertical-tabs .vertical-tab-button a:focus {
-  background: #d5d5d5;
-  text-decoration: none;
-  outline: 0;
-}
-.vertical-tabs .selected a,
-.vertical-tabs .selected a:hover,
-.vertical-tabs .selected a:focus,
-.vertical-tabs .selected a:active {
+  margin: 1em 0;
+  border: 1px solid #ccc;
   background: #fff;
-  border-right-color: #fff; /* LTR */
-  border-top: 1px solid #ccc;
 }
-[dir="rtl"] .vertical-tabs .selected a,
-[dir="rtl"] .vertical-tabs .selected a:hover,
-[dir="rtl"] .vertical-tabs .selected a:focus,
-[dir="rtl"] .vertical-tabs .selected a:active {
-  border-left-color: #fff;
+ @media (min-width: 750px) {
+  .vertical-tabs {
+    padding: 0 0 0 15em; /* LTR */
+  }
+   [dir="rtl"] .vertical-tabs {
+     padding-left: 0;
+     padding-right: 15em;
+  }
+  .vertical-tabs:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: 0;
+    width: 15em;
+    height: 100%;
+    background: #ccc;
+  }
 }
-.vertical-tabs .first.selected a,
-.vertical-tabs .first.selected a:hover {
-  border-top: 0;
-}
-.vertical-tabs .selected a:focus strong {
-  text-decoration: underline;
-}
-.vertical-tabs .vertical-tabs-panes {
-  margin: 0 0 0 265px; /* LTR */
-  padding: 10px 15px 10px 0; /* LTR */
-}
-[dir="rtl"] .vertical-tabs .vertical-tabs-panes {
-  margin: 0 265px 0 0;
-  padding: 10px 0 10px 15px;
-}
-fieldset.vertical-tabs-pane > legend {
+.vertical-tabs-list {
+  position: relative;
+  z-index: 1;
   display: none;
+  width: 15em;
+  border-top: 1px solid #ccc;
+  padding: 0;
 }
-.vertical-tabs-pane .fieldset-wrapper > div:first-child {
-  padding-top: 5px;
+ @media (min-width: 750px) {
+  .vertical-tabs-list {
+    display:block;
+    float: left; /* LTR */
+    margin: -1px 0 -1px -15em; /* LTR */
+  }
+   [dir="rtl"] .vertical-tabs-list {
+    margin-left: 0;
+    margin-right: -15em;
+    float: right;
+  }
+}
+.vertical-tab-item {
+  list-style: none;
+  font-size: 0.923em;
+}
+.vertical-tabs-pane {
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid #ccc;
+  border-radius: 0;
+}
+.vertical-tabs-pane:nth-last-child(2) {
+  border-bottom: 0;
+}
+.vertical-tabs-pane .fieldset-wrapper {
+  display: none;
+  padding: 0 1em;
+}
+.vertical-tab-selected .fieldset-wrapper {
+  display: block;
+}
+@media (min-width: 750px) {
+  .vertical-tabs-panes {
+    overflow: hidden;
+    width: 100%;
+  }
+  .vertical-tabs-pane {
+    /* Using position and height instead of display because of FF issue */
+    position: absolute;
+    left: -9999em;
+    height: 0;
+    border: 0;
+    background: transparent;
+  }
+  /* Show active pane */
+  .vertical-tabs-pane.vertical-tab-selected {
+    position: static;
+    height: auto;
+    padding: 10px 15px;
+    background: transparent;
+  }
+  .vertical-tabs-pane > legend {
+    display: none;
+  }
+  .vertical-tabs-pane .fieldset-wrapper {
+    display: block;
+  }
+}
+ /* Layout of each tab */
+.vertical-tab-item {
+  border: 1px solid #ccc;
+  border-left-width: 0; /* LTR */
+  border-top-width: 0;
+  padding: 0;
+  margin: 0;
+  background: #eee;
+}
+[dir="rtl"] .vertical-tab-item {
+  border-left-width: 1px;
+  border-right-width: 0;
+}
+/* .vertical-tab-link applies to fieldset legend at small screens and
+   a link in .vertical-tabs-list at larger screen sizes */
+.vertical-tab-link {
+  display: block;
+  text-decoration: none;
+  padding: 0.5em 0.6em;
+  font-size: 1em;
+  cursor: pointer;
+  transition:
+    background-color 0.3s,
+    color 0.3s;
+}
+.vertical-tab-link span{
+  display: block;
+}
+
+.vertical-tab-link strong,
+.vertical-tab-link .fieldset-legend {
+  position: static;
+  font-weight: bold;
+  color: #0074bd;
+  margin: 0;
+  padding: 0;
+}
+@media (min-width: 750px) {
+  .vertical-tab-link strong,
+  .vertical-tab-link .fieldset-legend {
+    font-size: 0.923em;
+  }
+}
+.vertical-tab-link:focus,
+.vertical-tab-link:active,
+.vertical-tab-link:hover,
+.vertical-tab-link:focus,
+.vertical-tab-link:active,
+.vertical-tab-link:hover {
+  text-decoration: none;
+  background: #d5d5d5;
+}
+.vertical-tab-link .summary {
+  font-size: 0.846em;
+  text-transform: none;
+  color: #666;
+}
+.vertical-tab-selected.vertical-tab-item {
+  background-color: #fff;
+  border-right-width: 0; /* LTR */
+}
+ [dir="rtl"] .vertical-tab-selected.vertical-tab-item {
+  border-left-width: 0;
+  border-right-width: 1px;
+}
+.vertical-tab-selected .vertical-tab-link {
+  background: #fff;
+}
+.vertical-tab-selected strong,
+.vertical-tab-selected .fieldset-legend {
+  color: #000;
+}
+.vertical-tabs .vertical-tabs .vertical-tabs-list .summary {
+  line-height: normal;
+  margin-bottom: 0;
+}
+/* Styles for legend at smaller screen sizes */
+.vertical-tabs-pane > .vertical-tab-link {
+  width: 100%;
+  box-sizing: border-box;
+  padding-left: 1em;
+  padding-right: 1em;
+  background: #eee;
+}
+.vertical-tabs-pane.vertical-tab-selected > .vertical-tab-link {
+  padding-top: 0.7em;
+  padding-bottom: 0.7em;
+  background: transparent;
+  border-bottom: 1px solid #eee;
+}
+.vertical-tabs-pane.vertical-tab-selected > .vertical-tab-link .summary {
+  display: none;
 }


### PR DESCRIPTION
At small screen sizes we're using an accordion design pattern
- Using the fieldset legend as the toggle
- Added summary to the fieldset legend
- Added all styles needed for mobile
  Also added more class names for elements
  As a result was able to reduce specificity in core styles and write simpler styles
  Reworked seven styles based on core's to achieve the same design we had at desktop before since markup/classes changed enough that figure out how to fix the old seven styles was a pain
