### PR TITLE
Issue #1172: Set default date field values to blank instead of now.

### DIFF
--- a/core/modules/date/date.field.inc
+++ b/core/modules/date/date.field.inc
@@ -232,7 +232,7 @@ function date_field_info() {
       'timezone_db' => 'UTC',
     ),
     'instance_settings' => array(
-      'default_value' => 'now',
+      'default_value' => 'blank',
       'default_value_code' => '',
       'default_value2' => 'same',
       'default_value_code2' => '',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1172

Replacement PR for https://github.com/backdrop/backdrop/pull/1056.
