### PR TITLE
Issue #1793: Use path alias on add menu item forms if the path alias …

### DIFF
--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -249,12 +249,13 @@ function menu_edit_item($form, &$form_state, $type, $item, $menu) {
   if (isset($item['options']['fragment'])) {
     $path .= '#' . $item['options']['fragment'];
   }
+  $path_alias = backdrop_get_path_alias($path);
   if ($item['module'] == 'menu') {
     $form['link_path'] = array(
       '#type' => 'textfield',
       '#title' => t('Path'),
       '#maxlength' => 255,
-      '#default_value' => $path,
+      '#default_value' => (!empty($path)) ? $path_alias : $path,
       '#description' => t('The path for this menu link. This can be an internal Backdrop path such as %add-node or an external URL such as %external. Enter %front to link to the front page.', array('%front' => '<front>', '%add-node' => 'node/add', '%external' => 'http://backdropcms.org')),
       '#required' => TRUE,
     );


### PR DESCRIPTION
…exists. This fixes: #1793 use path alias on menu add form.
