### PR TITLE
Issue #1825: Provide default region named  for layouts.

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1108,6 +1108,7 @@ function layout_get_layout_info($layout_name = NULL) {
     foreach ($info as $name => $layout_info) {
       $info[$name] += array(
         'preview' => 'preview.png',
+        'default region' => 'content',
         'stylesheets' => array(
           'all' => array(str_replace('_', '-', $name) . '.css'),
         ),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1825
