### PR TITLE
Issue #1819: Use real entity objects in hook_field_attach_form().

### DIFF
--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -165,16 +165,16 @@ function entity_extract_ids($entity_type, $entity) {
  *   An entity object, initialized with the IDs provided.
  */
 function entity_create_stub_entity($entity_type, $ids) {
-  $entity = new stdClass();
   $info = entity_get_info($entity_type);
-  $entity->{$info['entity keys']['id']} = $ids[0];
+  $entity_class = $info['entity class'];
+  $data[$info['entity keys']['id']] = $ids[0];
   if (!empty($info['entity keys']['revision']) && isset($ids[1])) {
-    $entity->{$info['entity keys']['revision']} = $ids[1];
+    $data[$info['entity keys']['revision']] = $ids[1];
   }
   if (!empty($info['entity keys']['bundle']) && isset($ids[2])) {
-    $entity->{$info['entity keys']['bundle']} = $ids[2];
+    $data[$info['entity keys']['bundle']] = $ids[2];
   }
-  return $entity;
+  return new $entity_class($data);
 }
 
 /**

--- a/core/modules/entity/tests/entity_query.test
+++ b/core/modules/entity/tests/entity_query.test
@@ -91,7 +91,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
 
     // Create entities which have a 'bundle key' defined.
     for ($i = 1; $i < 7; $i++) {
-      $entity = new stdClass();
+      $entity = new TestEntity();
       $entity->ftid = $i;
       $entity->fttype = ($i < 5) ? 'bundle1' : 'bundle2';
 
@@ -100,7 +100,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
       field_attach_insert('test_entity_bundle_key', $entity);
     }
 
-    $entity = new stdClass();
+    $entity = new TestEntity();
     $entity->ftid = 5;
     $entity->fttype = 'test_entity_bundle';
     $entity->{$this->field_names[1]}[LANGUAGE_NONE][0]['shape'] = 'square';
@@ -118,7 +118,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
 
     // Create entities with support for revisions.
     for ($i = 1; $i < 5; $i++) {
-      $entity = new stdClass();
+      $entity = new TestEntity();
       $entity->ftid = $i;
       $entity->ftvid = $i;
       $entity->fttype = 'test_bundle';
@@ -131,7 +131,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
 
     // Add two revisions to an entity.
     for ($i = 100; $i < 102; $i++) {
-      $entity = new stdClass();
+      $entity = new TestEntity();
       $entity->ftid = 4;
       $entity->ftvid = $i;
       $entity->fttype = 'test_bundle';
@@ -969,7 +969,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
     ), 'Test offset on a field.', TRUE);
 
     for ($i = 6; $i < 10; $i++) {
-      $entity = new stdClass();
+      $entity = new TestEntity();
       $entity->ftid = $i;
       $entity->fttype = 'test_entity_bundle';
       $entity->{$this->field_names[0]}[LANGUAGE_NONE][0]['value'] = $i - 5;
@@ -1051,7 +1051,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
     field_test_entity_info_translatable('test_entity', TRUE);
 
     // Create more items with different languages.
-    $entity = new stdClass();
+    $entity = new TestEntity();
     $entity->ftid = 1;
     $entity->ftvid = 1;
     $entity->fttype = 'test_bundle';
@@ -1088,7 +1088,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
     field_test_entity_info_translatable('test_entity', TRUE);
 
     // Create more items with different languages.
-    $entity = new stdClass();
+    $entity = new TestEntity();
     $entity->ftid = 1;
     $entity->ftvid = 1;
     $entity->fttype = 'test_bundle';

--- a/core/modules/field/field.crud.inc
+++ b/core/modules/field/field.crud.inc
@@ -913,7 +913,7 @@ function field_delete_instance($instance, $field_cleanup = TRUE) {
  * would look something like this:
  *
  * @code
- *   $entity = stdClass Object(
+ *   $entity = Node(array(
  *     [nid] => 37,
  *     [vid] => 37,
  *     [type] => 'story',
@@ -922,7 +922,7 @@ function field_delete_instance($instance, $field_cleanup = TRUE) {
  *         'value' => 'subtitle text',
  *       ),
  *     ),
- *   );
+ *   ));
  * @endcode
  *
  * See @link field Field API @endlink for information about the other parts of

--- a/core/modules/field/tests/field_test/field_test.entity.inc
+++ b/core/modules/field/tests/field_test/field_test.entity.inc
@@ -210,7 +210,7 @@ function field_test_delete_bundle($bundle) {
  * Creates a basic test_entity entity.
  */
 function field_test_create_stub_entity($id = 1, $vid = 1, $bundle = 'test_bundle', $label = '') {
-  $entity = new stdClass();
+  $entity = new TestEntity();
   // Only set id and vid properties if they don't come as NULL (creation form).
   if (isset($id)) {
     $entity->ftid = $id;

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -21,8 +21,8 @@ class CommonBackdropAlterTestCase extends BackdropWebTestCase {
     $base_theme_info = array();
 
     $array = array('foo' => 'bar');
-    $entity = new stdClass();
-    $entity->foo = 'bar';
+    $object = new stdClass();
+    $object->foo = 'bar';
 
     // Verify alteration of a single argument.
     $array_copy = $array;
@@ -30,23 +30,23 @@ class CommonBackdropAlterTestCase extends BackdropWebTestCase {
     backdrop_alter('backdrop_alter', $array_copy);
     $this->assertEqual($array_copy, $array_expected, 'Single array was altered.');
 
-    $entity_copy = clone $entity;
-    $entity_expected = clone $entity;
-    $entity_expected->foo = 'Backdrop theme';
-    backdrop_alter('backdrop_alter', $entity_copy);
-    $this->assertEqual($entity_copy, $entity_expected, 'Single object was altered.');
+    $object_copy = clone $object;
+    $object_expected = clone $object;
+    $object_expected->foo = 'Backdrop theme';
+    backdrop_alter('backdrop_alter', $object_copy);
+    $this->assertEqual($object_copy, $object_expected, 'Single object was altered.');
 
     // Verify alteration of multiple arguments.
     $array_copy = $array;
     $array_expected = array('foo' => 'Backdrop theme');
-    $entity_copy = clone $entity;
-    $entity_expected = clone $entity;
-    $entity_expected->foo = 'Backdrop theme';
+    $object_copy = clone $object;
+    $object_expected = clone $object;
+    $object_expected->foo = 'Backdrop theme';
     $array2_copy = $array;
     $array2_expected = array('foo' => 'Backdrop theme');
-    backdrop_alter('backdrop_alter', $array_copy, $entity_copy, $array2_copy);
+    backdrop_alter('backdrop_alter', $array_copy, $object_copy, $array2_copy);
     $this->assertEqual($array_copy, $array_expected, 'First argument to backdrop_alter() was altered.');
-    $this->assertEqual($entity_copy, $entity_expected, 'Second argument to backdrop_alter() was altered.');
+    $this->assertEqual($object_copy, $object_expected, 'Second argument to backdrop_alter() was altered.');
     $this->assertEqual($array2_copy, $array2_expected, 'Third argument to backdrop_alter() was altered.');
 
     // Verify alteration order when passing an array of types to backdrop_alter().


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1819.
