### PR TITLE
Issue #1478: Fixing failing cache path test.

### DIFF
--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -33,11 +33,13 @@ class PathTestCase extends BackdropWebTestCase {
     // created.
     cache('path')->flush();
     $this->backdropGet($edit['source']);
+    sleep(3); // Path cache is set in the background. Wait for it to populate.
     $this->assertTrue(cache('path')->get($edit['source']), 'Cache entry was created.');
 
     // Visit the alias for the node and confirm a cache entry is created.
     cache('path')->flush();
     $this->backdropGet($edit['alias']);
+    sleep(3); // Path cache is set in the background. Wait for it to populate.
     $this->assertTrue(cache('path')->get($edit['source']), 'Cache entry was created.');
   }
 


### PR DESCRIPTION
Fixes the failing PathTestCase test random failure.

Part of https://github.com/backdrop/backdrop-issues/issues/1478.
