### PR TITLE
Issue #1356: Fix 'Output this field as link' in views.

### DIFF
--- a/core/modules/views/handlers/views_handler_field.inc
+++ b/core/modules/views/handlers/views_handler_field.inc
@@ -1244,7 +1244,7 @@ If you would like to have the characters \'[\' and \']\' please use the html ent
 
     if (!empty($alter['make_link']) && !empty($alter['path'])) {
       if (!isset($tokens)) {
-        if (strpos($value, '[') !== FALSE) {
+        if (strpos($alter['path'], '[') !== FALSE) {
           $tokens = $this->get_render_tokens($alter);
         }
         else {


### PR DESCRIPTION
In a view, the 'Output this field as link' option wasn't rewriting the tokens from 'Link path'. The existing code only calls `get_render_tokens` if `$value` contains a '[', but the tokens to be replaced aren't in `$value`, they're in `$alter['path']`, so `$tokens` was just an empty array, which is why none of the tokens were being replaced.
