### PR TITLE
Issue #1358: SymLinksIfOwnerMatch may break Color module.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,9 +15,6 @@
 # Don't show directory listings for URLs which map to a directory.
 Options -Indexes
 
-# Follow symbolic links in this directory.
-Options +SymLinksIfOwnerMatch
-
 # Make Backdrop handle any 404 errors.
 ErrorDocument 404 /index.php
 

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -529,8 +529,7 @@ function file_save_htaccess($directory, $private = TRUE, $force_overwrite = FALS
 function file_htaccess_lines($private = TRUE) {
   $lines = <<<EOF
 # Turn off all options we don't need.
-Options None
-Options +SymLinksIfOwnerMatch
+Options -Indexes -ExecCGI -Includes
 
 # Set the catch-all handler to prevent scripts from being executed.
 SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1358.
