### PR TITLE
Issue #1420: Add the jquery ui.tooltip library information to system_library_info()

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -1601,6 +1601,21 @@ function system_library_info() {
       array('system', 'ui.widget'),
     ),
   );
+  $libraries['ui.tooltip'] = array(
+    'title' => 'jQuery UI: Tooltip',
+    'website' => 'http://jqueryui.com/tooltip/',
+    'version' => $libraries['ui']['version'],
+    'js' => array(
+      'core/misc/ui/jquery.ui.tooltip.min.js' => array(),
+    ),
+    'css' => array(
+      'core/misc/ui/jquery.ui.tooltip.css' => array(),
+    ),
+    'dependencies' => array(
+      array('system', 'ui.widget'),
+      array('system', 'ui.position'),
+    ),
+  );
   $libraries['ui.widget'] = array(
     'title' => 'jQuery UI: Widget',
     'website' => 'http://jqueryui.com/widget/',


### PR DESCRIPTION
This fixes issue https://github.com/backdrop/backdrop-issues/issues/1420.
