### PR TITLE
Issue #1478: Fixing PHP 5.3 encoding of JSON backslashes.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5426,6 +5426,7 @@ function backdrop_json_format($json) {
   $indent = "    ";
   $new_line = "\n";
   $prev_char = '';
+  $prev_prev_char = '';
   $out_of_quotes = TRUE;
 
   for ($i = 0; $i < $strlen; $i++) {
@@ -5433,7 +5434,7 @@ function backdrop_json_format($json) {
     $char = substr($json, $i, 1);
 
     // Are we inside a quoted string?
-    if ($char == '"' && $prev_char != '\\') {
+    if ($char === '"' && !($prev_char === '\\' && $prev_prev_char !== '\\')) {
       $out_of_quotes = !$out_of_quotes;
     }
     // If this character is the end of an element, output a new line and indent
@@ -5469,6 +5470,7 @@ function backdrop_json_format($json) {
         $result .= $indent;
       }
     }
+    $prev_prev_char = $prev_char;
     $prev_char = $char;
   }
 

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -2789,7 +2789,7 @@ class CommonJSONUnitTestCase extends BackdropUnitTestCase {
 
     // Verify reversibility for structured data. Also verify that necessary
     // characters are escaped.
-    $source = array(TRUE, FALSE, 0, 1, '0', '1', '[ ]', $str, array('key1' => $str, 'key2' => array('nested' => TRUE)));
+    $source = array(TRUE, FALSE, 0, 1, '0', '1', '[ ]', '\'', "\"", '\\', $str, array('key1' => $str, 'key2' => array('nested' => TRUE)));
     $json = backdrop_json_encode($source);
     foreach ($html_unsafe as $char) {
       $this->assertTrue(strpos($json, $char) === FALSE, format_string('A JSON encoded string does not contain @s.', array('@s' => $char)));


### PR DESCRIPTION
Fixes the PHP 5.3 pretty-print encoding of JSON when dealing with a trailing backslash. Added new tests to prevent this error in the future.

Part of fixing random test failures: https://github.com/backdrop/backdrop-issues/issues/1478.
