### PR TITLE
Issue #85: Avoid long cache lifetime on the maintenance page.

### DIFF
--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -507,16 +507,16 @@ function menu_get_item($path = NULL, $router_item = NULL) {
  */
 function menu_execute_active_handler($path = NULL, $deliver = TRUE, $route_handler = NULL) {
   // Check if site is offline.
-  $page_callback_result = _menu_site_is_offline() ? MENU_SITE_OFFLINE : MENU_SITE_ONLINE;
+  $site_status = _menu_site_is_offline() ? MENU_SITE_OFFLINE : MENU_SITE_ONLINE;
 
   // Allow other modules to change the site status but not the path because that
   // would not change the global variable. hook_url_inbound_alter() can be used
   // to change the path. Code later will not use the $read_only_path variable.
   $read_only_path = !empty($path) ? $path : $_GET['q'];
-  backdrop_alter('menu_site_status', $page_callback_result, $read_only_path);
+  backdrop_alter('menu_site_status', $site_status, $read_only_path);
 
-  // Only continue if the site status is not set.
-  if ($page_callback_result == MENU_SITE_ONLINE) {
+  // If online, check access to the page and call the menu handler.
+  if ($site_status == MENU_SITE_ONLINE) {
     if ($router_item = menu_get_item($path)) {
       if ($router_item['access']) {
         // In most cases, Layout module will provide the route handler if
@@ -536,6 +536,21 @@ function menu_execute_active_handler($path = NULL, $deliver = TRUE, $route_handl
     else {
       $page_callback_result = MENU_NOT_FOUND;
     }
+  }
+  // Offline pages are not cached in the database but have a Cache-Control
+  // header to allow reverse proxies to serve offline hits instead of Backdrop.
+  elseif ($site_status == MENU_SITE_OFFLINE) {
+    $page_cache_enabled = (bool) config_get('system.core', 'page_cache_maximum_age');
+    $maintenance_max_age = config_get('system.core', 'maintenance_page_maximum_age');
+    if ($page_cache_enabled && $maintenance_max_age) {
+      backdrop_add_http_header('Cache-Control', 'public; max-age: ' . $maintenance_max_age);
+    }
+    backdrop_page_is_cacheable(FALSE);
+    $page_callback_result = MENU_SITE_OFFLINE;
+  }
+  // Any other statuses that may have been set in hook_menu_site_status_alter().
+  else {
+    $page_callback_result = $site_status;
   }
 
   // Deliver the result of the page callback to the browser, or if requested,

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -35,6 +35,7 @@
     "log_facility": "",
     "log_format": "!base_url|!timestamp|!type|!ip|!request_uri|!referer|!uid|!link|!message",
     "maintenance_mode_message": "@site is currently under maintenance. We should be back shortly. Thank you for your patience.",
+    "maintenance_page_maximum_age": 10,
     "menu_route_handler": null,
     "node_admin_theme": "",
     "page_cache_maximum_age": 300,

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2687,6 +2687,13 @@ function system_update_1046() {
 }
 
 /**
+ * Provide a default value for maintenance_page_maximum_age.
+ */
+function system_update_1047() {
+  config_set('system.core', 'maintenance_page_maximum_age', 10);
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1041,6 +1041,7 @@ class CustomLogoTestCase extends BackdropWebTestCase {
  */
 class SiteMaintenanceTestCase extends BackdropWebTestCase {
   protected $admin_user;
+  protected $profile = 'testing';
 
   function setUp() {
     parent::setUp();
@@ -1056,6 +1057,9 @@ class SiteMaintenanceTestCase extends BackdropWebTestCase {
    * Verify site maintenance mode functionality.
    */
   function testSiteMaintenance() {
+    // Start with the page cache disabled.
+    config_set('system.core', 'page_cache_maximum_age', 0);
+
     // Turn on maintenance mode.
     $edit = array(
       'maintenance_mode' => TRUE,
@@ -1072,17 +1076,36 @@ class SiteMaintenanceTestCase extends BackdropWebTestCase {
 
     // Logout and verify that offline message is displayed.
     $this->backdropLogout();
-    $this->backdropGet('');
+
+    $this->backdropGet('token/tree');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
-    $this->backdropGet('node');
-    $this->assertText($offline_message);
+
+    // With caching disabled, the maintenance page is also disabled.
+    $this->assertIdentical(strpos($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate'), 0);
+
+    // Enable caching and check that the default maintenance max age is set.
+    config_set('system.core', 'page_cache_maximum_age', 300);
+    $this->backdropGet('token/tree');
+    $this->assertIdentical($this->backdropGetHeader('Cache-Control'), 'public; max-age: 10');
+
+    // Increase the cache lifetime and try a different path.
+    config_set('system.core', 'maintenance_page_maximum_age', 60);
     $this->backdropGet('user/register');
+    $this->assertResponse(503);
     $this->assertText($offline_message);
+    $this->assertIdentical($this->backdropGetHeader('Cache-Control'), 'public; max-age: 60');
 
     // Verify that user is able to log in.
     $this->backdropGet('user');
+    $this->assertResponse(200);
+    $this->assertNoText($offline_message);
+    // The user should also be able to reset their password.
+    $this->backdropGet('user/password');
+    $this->assertResponse(200);
     $this->assertNoText($offline_message);
     $this->backdropGet('user/login');
+    $this->assertResponse(200);
     $this->assertNoText($offline_message);
 
     // Log in user and verify that maintenance mode message is displayed


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/85

Replacing PR at https://github.com/backdrop/backdrop/pull/959.
