### PR TITLE
Issue #1478: Fix random failures in image style flood test.

### DIFF
--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -1654,8 +1654,8 @@ class ImageStyleFloodProtection extends BackdropWebTestCase {
     // Reduce the threshold down to 2 unauthorized images at a time.
     config_set('system.core', 'image_style_flood_limit', 2);
 
-    // The image_module_test_null effect has a 2 second delay on it. Make 3
-    // simultaneous requests and check that the 3rd one returns a 403.
+    // The image_module_test_wait_effect effect has a 5 second delay on it. Make
+    // 3 simultaneous requests and check that the 3rd one returns a 403.
     $images = array(
       image_style_url($this->style_name, $image1),
       image_style_url($this->style_name, $image2),

--- a/core/modules/image/tests/image_module_test/image_module_test.module
+++ b/core/modules/image/tests/image_module_test/image_module_test.module
@@ -21,7 +21,7 @@ function image_module_test_image_effect_info() {
     ),
     'image_module_test_wait' => array(
       'label' => t('Wait 2 seconds'),
-      'help' => t('Performs a NULL operation that takes 2 seconds.'),
+      'help' => t('Performs a NULL operation that takes 5 seconds.'),
       'effect callback' => 'image_module_test_wait_effect',
       'dimensions passthrough' => TRUE,
     )
@@ -55,7 +55,7 @@ function image_module_test_null_effect(array &$image, array $data) {
  * @return TRUE
  */
 function image_module_test_wait_effect() {
-  sleep(2);
+  sleep(5);
   return TRUE;
 }
 


### PR DESCRIPTION
Addresses the failing image style flood protection test in https://github.com/backdrop/backdrop-issues/issues/1478.
