### PR TITLE
Issue #1111: Remove leftover 'Preview' status from vertical tabs on…

### DIFF
--- a/core/modules/node/js/node.types.js
+++ b/core/modules/node/js/node.types.js
@@ -8,7 +8,6 @@ Backdrop.behaviors.contentTypes = {
     $context.find('fieldset#edit-submission').backdropSetSummary(function() {
       var vals = [];
       vals.push(Backdrop.checkPlain($context.find('input[name="title_label"]').val()) || Backdrop.t('Requires a title'));
-      vals.push(Backdrop.t('Preview !status', { '!status': $context.find('input[name="node_preview"]:checked').siblings('label').text() }));
       return vals.join(', ');
     });
 


### PR DESCRIPTION
…content type form.

Simple fix for https://github.com/backdrop/backdrop-issues/issues/1111. Follow up to 7e286f5.
