### PR TITLE
Issue #2371861 by DuaelFr, YesCT, pietmarcus, Gábor Hojtsy, tucho: Strings including tokens in href or src attributes cannot be translated due to safeness check incompatibilities

### DIFF
--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -551,6 +551,22 @@ function locale_language_url_rewrite_session(&$path, &$options) {
  * possible attack vector (img).
  */
 function locale_string_is_safe($string) {
+  // Some strings have tokens in them. For tokens in the first part of href or
+  // src HTML attributes, filter_xss() removes part of the token, the part
+  // before the first colon.  filter_xss() assumes it could be an attempt to
+  // inject javascript. When filter_xss() removes part of tokens, it causes the
+  // string to not be translatable when it should be translatable. See
+  // LocaleStringIsSafeTest::testLocaleStringIsSafe().
+  //
+  // We can recognize tokens since they are wrapped with brackets and are only
+  // composed of alphanumeric characters, colon, underscore, and dashes. We can
+  // be sure these strings are safe to strip out before the string is checked in
+  // filter_xss() because no dangerous javascript will match that pattern.
+  //
+  // @todo Do not strip out the token. Fix filter_xss() to not incorrectly
+  //   alter the string. https://www.drupal.org/node/2372127
+  $string = preg_replace('/\[[a-z0-9_-]+(:[a-z0-9_-]+)+\]/i', '', $string);
+
   return decode_entities($string) == decode_entities(filter_xss($string, array('a', 'abbr', 'acronym', 'address', 'b', 'bdo', 'big', 'blockquote', 'br', 'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'dfn', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'ins', 'kbd', 'li', 'ol', 'p', 'pre', 'q', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'ul', 'var')));
 }
 

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2808,3 +2808,46 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
     $this->backdropGet('admin/config/regional/language/detection');
   }
 }
+
+/**
+ * Tests locale translation safe string handling.
+ */
+class LocaleStringIsSafeTest extends DrupalWebTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Test if a string is safe',
+      'description' => 'Tests locale translation safe string handling.',
+      'group' => 'Locale',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('locale');
+  }
+
+  /**
+   * Tests for locale_string_is_safe().
+   */
+  public function testLocaleStringIsSafe() {
+    // Check a translatable string without HTML.
+    $string = 'Hello world!';
+    $result = locale_string_is_safe($string);
+    $this->assertTrue($result);
+
+    // Check a translatable string which includes trustable HTML.
+    $string = 'Hello <strong>world</strong>!';
+    $result = locale_string_is_safe($string);
+    $this->assertTrue($result);
+
+    // Check an untranslatable string which includes untrustable HTML (according
+    // to the locale_string_is_safe() function definition).
+    $string = 'Hello <img src="world.png" alt="world" />!';
+    $result = locale_string_is_safe($string);
+    $this->assertFalse($result);
+
+    // Check a translatable string which includes a token in an href attribute.
+    $string = 'Hi <a href="[current-user:url]">user</a>';
+    $result = locale_string_is_safe($string);
+    $this->assertTrue($result);
+  }
+}

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2812,7 +2812,7 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
 /**
  * Tests locale translation safe string handling.
  */
-class LocaleStringIsSafeTest extends DrupalWebTestCase {
+class LocaleStringIsSafeTest extends BackdropWebTestCase {
   public static function getInfo() {
     return array(
       'name' => 'Test if a string is safe',

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2813,14 +2813,6 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
  * Tests locale translation safe string handling.
  */
 class LocaleStringIsSafeTest extends BackdropWebTestCase {
-  public static function getInfo() {
-    return array(
-      'name' => 'Test if a string is safe',
-      'description' => 'Tests locale translation safe string handling.',
-      'group' => 'Locale',
-    );
-  }
-
   function setUp() {
     parent::setUp('locale');
   }
@@ -2851,3 +2843,4 @@ class LocaleStringIsSafeTest extends BackdropWebTestCase {
     $this->assertTrue($result);
   }
 }
+

--- a/core/modules/locale/tests/locale.tests.info
+++ b/core/modules/locale/tests/locale.tests.info
@@ -123,3 +123,9 @@ name = Language negotiation info
 description = Tests alterations to language types/negotiation info.
 group = Locale
 file = locale.test
+
+[LocaleStringIsSafeTest]
+name = Test if a string is safe
+description = Tests locale translation safe string handling.
+group = Locale
+file = locale.test


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/2013

This PR includes both committed patches from Issue #2371861
