### PR TITLE
Issue #1357: Block display of view can show page content

### DIFF
--- a/core/modules/views/views.module
+++ b/core/modules/views/views.module
@@ -1489,6 +1489,11 @@ function views_get_view($name, $reset = FALSE) {
       $cache[$name] = FALSE;
     }
   }
+  else {
+    if ($cache[$name]) {
+      $cache[$name] = $cache[$name]->clone_view();
+    }
+  }
 
   return $cache[$name];
 }


### PR DESCRIPTION
When retrieving a view from the cache, create a fresh clone. The drupal 7 views module does it, although it does it every time, I wrote it so that it's only when returning a cached view. Possibly a premature optimisation? Might be better to just return using `return $cache[$name]->clone_view()`.
