### PR TITLE
Correcting commit 746a181

### DIFF
--- a/core/themes/seven/css/vertical-tabs.css
+++ b/core/themes/seven/css/vertical-tabs.css
@@ -156,21 +156,21 @@
 .vertical-tab-selected.vertical-tab-item {
   background-color: #fff;
   border-right-width: 0; /* LTR */
-  border-left-width: 1px #000;
+  border-left-width: 1px;
   box-shadow: 0 5px 5px -5px hsla(0,0%,0%,0.3);
   z-index: 1;
   position: relative;
 }
  [dir="rtl"] .vertical-tab-selected.vertical-tab-item {
   border-left-width: 0;
-  border-right-width: 1px #000;
+  border-right-width: 1px;
 }
 .vertical-tab-selected .vertical-tab-link {
   background: #fff;
-  border-left: 4px solid;
+  border-left: 4px solid #000;
 }
 [dir="rtl"] .vertical-tab-selected .vertical-tab-link {
-  border-right: 4px solid;
+  border-right: 4px solid #000;
 }
 .vertical-tab-selected strong,
 .vertical-tab-selected .fieldset-legend {


### PR DESCRIPTION
In https://github.com/backdrop/backdrop/commit/746a181f2d0db4eeff046023bdc05a554b90a5d5 by (my) mistake, the color was applied to the border width properties instead of the borders for RTL and LTR.

What a shame :disappointed: 
