### PR TITLE
Issue #717: Use custom menu names in block listings.

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2217,10 +2217,12 @@ function system_block_info() {
     'description' => t('Displays a link to <a href="http://backdropcms.org">Backdrop CMS</a>.'),
     'weight' => '10',
   );
-  // System-defined menu blocks.
+  // System-defined menu blocks. Load customizations from Menu module.
+  $all_menus = function_exists('menu_get_menus') ? menu_get_menus() : array();
   foreach (menu_list_system_menus() as $menu_name => $title) {
+    $custom_title = isset($all_menus[$menu_name]) ? $all_menus[$menu_name] : $title;
     $blocks[$menu_name] = array(
-      'info' => check_plain(t($title)),
+      'info' => check_plain(t($custom_title)),
       'description' => t('A hierarchical list of links for the @menu.', array('@menu' => t($title))),
     );
   }
@@ -2260,7 +2262,10 @@ function system_block_view($delta = '', $settings = array()) {
       // All system menu blocks.
       $system_menus = menu_list_system_menus();
       if (isset($system_menus[$delta])) {
-        $block['subject'] = t($system_menus[$delta]);
+        // Load customizations from Menu module if present.
+        $all_menus = function_exists('menu_get_menus') ? menu_get_menus() : array();
+        $custom_title = isset($all_menus[$delta]) ? $all_menus[$delta] : $system_menus[$delta];
+        $block['subject'] = t($custom_title);
         $block['content'] = menu_tree($delta);
         return $block;
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/717.

Replacement PR for https://github.com/backdrop/backdrop/pull/967.
