### PR TITLE
Issue #1469: Remove hook_image_default_styles() from API docs.

### DIFF
--- a/core/modules/image/image.api.php
+++ b/core/modules/image/image.api.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Hooks related to image styles and effects.
@@ -150,49 +149,6 @@ function hook_image_styles_alter(&$styles) {
       'effect callback' => 'image_desaturate_effect',
     );
   }
-}
-
-/**
- * Provide module-based image styles for reuse throughout Backdrop.
- *
- * This hook allows your module to provide image styles. This may be useful if
- * you require images to fit within exact dimensions. Note that you should
- * attempt to re-use the default styles provided by Image module whenever
- * possible, rather than creating image styles that are specific to your module.
- * Image provides the styles "thumbnail", "medium", and "large".
- *
- * You may use this hook to more easily manage your site's changes by moving
- * existing image styles from the database to a custom module. Note however that
- * moving image styles to code instead storing them in the database has a
- * negligible effect on performance, since custom image styles are loaded
- * from the database all at once. Even if all styles are pulled from modules,
- * Image module will still perform the same queries to check the database for
- * any custom styles.
- *
- * @return
- *   An array of image styles, keyed by the style name.
- * @see image_image_default_styles()
- */
-function hook_image_default_styles() {
-  $styles = array();
-
-  $styles['mymodule_preview'] = array(
-    'label' => 'My module preview',
-    'effects' => array(
-      array(
-        'name' => 'image_scale',
-        'data' => array('width' => 400, 'height' => 400, 'upscale' => 1),
-        'weight' => 0,
-      ),
-      array(
-        'name' => 'image_desaturate',
-        'data' => array(),
-        'weight' => 1,
-      ),
-    ),
-  );
-
-  return $styles;
 }
 
  /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1469
