### PR TITLE
Issue #1290: Fix path not applying taxonomy specific path patterns.

### DIFF
--- a/core/modules/path/path.inc
+++ b/core/modules/path/path.inc
@@ -382,7 +382,13 @@ function path_generate_entity_alias(Entity $entity, $source = NULL, $langcode = 
   $entity_type_name = $entity->entityType();
   $entity_type = entity_get_info($entity_type_name);
   $token_type = isset($entity_type['token type']) ? $entity_type['token type'] : NULL;
-  $bundle = $entity->bundle();
+  //$bundle = $entity->bundle();
+  if ($entity_type_name == 'taxonomy_term') {
+    $bundle = $entity->vocabulary;
+  }
+  else {
+    $bundle = $entity->bundle();
+  }
 
   if (!isset($source)) {
     $uri = $entity->uri();

--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -205,7 +205,7 @@ class PathTaxonomyTermTestCase extends BackdropWebTestCase {
   function testTermAlias() {
     // Create a term in the default 'Tags' vocabulary with URL alias.
     $vocabulary = taxonomy_vocabulary_load('tags');
-    $description = $this->randomName();;
+    $description = $this->randomName();
     $edit = array();
     $edit['name'] = $this->randomName();
     $edit['description[value]'] = $description;


### PR DESCRIPTION
Respect the path patterns set on `/admin/config/search/path/patterns` for specific taxonomies.
