### PR TITLE
Issue #1810: Fixing incorrect removal of system menu links with slashes.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2756,7 +2756,7 @@ function system_update_1052() {
  * Remove unnecessary items from the "main-menu" menu.
  */
 function system_update_1053() {
-  db_query("DELETE FROM {menu_links} WHERE link_path LIKE '%/%%%' AND module = 'system' AND menu_name = 'main-menu'");
+  db_query("DELETE FROM {menu_links} WHERE link_path LIKE '%/\%%' AND module = 'system' AND menu_name = 'main-menu'");
   db_query("DELETE FROM {menu_links} WHERE link_path LIKE 'search/%' AND module = 'system' AND menu_name = 'main-menu'");
 
   // Move the 404 redirect link (if present) to the internal menu.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1810.

Solves a regression where menu items defined in `hook_menu()` containing a slash may be removed from the main menu.
