### PR TITLE
Issue #1940: Fixing incorrect collapsing of whitespace in JSON encoding.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5358,7 +5358,7 @@ function backdrop_json_encode($var, $pretty_print = FALSE) {
     }
     // Collapse empty brackets, needed for PHP 5.3.x - PHP 5.4.27 to be
     // consistent with PHP 5.4.28+.
-    $string = preg_replace('/\[[\s]+\]/m', '[]', $string);
+    $string = preg_replace('/\[\n[\s]+\]/m', '[]', $string);
     return $string;
   }
   // The non-pretty JSON is HTML markup compatible, encoding <, >, ', &, and ".
@@ -5451,7 +5451,14 @@ function backdrop_json_decode_unicode($json) {
   // Convert escaped characters, such as \u00e9 to the unescaped version (é).
   // See http://stackoverflow.com/questions/2934563/how-to-decode-unicode-escape-sequences-like-u00ed-to-proper-utf-8-encoded-cha
   $decode_callback = function ($match) {
-    return $match[1] . mb_convert_encoding(pack('H*', $match[2]), 'UTF-8', 'UCS-2BE');
+    // Leave control characters such as NULL, backspace, etc. encoded.
+    if (hexdec($match[2]) < 32) {
+      $string = '\u' . $match[2];
+    }
+    else {
+      $string = mb_convert_encoding(pack('H*', $match[2]), 'UTF-8', 'UCS-2BE');
+    }
+    return $match[1] . $string;
   };
   // To prevent unintentionally unescaping the string "\u", be sure that the
   // the backslash itself is not also escaped. Note that because the replacement

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -2789,7 +2789,7 @@ class CommonJSONUnitTestCase extends BackdropUnitTestCase {
 
     // Verify reversibility for structured data. Also verify that necessary
     // characters are escaped.
-    $source = array(TRUE, FALSE, 0, 1, '0', '1', $str, array('key1' => $str, 'key2' => array('nested' => TRUE)));
+    $source = array(TRUE, FALSE, 0, 1, '0', '1', '[ ]', $str, array('key1' => $str, 'key2' => array('nested' => TRUE)));
     $json = backdrop_json_encode($source);
     foreach ($html_unsafe as $char) {
       $this->assertTrue(strpos($json, $char) === FALSE, format_string('A JSON encoded string does not contain @s.', array('@s' => $char)));
@@ -2801,6 +2801,11 @@ class CommonJSONUnitTestCase extends BackdropUnitTestCase {
     $json_decoded = backdrop_json_decode($json);
     $this->assertNotIdentical($source, $json, 'An array encoded in JSON is not identical to the source.');
     $this->assertIdentical($source, $json_decoded, 'Encoding structured data to JSON and decoding back results in the original data.');
+
+    // Do an additional check on structured data when pretty printing.
+    $json = backdrop_json_encode($source, TRUE);
+    $json_decoded = backdrop_json_decode($json);
+    $this->assertIdentical($source, $json_decoded, 'Encoding structured data to pretty-printed JSON and decoding back results in the original data.');
 
     // Unicode test strings.
     $unicode_decoded = 'üéåâ';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1940.
