### PR TITLE
Issue #2110: Show the "Machine name:" label for user roles?

### DIFF
--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -507,7 +507,6 @@ function user_admin_roles($form, $form_state) {
       'source' => array('label'),
       'exists' => 'user_role_load',
       'standalone' => TRUE,
-      'label' => '',
     ),
     '#description' => t('A unique machine-readable name for this role. It must only contain lowercase letters, numbers, and underscores.'),
   );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2110
