### PR TITLE
Issue #1478: Fixing failing cache path test.

### DIFF
--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -33,11 +33,13 @@ class PathTestCase extends BackdropWebTestCase {
     // created.
     cache('path')->flush();
     $this->backdropGet($edit['source']);
+    sleep(3); // Sleep to allow background process to save cache paths.
     $this->assertTrue(cache('path')->get($edit['source']), 'Cache entry was created.');
 
     // Visit the alias for the node and confirm a cache entry is created.
     cache('path')->flush();
     $this->backdropGet($edit['alias']);
+    sleep(3); // Sleep to allow background process to save cache paths.
     $this->assertTrue(cache('path')->get($edit['source']), 'Cache entry was created.');
   }
 


### PR DESCRIPTION
Fixes another random fail in Path tests caused by background cache updating.
