### PR TITLE
 Issue #2016: Remove the trailing dot from the "Browse available toke…

### DIFF
--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -482,7 +482,7 @@ function theme_system_admin_index($variables) {
  */
 function theme_token_tree_link($variables) {
   if (empty($variables['text'])) {
-    $variables['text'] = t('Browse available tokens.');
+    $variables['text'] = t('Browse available tokens');
   }
 
   if (!empty($variables['dialog'])) {


### PR DESCRIPTION
…ns." link.

Fixes https://github.com/backdrop/backdrop-issues/issues/2016
