### PR TITLE
Issue #1761: drupal_path_alias_whitelist_rebuild() should return an array

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -2155,7 +2155,7 @@ function drupal_match_path($path, $patterns) {
  * @deprecated since 1.0.0
  */
 function drupal_path_alias_whitelist_rebuild($source = NULL) {
-  return;
+  return array();
 }
 
 /**


### PR DESCRIPTION
This fixes https://github.com/backdrop/backdrop-issues/issues/1761

See: https://api.drupal.org/api/drupal/includes!path.inc/function/drupal_path_alias_whitelist_rebuild/7.x
