### PR TITLE
Issue #1876: Position responsive tabs relative.

### DIFF
--- a/core/themes/seven/css/responsive-tabs.css
+++ b/core/themes/seven/css/responsive-tabs.css
@@ -1,3 +1,9 @@
+/**
+ * Styles for collapsible, responsive tabs.
+ */
+.responsive-tabs-processed {
+  position: relative;
+}
 .responsive-tabs-processed ul.primary {
   height: 2.6em;
   overflow: hidden;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1876.
