### PR TITLE
Issue #511: Fixing random test failures caused by unintentionally escaped characters in JSON config files.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5309,8 +5309,11 @@ function backdrop_json_encode($var, $pretty_print = FALSE) {
     }
     else {
       $string = json_encode($var);
+      // PHP 5.3 JSON_PRETTY_PRINT.
       $string = backdrop_json_format($string);
+      // PHP 5.3 JSON_UNESCAPED_UNICODE.
       $string = backdrop_json_decode_unicode($string);
+      // PHP 5.3 JSON_UNESCAPED_SLASHES.
       $string = str_replace('\/', '/', $string);
     }
     // Collapse empty brackets, needed for PHP 5.3.x - PHP 5.4.27 to be
@@ -5405,9 +5408,20 @@ function backdrop_json_format($json) {
  * Decode Unicode characters in JSON strings.
  */
 function backdrop_json_decode_unicode($json) {
-  return preg_replace_callback('/\\\\u([0-9a-f]{4})/i', function ($match) {
-    return mb_convert_encoding(pack('H*', $match[1]), 'UTF-8', 'UCS-2BE');
-  }, $json);
+  // Convert escaped characters, such as \u00e9 to the unescaped version (é).
+  // See http://stackoverflow.com/questions/2934563/how-to-decode-unicode-escape-sequences-like-u00ed-to-proper-utf-8-encoded-cha
+  $decode_callback = function ($match) {
+    return $match[1] . mb_convert_encoding(pack('H*', $match[2]), 'UTF-8', 'UCS-2BE');
+  };
+  // To prevent unintentionally unescaping the string "\u", be sure that the
+  // the backslash itself is not also escaped. Note that because the replacement
+  // may include part of a 4-digit code for a previous Unicode character, this
+  // will only escape every-other Unicode character if they are next to each
+  // other.
+  $pattern = '/([^\\\\])\\\\u([0-9a-fA-F]{4})/';
+  $json = preg_replace_callback($pattern, $decode_callback, $json);
+  // Replace a second time to catch any sequences multiple Unicode characters.
+  return preg_replace_callback($pattern, $decode_callback, $json);
 }
 
 /**

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -2698,7 +2698,6 @@ class CommonJSONUnitTestCase extends BackdropUnitTestCase {
    */
   function testJSON() {
     // Setup a string with the full ASCII table.
-    // @todo: Add tests for non-ASCII characters and Unicode.
     $str = '';
     for ($i=0; $i < 128; $i++) {
       $str .= chr($i);
@@ -2742,6 +2741,29 @@ class CommonJSONUnitTestCase extends BackdropUnitTestCase {
     $json_decoded = backdrop_json_decode($json);
     $this->assertNotIdentical($source, $json, 'An array encoded in JSON is not identical to the source.');
     $this->assertIdentical($source, $json_decoded, 'Encoding structured data to JSON and decoding back results in the original data.');
+
+    // Unicode test strings.
+    $unicode_decoded = 'üéåâ';
+    $unicode_encoded = '\u00fc\u00e9\u00e5\u00e2';
+    $unicode_encoded_escaped = '\\\\u00fc\\\\u00e9\\\\u00e5\\\\u00e2';
+
+    // Verify that Unicode characters are not encoded when using pretty print.
+    $this->assertIdentical('"' . $unicode_decoded . '"', backdrop_json_encode($unicode_decoded, TRUE), 'UTF-8 characters are not encoded in pretty print JSON.');
+    $this->assertIdentical('"' . $unicode_encoded_escaped . '"', backdrop_json_encode($unicode_encoded, TRUE), 'Escaped Unicode characters are double-escaped in pretty print JSON.');
+
+    // Non-pretty print JSON uses encoded characters.
+    $this->assertIdentical('"' . $unicode_encoded . '"', backdrop_json_encode($unicode_decoded), 'UTF-8 characters are Unicode encoded in non-pretty JSON.');
+    $this->assertIdentical('"' . $unicode_encoded_escaped . '"', backdrop_json_encode($unicode_encoded), 'Escaped Unicode characters are double-escaped in non-pretty JSON.');
+
+    // Verify reversibility of Unicode characters (pretty print).
+    $this->assertIdentical($unicode_decoded, backdrop_json_decode(backdrop_json_encode($unicode_decoded, TRUE)), 'UTF-8 characters escaped and then unescaped matches original.');
+    $this->assertIdentical($unicode_encoded, backdrop_json_decode(backdrop_json_encode($unicode_encoded, TRUE)), 'Unicode characters escaped and then unescaped matches original.');
+    $this->assertIdentical($unicode_encoded_escaped, backdrop_json_decode(backdrop_json_encode($unicode_encoded_escaped, TRUE)), 'Escaped Unicode characters escaped and then unescaped matches original.');
+
+    // Verify reversibility of Unicode characters (non-pretty print).
+    $this->assertIdentical($unicode_decoded, backdrop_json_decode(backdrop_json_encode($unicode_decoded)), 'UTF-8 characters escaped and then unescaped matches original.');
+    $this->assertIdentical($unicode_encoded, backdrop_json_decode(backdrop_json_encode($unicode_encoded)), 'Unicode characters escaped and then unescaped matches original.');
+    $this->assertIdentical($unicode_encoded_escaped, backdrop_json_decode(backdrop_json_encode($unicode_encoded_escaped)), 'Escaped Unicode characters escaped and then unescaped matches original.');
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/511.
