### PR TITLE
Issue #1720: Footer: Contextual link text bleeds out of the contextua…

### DIFF
--- a/core/modules/contextual/css/contextual.css
+++ b/core/modules/contextual/css/contextual.css
@@ -103,6 +103,7 @@ ul.contextual-links li a {
   display: block;
   margin: 0.25em 0;
   padding: 0.25em 1em 0.25em 0.5em; /* LTR */
+  text-indent: 0;
 }
 [dir="rtl"] ul.contextual-links li a {
   padding: 0.25em 0.5em 0.25em 1em;


### PR DESCRIPTION
…l link pop-down.

Fixes https://github.com/backdrop/backdrop-issues/issues/1720
