### PR TITLE
Issue #1600/2156405: Remove check for adding js setting twice.

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -2655,12 +2655,7 @@ function user_form_process_password_confirm($element) {
   );
 
   $element['#attached']['js'][] = backdrop_get_path('module', 'user') . '/js/user.js';
-  // Ensure settings are only added once per page.
-  static $already_added = FALSE;
-  if (!$already_added) {
-    $already_added = TRUE;
-    $element['#attached']['js'][] = array('data' => $js_settings, 'type' => 'setting');
-  }
+  $element['#attached']['js'][] = array('data' => $js_settings, 'type' => 'setting');
 
   return $element;
 }


### PR DESCRIPTION
this is handled by backdrop_array_merge_deep().
