### PR TITLE
HTML5-style script tags

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -4541,12 +4541,6 @@ function backdrop_pre_render_scripts($elements) {
   // page request.
   $default_query_string = !defined('MAINTENANCE_MODE') ? state_get('css_js_query_string', '0') : '';
 
-  // For inline JavaScript to validate as XHTML, all JavaScript containing
-  // XHTML needs to be wrapped in CDATA. To make that backwards compatible
-  // with HTML 4, we need to comment out the CDATA-tag.
-  $embed_prefix = "\n<!--//--><![CDATA[//><!--\n";
-  $embed_suffix = "\n//--><!]]>\n";
-
   // Defaults for each SCRIPT element.
   $element_defaults = array(
     '#type' => 'head_tag',
@@ -4579,15 +4573,11 @@ function backdrop_pre_render_scripts($elements) {
         // Element properties that depend on item type.
         switch ($item['type']) {
           case 'setting':
-            $element['#value_prefix'] = $embed_prefix;
             $element['#value'] = 'window.Backdrop = {settings: ' . backdrop_json_encode(backdrop_array_merge_deep_array($item['data'])) . "};";
-            $element['#value_suffix'] = $embed_suffix;
             break;
 
           case 'inline':
-            $element['#value_prefix'] = $embed_prefix;
             $element['#value'] = $item['data'];
-            $element['#value_suffix'] = $embed_suffix;
             break;
 
           case 'file':

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -4552,9 +4552,6 @@ function backdrop_pre_render_scripts($elements) {
     '#type' => 'head_tag',
     '#tag' => 'script',
     '#value' => '',
-    '#attributes' => array(
-      'type' => 'text/javascript',
-    ),
   );
 
   // Loop through each group.

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1314,7 +1314,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     $javascript = backdrop_get_js();
 
     $expected_1 = "<!--[if lte IE 8]>\n" . '<script src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>' . "\n<![endif]-->";
-    $expected_2 = "<!--[if !IE]><!-->\n" . '<script>' . "\n<!--//--><![CDATA[//><!--\n" . 'jQuery(function () { });' . "\n//--><!]]>\n" . '</script>' . "\n<!--<![endif]-->";
+    $expected_2 = "<!--[if !IE]><!-->\n" . '<script>' . 'jQuery(function () { });' . '</script>' . "\n<!--<![endif]-->";
 
     $this->assertTrue(strpos($javascript, $expected_1) > 0, t('Rendered JavaScript within downlevel-hidden conditional comments.'));
     $this->assertTrue(strpos($javascript, $expected_2) > 0, t('Rendered JavaScript within downlevel-revealed conditional comments.'));

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1313,8 +1313,8 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     backdrop_add_js('jQuery(function () { });', array('type' => 'inline', 'browsers' => array('IE' => FALSE)));
     $javascript = backdrop_get_js();
 
-    $expected_1 = "<!--[if lte IE 8]>\n" . '<script type="text/javascript" src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>' . "\n<![endif]-->";
-    $expected_2 = "<!--[if !IE]><!-->\n" . '<script type="text/javascript">' . "\n<!--//--><![CDATA[//><!--\n" . 'jQuery(function () { });' . "\n//--><!]]>\n" . '</script>' . "\n<!--<![endif]-->";
+    $expected_1 = "<!--[if lte IE 8]>\n" . '<script src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>' . "\n<![endif]-->";
+    $expected_2 = "<!--[if !IE]><!-->\n" . '<script>' . "\n<!--//--><![CDATA[//><!--\n" . 'jQuery(function () { });' . "\n//--><!]]>\n" . '</script>' . "\n<!--<![endif]-->";
 
     $this->assertTrue(strpos($javascript, $expected_1) > 0, t('Rendered JavaScript within downlevel-hidden conditional comments.'));
     $this->assertTrue(strpos($javascript, $expected_2) > 0, t('Rendered JavaScript within downlevel-revealed conditional comments.'));
@@ -1346,10 +1346,10 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     backdrop_add_js('core/misc/batch.js', array('every_page' => TRUE));
     $javascript = backdrop_get_js();
     $expected = implode("\n", array(
-      '<script type="text/javascript" src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>',
-      '<script type="text/javascript" src="' . file_create_url('core/misc/batch.js') . '?' . $default_query_string . '"></script>',
-      '<script type="text/javascript" src="' . file_create_url('core/misc/ajax.js') . '?' . $default_query_string . '"></script>',
-      '<script type="text/javascript" src="' . file_create_url('core/misc/autocomplete.js') . '?' . $default_query_string . '"></script>',
+      '<script src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>',
+      '<script src="' . file_create_url('core/misc/batch.js') . '?' . $default_query_string . '"></script>',
+      '<script src="' . file_create_url('core/misc/ajax.js') . '?' . $default_query_string . '"></script>',
+      '<script src="' . file_create_url('core/misc/autocomplete.js') . '?' . $default_query_string . '"></script>',
     ));
     $this->assertTrue(strpos($javascript, $expected) > 0, t('Unaggregated JavaScript is added in the expected group order.'));
 
@@ -1364,8 +1364,8 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     $js_items = backdrop_add_js();
     $javascript = backdrop_get_js();
     $expected = implode("\n", array(
-      '<script type="text/javascript" src="' . file_create_url(backdrop_build_js_cache(array('core/misc/collapse.js' => $js_items['core/misc/collapse.js'], 'core/misc/batch.js' => $js_items['core/misc/batch.js']))) . '"></script>',
-      '<script type="text/javascript" src="' . file_create_url(backdrop_build_js_cache(array('core/misc/ajax.js' => $js_items['core/misc/ajax.js'], 'core/misc/autocomplete.js' => $js_items['core/misc/autocomplete.js']))) . '"></script>',
+      '<script src="' . file_create_url(backdrop_build_js_cache(array('core/misc/collapse.js' => $js_items['core/misc/collapse.js'], 'core/misc/batch.js' => $js_items['core/misc/batch.js']))) . '"></script>',
+      '<script src="' . file_create_url(backdrop_build_js_cache(array('core/misc/ajax.js' => $js_items['core/misc/ajax.js'], 'core/misc/autocomplete.js' => $js_items['core/misc/autocomplete.js']))) . '"></script>',
     ));
     $this->assertTrue(strpos($javascript, $expected) > 0, t('JavaScript is aggregated in the expected groups and order.'));
   }

--- a/core/modules/simpletest/tests/theme.test
+++ b/core/modules/simpletest/tests/theme.test
@@ -94,7 +94,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
     // test theme. First we test with CSS aggregation disabled.
     config_set('system.core', 'preprocess_css', 0);
     $this->backdropGet('theme-test/suggestion');
-    $this->assertNoText('system.css', "The theme's .info file is able to override a module CSS file from being added to the page.");
+    $this->assertNoText('modules/system/css/system.css', "The theme's .info file is able to override a module CSS file from being added to the page.");
 
     // Also test with aggregation enabled, simply ensuring no PHP errors are
     // triggered during backdrop_build_css_cache() when a source file doesn't


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1397

Removes compatibility with HTML4 and XHTML 1.x validation for script tags. Welcome to 2010, Backdrop.
