### PR TITLE
Issue #277: Allow users to log in with either username or email.

### DIFF
--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -910,7 +910,7 @@ class BackdropWebTestCase extends BackdropTestCase {
   /**
    * The current user logged in using the internal browser.
    *
-   * @var bool
+   * @var FALSE|User
    */
   protected $loggedInUser = FALSE;
 
@@ -1328,16 +1328,23 @@ class BackdropWebTestCase extends BackdropTestCase {
    *
    * @param $account
    *   User object representing the user to log in.
+   * @param $by_email
+   *   Whether to use email for login instead of username.
    *
    * @see backdropCreateUser()
    */
-  protected function backdropLogin($account) {
+  protected function backdropLogin($account, $by_email = FALSE) {
+    global $user;
     if ($this->loggedInUser) {
+      $this->backdropLogout();
+    }
+    // Sometimes $this->loggedInUser is FALSE even when user is logged in.
+    elseif ($user->uid) {
       $this->backdropLogout();
     }
 
     $edit = array(
-      'name' => $account->name,
+      'name' => $by_email ? $account->mail : $account->name,
       'pass' => $account->pass_raw
     );
     $this->backdropPost('user', $edit, t('Log in'));

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -57,6 +57,8 @@
     "user_admin_role": "",
     "user_cancel_method": "user_cancel_block",
     "user_email_verification": 1,
+    "user_email_match": 1,
+    "user_login_method": "username_or_email",
     "user_mail_status_activated_notify": 1,
     "user_mail_status_blocked_notify": 0,
     "user_mail_status_canceled_notify": 0,

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -3,10 +3,74 @@
  * @file
  * Tests for user.module.
  */
+class UserLoginTestBase extends BackdropWebTestCase {
+  protected $profile = 'minimal';
 
-class UserRegistrationTestCase extends BackdropWebTestCase {
+  /**
+   * Make an unsuccessful login attempt.
+   *
+   * @param User $account
+   *   A user object with name and pass_raw attributes for the login attempt.
+   * @param bool $by_email
+   *   Fail with an incorrect email instead of username.
+   * @param $incorrect_pass
+   *   Fail because of an incorrect password.
+   * @param $flood_trigger
+   *   Whether or not to expect that the flood control mechanism will be
+   *   triggered..
+   */
+  function assertFailedLogin($account, $by_email = FALSE, $incorrect_pass = FALSE, $flood_trigger = NULL) {
+    if ($this->loggedInUser) {
+      $this->backdropLogout();
+    }
+    $edit = array(
+      'name' => $by_email ? $account->mail : $account->name,
+      'pass' => $account->pass_raw,
+    );
+    $this->backdropPost('user', $edit, t('Log in'));
+    $this->assertNoFieldByXPath("//input[@name='pass' and @value!='']", NULL, 'Password value attribute is blank.');
+    if (isset($flood_trigger)) {
+      if ($flood_trigger == 'user') {
+        $this->assertRaw(format_plural(config_get('user.flood', 'flood_user_limit'), 'Sorry, there has been more than one failed login attempt for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', 'Sorry, there have been more than @count failed login attempts for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+      }
+      else {
+        // No uid, so the limit is IP-based.
+        $this->assertRaw(t('Sorry, too many failed login attempts from your IP address. This IP address is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
+      }
+    }
+    elseif ($incorrect_pass) {
+      $this->assertRaw(t('Sorry, incorrect password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $edit['name']))))));
+    }
+    else {
+      $login_method = config_get('system.core', 'user_login_method');
+      switch ($login_method) {
+        case USER_LOGIN_EMAIL_ONLY:
+          if (!$by_email) {
+            $this->assertRaw(t('The e-mail address %email is not valid.', array('%email' => $account->name)));
+          }
+          else {
+            $this->assertRaw(t('Sorry, no account with that email address found.'));
+          }
+          break;
+        case USER_LOGIN_USERNAME_OR_EMAIL:
+          if (!$by_email) {
+            $this->assertRaw(t('Sorry, unrecognized username.'));
+          }
+          else {
+            $this->assertRaw(t('Sorry, no account with that email address found.'));
+          }
+          break;
+        case USER_LOGIN_USERNAME_ONLY:
+        default:
+          $this->assertRaw(t('Sorry, unrecognized username.'));
+      }
+    }
+  }
+}
+
+class UserRegistrationTestCase extends UserLoginTestBase {
   function setUp() {
-    parent::setUp('field_test');
+    parent::setUp(array('field', 'field_test'));
   }
 
   function testRegistrationWithEmailVerification() {
@@ -86,7 +150,7 @@ class UserRegistrationTestCase extends BackdropWebTestCase {
       'pass' => $pass,
     );
     $this->backdropPost('user/login', $auth, t('Log in'));
-    $this->assertText(t('The username @name has not been activated or is blocked.', array('@name' => $name)), 'User cannot login yet.');
+    $this->assertText(t('The account for @name has not been activated or is blocked.', array('@name' => $name)), 'User cannot login yet.');
 
     // Activate the new account.
     $accounts = user_load_multiple(array(), array('name' => $name, 'mail' => $mail));
@@ -122,13 +186,13 @@ class UserRegistrationTestCase extends BackdropWebTestCase {
 
     // Attempt to create a new account using an existing e-mail address.
     $this->backdropPost('user/register', $edit, t('Create new account'));
-    $this->assertText(t('The e-mail address @email is already registered.', array('@email' => $duplicate_user->mail)), 'Supplying an exact duplicate email address displays an error message');
+    $this->assertRaw(t('The e-mail address %email is already registered.', array('%email' => $duplicate_user->mail)), 'Supplying an exact duplicate email address displays an error message');
 
     // Attempt to bypass duplicate email registration validation by adding spaces.
     $edit['mail'] = '   ' . $duplicate_user->mail . '   ';
 
     $this->backdropPost('user/register', $edit, t('Create new account'));
-    $this->assertText(t('The e-mail address @email is already registered.', array('@email' => $duplicate_user->mail)), 'Supplying a duplicate email address with added whitespace displays an error message');
+    $this->assertRaw(t('The e-mail address %email is already registered.', array('%email' => $duplicate_user->mail)), 'Supplying a duplicate email address with added whitespace displays an error message');
   }
 
   function testRegistrationDefaultValues() {
@@ -256,6 +320,67 @@ class UserRegistrationTestCase extends BackdropWebTestCase {
       $this->assertEqual($new_user->test_user_field[LANGUAGE_NONE][2]['value'], $value + 2, format_string('@js : The field value was correclty saved.', array('@js' => $js)));
     }
   }
+
+  /**
+   * Tests new users username matches their email if username is an email.
+   */
+  function testRegistrationEmailAsUsername() {
+    // Don't require email verification.
+    // Allow registration by site visitors without administrator approval.
+    config('system.core')
+      ->set('user_email_verification', FALSE)
+      ->set('user_register', USER_REGISTER_VISITORS)
+      ->save();
+
+    $mail = $this->randomName() . '@example.com';
+    $different = $this->randomName() . $mail;
+
+    // Set up edit array.
+    $edit = array();
+    $edit['mail'] = $mail;
+    $edit['name'] = $different;
+    $edit['pass[pass1]'] = $edit['pass[pass2]'] = $this->randomName();
+
+    // Attempt to create an account using an email that doesn't match the name.
+    $this->backdropPost('user/register', $edit, t('Create new account'));
+    $this->assertText(t('An email address was provided as a username, but does not match the account email address.'), 'Email username does not match user email - error message found.');
+    $this->assertNoText(t('Registration successful. You are now logged in.'), 'The user was not created and logged in.');
+
+    // Attempt to create new account using matching email address.
+    $edit['name'] = $edit['mail'] = $this->randomName() . '@example.com';
+
+    $this->backdropPost('user/register', $edit, t('Create new account'));
+    $this->assertText(t('Registration successful. You are now logged in.'), 'The user was created and logged in with matching email.');
+
+    $new_user = user_load_by_name($edit['name']);
+    $this->assertTrue(($new_user->name === $edit['name']) && ($new_user->mail === $edit['mail']), 'Created user with matching username and email address.');
+  }
+
+  /**
+   * Tests new users username not matching their email if username is an email.
+   */
+  function testRegistrationEmailAsUsernameDisabled() {
+    // Test that 'user_email_match' turned off allows emails that don't match.
+    config('system.core')
+      ->set('user_email_match', FALSE)
+      ->set('user_email_verification', FALSE)
+      ->set('user_register', USER_REGISTER_VISITORS)
+      ->save();
+
+    $mail = $this->randomName() . '@example.com';
+    $different = $this->randomName() . $mail;
+
+    $edit = array();
+    $edit['mail'] = $mail;
+    $edit['name'] = $different;
+    $edit['pass[pass1]'] = $edit['pass[pass2]'] = $this->randomName();
+
+    // Attempt to create an account using an email that doesn't match the name.
+    // This should be OK, as 'user_email_match' is disabled.
+    $this->backdropPost('user/register', $edit, t('Create new account'));
+    $this->assertNoText(t('An email address was provided as a username, but does not match the account email address.'), 'Email username does not match user email - error message found.');
+    $this->assertText(t('Registration successful. You are now logged in.'), 'The user was not created and logged in.');
+  }
 }
 
 class UserValidationTestCase extends BackdropWebTestCase {
@@ -290,7 +415,40 @@ class UserValidationTestCase extends BackdropWebTestCase {
 /**
  * Functional tests for user logins, including rate limiting of login attempts.
  */
-class UserLoginTestCase extends BackdropWebTestCase {
+class UserLoginTestCase extends UserLoginTestBase {
+
+  /**
+   * Test that login credentials work (or not) in different login modes.
+   */
+  function testLoginMethods() {
+    $account = $this->backdropCreateUser(array());
+
+    // Login via name or email (both succeed). The default for new sites.
+    config_set('system.core', 'user_login_method', USER_LOGIN_USERNAME_OR_EMAIL);
+    $this->backdropLogin($account, TRUE);
+    $this->backdropLogin($account);
+
+    // Login via email only.
+    config_set('system.core', 'user_login_method', USER_LOGIN_EMAIL_ONLY);
+    $this->backdropLogin($account, TRUE);
+    // Fail login via name.
+    $this->assertFailedLogin($account);
+
+    // Login via name.
+    config_set('system.core', 'user_login_method', USER_LOGIN_USERNAME_ONLY);
+    $this->backdropLogin($account);
+    // Fail login via email.
+    $this->assertFailedLogin($account, TRUE);
+
+    // Test login when no user_login_method is set. Allows for logging in for
+    // users that are upgrading their site for the first time to support login
+    // by username.
+    config_set('system.core', 'user_login_method', NULL);
+    $this->backdropLogin($account);
+    // Fail login via email.
+    $this->assertFailedLogin($account, TRUE);
+  }
+
   /**
    * Test the global login flood control.
    */
@@ -307,7 +465,7 @@ class UserLoginTestCase extends BackdropWebTestCase {
 
     // Try 2 failed logins.
     for ($i = 0; $i < 2; $i++) {
-      $this->assertFailedLogin($incorrect_user1);
+      $this->assertFailedLogin($incorrect_user1, NULL, TRUE);
     }
 
     // A successful login will not reset the IP-based flood control count.
@@ -317,15 +475,15 @@ class UserLoginTestCase extends BackdropWebTestCase {
     // Try 8 more failed logins, they should not trigger the flood control
     // mechanism.
     for ($i = 0; $i < 8; $i++) {
-      $this->assertFailedLogin($incorrect_user1);
+      $this->assertFailedLogin($incorrect_user1, NULL, TRUE);
     }
 
     // The next login trial should result in an IP-based flood error message.
-    $this->assertFailedLogin($incorrect_user1, 'ip');
+    $this->assertFailedLogin($incorrect_user1, NULL, TRUE, 'ip');
 
     // A login with the correct password should also result in a flood error
     // message.
-    $this->assertFailedLogin($user1, 'ip');
+    $this->assertFailedLogin($user1, NULL, TRUE, 'ip');
   }
 
   /**
@@ -346,7 +504,7 @@ class UserLoginTestCase extends BackdropWebTestCase {
 
     // Try 2 failed logins.
     for ($i = 0; $i < 2; $i++) {
-      $this->assertFailedLogin($incorrect_user1);
+      $this->assertFailedLogin($incorrect_user1, NULL, TRUE);
     }
 
     // A successful login will reset the per-user flood control count.
@@ -355,7 +513,7 @@ class UserLoginTestCase extends BackdropWebTestCase {
 
     // Try 3 failed logins for user 1, they will not trigger flood control.
     for ($i = 0; $i < 3; $i++) {
-      $this->assertFailedLogin($incorrect_user1);
+      $this->assertFailedLogin($incorrect_user1, NULL, TRUE);
     }
 
     // Try one successful attempt for user 2, it should not trigger any
@@ -365,7 +523,7 @@ class UserLoginTestCase extends BackdropWebTestCase {
 
     // Try one more attempt for user 1, it should be rejected, even if the
     // correct password has been used.
-    $this->assertFailedLogin($user1, 'user');
+    $this->assertFailedLogin($user1, NULL, TRUE, 'user');
   }
 
   /**
@@ -411,36 +569,6 @@ class UserLoginTestCase extends BackdropWebTestCase {
     $this->backdropPost('user', $edit, t('Log in'));
     $this->assertText(t('Sorry, unrecognized username.'));
   }
-
-  /**
-   * Make an unsuccessful login attempt.
-   *
-   * @param $account
-   *   A user object with name and pass_raw attributes for the login attempt.
-   * @param $flood_trigger
-   *   Whether or not to expect that the flood control mechanism will be
-   *   triggered.
-   */
-  function assertFailedLogin($account, $flood_trigger = NULL) {
-    $edit = array(
-      'name' => $account->name,
-      'pass' => $account->pass_raw,
-    );
-    $this->backdropPost('user', $edit, t('Log in'));
-    $this->assertNoFieldByXPath("//input[@name='pass' and @value!='']", NULL, 'Password value attribute is blank.');
-    if (isset($flood_trigger)) {
-      if ($flood_trigger == 'user') {
-        $this->assertRaw(format_plural(config_get('user.flood', 'flood_user_limit'), 'Sorry, there has been more than one failed login attempt for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', 'Sorry, there have been more than @count failed login attempts for this account. It is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
-      }
-      else {
-        // No uid, so the limit is IP-based.
-        $this->assertRaw(t('Sorry, too many failed login attempts from your IP address. This IP address is temporarily blocked. Try again later or <a href="@url">request a new password</a>.', array('@url' => url('user/password'))));
-      }
-    }
-    else {
-      $this->assertText(t('Sorry, incorrect password. Have you forgotten your password?'));
-    }
-  }
 }
 
 /**
@@ -448,7 +576,7 @@ class UserLoginTestCase extends BackdropWebTestCase {
  */
 class UserCancelTestCase extends BackdropWebTestCase {
   function setUp() {
-    parent::setUp('comment');
+    parent::setUp(array('comment'));
   }
 
   /**
@@ -1872,6 +2000,9 @@ class UserSignatureTestCase extends BackdropWebTestCase {
  * Test that a user, having editing their own account, can still log in.
  */
 class UserEditedOwnAccountTestCase extends BackdropWebTestCase {
+  /**
+   * Tests a user editing their own account.
+   */
   function testUserEditedOwnAccount() {
     // Change account setting 'Who can register accounts?' to Administrators
     // only.
@@ -1892,6 +2023,29 @@ class UserEditedOwnAccountTestCase extends BackdropWebTestCase {
     // Set the new name on the user account and attempt to log back in.
     $account->name = $edit['name'];
     $this->backdropLogin($account);
+
+    // Attempt to change username to an email other than my own.
+    $edit['name'] = $this->randomName() . '@example.com';
+    $this->backdropPost('user/' . $account->uid . '/edit', $edit, t('Save'));
+    $this->assertText(t('An email address was provided as a username, but does not match the account email address.', array('%name' => $edit['name'])), 'Error message found when an email username does not match user email.');
+    $this->assertNoText(t('The changes have been saved.'), 'The user account was not saved.');
+
+    // Lookup user by name to make sure we didn't actually change the name.
+    $changed = user_load_by_name($edit['name']);
+    $this->assertFalse($changed, 'Username was not changed to email address other than my own.');
+
+    // Change username to my email address.
+    $edit['name'] = $account->mail;
+    $this->backdropPost('user/' . $account->uid . '/edit', $edit, t('Save'));
+    $this->assertText(t('The changes have been saved.'), 'The user account was saved.');
+
+    // Test that 'verify_email_match' turned off allows emails that don't match.
+    config_set('system.core', 'user_email_match', FALSE);
+
+    // Change username to random, non-matching email address.
+    $edit['name'] = $this->randomName() . '@example.com';
+    $this->backdropPost('user/' . $account->uid . '/edit', $edit, t('Save'));
+    $this->assertText(t('The changes have been saved.'), 'The user account was saved.');
   }
 }
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -155,6 +155,22 @@ function user_admin_settings($form, &$form_state) {
     '#description' => t('This role will be automatically assigned new permissions whenever a module is enabled. Changing this setting will not affect existing permissions.'),
   );
 
+  // User login settings.
+  $form['user_login'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('User log in'),
+  );
+  $form['user_login']['user_login_method'] = array(
+    '#type' => 'radios',
+    '#title' => t('Users may log in using'),
+    '#options' => array(
+      USER_LOGIN_USERNAME_OR_EMAIL => t('Username or email address'),
+      USER_LOGIN_USERNAME_ONLY => t('Username'),
+      USER_LOGIN_EMAIL_ONLY => t('Email address'),
+    ),
+    '#default_value' => $config->get('user_login_method'),
+  );
+
   // User registration settings.
   $form['registration_cancellation'] = array(
     '#type' => 'fieldset',
@@ -176,6 +192,11 @@ function user_admin_settings($form, &$form_state) {
     '#title' => t('Require e-mail verification when a visitor creates an account.'),
     '#default_value' => $config->get('user_email_verification'),
     '#description' => t('New users will be required to validate their e-mail address prior to logging into the site, and will be assigned a system-generated password. With this setting disabled, users will be logged in immediately upon registering, and may select their own passwords during registration.')
+  );
+  $form['registration_cancellation']['user_email_match'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('When an email address is used as username, require a matching email address.'),
+    '#default_value' => $config->get('user_email_match'),
   );
   module_load_include('inc', 'user', 'user.pages');
   $form['registration_cancellation']['user_cancel_method'] = array(
@@ -551,12 +572,15 @@ function user_admin_settings($form, &$form_state) {
  */
 function user_admin_settings_submit($form, &$form_state) {
   $values = $form_state['values'];
+
   $config = config('system.core');
   $config->set('anonymous', $values['anonymous']);
   $config->set('user_admin_role', $values['user_admin_role']);
   $config->set('user_cancel_method', $values['user_cancel_method']);
+  $config->set('user_login_method', $form_state['values']['user_login_method']);
   $config->set('user_register', $values['user_register']);
   $config->set('user_email_verification', $values['user_email_verification']);
+  $config->set('user_email_match', $form_state['values']['user_email_match']);
   $config->set('user_signatures', $values['user_signatures']);
   $config->set('user_pictures', $values['user_pictures']);
   $config->set('user_picture_path', $values['user_picture_path']);

--- a/core/modules/user/user.entity.inc
+++ b/core/modules/user/user.entity.inc
@@ -263,6 +263,14 @@ class UserStorageController extends EntityDatabaseStorageController {
       }
     }
 
+    if (valid_email_address($entity->name)) {
+      // Check to see if matching is required.
+      $user_email_match = config_get('system.core', 'user_email_match');
+      if ($user_email_match && ($entity->name != $entity->mail)) {
+        throw new EntityMalformedException('The username and email are both addresses that do not match.');
+      }
+    }
+
     if (!empty($entity->picture_upload)) {
       $entity->picture = $entity->picture_upload;
     }

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -1100,10 +1100,6 @@ function user_update_1009() {
 }
 
 /**
- * @} End of "addtogroup updates-7.x-to-1.x"
- */
-
-/**
  * Update 'People' menus to 'User accounts'
  */
 function user_update_1010() {
@@ -1116,3 +1112,17 @@ function user_update_1010() {
   }
   $config->save();
 }
+
+/**
+ * Set default option for login method to use accounts only.
+ */
+function user_update_1011() {
+  $config = config('system.core');
+  $config->set('user_login_method', 'username_only');
+  $config->set('user_email_match', 1);
+  $config->save();
+}
+
+/**
+ * @} End of "addtogroup updates-7.x-to-1.x"
+ */

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -10,6 +10,21 @@
 define('USERNAME_MAX_LENGTH', 60);
 
 /**
+ * Users can login with username only.
+ */
+define('USER_LOGIN_USERNAME_ONLY', 'username_only');
+
+/**
+ * Users can login with email address only.
+ */
+define('USER_LOGIN_EMAIL_ONLY', 'email_only');
+
+/**
+ * Users can login using either username or email address.
+ */
+define('USER_LOGIN_USERNAME_OR_EMAIL', 'username_or_email');
+
+/**
  * Only administrators can create user accounts.
  */
 define('USER_REGISTER_ADMINISTRATORS_ONLY', 'admin_only');
@@ -229,7 +244,7 @@ function user_load($uid, $reset = FALSE) {
  * Fetch a user object by email address.
  *
  * @param $mail
- *   String with the account's e-mail address.
+ *   String with the account's email address.
  * @return
  *   A fully-loaded $user object upon successful user load or FALSE if user
  *   cannot be loaded.
@@ -849,9 +864,12 @@ function user_validate_current_pass(&$form, &$form_state) {
  */
 function user_account_form_validate($form, &$form_state) {
   $account = $form['#user'];
+  $mail = $form_state['values']['mail'];
+
   // Validate new or changing username.
   if (isset($form_state['values']['name'])) {
-    if ($error = user_validate_name($form_state['values']['name'])) {
+    $name = $form_state['values']['name'];
+    if ($error = user_validate_name($name)) {
       form_set_error('name', $error);
     }
     // Cast the user ID as an integer. It might have been set to NULL, which
@@ -860,18 +878,23 @@ function user_account_form_validate($form, &$form_state) {
       $name_taken = (bool) db_select('users')
         ->fields('users', array('uid'))
         ->condition('uid', (int) $account->uid, '<>')
-        ->condition('name', db_like($form_state['values']['name']), 'LIKE')
+        ->condition('name', db_like($name), 'LIKE')
         ->range(0, 1)
         ->execute()
         ->fetchField();
 
       if ($name_taken) {
-        form_set_error('name', t('The name %name is already taken.', array('%name' => $form_state['values']['name'])));
+        form_set_error('name', t('The name %name is already taken.', array('%name' => $name)));
+      }
+      // Check whether the user name provided is an email address. If so, make
+      // sure it matches the mail value.
+      if (config('system.core')->get('user_email_match') && (valid_email_address($name))) {
+        if ($name !== $mail) {
+          form_set_error('name', t('An email address was provided as a username, but does not match the account email address.'));
+        }
       }
     }
   }
-
-  $mail = $form_state['values']['mail'];
 
   if (!empty($mail)) {
     $mail_taken = (bool) db_select('users')
@@ -909,14 +932,16 @@ function user_account_form_validate($form, &$form_state) {
 }
 
 function user_login_block($form) {
+  $credentials = config_get('system.core', 'user_login_method');
+
   $form['#action'] = url(current_path(), array('query' => backdrop_get_destination(), 'external' => FALSE));
   $form['#id'] = 'user-login-form';
   $form['#validate'] = user_login_default_validators();
   $form['#submit'][] = 'user_login_submit';
   $form['name'] = array(
     '#type' => 'textfield',
-    '#title' => t('Username'),
-    '#maxlength' => USERNAME_MAX_LENGTH,
+    '#title' => $credentials === USER_LOGIN_EMAIL_ONLY ? t('Email address') : ($credentials === USER_LOGIN_USERNAME_OR_EMAIL ? t('Username or email') : t('Username')),
+    '#maxlength' => $credentials === USER_LOGIN_USERNAME_ONLY ? USERNAME_MAX_LENGTH : EMAIL_MAX_LENGTH,
     '#size' => 15,
     '#required' => TRUE,
     '#weight' => 1,
@@ -1473,10 +1498,11 @@ function user_login($form, &$form_state) {
   backdrop_set_title(t('Log in'));
 
   // Display login form:
+  $credentials = config_get('system.core', 'user_login_method');
   $form['name'] = array('#type' => 'textfield',
-    '#title' => t('Username'),
+    '#title' => $credentials === USER_LOGIN_EMAIL_ONLY ? t('Email address') : ($credentials === USER_LOGIN_USERNAME_OR_EMAIL ? t('Username or email') : t('Username')),
+    '#maxlength' => $credentials === USER_LOGIN_USERNAME_ONLY ? USERNAME_MAX_LENGTH : EMAIL_MAX_LENGTH,
     '#size' => 60,
-    '#maxlength' => USERNAME_MAX_LENGTH,
     '#required' => TRUE,
   );
 
@@ -1514,19 +1540,37 @@ function user_login_default_validators() {
 }
 
 /**
- * A FAPI validate handler. Sets an error if supplied username has been blocked.
+ * First phase validation handler for the login form.
+ *
+ * Check for invalid email addresses and blocked accounts.
  */
 function user_login_name_validate($form, &$form_state) {
-  if (!empty($form_state['values']['name']) && user_is_blocked($form_state['values']['name'])) {
-    // Blocked in user administration.
-    form_set_error('name', t('The username %name has not been activated or is blocked.', array('%name' => $form_state['values']['name'])));
+  if (isset($form_state['values']['name'])) {
+    $name = $form_state['values']['name'];
+    $credentials = config_get('system.core', 'user_login_method');
+    if ($credentials !== USER_LOGIN_USERNAME_ONLY) {
+      if ($account = db_query("SELECT * FROM {users} WHERE mail = :mail", array(':mail' => $name))->fetchObject()) {
+        $name = $account->name;
+      }
+      // If can't find account, check if valid email address.
+      elseif ($credentials === USER_LOGIN_EMAIL_ONLY && !valid_email_address($name)) {
+        form_set_error('name', t('The e-mail address %email is not valid.', array('%email' => $form_state['values']['name'])));
+      }
+    }
+    // If can find account, check if user is blocked.
+    if ($name && user_is_blocked($name)) {
+      form_set_error('name', t('The account for %name has not been activated or is blocked.', array('%name' => $form_state['values']['name'])));
+    }
   }
 }
 
 /**
- * A validate handler on the login form. Check supplied username/password
- * against local users table. If successful, $form_state['uid']
- * is set to the matching user ID.
+ * Second phase validation handler on the login form.
+ *
+ * Checks supplied username/password against local users table. If successful,
+ * $form_state['uid'] is set to the matching user ID. If an account is found
+ * $form_state['account_found'] is set to TRUE, though the password may still
+ * fail even if an account is found.
  */
 function user_login_authenticate_validate($form, &$form_state) {
   $password = trim($form_state['values']['pass']);
@@ -1541,7 +1585,15 @@ function user_login_authenticate_validate($form, &$form_state) {
       $form_state['flood_control_triggered'] = 'ip';
       return;
     }
-    $account = db_query("SELECT * FROM {users} WHERE name = :name AND status = 1", array(':name' => $form_state['values']['name']))->fetchObject();
+    $account = FALSE;
+    $credentials = config_get('system.core', 'user_login_method');
+    if (($credentials === USER_LOGIN_USERNAME_OR_EMAIL || $credentials === USER_LOGIN_EMAIL_ONLY) && valid_email_address($form_state['values']['name'])) {
+      $account = db_query("SELECT * FROM {users} WHERE mail = :mail AND status = 1", array(':mail' => $form_state['values']['name']))->fetchObject();
+    }
+    if (!$account && $credentials !== USER_LOGIN_EMAIL_ONLY) {
+      $account = db_query("SELECT * FROM {users} WHERE name = :name AND status = 1", array(':name' => $form_state['values']['name']))->fetchObject();
+    }
+
     if ($account) {
       $form_state['account_found'] = TRUE;
       if ($flood_config->get('flood_uid_only')) {
@@ -1563,13 +1615,13 @@ function user_login_authenticate_validate($form, &$form_state) {
         $form_state['flood_control_triggered'] = 'user';
         return;
       }
+      // We are not limited by flood control, so try to authenticate.
+      // Set $form_state['uid'] as a flag for user_login_final_validate().
+      $form_state['uid'] = user_authenticate($account->name, $password);
     }
     else {
       $form_state['account_found'] = FALSE;
     }
-    // We are not limited by flood control, so try to authenticate.
-    // Set $form_state['uid'] as a flag for user_login_final_validate().
-    $form_state['uid'] = user_authenticate($form_state['values']['name'], $password);
   }
 }
 
@@ -1600,8 +1652,14 @@ function user_login_final_validate($form, &$form_state) {
       }
     }
     elseif (empty($form_state['account_found'])) {
-      form_set_error('name', t('Sorry, unrecognized username.'));
-      watchdog('user', 'The user account %name could not be found.', array('%name' => $form_state['values']['name']));
+      $login_method = config_get('system.core', 'user_login_method');
+      if ((valid_email_address($form_state['values']['name']) && $login_method === USER_LOGIN_USERNAME_OR_EMAIL) || $login_method === USER_LOGIN_EMAIL_ONLY) {
+        form_set_error('name', t('Sorry, no account with that email address found.'));
+      }
+      else {
+        form_set_error('name', t('Sorry, unrecognized username.'));
+      }
+      watchdog('user', 'The user account or email %name could not be found.', array('%name' => $form_state['values']['name']));
     }
     else {
       form_set_error('pass', t('Sorry, incorrect password. <a href="@password">Have you forgotten your password?</a>', array('@password' => url('user/password', array('query' => array('name' => $form_state['values']['name']))))));
@@ -2074,7 +2132,7 @@ function _user_mail_text($key, $language = NULL, $variables = array()) {
   $langcode = isset($language) ? $language->langcode : NULL;
 
   // We do not sanitize the token replacement, since the output of this
-  // replacement is intended for an e-mail message, not a web browser.
+  // replacement is intended for an email message, not a web browser.
   return token_replace(config('user.mail')->get($key), $variables, array('langcode' => $langcode, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
 }
 
@@ -3016,7 +3074,7 @@ function user_register_submit($form, &$form_state) {
   if ($admin && !$notify) {
     backdrop_set_message(t('Created a new user account for <a href="@url">%name</a>. No e-mail has been sent.', array('@url' => url($uri['path'], $uri['options']), '%name' => $account->name)));
   }
-  // No e-mail verification required; log in user immediately.
+  // No email verification required; log in user immediately.
   elseif (!$admin && !config_get('system.core', 'user_email_verification') && $account->status) {
     _user_mail_notify('register_no_approval_required', $account);
     $form_state['uid'] = $account->uid;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/277.

Replaces previous PRs at https://github.com/backdrop/backdrop/pull/951 and https://github.com/backdrop/backdrop/pull/1156.
