### PR TITLE
Issue #1241: Version number missing from CKEditor and Date core modules.

### DIFF
--- a/core/modules/ckeditor/ckeditor.info
+++ b/core/modules/ckeditor/ckeditor.info
@@ -1,6 +1,7 @@
 name = CKEditor
 description = WYSIWYG editing for rich text fields using CKEditor.
 package = User interface
+version = BACKDROP_VERSION
 backdrop = 1.x
 type = module
 configure = admin/config/content/formats

--- a/core/modules/date/date.info
+++ b/core/modules/date/date.info
@@ -1,6 +1,7 @@
 name = Date
 description = Makes date/time fields available.
 package = Date/Time
+version = BACKDROP_VERSION
 backdrop = 1.x
 type = module
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1241.
