### PR TITLE
Issue #1893: [UX] Remove "new" from any "Add new X" page titles.

### DIFF
--- a/core/modules/block/block.admin.inc
+++ b/core/modules/block/block.admin.inc
@@ -75,7 +75,7 @@ function block_admin_configure($form, &$form_state, $delta = NULL) {
     backdrop_set_title(t("'%name' block", array('%name' => $custom_block['info'])), PASS_THROUGH);
   }
   else {
-    backdrop_set_title(t('Add new block'));
+    backdrop_set_title(t('Add custom block'));
   }
 
   // Call our own block configuration form (also used by Layout module).

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -236,7 +236,7 @@ function comment_menu() {
     'weight' => 2,
   );
   $items['comment/reply/%node'] = array(
-    'title' => 'Add new comment',
+    'title' => 'Add comment',
     'page callback' => 'comment_reply',
     'page arguments' => array(2),
     'access callback' => 'node_access',
@@ -639,7 +639,7 @@ function comment_node_view(Node $node, $view_mode) {
         $comment_form_location = $node_type->settings['comment_form_location'];
         if (user_access('post comments')) {
           $links['comment-add'] = array(
-            'title' => t('Add new comment'),
+            'title' => t('Add comment'),
             'href' => "node/$node->nid",
             'attributes' => array('title' => t('Add a new comment to this page.')),
             'fragment' => 'comment-form',
@@ -668,7 +668,7 @@ function comment_node_view(Node $node, $view_mode) {
           // if there are existing comments that the link will skip past.
           if ($comment_form_location == COMMENT_FORM_SEPARATE_PAGE || (!empty($node->comment_count) && user_access('access comments'))) {
             $links['comment-add'] = array(
-              'title' => t('Add new comment'),
+              'title' => t('Add comment'),
               'attributes' => array('title' => t('Share your thoughts and opinions related to this posting.')),
               'href' => "node/$node->nid",
               'fragment' => 'comment-form',

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -484,7 +484,7 @@ class CommentInterfaceTest extends CommentHelperCase {
     $this->assertNoLink(t('@count new comments', array('@count' => 0)));
     $this->assertLink(t('Read more'));
     $count = $this->xpath('//article[@id=:id]//ul/li', array(':id' => 'node-' . $this->node->nid));
-    $this->assertTrue(count($count) == 2, 'Two node links found (Read more and Add new comment)');
+    $this->assertTrue(count($count) == 2, 'Two node links found ("Read more" and "Add comment")');
 
     // Create a new comment. This helper function may be run with different
     // comment settings so use comment_save() to avoid complex setup.
@@ -936,7 +936,7 @@ class CommentInterfaceTest extends CommentHelperCase {
 
       // User is not allowed to post comments.
       if (!$info['post comments']) {
-        $this->assertNoLink('Add new comment');
+        $this->assertNoLink('Add comment');
 
         // Anonymous users should see a note to log in or register in case
         // authenticated users are allowed to post comments.
@@ -961,15 +961,15 @@ class CommentInterfaceTest extends CommentHelperCase {
       else {
         $this->assertNoText('Log in or register to post comments');
 
-        // "Add new comment" is always expected, except when there are no
+        // "Add comment" is always expected, except when there are no
         // comments or if the user cannot see them.
         if ($path == "node/$nid" && $info['form'] == COMMENT_FORM_BELOW && (!$info['comment count'] || !$info['access comments'])) {
-          $this->assertNoLink('Add new comment');
+          $this->assertNoLink('Add comment');
         }
         else {
-          $this->assertLink('Add new comment');
+          $this->assertLink('Add comment');
 
-          // Verify that the "Add new comment" link points to the correct URL
+          // Verify that the "Add comment" link points to the correct URL
           // based on the comment form location configuration.
           if ($info['form'] == COMMENT_FORM_SEPARATE_PAGE) {
             $this->assertLinkByHref("comment/reply/$nid#comment-form", 0, 'Comment form link destination is on a separate page.');
@@ -1229,7 +1229,7 @@ class CommentAnonymous extends CommentHelperCase {
     // "Login or register to post comments" type link may be shown.
     $this->backdropGet('node/' . $this->node->nid);
     $this->assertNoPattern('@<h2[^>]*>Comments</h2>@', 'Comments were not displayed.');
-    $this->assertNoLink('Add new comment', 'Link to add comment was found.');
+    $this->assertNoLink('Add comment', 'Link to add comment was found.');
 
     // Attempt to view node-comment form while disallowed.
     $this->backdropGet('comment/reply/' . $this->node->nid);

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2120,7 +2120,7 @@ function node_page_default() {
 
     $default_links = array();
     if (_node_add_access()) {
-      $default_links[] = l(t('Add new content'), 'node/add');
+      $default_links[] = l(t('Add content'), 'node/add');
     }
     if (!empty($default_links)) {
       $default_message .= theme('item_list', array('items' => $default_links));

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -90,7 +90,7 @@ function node_type_form($form, &$form_state, $type = NULL) {
     '#title' => t('Name'),
     '#type' => 'textfield',
     '#default_value' => $type->name,
-    '#description' => t('The human-readable name of this content type. This text will be displayed as part of the list on the <em>Add new content</em> page. It is recommended that this name begin with a capital letter and contain only letters, numbers, and spaces. This name must be unique.'),
+    '#description' => t('The human-readable name of this content type. This text will be displayed as part of the list on the <em>Add content</em> page. It is recommended that this name begin with a capital letter and contain only letters, numbers, and spaces. This name must be unique.'),
     '#required' => TRUE,
     '#size' => 30,
   );
@@ -104,7 +104,7 @@ function node_type_form($form, &$form_state, $type = NULL) {
       'exists' => 'node_type_load',
     ),
     '#description' => t('A unique machine-readable name for this content type. It must only contain lowercase letters, numbers, and underscores. This name will be used for constructing the URL of the %node-add page, in which underscores will be converted into hyphens.', array(
-      '%node-add' => t('Add new content'),
+      '%node-add' => t('Add content'),
     )),
   );
 
@@ -112,7 +112,7 @@ function node_type_form($form, &$form_state, $type = NULL) {
     '#title' => t('Description'),
     '#type' => 'textarea',
     '#default_value' => $type->description,
-    '#description' => t('Describe this content type. The text will be displayed on the <em>Add new content</em> page.'),
+    '#description' => t('Describe this content type. The text will be displayed on the <em>Add content</em> page.'),
   );
 
   $form['additional_settings'] = array(

--- a/core/modules/node/templates/node.tpl.php
+++ b/core/modules/node/templates/node.tpl.php
@@ -117,7 +117,7 @@
       <?php endif; ?>
 
       <?php if ($comments['comment_form']): ?>
-        <h2 class="title comment-form"><?php print t('Add new comment'); ?></h2>
+        <h2 class="title comment-form"><?php print t('Add comment'); ?></h2>
         <?php print render($comments['comment_form']); ?>
       <?php endif; ?>
     </section>

--- a/core/modules/search/tests/search.test
+++ b/core/modules/search/tests/search.test
@@ -867,7 +867,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
   }
 
   /**
-   * Verify that 'add new comment' does not appear in search results or index.
+   * Verify that 'Add comment' does not appear in search results or index.
    */
   function testAddNewComment() {
     // Create a node with a short body.
@@ -881,10 +881,10 @@ class SearchCommentTestCase extends BackdropWebTestCase {
     $this->backdropLogin($user);
 
     $node = $this->backdropCreateNode($settings);
-    // Verify that if you view the node on its own page, 'add new comment'
-    // is there.
+    // Verify that if you view the node on its own page, 'Add comment' is
+    // there.
     $this->backdropGet('node/' . $node->nid);
-    $this->assertText(t('Add new comment'), 'Add new comment appears on node page');
+    $this->assertText(t('Add comment'), '"Add comment" appears on node page');
 
     // Run cron to index this page.
     $this->backdropLogout();
@@ -895,11 +895,11 @@ class SearchCommentTestCase extends BackdropWebTestCase {
     $this->backdropPost('search/node', array('keys' => 'comment'), t('Search'));
     $this->assertText(t('Your search yielded no results'), 'No results searching for the word comment');
 
-    // Search for the node title. Should be found, and 'Add new comment' should
-    // not be part of the search snippet.
+    // Search for the node title. Should be found, and 'Add comment' should not
+    // be part of the search snippet.
     $this->backdropPost('search/node', array('keys' => 'short'), t('Search'));
     $this->assertText($node->title, 'Search for keyword worked');
-    $this->assertNoText(t('Add new comment'), 'Add new comment does not appear on search results page');
+    $this->assertNoText(t('Add comment'), '"Add comment" does not appear on search results page');
   }
 
 }

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -991,11 +991,11 @@ function hook_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   $data['actions']['output'][] = array(
     '#theme' => 'menu_local_task',
     '#link' => array(
-      'title' => t('Add new content'),
+      'title' => t('Add content'),
       'href' => 'node/add',
       'localized_options' => array(
         'attributes' => array(
-          'title' => t('Add new content'),
+          'title' => t('Add content'),
         ),
       ),
     ),
@@ -1009,7 +1009,7 @@ function hook_menu_local_tasks_alter(&$data, $router_item, $root_path) {
       'href' => 'node/add',
       'localized_options' => array(
         'attributes' => array(
-          'title' => t('Add new content'),
+          'title' => t('Add content'),
         ),
       ),
     ),

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -492,7 +492,7 @@ function user_admin_roles($form, $form_state) {
 
   $form['label'] = array(
     '#type' => 'textfield',
-    '#title' => t('Add new role'),
+    '#title' => t('Add role'),
     '#title_display' => 'invisible',
     '#required' => TRUE,
     '#size' => 32,

--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -373,7 +373,7 @@ function _views_ui_get_operations(view $view) {
  */
 function views_ui_add_page() {
   views_ui_add_admin_css();
-  backdrop_set_title(t('Add new view'));
+  backdrop_set_title(t('Add view'));
   return backdrop_get_form('views_ui_add_form');
 }
 

--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -378,7 +378,7 @@ function views_ui_add_page() {
 }
 
 /**
- * Form builder for the "add new view" page.
+ * Form builder for the "Add view" page.
  */
 function views_ui_add_form($form, &$form_state) {
   $form['#attached']['js'][] = backdrop_get_path('module', 'views_ui') . '/js/views-admin.js';

--- a/core/themes/bartik/templates/node.tpl.php
+++ b/core/themes/bartik/templates/node.tpl.php
@@ -104,7 +104,7 @@
   </div>
 
   <?php
-    // Remove the "Add new comment" link on the teaser page or if the comment
+    // Remove the "Add comment" link on the teaser page or if the comment
     // form is being displayed on the same page.
     if ($teaser || !empty($comments['comment_form'])) {
       unset($content['links']['comment']['#links']['comment-add']);
@@ -126,7 +126,7 @@
       <?php endif; ?>
 
       <?php if ($comments['comment_form']): ?>
-        <h2 class="title comment-form"><?php print t('Add new comment'); ?></h2>
+        <h2 class="title comment-form"><?php print t('Add comment'); ?></h2>
         <?php print render($comments['comment_form']); ?>
       <?php endif; ?>
     </section>


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1893
