### PR TITLE
Issue #1937: Followup to be less strict in _backdrop_decode_exception().

### DIFF
--- a/core/includes/errors.inc
+++ b/core/includes/errors.inc
@@ -77,13 +77,14 @@ function _backdrop_error_handler_real($error_level, $message, $filename, $line, 
 /**
  * Decodes an exception and retrieves the correct caller.
  *
- * @param Exception $exception
- *   The exception object that was thrown.
+ * @param Exception|Error $exception
+ *   The exception or error object that was thrown. PHP 7 throws Error objects
+ *   for PHP errors.
  *
  * @return
  *   An error in the format expected by _backdrop_log_error().
  */
-function _backdrop_decode_exception(Exception $exception) {
+function _backdrop_decode_exception($exception) {
   $message = $exception->getMessage();
 
   $backtrace = $exception->getTrace();


### PR DESCRIPTION
Follow-up fix for https://github.com/backdrop/backdrop-issues/issues/1937.

In PHP 7, it throws an "Error" class (http://php.net/Error) when it hits a fatal error. This acts identical to an Exception (identical methods) but is not a subclass of an Exception. As such, _backdrop_decode_exception() must be able to accept either an `Error` or `Exception` object.
