### PR TITLE
Issue #1896: [UX] Views UI: Remove the .views-display-help text

### DIFF
--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -1078,12 +1078,6 @@ function views_ui_edit_form($form, &$form_state, $view, $display_id = NULL) {
     $form['changed']['#attributes']['class'][] = 'js-hide';
   }
 
-  $form['help_text'] = array(
-    '#prefix' => '<div class="views-display-help">',
-    '#suffix' => '</div>',
-    '#markup' => t('Modify the display(s) of your view below or add new displays.'),
-  );
-
   $form['actions'] = array(
     '#type' => 'actions',
     '#weight' => 0,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1896 by removing this text altogether.
