### PR TITLE
Issue #1566: Prevent Travis CI (or other tests) from reporting via update module.

### DIFF
--- a/core/modules/update/tests/update.test
+++ b/core/modules/update/tests/update.test
@@ -23,6 +23,7 @@
  * Defines some shared functions used by all update tests.
  */
 class UpdateTestHelper extends BackdropWebTestCase {
+  protected $profile = 'testing';
 
   /**
    * Refreshes the update status based on the desired available update scenario.
@@ -60,7 +61,7 @@ class UpdateTestHelper extends BackdropWebTestCase {
 
 class UpdateCoreTestCase extends UpdateTestHelper {
   function setUp() {
-    parent::setUp('update_test', 'update');
+    parent::setUp(array('update_test', 'update'));
     $admin_user = $this->backdropCreateUser(array('administer site configuration', 'administer modules'));
     $this->backdropLogin($admin_user);
   }
@@ -253,6 +254,26 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   }
 
   /**
+   * Tests _update_checking_enabled() returns the expected value during tests.
+   */
+  function testUpdateCheckingEnabled() {
+    $config = config('update.settings');
+    $this->assertEqual($config->get('update_url'), '', 'No update server specified in the default installation.');
+    $this->assertFalse(_update_checking_enabled(), 'Update checking is not enabled when using the default server.');
+
+    $this->backdropGet('admin/reports/updates/check');
+    $this->assertText(t('Update checking is disabled on this site.'));
+
+    $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
+    $config->save();
+
+    $this->assertTrue(_update_checking_enabled(), 'Update checking enabled during tests when using a local host update URL.');
+
+    $this->backdropGet('admin/reports/updates/check');
+    $this->assertNoText(t('Update checking is disabled on this site.'));
+  }
+
+  /**
    * Sets the version to 1.0 when no project-specific mapping is defined.
    */
   protected function setSystemInfo1_0() {
@@ -268,7 +289,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
 
 class UpdateTestContribCase extends UpdateTestHelper {
   function setUp() {
-    parent::setUp('update_test', 'update', 'aaa_update_test', 'bbb_update_test', 'ccc_update_test');
+    parent::setUp(array('update_test', 'update', 'aaa_update_test', 'bbb_update_test', 'ccc_update_test'));
     $admin_user = $this->backdropCreateUser(array('administer site configuration'));
     $this->backdropLogin($admin_user);
   }
@@ -624,7 +645,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
 
 class UpdateTestUploadCase extends UpdateTestHelper {
   public function setUp() {
-    parent::setUp('update', 'update_test');
+    parent::setUp(array('update', 'update_test'));
     $GLOBALS['settings']['allow_authorize_operations'] = TRUE;
     $admin_user = $this->backdropCreateUser(array('administer software updates', 'administer site configuration'));
     $this->backdropLogin($admin_user);
@@ -717,7 +738,7 @@ class UpdateTestUploadCase extends UpdateTestHelper {
  */
 class UpdateCoreUnitTestCase extends BackdropUnitTestCase {
   function setUp() {
-    parent::setUp('update');
+    parent::setUp(array('update'));
     module_load_include('inc', 'update', 'update.fetch');
   }
 

--- a/core/modules/update/update.fetch.inc
+++ b/core/modules/update/update.fetch.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Code required only when fetching information about available updates.
@@ -13,6 +12,12 @@
  * @see update_menu()
  */
 function update_manual_status() {
+  // Do not trigger an update if in testing.
+  if (!_update_checking_enabled()) {
+    backdrop_set_message(t('Update checking is disabled on this site.'), 'error');
+    return;
+  }
+
   _update_refresh();
   $batch = array(
     'operations' => array(

--- a/core/modules/update/update.install
+++ b/core/modules/update/update.install
@@ -28,7 +28,7 @@
 function update_requirements($phase) {
   $requirements = array();
   if ($phase == 'runtime') {
-    if ($available = update_get_available(FALSE)) {
+    if (_update_checking_enabled() && ($available = update_get_available(FALSE))) {
       module_load_include('inc', 'update', 'update.compare');
       $data = update_calculate_project_data($available);
       // First, populate the requirements for core:

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -260,6 +260,11 @@ function update_theme() {
  * Implements hook_cron().
  */
 function update_cron() {
+  // Check to see if we are running a test before checking for updates.
+  if (!_update_checking_enabled()) {
+    return;
+  }
+
   $frequency = config_get('update.settings', 'update_interval_days');
   $interval = 60 * 60 * 24 * $frequency;
   if ((REQUEST_TIME - state_get('update_last_check', 0)) > $interval) {
@@ -336,6 +341,16 @@ function _update_no_data() {
     '@run_cron' => url('admin/reports/status/run-cron', array('query' => $destination)),
     '@check_manually' => url('admin/reports/updates/check', array('query' => $destination)),
   ));
+}
+
+/**
+ * Check if update checking should make HTTP requests to the update server.
+ *
+ * This function primarily is to ensure that Backdrop does not do update
+ * checking against backdropcms.org or other remote servers during tests.
+ */
+function _update_checking_enabled() {
+  return empty($GLOBALS['backdrop_test_info']['test_run_id']) || strstr(config_get('update.settings', 'update_url'), $GLOBALS['base_url']);
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1566

Replaces https://github.com/backdrop/backdrop/pull/1227.
