### PR TITLE
Issue #1236:  Cleaning up .htaccess directives for php versions >= 5.3.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,15 +27,11 @@ DirectoryIndex index.php index.html index.htm
 # Override PHP settings that cannot be changed at runtime. See
 # settings.php and backdrop_environment_initialize() in includes/bootstrap.inc
 # for settings that can be changed at runtime.
-
-# PHP 5, Apache 1 and 2.
 <IfModule mod_php5.c>
-  php_flag magic_quotes_gpc                 off
-  php_flag magic_quotes_sybase              off
-  php_flag register_globals                 off
   php_flag session.auto_start               off
   php_value mbstring.http_input             pass
   php_value mbstring.http_output            pass
+  php_value max_input_vars                  10007
   php_flag mbstring.encoding_translation    off
 </IfModule>
 


### PR DESCRIPTION
This fixes #1236: Clean up .htaccess directives to reflect php versions >= 5.3.
