### PR TITLE
Issue #1692: Layout UI: Page title type drop-down label says "Block t…

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -714,7 +714,7 @@ function layout_content_form($form, &$form_state, Layout $layout, $renderer_name
   $form['title_display']['#tree'] = FALSE;
   $form['title_display']['title_display'] = array(
     '#type' => 'select',
-    '#title' => t('Block title type'),
+    '#title' => t('Page title type'),
     '#default_value' => $layout->settings['title_display'],
     '#options' => array(
       LAYOUT_TITLE_DEFAULT => t('Default title'),


### PR DESCRIPTION
…itle type"

Fixes https://github.com/backdrop/backdrop-issues/issues/1692
