### PR TITLE
Issue #1864: Correct commit 746a181: remove vertical-tabs.css color a…

### DIFF
--- a/core/themes/seven/css/vertical-tabs.css
+++ b/core/themes/seven/css/vertical-tabs.css
@@ -156,14 +156,14 @@
 .vertical-tab-selected.vertical-tab-item {
   background-color: #fff;
   border-right-width: 0; /* LTR */
-  border-left-width: 1px #000;
+  border-left-width: 1px;
   box-shadow: 0 5px 5px -5px hsla(0,0%,0%,0.3);
   z-index: 1;
   position: relative;
 }
  [dir="rtl"] .vertical-tab-selected.vertical-tab-item {
   border-left-width: 0;
-  border-right-width: 1px #000;
+  border-right-width: 1px;
 }
 .vertical-tab-selected .vertical-tab-link {
   background: #fff;


### PR DESCRIPTION
…pplied to the wrong css rules.

Fixes https://github.com/backdrop/backdrop-issues/issues/1864

Replaces https://github.com/backdrop/backdrop/pull/1373
