### PR TITLE
Issue #1753: 'Database log messages to keep' setting not saving.

### DIFF
--- a/core/modules/dblog/dblog.module
+++ b/core/modules/dblog/dblog.module
@@ -161,6 +161,6 @@ function dblog_form_system_logging_settings_alter(&$form, $form_state) {
  * @see dblog_form_system_logging_settings_alter()
  */
 function dblog_logging_settings_submit($form, &$form_state) {
-  config_set('system.core', 'row_limit', $form_state['values']['dblog_row_limit']);
+  config_set('system.core', 'log_row_limit', $form_state['values']['dblog_row_limit']);
 }
 

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2801,6 +2801,19 @@ function system_update_1055() {
 }
 
 /**
+ * Move incorrectly stored "log_row_limit" setting.
+ */
+function system_update_1056() {
+  // Move "row_limit" if set to "log_row_limit" in the system.core config file.
+  $config = config('system.core');
+  if ($limit = $config->get('row_limit')) {
+    $config->set('log_row_limit', $limit);
+    $config->clear('row_limit');
+    $config->save();
+  }
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1753.
