### PR TITLE
Issue #1736: Notice: Undefined index: HTTP_ACCEPT in backdrop_is_html()

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -3811,7 +3811,7 @@ function backdrop_is_cli() {
  * in order to be returned in an alternative format.
  */
 function backdrop_is_html() {
-  return strpos($_SERVER['HTTP_ACCEPT'], 'text/html') === 0 || empty($_SERVER['HTTP_ACCEPT']) || empty($_SERVER['HTTP_X_REQUESTED_WITH']);
+  return empty($_SERVER['HTTP_ACCEPT']) || strpos($_SERVER['HTTP_ACCEPT'], 'text/html') === 0 || empty($_SERVER['HTTP_X_REQUESTED_WITH']);
 }
 
 /**


### PR DESCRIPTION
Resolving Issue #1736 by moving check for `empty($_SERVER['HTTP_ACCEPT'])` to the beginning of the line.
