### PR TITLE
Fix gitignore patterns to only match webroot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ settings*.php
 sites/*/settings*.php
 
 # Ignore paths that contain user-generated content.
-files
-private
+/files
+/private
 sites/*/files
 sites/*/private


### PR DESCRIPTION
The current .gitignore pattern matches any instance of the words "files" or "private" in your folder hierarchy.  On a simple install, that means that these folders were getting ignored by git:

```
core/modules/simpletest/files/
modules/civicrm/packages/kcfinder/themes/dark/img/files/
modules/civicrm/packages/kcfinder/themes/default/img/files/
```

This is almost certainly unintentional, so submitting this PR.
