### PR TITLE
Issue #1478: Flush output buffer under PHP 5.3.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -2947,6 +2947,9 @@ function backdrop_page_footer() {
 
   // If we're not already in a background request, flush to the browser.
   if (!backdrop_is_background() && $_SERVER['REQUEST_METHOD'] !== 'HEAD') {
+    // End the request and send the response to the browser.
+    ob_end_flush();
+    
     // Flushing for PHP-FPM based installations.
     if (function_exists('fastcgi_finish_request')) {
       fastcgi_finish_request();


### PR DESCRIPTION
Another test failure fix for https://github.com/backdrop/backdrop-issues/issues/1478.

Replaces https://github.com/backdrop/backdrop/pull/1378.

mod_php for PHP 5.3 can sometimes fail this test:

```
---- Bootstrap: Page cache test (BootstrapPageCacheTestCase) ----

Status    Group      Filename          Line Function
--------------------------------------------------------------------------------
Fail      Other      bootstrap.test     201 BootstrapPageCacheTestCase->testPag
    Initial page requests returned before shutdown functions are executed.
```
