### PR TITLE
Jenlampton 2022 pathauto new type

### DIFF
--- a/core/modules/path/path.module
+++ b/core/modules/path/path.module
@@ -169,7 +169,7 @@ function path_form_node_form_alter(&$form, $form_state) {
  */
 function path_form_node_type_form_alter(&$form, $form_state) {
   $url_pattern = config_get('path.settings', 'node_pattern');
-  if (isset($form['type']['#default_value'])) {
+  if (!empty($form['type']['#default_value'])) {
     $type = $form['type']['#default_value'];
     $specific_url_pattern = config_get('path.settings', 'node_' . $type . '_pattern');
     if ($specific_url_pattern != NULL) {
@@ -192,19 +192,19 @@ function path_form_node_type_form_alter(&$form, $form_state) {
 function path_node_type_form_submit($form, &$form_state) {
   if (isset($form_state['values']['path_pattern'])) {
     $config = config('path.settings');
-    $pattern_type  = 'node_' . $form['type']['#default_value'] . '_pattern';
+    $pattern_type  = 'node_' . $form_state['values']['type'] . '_pattern';
     $pattern = trim($form_state['values']['path_pattern']);
     $generic_pattern = $config->get('node_pattern');
     // Don't save the specific pattern if it matches the general pattern.
-    if ($pattern && $pattern !== $generic_pattern) {
+    if (($pattern != '') && ($pattern !== $generic_pattern)) {
       $config->set($pattern_type, $pattern);
     }
     else {
       // If the specific pattern matches the general pattern or is empty delete
       // the specific pattern.
       $config->clear($pattern_type);
-      if (empty($pattern)) {
-        backdrop_set_message(t('The Default URL pattern was empty, so the generic pattern of "@pattern" will still be used. This may be changed on the !url_alias_patterns page.', array('@pattern' => $generic_pattern, '!url_alias_patterns' => l('URL alias patterns', 'admin/config/search/path/patterns'))));
+      if (empty($pattern) && !empty($generic_pattern)) {
+        backdrop_set_message(t('A specific URL pattern was not provided here, but the generic URL pattern of "@pattern" will still be used. This may be changed on the !url_alias_patterns page.', array('@pattern' => $generic_pattern, '!url_alias_patterns' => l('URL alias patterns', 'admin/config/search/path/patterns'))));
       }
     }
     $config->save();

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -425,7 +425,46 @@ class PathPatternFunctionalTestHelper extends PathPatternTestHelper {
  */
 class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
-   * Basic functional testing of Path patterns.
+   * Create a new content type with new path pattern.
+   */
+  function testNodeTypeCreate() {
+    // Create a user with more permissions.
+    $permissions = array(
+      'administer path patterns',
+      'administer content types',
+      'administer taxonomy',
+      'administer account settings',
+    );
+    $this->admin_user = $this->backdropCreateUser($permissions);
+    $this->backdropLogin($this->admin_user);
+
+    // Set the path pattern when creating a new content type.
+    $this->backdropGet('admin/structure/types/add');
+    $edit = array(
+      'name' => 'foo',
+      'type' => 'foo',
+      'path_pattern' => 'bar/[node:title]',
+    );
+    $this->backdropPost(NULL, $edit, t('Save content type'));
+
+    // Create a test node.
+    $node1 = $this->backdropCreateNode(array('type' => 'foo', 'title' => 'node1'));
+    $this->assertEntityAlias('node', $node1, 'bar/node1');
+
+    // Change the path pattern on the content type.
+    $this->backdropGet('admin/structure/types/manage/foo/configure');
+    $edit = array(
+      'path_pattern' => 'baz/[node:title]',
+    );
+    $this->backdropPost(NULL, $edit, t('Save content type'));
+
+    // Create a test node.
+    $node2 = $this->backdropCreateNode(array('type' => 'foo', 'title' => 'node2'));
+    $this->assertEntityAlias('node', $node2, 'baz/node2');
+  }
+
+  /**
+   * Basic functional testing of node Path patterns.
    */
   function testNodeEditing() {
     $config = config('path.settings');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2022.

Replaces https://github.com/backdrop/backdrop/pull/1469.

Same PR but adds a `backdrop_static_reset()` in between updating the content type and creating a second test node in the test case.
