### PR TITLE
Issue #1200: Image caption should wrap.

### DIFF
--- a/core/modules/system/css/system.theme.css
+++ b/core/modules/system/css/system.theme.css
@@ -573,7 +573,9 @@ img.align-right {
   max-width: 100%;
 }
 .caption > figcaption {
-  display: block;
+  display: table;
+  box-sizing: border-box;
+  width: 100%;
   caption-side: bottom;
   max-width: none;
   padding: 3px 6px;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1200.
