### PR TITLE
Issue #1810: Follow-up to prevent menus other than the default menu from being affected.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2763,8 +2763,8 @@ function system_update_1052() {
  * Remove unnecessary items from the "main-menu" menu.
  */
 function system_update_1053() {
-  db_query("DELETE FROM {menu_links} WHERE link_path LIKE '%/%%%' AND module = 'system'");
-  db_query("DELETE FROM {menu_links} WHERE link_path LIKE 'search/%' AND module = 'system'");
+  db_query("DELETE FROM {menu_links} WHERE link_path LIKE '%/%%%' AND module = 'system' AND menu_name = 'main-menu'");
+  db_query("DELETE FROM {menu_links} WHERE link_path LIKE 'search/%' AND module = 'system' AND menu_name = 'main-menu'");
 
   // Move the 404 redirect link (if present) to the internal menu.
   $add_redirect_path = config_get('system.core', 'site_404');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1810.
