### PR TITLE
Issue #1323: Prevent PHP notices when using views exposed form in block.

### DIFF
--- a/core/modules/views/views.module
+++ b/core/modules/views/views.module
@@ -563,7 +563,10 @@ function views_preprocess_layout(&$variables) {
       $view = $view->view;
     }
 
-    views_add_contextual_links($variables['content'], 'page', $view, $view->current_display);
+    // Since views exposed filters do not have a current display, test first.
+    if (property_exists($view, 'current_display') && isset($view->current_display)) {
+      views_add_contextual_links($variables['content'], 'page', $view, $view->current_display);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1323
