### PR TITLE
Issue #1478: Adding check in _simpletest_batch_finished() to detect if any test ID may be retrieved.

### DIFF
--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -215,14 +215,19 @@ function _simpletest_batch_finished($success, $results, $operations, $elapsed) {
     backdrop_set_message(t('The test run finished in @elapsed.', array('@elapsed' => $elapsed)));
   }
   else {
-    // Use the test_id passed as a parameter to _simpletest_batch_operation().
-    $test_id = $operations[0][1][1];
+    // If any uncompleted operations are left, we can use the next item to pull
+    // the test_id and report any errors from the test log.
+    if (!empty($operations)) {
+      // Use the test_id passed as a parameter to _simpletest_batch_operation().
+      $next_operation = reset($operations);
+      $test_id = $next_operation[1][1];
 
-    // Retrieve the last database prefix used for testing and the last test
-    // class that was run from. Use the information to read the lgo file
-    // in case any fatal errors caused the test to crash.
-    list($last_prefix, $last_test_class) = simpletest_last_test_get($test_id);
-    simpletest_log_read($test_id, $last_prefix, $last_test_class);
+      // Retrieve the last database prefix used for testing and the last test
+      // class that was run from. Use the information to read the lgo file
+      // in case any fatal errors caused the test to crash.
+      list($last_prefix, $last_test_class) = simpletest_last_test_get($test_id);
+      simpletest_log_read($test_id, $last_prefix, $last_test_class);
+    }
 
     backdrop_set_message(t('The test run did not successfully finish.'), 'error');
     backdrop_set_message(t('Use the <em>Clean environment</em> button to clean-up temporary files and tables.'), 'warning');


### PR DESCRIPTION
Fixes one of the issues in https://github.com/backdrop/backdrop-issues/issues/1478 on PHP 7.
