### PR TITLE
Issue #1962: Making Backdrop.featuredDetect.flexbox() more strict

### DIFF
--- a/core/misc/backdrop.js
+++ b/core/misc/backdrop.js
@@ -507,8 +507,7 @@ Backdrop.featureDetect.flexbox = function() {
     return false;
   } else {
     $body.append($flexboxTestElement);
-
-    if ($flexboxTestElement.css('flex-wrap')) {
+    if ($flexboxTestElement.css('display') === 'flex' && $flexboxTestElement.css('flex-wrap') === 'wrap') {
       $body.addClass('has-flexbox');
       $flexboxTestElement.remove();
       return true;

--- a/core/modules/layout/css/grid-float.css
+++ b/core/modules/layout/css/grid-float.css
@@ -56,6 +56,11 @@
 .row {
   margin-left: -1rem;
   margin-right: -1rem;
+  /* Override flexbox values in case they're set */
+  display: block;
+  -webkit-flex-wrap: unset;
+  -ms-flex-wrap: unset;
+  flex-wrap: unset;
 }
 
 .row:after {
@@ -141,6 +146,11 @@
   padding-right: 1rem;
   padding-left: 1rem;
   float: left;
+  /* Override flexbox values in case they're set */
+  -webkit-box-flex: unset;
+  -webkit-flex: unset;
+  -ms-flex: unset;
+  flex: unset;
 }
 
 .col-xs-1 {
@@ -949,4 +959,64 @@
   .offset-xl-11 {
     margin-left: 91.666667%;
   }
+}
+
+/**
+ * Override flexbox values in case they're set
+ */
+.col-xs-first,
+.col-xs-last,
+.col-sm-first,
+.col-sm-last,
+.col-md-first,
+.col-md-last,
+.col-lg-first,
+.col-lg-last,
+.col-xl-first,
+.col-xl-last {
+  -webkit-box-ordinal-group: unset;
+  -webkit-order: unset;
+  -ms-flex-order:unset;
+  order: unset;
+}
+
+.row-xs-top,
+.row-xs-center,
+.row-xs-bottom,
+.row-sm-top,
+.row-sm-center,
+.row-sm-bottom,
+.row-md-top,
+.row-md-center,
+.row-md-bottom,
+.row-lg-top,
+.row-lg-center,
+.row-lg-bottom,
+.row-xl-top,
+.row-xl-center,
+.row-xl-bottom {
+  -webkit-box-align: unset;
+  -webkit-align-items: unset;
+  -ms-flex-align: unset;
+  align-items: unset;
+}
+
+.col-xs-top,
+.col-xs-center,
+.col-xs-bottom,
+.col-sm-top,
+.col-sm-center,
+.col-sm-bottom,
+.col-md-top,
+.col-md-center,
+.col-md-bottom,
+.col-lg-top,
+.col-lg-center,
+.col-lg-bottom,
+.col-xl-top,
+.col-xl-center,
+.col-xl-bottom {
+  -webkit-align-self: unset;
+  -ms-flex-item-align: unset;
+  align-self: unset;
 }

--- a/core/modules/layout/js/grid-fallback.js
+++ b/core/modules/layout/js/grid-fallback.js
@@ -15,9 +15,11 @@
  * height matching for each row of layout template icons.
  */
 Backdrop.behaviors.gridFloatFallback = {
-  attach: function(context) {
-    if (!Backdrop.featureDetect.flexbox()) {
+  attach: function() {
+    var $body = $('body');
+    if (!$body.hasClass('grid-float-fallback-processed') && !Backdrop.featureDetect.flexbox()) {
       $('head').append('<link rel="stylesheet" type="text/css" href="/core/modules/layout/css/grid-float.css">');
+      $body.addClass('grid-float-fallback-processed');
     }
   }
 };


### PR DESCRIPTION
PR for https://github.com/backdrop/backdrop-issues/issues/1962

Safari should not have been passing before as it didn't return the proper flex-wrap property
Added another check to make sure display comes back as 'flex' and not 'webkit-flex', which is buggy
Also made sure that the float fallback is only added once

Override flex-grid styles in float css, since we're adding grid-float.css over top of grid-flex.css we need to override all of the values with the cascade.
