### PR TITLE
Fix drupal_array_merge_deep()

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -139,7 +139,8 @@ function drupal_hash_base64($data) {
   return backdrop_hash_base64($data);
 }
 function drupal_array_merge_deep() {
-  return backdrop_array_merge_deep();
+  $args = func_get_args(); // pass $args to function
+  return call_user_func_array('backdrop_array_merge_deep', $args);
 }
 function drupal_array_merge_deep_array($arrays) {
   return backdrop_array_merge_deep_array($arrays);


### PR DESCRIPTION
`drupal_array_merge_deep` doesn't even work (no arguments passed) and requires a minimum of 2 arguments (two arrays to merge)

Discovered this when attempting to support Backdrop for Bootstrap:
https://www.drupal.org/node/2483391
