### PR TITLE
Issue #1810: Save menu router-based links to a default 'internal' menu instead of the 'main-menu'.

### DIFF
--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -2820,7 +2820,7 @@ function _menu_link_build($item) {
   // the menu links generated automatically from entries in {menu_router}.
   $item['module'] = 'system';
   $item += array(
-    'menu_name' => 'main-menu',
+    'menu_name' => 'internal',
     'link_title' => $item['title'],
     'link_path' => $item['path'],
     'hidden' => 0,

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -1645,7 +1645,6 @@ function node_menu() {
   $items['node'] = array(
     'page callback' => 'node_page_default',
     'access arguments' => array('access content'),
-    'menu_name' => 'main-menu',
     'type' => MENU_CALLBACK,
   );
   $items['node/add'] = array(

--- a/core/modules/search/search.module
+++ b/core/modules/search/search.module
@@ -182,6 +182,7 @@ function search_menu() {
         'type' => MENU_LOCAL_TASK,
         'file' => 'search.pages.inc',
         'weight' => $module == $default_info['module'] ? -10 : 0,
+        'menu_name' => 'internal',
       );
       $items["$path/%menu_tail"] = array(
         'title' => $search_info['title'],
@@ -199,6 +200,7 @@ function search_menu() {
         'tab_root' => 'search/' . $default_info['path'] . '/%',
         // These tabs need to display at the same level.
         'tab_parent' => 'search/' . $default_info['path'],
+        'menu_name' => 'internal',
       );
     }
   }

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -135,68 +135,45 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   }
 
   /**
-   * Test title callback set to FALSE.
+   * Tests title and theme callbacks in hook_menu().
    */
-  function testTitleCallbackFalse() {
+  function testMenuCallbacks() {
+    // Test title callback set to FALSE.
     $this->backdropGet('node');
     $this->assertText('A title with @placeholder', 'Raw text found on the page');
     $this->assertNoText(t('A title with @placeholder', array('@placeholder' => 'some other text')), 'Text with placeholder substitutions not found.');
-  }
 
-  /**
-   * Tests page title of MENU_CALLBACKs.
-   */
-  function testTitleMenuCallback() {
+    // Test page title of MENU_CALLBACK items.
     // Verify that the menu router item title is not visible.
     $this->backdropGet('');
     $this->assertNoText(t('Menu Callback Title'));
     // Verify that the menu router item title is output as page title.
     $this->backdropGet('menu_callback_title');
     $this->assertText(t('Menu Callback Title'));
-  }
 
-  /**
-   * Test the theme callback when it is set to use an administrative theme.
-   */
-  function testThemeCallbackAdministrative() {
+    // Test the theme callback when it is set to use an administrative theme.
     $this->backdropGet('menu-test/theme-callback/use-admin-theme');
     $this->assertText('Custom theme: seven. Actual theme: seven.', 'The administrative theme can be correctly set in a theme callback.');
     $this->assertRaw('seven/css/style.css', "The administrative theme's CSS appears on the page.");
-  }
 
-  /**
-   * Test that the theme callback is properly inherited.
-   */
-  function testThemeCallbackInheritance() {
+    // Test that the theme callback is properly inherited.
     $this->backdropGet('menu-test/theme-callback/use-admin-theme/inheritance');
     $this->assertText('Custom theme: seven. Actual theme: seven. Theme callback inheritance is being tested.', 'Theme callback inheritance correctly uses the administrative theme.');
     $this->assertRaw('seven/css/style.css', "The administrative theme's CSS appears on the page.");
-  }
 
-  /**
-   * Test that 'page callback', 'file' and 'file path' keys are properly
-   * inherited from parent menu paths.
-   */
-  function testFileInheritance() {
+    // Test that 'page callback', 'file' and 'file path' keys are properly
+    // inherited from parent menu paths.
     $this->backdropGet('admin/config/development/file-inheritance');
     $this->assertText('File inheritance test description', 'File inheritance works.');
-  }
 
-  /**
-   * Test path containing "exotic" characters.
-   */
-  function testExoticPath() {
+    // Test path containing "exotic" characters.
     $path = "menu-test/ -._~!$'\"()*@[]?&+%#,;=:" . // "Special" ASCII characters.
       "%23%25%26%2B%2F%3F" . // Characters that look like a percent-escaped string.
       "éøïвβ中國書۞"; // Characters from various non-ASCII alphabets.
     $this->backdropGet($path);
     $this->assertRaw('This is menu_test_callback().');
-  }
 
-  /**
-   * Test the theme callback when the site is in maintenance mode.
-   */
-  function testThemeCallbackMaintenanceMode() {
+    // Test the theme callback when the site is in maintenance mode.
     state_set('maintenance_mode', TRUE);
 
     // For a regular user, the fact that the site is in maintenance mode means
@@ -210,26 +187,37 @@ class MenuRouterTestCase extends BackdropWebTestCase {
     $this->backdropGet('menu-test/theme-callback/use-admin-theme');
     $this->assertText('Custom theme: seven. Actual theme: seven.', 'The theme callback system is correctly triggered for an administrator when the site is in maintenance mode.');
     $this->assertRaw('seven/css/style.css', "The administrative theme's CSS appears on the page.");
-
-    config_set('system.core', 'maintenance_mode', FALSE);
-  }
-
-  /**
-   * Make sure the maintenance mode can be bypassed using hook_menu_site_status_alter().
-   *
-   * @see hook_menu_site_status_alter().
-   */
-  function testMaintenanceModeLoginPaths() {
-    state_set('maintenance_mode', TRUE);
-
-    $offline_message = t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => config_get('system.core', 'site_name')));
     $this->backdropLogout();
+
+    // Make sure the maintenance mode can be bypassed using hook_menu_site_status_alter().
+    $offline_message = t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => config_get('system.core', 'site_name')));
     $this->backdropGet('node');
     $this->assertText($offline_message);
     $this->backdropGet('menu_login_callback');
     $this->assertText('This is menu_login_callback().', 'Maintenance mode can be bypassed through hook_login_paths().');
+    state_set('maintenance_mode', FALSE);
 
-    config_set('system.core', 'maintenance_mode', FALSE);
+    // Test the theme callback when it is set to use an optional theme.
+    // Request a theme that is not enabled.
+    $this->backdropGet('menu-test/theme-callback/use-stark-theme');
+    $this->assertText('Custom theme: NONE. Actual theme: bartik.', 'The theme callback system falls back on the default theme when a theme that is not enabled is requested.');
+    $this->assertRaw('bartik/css/style.css', "The default theme's CSS appears on the page.");
+
+    // Now enable the theme and request it again.
+    theme_enable(array('stark'));
+    $this->backdropGet('menu-test/theme-callback/use-stark-theme');
+    $this->assertText('Custom theme: stark. Actual theme: stark.', 'The theme callback system uses an optional theme once it has been enabled.');
+    $this->assertRaw('stark/layout.css', "The optional theme's CSS appears on the page.");
+
+    // Test the theme callback when it is set to use a theme that does not exist.
+    $this->backdropGet('menu-test/theme-callback/use-fake-theme');
+    $this->assertText('Custom theme: NONE. Actual theme: bartik.', 'The theme callback system falls back on the default theme when a theme that does not exist is requested.');
+    $this->assertRaw('bartik/css/style.css', "The default theme's CSS appears on the page.");
+
+    // Test the theme callback when no theme is requested.
+    $this->backdropGet('menu-test/theme-callback/no-theme-requested');
+    $this->assertText('Custom theme: NONE. Actual theme: bartik.', 'The theme callback system falls back on the default theme when no theme is requested.');
+    $this->assertRaw('bartik/css/style.css', "The default theme's CSS appears on the page.");
   }
 
   /**
@@ -247,40 +235,6 @@ class MenuRouterTestCase extends BackdropWebTestCase {
     // user/register should redirect to user/UID/edit.
     $this->backdropGet('user/register');
     $this->assertTrue($this->url == url('user/' . $this->loggedInUser->uid . '/edit', array('absolute' => TRUE)), "Logged-in user redirected to q=user/UID/edit on accessing q=user/register");
-  }
-
-  /**
-   * Test the theme callback when it is set to use an optional theme.
-   */
-  function testThemeCallbackOptionalTheme() {
-    // Request a theme that is not enabled.
-    $this->backdropGet('menu-test/theme-callback/use-stark-theme');
-    $this->assertText('Custom theme: NONE. Actual theme: bartik.', 'The theme callback system falls back on the default theme when a theme that is not enabled is requested.');
-    $this->assertRaw('bartik/css/style.css', "The default theme's CSS appears on the page.");
-
-    // Now enable the theme and request it again.
-    theme_enable(array('stark'));
-    $this->backdropGet('menu-test/theme-callback/use-stark-theme');
-    $this->assertText('Custom theme: stark. Actual theme: stark.', 'The theme callback system uses an optional theme once it has been enabled.');
-    $this->assertRaw('stark/layout.css', "The optional theme's CSS appears on the page.");
-  }
-
-  /**
-   * Test the theme callback when it is set to use a theme that does not exist.
-   */
-  function testThemeCallbackFakeTheme() {
-    $this->backdropGet('menu-test/theme-callback/use-fake-theme');
-    $this->assertText('Custom theme: NONE. Actual theme: bartik.', 'The theme callback system falls back on the default theme when a theme that does not exist is requested.');
-    $this->assertRaw('bartik/css/style.css', "The default theme's CSS appears on the page.");
-  }
-
-  /**
-   * Test the theme callback when no theme is requested.
-   */
-  function testThemeCallbackNoThemeRequested() {
-    $this->backdropGet('menu-test/theme-callback/no-theme-requested');
-    $this->assertText('Custom theme: NONE. Actual theme: bartik.', 'The theme callback system falls back on the default theme when no theme is requested.');
-    $this->assertRaw('bartik/css/style.css', "The default theme's CSS appears on the page.");
   }
 
   /**

--- a/core/modules/simpletest/tests/menu_test.module
+++ b/core/modules/simpletest/tests/menu_test.module
@@ -21,6 +21,7 @@ function menu_test_menu() {
     'page callback' => 'menu_test_callback',
     'type' => MENU_CALLBACK,
     'access arguments' => array('access content'),
+    'menu_name' => 'main-menu',
   );
   // Use FALSE as 'title callback' to bypass t().
   $items['menu_no_title_callback'] = array(
@@ -29,6 +30,7 @@ function menu_test_menu() {
     'title arguments' => array('@placeholder' => 'some other text'),
     'page callback' => 'menu_test_callback',
     'access arguments' => array('access content'),
+    'menu_name' => 'main-menu',
   );
 
   // Hidden link for menu_link_maintain tests
@@ -41,6 +43,7 @@ function menu_test_menu() {
   $items['menu-test/hierarchy/parent'] = array(
     'title' => 'Parent menu router',
     'page callback' => 'node_page_default',
+    'menu_name' => 'main-menu',
   );
   $items['menu-test/hierarchy/parent/child'] = array(
     'title' => 'Child menu router',
@@ -86,6 +89,7 @@ function menu_test_menu() {
     'title' => 'Menu test root',
     'page callback' => 'node_page_default',
     'access arguments' => array('access content'),
+    'menu_name' => 'main-menu',
   );
   $items['menu-test/hidden'] = array(
     'title' => 'Hidden test root',

--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -558,7 +558,7 @@ class TokenMenuTestCase extends TokenTestHelper {
       'menu:name' => 'Primary navigation',
       'menu:machine-name' => 'main-menu',
       'menu:description' => 'The <em>Primary navigation</em> menu is used on many sites to show the major sections of the site, often in a top navigation bar.',
-      'menu:menu-link-count' => 11,
+      'menu:menu-link-count' => 2,
       'menu:edit-url' => url("admin/structure/menu/manage/main-menu", array('absolute' => TRUE)),
       'url' => url('root/parent', array('absolute' => TRUE)),
       'url:absolute' => url('root/parent', array('absolute' => TRUE)),

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2761,6 +2761,24 @@ function system_update_1052() {
 }
 
 /**
+ * Remove unnecessary items from the "main-menu" menu.
+ */
+function system_update_1053() {
+  db_query("DELETE FROM {menu_links} WHERE link_path LIKE '%/%%%' AND module = 'system'");
+  db_query("DELETE FROM {menu_links} WHERE link_path LIKE 'search/%' AND module = 'system'");
+
+  // Move the 404 redirect link (if present) to the internal menu.
+  $add_redirect_path = config_get('system.core', 'site_404');
+  if (empty($path)) {
+    $add_redirect_path = 'system/404';
+  }
+  $add_redirect_path .= '/add-redirect';
+  db_query("UPDATE {menu_links} SET menu_name = 'internal' WHERE link_path = :redirect_path AND menu_name = 'main-menu'", array(':redirect_path' => $add_redirect_path));
+
+  state_set('menu_rebuild_needed', TRUE);
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1810.
