### PR TITLE
Issue #1194: Pages that are admin-URLs use the wrong layout when a user cannot view the admin theme.

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -424,6 +424,13 @@ function layout_route_handler($router_item) {
     }
   }
 
+  // Safety check that we don't show an admin layout to a user who cannot view
+  // the admin theme. This may happen because the cached layout list does not
+  // include a permissions check on the admin theme.
+  if ($selected_layout->name === 'admin_default' && !user_access('view the administration theme')) {
+    $selected_layout = layout_load('default');
+  }
+
   // Special handling for 404 and 403 pages to render in admin theme. The
   // current path will be the 404/403 system path, and we need to check the
   // original path, which is stored in "destination" by

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -945,21 +945,46 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
  * Tests that the correct layout is used in various situations.
  */
 class LayoutSelectionTest extends BackdropWebTestCase {
-  /**
-   * Tests the correct layout is used on 404 and 403 pages.
-   */
-  function testErrorPages() {
+  protected $profile = 'testing';
+  protected $content_type;
+  protected $web_user;
+  protected $admin_user;
+
+  function setUp() {
+    parent::setUp(array('layout'));
+    config_set('system.core', 'node_admin_theme', TRUE);
+
+    // Create a content type for checking node/add page layouts.
+    $this->content_type = $this->backdropCreateContentType();
+
+    // Create a limited-ability user that cannot access the admin theme.
+    $this->web_user = $this->backdropCreateUser(array(
+      'access content',
+      'create ' . $this->content_type->type . ' content',
+    ));
+
     // Create and login admin user.
-    $admin_user = $this->backdropCreateUser(array(
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access content',
+      'create ' . $this->content_type->type . ' content',
       'access administration pages',
       'administer content types',
       'view the administration theme',
       'administer filters',
     ));
-    $this->backdropLogin($admin_user);
+    $this->backdropLogin($this->admin_user);
+  }
 
+  /**
+   * Tests the correct layout is used on 404 and 403 pages.
+   */
+  function testPages() {
     // Check that a known page is using the admin (one-column) layout.
     $this->backdropGet('admin/config/content/formats/plain_text');
+    $this->assertIsAdminLayout();
+
+    // Check that node/add uses the admin layout for the admin user.
+    $this->backdropGet('node/add/' . $this->content_type->type);
     $this->assertIsAdminLayout();
 
     // Check that a 403 page uses the admin layout.
@@ -983,6 +1008,12 @@ class LayoutSelectionTest extends BackdropWebTestCase {
 
     // Anonymous 404.
     $this->backdropGet('admin/config/content/formats/fake-format');
+    $this->assertIsDefaultLayout();
+
+    // Check that a logged in user that can access an admin page but not the
+    // admin theme uses the default layout.
+    $this->backdropLogin($this->web_user);
+    $this->backdropGet('node/add/' . $this->content_type->type);
     $this->assertIsDefaultLayout();
   }
 

--- a/core/modules/layout/tests/layout_test/layout_test.module
+++ b/core/modules/layout/tests/layout_test/layout_test.module
@@ -71,6 +71,9 @@ function layout_test_block_view($delta = '', $settings = array(), $contexts = ar
 
   switch ($delta) {
     case 'foo':
+      $settings += array(
+        'count' => 0,
+      );
       $block['subject'] = 'Foo subject';
       $block['content'] = format_string('The setting of count is @setting.', array('@setting' => $settings['count']));
       break;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1194.
