### PR TITLE
Serundeputy 1793/show menu items as paths instead of node nid

### DIFF
--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -249,12 +249,13 @@ function menu_edit_item($form, &$form_state, $type, $item, $menu) {
   if (isset($item['options']['fragment'])) {
     $path .= '#' . $item['options']['fragment'];
   }
+  $path_alias = backdrop_get_path_alias($path);
   if ($item['module'] == 'menu') {
     $form['link_path'] = array(
       '#type' => 'textfield',
       '#title' => t('Path'),
       '#maxlength' => 255,
-      '#default_value' => $path,
+      '#default_value' => (!empty($path)) ? $path_alias : $path,
       '#description' => t('The path for this menu link. This can be an internal Backdrop path such as %add-node or an external URL such as %external. Enter %front to link to the front page.', array('%front' => '<front>', '%add-node' => 'node/add', '%external' => 'http://backdropcms.org')),
       '#required' => TRUE,
     );

--- a/core/modules/menu/tests/menu.test
+++ b/core/modules/menu/tests/menu.test
@@ -240,6 +240,23 @@ class MenuTestCase extends BackdropWebTestCase {
     $this->assertMenuLink($item4['mlid'], array('depth' => 1, 'has_children' => 1, 'p1' => $item4['mlid'], 'p2' => 0));
     $this->assertMenuLink($item5['mlid'], array('depth' => 2, 'has_children' => 0, 'p1' => $item4['mlid'], 'p2' => $item5['mlid'], 'p3' => 0));
 
+    // Add an alias to node 4 to test adding a menu link via alias.
+    $node4->path = array(
+      'pid' => NULL,
+      'source' => 'node/' . $node4->nid,
+      'alias' => 'node' . $node4->nid . '-alias',
+      'langcode' => LANGUAGE_NONE,
+      'auto' => FALSE,
+    );
+    $node4->save();
+
+    $item6 = $this->addMenuLink(0, 'node' . $node4->nid . '-alias', $menu_name);
+    $this->assertMenuLink($item6['mlid'], array('link_path' => 'node/' . $node4->nid));
+
+    // Check that the menu UI shows the alias for the node and not the source.
+    $this->backdropGet('admin/structure/menu/item/' . $item6['mlid'] . '/edit');
+    $this->assertFieldByXPath('//input[@name="link_path"]', 'node' . $node4->nid . '-alias');
+
     // Modify menu links.
     $this->modifyMenuLink($item1);
     $this->modifyMenuLink($item2);
@@ -323,9 +340,15 @@ class MenuTestCase extends BackdropWebTestCase {
     // Unlike most other modules, there is no confirmation message displayed.
     $this->assertText($title, 'Menu link was added');
 
+    // Resolve aliases if used.
+    $source = backdrop_lookup_path('source', $link);
+    if (empty($source)) {
+      $source = $link;
+    }
+
     $item = db_query('SELECT * FROM {menu_links} WHERE link_title = :title', array(':title' => $title))->fetchAssoc();
     $this->assertTrue(t('Menu link was found in database.'));
-    $this->assertMenuLink($item['mlid'], array('menu_name' => $menu_name, 'link_path' => $link, 'has_children' => 0, 'plid' => $plid));
+    $this->assertMenuLink($item['mlid'], array('menu_name' => $menu_name, 'link_path' => $source, 'has_children' => 0, 'plid' => $plid));
 
     return $item;
   }
@@ -526,7 +549,7 @@ class MenuTestCase extends BackdropWebTestCase {
       $item['link_path'] .= '#' . $options['fragment'];
     }
     foreach ($expected_item as $key => $value) {
-      $this->assertEqual($item[$key], $value, format_string('Parameter %key had expected value.', array('%key' => $key)));
+      $this->assertEqual($item[$key], $value, format_string('Parameter %key had value %actual, expected %expected for the %path path.', array('%key' => $key, '%path' => $item['link_path'], '%actual' => $item[$key], '%expected' => $value)));
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1793.

Replaces https://github.com/backdrop/backdrop/pull/1320.
