### PR TITLE
Issue #1972: Layout UI: Settings and Add/Edit layout pages: some temp…

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -67,7 +67,7 @@
 }
 .layout-settings-page .layout-options .form-type-checkbox,
 .layout-settings-form .layout-options .form-type-radio {
-  width: 100px;
+  width: 115px;
   margin: 0 5px 5px 0;
   padding: 0;
   text-align: center;


### PR DESCRIPTION
…lates have long names and their titles are not of equal height with the rest.

Fixes https://github.com/backdrop/backdrop-issues/issues/1972
