### PR TITLE
Issue #1478: Adding a sleep() to ensure page cache is set.

### DIFF
--- a/core/modules/simpletest/tests/bootstrap.test
+++ b/core/modules/simpletest/tests/bootstrap.test
@@ -201,6 +201,7 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
     $this->assertEqual($this->backdropGetHeader('X-Backdrop-Cache'), 'MISS', 'Initial page request was miss.');
     $this->assertTrue($total < 5, 'Initial page requests returned before shutdown functions are executed.');
 
+    sleep(5); // Delay to ensure caches are set.
     $start = microtime(TRUE);
     $this->backdropGet('system-test/sleep/shutdown/5', array(), $headers);
     $total = microtime(TRUE) - $start;


### PR DESCRIPTION
Fixes another random fail in https://github.com/backdrop/backdrop-issues/issues/1478.

```
---- Bootstrap: Page cache test (BootstrapPageCacheTestCase) ----

Status    Group      Filename          Line Function                            
--------------------------------------------------------------------------------
Fail      Other      bootstrap.test     207 BootstrapPageCacheTestCase->testPag
    Cached page request.
```

This page cache test did not have a sleep() command to wait for the page cache to be set.
