### PR TITLE
l10n: Translate content type name.

### DIFF
--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -69,7 +69,7 @@ function node_add($type) {
     'type' => $type,
     'langcode' => LANGUAGE_NONE,
   ));
-  backdrop_set_title(t('Create @name', array('@name' => $types[$type]->name)), PASS_THROUGH);
+  backdrop_set_title(t('Create @name', array('@name' => t($types[$type]->name))), PASS_THROUGH);
   $output = backdrop_get_form($type . '_node_form', $node);
 
   return $output;


### PR DESCRIPTION
When I go to node/add/article in a spanish translated site I expect the title to be: "Crear Artículo". Instead I'm getting "Crear Article".
