### PR TITLE
Issue#2040: Change default for 'Error messages to display'.

### DIFF
--- a/core/modules/simpletest/tests/error.test
+++ b/core/modules/simpletest/tests/error.test
@@ -61,6 +61,7 @@ class BackdropErrorHandlerUnitTest extends BackdropWebTestCase {
    * Test the exception handler.
    */
   function testExceptionHandler() {
+    $config = config('system.core');    
     $error_exception = array(
       '%type' => 'Exception',
       '!message' => 'Backdrop is awesome',
@@ -76,6 +77,9 @@ class BackdropErrorHandlerUnitTest extends BackdropWebTestCase {
       '%file' => backdrop_realpath('core/modules/simpletest/tests/error_test.module'),
     );
 
+    // Set error reporting to collect notices as assumed in the module.
+    $config->set('error_level', ERROR_REPORTING_DISPLAY_ALL)->save();
+    
     $this->backdropGet('error-test/trigger-exception');
     $this->assertTrue(strpos($this->backdropGetHeader(':status'), '500 Service unavailable (with message)'), 'Received expected HTTP status line.');
     $this->assertErrorMessage($error_exception);

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -14,7 +14,7 @@
     "cron_max_threshold": 10800,
     "cron_threshold_error": 1209600,
     "default_nodes_main": 10,
-    "error_level": "all",
+    "error_level": "hide",
     "field_purge_batch_size": 200,
     "file_default_scheme": "public",
     "file_private_path": "",

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -538,6 +538,30 @@ function system_requirements($phase) {
       );
     }
   }
+  
+  if ($phase == 'runtime') {
+    // Inform user about status of display error messages.
+    $error_level = config_get('system.core', 'error_level');
+    $description_start = $t('Backdrop CMS provides the ability to display error messages, which can be useful while a site is in development.');
+    $logging_url = base_path() . 'admin/config/development/logging';
+    if ($error_level != ERROR_REPORTING_HIDE) {
+      $value =  $t('Enabled');
+      $severity =  REQUIREMENT_WARNING;
+      $description = $description_start . ' ' . $t('Do not forget to <a href="@error_level">disable the display of errors</a> when you have finished testing and this site goes live.', array('@error_level' => $logging_url));
+    }
+    else {
+      $value =  $t('Disabled');
+      $severity =  REQUIREMENT_OK;
+      $description = $description_start . ' ' . $t('If your site is in development, you might want to <a href="@error_level">enable the display of errors</a>.', array('@error_level' => $logging_url));
+    }
+
+    $requirements['error_level'] = array(
+      'title' => $t('Display error messages'),
+      'value' => $value,
+      'severity' => $severity,
+      'description' => $description,
+    );
+  }
 
   return $requirements;
 }


### PR DESCRIPTION
As described in issue - default changed and warning message added to "Status report".
Fixes: https://github.com/backdrop/backdrop-issues/issues/2040
