### PR TITLE
Issue #988: Converted layouts admin to flexbox with fallbacks

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -13,16 +13,31 @@
 }
 
 /* Individual layout settings form. */
-.layout-settings-form .layout-options {
+.layout-settings-form .form-type-radios {
   width: 100%;
 }
+.layout-settings-form .layout-options .form-radios {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+      -ms-flex-wrap: wrap;
+          flex-wrap: wrap;
+  line-height: 1.3;
+  max-width: calc(100vw - 60px); /* Fix flex-wrap issue in some browsers */
+}
+.layout-settings-form .layout-options.no-flexbox .form-radios {
+  display: block;
+}
 .layout-settings-form .layout-options .form-type-radio {
-  float: left;
+  width: 100px;
+  margin: 0 5px 5px 0;
+  padding: 0;
   text-align: center;
 }
-.layout-settings-form .layout-icon .layout-caption {
-  width: 90px;
-  margin-bottom: 1em;
+.layout-settings-form .layout-options.no-flexbox .form-type-radio {
+  float: left;
 }
 
 /* Menu item argument settings. */

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -9,12 +9,32 @@
 "use strict";
 
 /**
+ * Behavior for showing a list of layouts.
+ *
+ * Detect flexbox support for displaying our list of layouts with vertical
+ * height matching for each row of layout template icons.
+ */
+Backdrop.behaviors.layoutList = {
+  attach: function(context) {
+    var $element = $(context).find('.layout-options');
+    if ($element.length) {
+      if ($element.css('flex-wrap')) {
+        $element.addClass('flexbox');
+      }
+      else {
+        $element.addClass('no-flexbox');
+      }
+    }
+  }
+};
+
+/**
  * Behavior for creating/configuring layout settings.
  */
 Backdrop.behaviors.layoutConfigure = {
   attach: function(context) {
     var $form = $('.layout-settings-form').once('layout-settings');
-    if ($form.length) {
+    if ($form.length && Backdrop.ajax) {
       var ajax = Backdrop.ajax['edit-path-update'];
       var updateContexts = function() {
         // Cancel existing AJAX requests and start a new one.
@@ -114,7 +134,7 @@ Backdrop.behaviors.layoutDisplayEditor = {
  * Filters the 'Add block' list by a text input search string.
  */
 Backdrop.behaviors.blockListFilterByText = {
-  attach: function(context, settings) {
+  attach: function (context, settings) {
     var $input = $('input#layout-block-list-search').once('layout-block-list-search');
     var $form = $('.layout-block-list');
     var $rows, zebraClass;
@@ -148,7 +168,7 @@ Backdrop.behaviors.blockListFilterByText = {
         $('.filter-empty').remove();
       }
     }
-    
+
     function stripeRow($match) {
       zebraClass = (zebraCounter % 2) ? 'odd' : 'even';
       $match.removeClass('even odd');
@@ -158,7 +178,7 @@ Backdrop.behaviors.blockListFilterByText = {
 
     if ($form.length && $input.length) {
       $rows = $form.find('div.layout-block-add-row');
-      $rows.each(function() {
+      $rows.each(function () {
         stripeRow($(this));
       });
 
@@ -166,6 +186,6 @@ Backdrop.behaviors.blockListFilterByText = {
       $input.focus().on('keyup', filterBlockList);
     }
   }
-};
+}
 
 })(jQuery);

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -1101,6 +1101,56 @@ div.admin-panel h3 {
   float: none;
 }
 
+/**
+ * Pretty block radios, `:not(#foo) >` rules out browsers that can't support this
+ */
+:not(#foo) > .layout-settings-form .layout-options .form-type-radio input {
+  /* Hide radios from visuals but not screen-readers */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.layout-settings-form .layout-options .form-type-radio label {
+  position: relative;
+  z-index: 2; /* Fix IE issue clicking on image doesn't trigger radio */
+  display: block;
+  padding: .6em;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  min-height: 145px;
+  -webkit-transition: border-color 0.25s ease-in-out, background-color 0.25s ease-in-out;
+  -moz-transition: border-color 0.25s ease-in-out, background-color 0.25s ease-in-out;
+  -ms-transition: border-color 0.25s ease-in-out, background-color 0.25s ease-in-out;
+  -o-transition: border-color 0.25s ease-in-out, background-color 0.25s ease-in-out;
+  transition: border-color 0.25s ease-in-out, background-color 0.25s ease-in-out;
+  will-change: border-color, background-color;
+}
+.layout-settings-form .layout-options.no-flexbox .form-type-radio label {
+  min-height: 150px;
+}
+.layout-settings-form .layout-options .form-type-radio:active label,
+.layout-settings-form .layout-options .form-type-radio:hover label,
+.layout-settings-form .layout-options .form-type-radio input:checked + label {
+  background-color: #ffffff;
+  border-color: #d0d0d0;
+}
+.layout-settings-form .layout-options .form-type-radio input:focus + label {
+  background-color: #ffffff;
+  border-color: #43afe4;
+}
+.layout-settings-form .layout-options .form-type-radio img {
+  position: relative;
+  z-index: -1; /* Fix IE issue clicking on image doesn't trigger radio */
+  padding: 4px;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
 /* Update options. */
 div.admin-options {
   background: #f8f8f8;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/988.

Replacement PR for https://github.com/backdrop/backdrop/pull/965.

---

Changes from original PR:
- All styles related to the pretty radio buttons move to the Seven theme.
- Added specific `:focus` styles so that keyboard access is visible.
- I couldn't find a way to make the green background mesh with a focus color, so I copied the appearance of textfields with focus.
