### PR TITLE
Port default clickjacking defense from Drupal 7 issue #2514136.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -2853,6 +2853,15 @@ function backdrop_deliver_html_page($page_callback_result) {
   global $language;
   backdrop_add_http_header('Content-Language', $language->langcode);
 
+  // By default, do not allow the site to be rendered in an iframe on another
+  // domain, but provide a variable to override this. If the code running for
+  // this page request already set the X-Frame-Options header earlier, don't
+  // overwrite it here.
+  $frame_options = config_get('system.core', 'x_frame_options');
+  if ($frame_options && is_null(backdrop_get_http_header('X-Frame-Options'))) {
+    backdrop_add_http_header('X-Frame-Options', $frame_options);
+  }
+
   // Menu status constants are integers; page content is a string or array.
   if (is_int($page_callback_result)) {
     $site_config = config('system.core');

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -78,5 +78,6 @@
     "user_picture_style": "thumbnail",
     "user_picture_dimensions": "1024x1024",
     "user_picture_file_size": "800",
-    "user_picture_guidelines": ""
+    "user_picture_guidelines": "",
+    "x_frame_options": "SAMEORIGIN"
 }


### PR DESCRIPTION
Drupal 7 just added a new security feature! This request is to merge a port of the addition of the X-Frame-Options HTTP header from https://www.drupal.org/node/2514136.

This provides a compensating control for a vulnerability to clickjacking (embedding a site in an iframe to trick the user into taking an admin action by clicking a button in the frame).

The specific Drupal commit is:
http://cgit.drupalcode.org/drupal/commit/?id=ebd9325
