### PR TITLE
Issue #1183: Skip the field settings page if no field settings exist.

### DIFF
--- a/core/modules/field/tests/field_test/field_test.field.inc
+++ b/core/modules/field/tests/field_test/field_test.field.inc
@@ -134,6 +134,12 @@ function field_test_field_is_empty($item, $field) {
 function field_test_field_settings_form($field, $instance, $has_data) {
   $settings = $field['settings'];
 
+  // Return no settings if so set to test skipping the field settings
+  // form step when adding new fields.
+  if (state_get('field_ui_test_field_settings', TRUE) === FALSE) {
+    return array();
+  }
+
   $form['test_field_setting'] = array(
     '#type' => 'textfield',
     '#title' => t('Field test field setting'),

--- a/core/modules/field_ui/field_ui.admin.inc
+++ b/core/modules/field_ui/field_ui.admin.inc
@@ -1528,9 +1528,6 @@ function field_ui_field_settings_form($form, &$form_state, $instance) {
   // See if data already exists for this field.
   // If so, prevent changes to the field settings.
   $has_data = field_has_data($field);
-  if ($has_data) {
-    $form['field']['#description'] = '<div class="messages error">' . t('There is data for this field in the database. The field settings can no longer be changed.') . '</div>' . $form['field']['#description'];
-  }
 
   // Build the non-configurable field values.
   $form['field']['field_name'] = array('#type' => 'value', '#value' => $field['field_name']);
@@ -1544,9 +1541,19 @@ function field_ui_field_settings_form($form, &$form_state, $instance) {
   $form['field']['settings'] = array();
   $additions = module_invoke($field['module'], 'field_settings_form', $field, $instance, $has_data);
   if (is_array($additions)) {
+    if ($has_data) {
+      $form['field']['#description'] = '<div class="messages warning">' . t('There is data for this field in the database. Some field settings may no longer be changed.') . '</div>' . $form['field']['#description'];
+    }
     $form['field']['settings'] = $additions;
   }
-  if (empty($form['field']['settings'])) {
+  if (empty($additions)) {
+    // If there are no settings and we are in the middle of adding a field for
+    // the first time, skip this page entirely and proceed to the widget
+    // settings.
+    $redirect = field_ui_next_destination($entity_type, $bundle);
+    if (is_array($redirect)) {
+      call_user_func_array('backdrop_goto', $redirect);
+    }
     $form['field']['settings'] = array(
       '#markup' => t('%field has no field settings.', array('%field' => $instance['label'])),
     );

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -62,18 +62,25 @@ class FieldUITestCase extends BackdropWebTestCase {
 
     // First step : 'Add new field' on the 'Manage fields' page.
     $this->backdropPost("$bundle_path/fields",  $initial_edit, t('Save'));
-    $this->assertRaw(t('These settings apply to the %label field everywhere it is used.', array('%label' => $label)), 'Field settings page was displayed.');
 
     // Second step : 'Field settings' form.
-    $this->backdropPost(NULL, $field_edit, t('Save field settings'));
-    $this->assertRaw(t('Updated field %label field settings.', array('%label' => $label)), 'Redirected to instance and widget settings page.');
+    if (state_get('field_ui_test_field_settings', TRUE)) {
+      $this->assertRaw(format_string('These settings apply to the %label field everywhere it is used.', array('%label' => $label)), 'Field settings page was displayed.');
+      $this->backdropPost(NULL, $field_edit, t('Save field settings'));
+      $this->assertRaw(format_string('Updated field %label field settings.', array('%label' => $label)), 'Redirected to instance and widget settings page.');
+    }
+    // Second step is skipped if the field has no settings.
+    else {
+      $this->assertNoRaw(format_string('These settings apply to the %label field everywhere it is used.', array('%label' => $label)), 'Field settings page was skipped because it had no settings.');
+    }
 
     // Third step : 'Instance settings' form.
+    $this->assertRaw(format_string('These settings apply only to the %field field', array('%field' => $label)), 'Field instance settings page was displayed.');
     $this->backdropPost(NULL, $instance_edit, t('Save settings'));
-    $this->assertRaw(t('Saved %label configuration.', array('%label' => $label)), 'Redirected to "Manage fields" page.');
+    $this->assertRaw(format_string('Saved %label configuration.', array('%label' => $label)), 'Redirected to "Manage fields" page.');
 
     // Check that the field appears in the overview form.
-    $this->assertFieldByXPath('//table[@id="field-overview"]//td[1]', $label, 'Field was created and appears in the overview page.');
+    $this->assertLinkByHref("$bundle_path/fields/field_$field_name", 0, 'Field was created and appears in the overview page.');
   }
 
   /**
@@ -104,7 +111,7 @@ class FieldUITestCase extends BackdropWebTestCase {
     $this->assertRaw(t('Saved %label configuration.', array('%label' => $label)), 'Redirected to "Manage fields" page.');
 
     // Check that the field appears in the overview form.
-    $this->assertFieldByXPath('//table[@id="field-overview"]//td[1]', $label, 'Field was created and appears in the overview page.');
+    $this->assertLinkByHref("$bundle_path/fields/$field_name", 0, 'Field was created and appears in the overview page.');
   }
 
   /**
@@ -184,6 +191,18 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
     $this->createField();
     $this->updateField();
     $this->addExistingField();
+  }
+
+  /**
+   * Create a field that has no global field settings.
+   *
+   * This test creates a field but in one fewer step because the field has
+   * no global field settings.
+   */
+  function testCreateFieldNoSettings() {
+    // This setting is checked in field_test_field_settings_form().
+    state_get('field_ui_test_field_settings', FALSE);
+    $this->createField();
   }
 
   /**
@@ -402,7 +421,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
    * Tests that Field UI respects the 'no_ui' option in hook_field_info().
    */
   function testHiddenFields() {
-    $bundle_path = 'admin/structure/types/manage/' . $this->hyphen_type . '/fields/';
+    $bundle_path = 'admin/structure/types/manage/' . $this->hyphen_type . '/fields';
 
     // Check that the field type is not available in the 'add new field' row.
     $this->backdropGet($bundle_path);
@@ -424,11 +443,11 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
     // Check that the newly added instance appears on the 'Manage Fields'
     // screen.
     $this->backdropGet($bundle_path);
-    $this->assertFieldByXPath('//table[@id="field-overview"]//td[1]', $instance['label'], 'Field was created and appears in the overview page.');
+    $this->assertLinkByHref("$bundle_path/$field_name", 0, 'Field was created and appears in the overview page.');
 
     // Check that the instance does not appear in the 'add existing field' row
     // on other bundles.
-    $bundle_path = 'admin/structure/types/manage/post/fields/';
+    $bundle_path = 'admin/structure/types/manage/post/fields';
     $this->backdropGet($bundle_path);
     $this->assertFalse($this->xpath('//select[@id="edit-add-existing-field-field-name"]//option[@value=:field_name]', array(':field_name' => $field_name)), "The 'add existing field' select respects field types 'no_ui' property.");
   }

--- a/core/modules/link/tests/link.test
+++ b/core/modules/link/tests/link.test
@@ -53,7 +53,10 @@ class LinkBaseTestClass extends BackdropWebTestCase {
     );
     $field_name = 'field_' . $name;
     $this->backdropPost('admin/structure/types/manage/' . $node_type . '/fields', $edit, t('Save'));
-    $this->backdropPost(NULL, array(), t('Save field settings'));
+
+    // Lind does not have any field settings, so these are skipped.
+    // $this->backdropPost(NULL, array(), t('Save field settings'));
+
     $this->backdropPost(NULL, $settings, t('Save settings'));
 
     // Is field created?

--- a/core/modules/link/tests/link.ui.test
+++ b/core/modules/link/tests/link.ui.test
@@ -38,7 +38,6 @@ class LinkUITest extends LinkBaseTestClass {
       'fields[_add_new_field][widget_type]' => 'link_field',
     );
     $this->backdropPost('admin/structure/types/manage/page/fields', $edit, t('Save'));
-    $this->backdropPost(NULL, array(), t('Save field settings'));
     $this->backdropPost(NULL, array(), t('Save settings'));
 
     // Is field created?
@@ -152,10 +151,10 @@ class LinkUITest extends LinkBaseTestClass {
       'fields[_add_new_field][widget_type]' => 'link_field',
     );
     $this->backdropPost('admin/structure/types/manage/page/fields', $edit, t('Save'));
-    $this->backdropPost(NULL, array(), t('Save field settings'));
     $this->backdropPost(NULL, array(
       'instance[settings][title]' => 'value',
-      'instance[settings][title_value]' => '<strong>' . $name . '</strong>'), t('Save settings'));
+      'instance[settings][title_value]' => '<strong>' . $name . '</strong>'), t('Save settings')
+    );
 
     // Is field created?
     $this->assertRaw(t('Saved %label configuration', array('%label' => $name)), 'Field added');
@@ -189,7 +188,6 @@ class LinkUITest extends LinkBaseTestClass {
       'fields[_add_new_field][widget_type]' => 'link_field',
     );
     $this->backdropPost('admin/structure/types/manage/page/fields', $edit, t('Save'));
-    $this->backdropPost(NULL, array(), t('Save field settings'));
     $this->backdropPost(NULL, array(
       'instance[settings][url]' => 1,
     ), t('Save settings'));
@@ -228,7 +226,6 @@ class LinkUITest extends LinkBaseTestClass {
       'fields[_add_new_field][widget_type]' => 'link_field',
     );
     $this->backdropPost('admin/structure/types/manage/page/fields', $edit, t('Save'));
-    $this->backdropPost(NULL, array(), t('Save field settings'));
     $this->backdropPost(NULL, array(), t('Save settings'));
 
     // Is field created?
@@ -263,7 +260,6 @@ class LinkUITest extends LinkBaseTestClass {
     );
     $this->backdropPost('admin/structure/types/manage/page/fields', $edit, t('Save'));
 
-    $this->backdropPost(NULL, array(), t('Save field settings'));
     $link_class_name = 'basic-link-' . strtolower($this->randomName());
     $edit = array(
       'instance[settings][attributes][class]' => $link_class_name,
@@ -322,7 +318,6 @@ class LinkUITest extends LinkBaseTestClass {
     );
     $this->backdropPost('admin/structure/types/manage/page/fields', $edit, t('Save'));
 
-    $this->backdropPost(NULL, array(), t('Save field settings'));
     $link_class_name = 'basic-link ' . strtoupper($this->randomName());
     $edit = array(
       'instance[settings][attributes][class]' => $link_class_name,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1183.
