### PR TITLE
Issue #2109: Canceling the deletion of a role redirects to the "Manag…

### DIFF
--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2120,6 +2120,13 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     // Set this as the administrator role.
     config_set('system.core', 'user_admin_role', $admin_role->name);
 
+    // Test cancel deleting a role.
+    $role_name = 'administrator';
+    $this->backdropGet("admin/config/people/roles/delete/$role_name");
+    $this->clickLink(t('Cancel'));
+    $this->assertResponse(200);
+    $this->assertUrl('admin/config/people/roles', array(), 'Redirected to correct URL after cancel.');
+
     // Test deleting the default administrator role.
     $role_name = 'administrator';
     $role = user_role_load($role_name);

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -613,7 +613,7 @@ function user_admin_role_delete_confirm($form, &$form_state, $role) {
     '#type' => 'value',
     '#value' => $role->name,
   );
-  return confirm_form($form, t('Are you sure you want to delete the role %name ?', array('%name' => $role->label)), 'admin/people/roles', t('This action cannot be undone.'), t('Delete'));
+  return confirm_form($form, t('Are you sure you want to delete the role %name ?', array('%name' => $role->label)), 'admin/config/people/roles', t('This action cannot be undone.'), t('Delete'));
 }
 
 /**


### PR DESCRIPTION
…e user accounts" page instead of back to "Roles" page.

Fixes https://github.com/backdrop/backdrop-issues/issues/2109
