### PR TITLE
Issue #1525: Rename User email settings page to Account emails.

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1274,7 +1274,7 @@ function user_menu() {
 
   // User email settings.
   $items['admin/config/people/emails'] = array(
-    'title' => 'User email settings',
+    'title' => 'Account emails',
     'description' => 'Configure email templates used for account registration and management.',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('user_settings_email'),


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/1525
