### PR TITLE
Issue #1173: Default to user-entered tokens being off for Link module.

### DIFF
--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -35,7 +35,7 @@ function link_field_info() {
         'title_value' => '',
         'title_label_use_field_label' => FALSE,
         'title_maxlength' => 128,
-        'enable_tokens' => 1,
+        'enable_tokens' => 0,
         'display' => array(
           'url_cutoff' => 80,
         ),
@@ -123,19 +123,18 @@ function link_field_instance_settings_form($field, $instance) {
     '#size' => 3,
   );
 
-  $form['enable_tokens'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Allow user-entered tokens'),
-    '#default_value' => $instance['settings']['enable_tokens'],
-    '#description' => t('Checking will allow users to enter tokens in URLs and Titles on the content form. This does not affect the field settings on this page, which always support tokens.'),
-  );
-
   $form['advanced'] = array(
     '#type' => 'fieldset',
     '#title' => t('Advanced Options'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#parents' => array('instance', 'settings'),
+  );
+  $form['advanced']['enable_tokens'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow user-entered tokens'),
+    '#default_value' => $instance['settings']['enable_tokens'],
+    '#description' => t('Checking will allow users to enter tokens in URLs and Titles on the content form. This does not affect the field settings on this page, which always support tokens.'),
   );
   $form['advanced']['display']['url_cutoff'] = array(
     '#type' => 'textfield',

--- a/core/modules/link/tests/link.ui.test
+++ b/core/modules/link/tests/link.ui.test
@@ -241,7 +241,7 @@ class LinkUITest extends LinkBaseTestClass {
     $this->assertFalse($instance['required'], 'Make sure field is not required.');
     $this->assertEqual($instance['settings']['title'], 'optional', 'Title should be optional by default.');
     $this->assertTrue($instance['settings']['validate_url'], 'Make sure validation is on.');
-    $this->assertTrue($instance['settings']['enable_tokens'], 'Enable Tokens should be on by default.');
+    $this->assertFalse($instance['settings']['enable_tokens'], 'Enable Tokens should be off by default.');
     $this->assertEqual($instance['settings']['display']['url_cutoff'], 80, 'Url cutoff should be at 80 characters.');
     $this->assertEqual($instance['settings']['attributes']['target'], 'default', 'Target should be "default"');
     $this->assertFalse($instance['settings']['attributes']['rel'], 'Rel should be blank by default.');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1173
