### PR TITLE
Issue #1229:  Prevent users from using the word node for a URL Alias.

### DIFF
--- a/core/modules/path/js/path.js
+++ b/core/modules/path/js/path.js
@@ -17,6 +17,21 @@ Backdrop.behaviors.pathFieldsetSummaries = {
         return Backdrop.t('Automatic alias');
       }
       if (path) {
+        $('#edit-path-alias').keyup(function (event) {
+          var my_path = $element.find('[name="path[alias]"]').val();
+          console.log(path);
+          if (my_path == 'node') {
+            $('input#edit-path-alias').css('color', '#f00');
+            $('input#edit-submit').prop('disabled', true);
+            $('input#edit-submit').css('background-color', '#fafafa');
+          }
+          else {
+            $('input#edit-submit').prop('disabled', false);
+            $('input#edit-path-alias').css('color', '#000');
+            $('input#edit-submit').css('background-color', '#1766ae');
+          }
+        });
+
         return Backdrop.t('Alias: @alias', { '@alias': path });
       }
       else {


### PR DESCRIPTION
This fixes #1229: Prevent users from using the word node in as a URL Alias.
