### PR TITLE
Issue #1182: Date field "Show end date" checkbox does not work with Date Popup widget.

### DIFF
--- a/core/modules/date/date.elements.inc
+++ b/core/modules/date/date.elements.inc
@@ -1466,7 +1466,6 @@ function date_combo_element_process($element, &$form_state, $form) {
       $element[$from_field]['#type'] = 'date_select';
       $element[$from_field]['#theme_wrappers'] = array('date_select');
       $element[$from_field]['#ajax'] = !empty($element['#ajax']) ? $element['#ajax'] : FALSE;
-      $element['#attached']['js'][] = backdrop_get_path('module', 'date') . '/js/date-select.js';
       break;
 
     case 'date_popup':
@@ -1494,6 +1493,7 @@ function date_combo_element_process($element, &$form_state, $form) {
     $element[$to_field]['#weight'] += .2;
     $element[$to_field]['#prefix'] = '';
     $element[$to_field]['#date_title'] = $instance['label'];
+    $element['#attached']['js'][] = backdrop_get_path('module', 'date') . '/js/date-range.js';
   }
   else {
     $element[$from_field]['#description'] = $description;

--- a/core/modules/date/js/date-range.js
+++ b/core/modules/date/js/date-range.js
@@ -2,9 +2,9 @@
 
 "use strict";
 
-Backdrop.behaviors.dateSelect = {};
+Backdrop.behaviors.dateRange = {};
 
-Backdrop.behaviors.dateSelect.attach = function (context, settings) {
+Backdrop.behaviors.dateRange.attach = function (context, settings) {
   var $context = $(context);
   var $widgets = $context.find('.end-date-wrapper').once('date-select-range');
   for (var i = 0; i < $widgets.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1182.
