### PR TITLE
Issue #1281: Set the default value for error messages to None.

### DIFF
--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -14,7 +14,7 @@
     "cron_max_threshold": 10800,
     "cron_threshold_error": 1209600,
     "default_nodes_main": 10,
-    "error_level": "all",
+    "error_level": "hide",
     "field_purge_batch_size": 200,
     "file_default_scheme": "public",
     "file_private_path": "",


### PR DESCRIPTION
This fixes: https://github.com/backdrop/backdrop-issues/issues/1281 
