### PR TITLE
Issue #1647: Disabled menu options on node form may delete menu items.

### DIFF
--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -506,7 +506,7 @@ function menu_node_update(Node $node) {
 function menu_node_save(Node $node) {
   if (isset($node->menu)) {
     $link = &$node->menu;
-    if (empty($link['enabled'])) {
+    if (isset($link['enabled']) && !$link['enabled']) {
       if (!empty($link['mlid'])) {
         menu_link_delete($link['mlid']);
       }

--- a/core/modules/menu/tests/menu.test
+++ b/core/modules/menu/tests/menu.test
@@ -625,6 +625,7 @@ class MenuNodeTestCase extends BackdropWebTestCase {
       'menu_options[main-menu]' => 1,
     );
     $this->backdropPost('admin/structure/types/manage/page', $edit, t('Save content type'));
+
     // Change default parent item to Main menu, so we can assert more
     // easily.
     $edit = array(
@@ -667,6 +668,24 @@ class MenuNodeTestCase extends BackdropWebTestCase {
 
     $this->backdropGet('node/' . $node->nid . '/edit');
     $this->assertOptionSelected('edit-menu-weight', 17, 'Menu weight correct in edit form');
+
+    // Disable Main menu as available menu to ensure the link stays when saving
+    // the node while menu options are not on the node form.
+    $edit = array(
+      'menu_options[main-menu]' => 0,
+    );
+    $this->backdropPost('admin/structure/types/manage/page', $edit, t('Save content type'));
+    $this->backdropPost('node/' . $node->nid . '/edit', array(), t('Save'));
+
+    // Check that the link is still present.
+    $this->backdropGet('');
+    $this->assertLink($node_title);
+
+    // Re-enable Main menu as available menu, then remove the link.
+    $edit = array(
+      'menu_options[main-menu]' => 1,
+    );
+    $this->backdropPost('admin/structure/types/manage/page', $edit, t('Save content type'));
 
     // Edit the node and remove the menu link.
     $edit = array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1647.
