### PR TITLE
Issue #1373: Adding option for disabling uploads within editors on a per-field basis.

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -578,7 +578,7 @@ EOF;
  *   EntityFieldQuery to retrieve a list of entity IDs loadable by
  *   this function.
  *
- * @return array
+ * @return File[]
  *   An array of file entities, indexed by fid.
  *
  * @see hook_file_load()
@@ -687,7 +687,7 @@ function file_usage_add(File $file, $module, $type, $id, $count = 1) {
     ->expression('count', 'count + :count', array(':count' => $count))
     ->execute();
 
-  // Make sure that a used file is permament.
+  // Make sure that a used file is permanent.
   if ($file->status != FILE_STATUS_PERMANENT) {
     $file->status = FILE_STATUS_PERMANENT;
     $file->save();

--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -141,7 +141,7 @@ function block_block_view($delta = '') {
  * @param $delta
  *   ID of the block to get information for.
  *
- * @return
+ * @return array
  *   Associative array of information stored in configuration for this block, or FALSE if it doesn't exist
  *   Array keys:
  *   - delta: Block ID.
@@ -253,11 +253,9 @@ function block_custom_block_form($edit = array(), $stand_alone = TRUE) {
  *     - value: Block contents.
  *     - format: Filter ID of the filter format for the body.
  * @param string|NULL $delta
- *   Machine name of the block to save, comprised of lower-case letters, numbers, and underscores
- *   Note: null values are still accepted when creating new nodes to maintain API contiguity
- *
- * @return
- *   Always returns TRUE.
+ *   Machine name of the block to save, comprised of lower-case letters,
+ *   numbers, and underscores. Note: NULL values are still accepted when
+ *   creating new nodes to maintain API contiguity.
  */
 function block_custom_block_save(array $edit, $delta = NULL) {
   $delta = $delta ? $delta : preg_replace('/[^a-z0-9_]+/', '_', strtolower($edit['info']));
@@ -267,7 +265,7 @@ function block_custom_block_save(array $edit, $delta = NULL) {
       'delta' => $delta,
       'info' => '',
       'title' => '',
-      'body' => '',
+      'body' => array('value' => '', 'format' => ''),
     );
   }
   foreach ($block as $key => $value) {
@@ -278,6 +276,21 @@ function block_custom_block_save(array $edit, $delta = NULL) {
   $config = config('block.custom.' . $delta);
   $config->setData($block);
   $config->save();
+
+  // Save each file as permanent, preventing it from being deleted. The same
+  // process is used in Layout::save(), but that only applies to non-reusable
+  // blocks (BlockText objects). If a block has been marked reusable, the files
+  // are immediately marked as permanent.
+  // File usages are not currently removed for custom blocks.
+  // See https://github.com/backdrop/backdrop-issues/issues/2137.
+  $fids = filter_parse_file_fids($block['body']['value']);
+  $files = file_load_multiple($fids);
+  foreach ($files as $fid => $file) {
+    if ($file && $file->status !== FILE_STATUS_PERMANENT) {
+      // This makes the file "self-referencing", so it will never be deleted.
+      file_usage_add($file, 'file', 'file', $file->fid);
+    }
+  }
 
   // Reset the static cache on the block list so this block is picked up.
   backdrop_static_reset('block_block_info');

--- a/core/modules/block/tests/block.test
+++ b/core/modules/block/tests/block.test
@@ -24,19 +24,28 @@ class BlockTestCase extends BackdropWebTestCase {
   }
 
   /**
-   * Test creating custom block, moving it to a specific region and then deleting it.
+   * Test creating custom block, editing, and then deleting it.
    */
   function testCustomBlock() {
     // Confirm that the add block link appears on block overview pages.
     $this->backdropGet('admin/structure/block');
     $this->assertRaw(l('Add custom block', 'admin/structure/block/add'), 'Add block link is present on block overview page for default theme.');
 
+    // Save a file to test file usage saving.
+    $files = $this->backdropGetTestFiles('image');
+    $file_info = (array) array_pop($files);
+    $file_info['status'] = 0;
+    $file = new File($file_info);
+    $file->save();
+    $file_info['attributes']['data-file-id'] = $file->fid;
+    $image_string = theme('image', $file_info);
+
     // Add a new custom block by filling out the input form on the admin/structure/block/add page.
     $custom_block = array();
     $custom_block['info'] = $this->randomName(8);
     $custom_block['delta'] = strtolower($this->randomName(8));
     $custom_block['title'] = $this->randomName(8);
-    $custom_block['body[value]'] = $this->randomName(32);
+    $custom_block['body[value]'] = $this->randomName(32) . $image_string;
     $this->backdropPost('admin/structure/block/add', $custom_block, 'Save block');
 
     // Confirm that the custom block has been created, and then find its config file
@@ -50,6 +59,12 @@ class BlockTestCase extends BackdropWebTestCase {
     $data = block_block_view($custom_block['delta']);
     $this->assertEqual($data['subject'], $custom_block['title'], 'block_block_view() provides the correct block title.');
     $this->assertEqual(check_markup($custom_block['body']['value'], $custom_block['body']['format']), $data['content'], 'block_block_view() provides correct block content.');
+
+    // Check that a file usage was recorded for the file within the block.
+    $file = file_load($file->fid);
+    $references = file_usage_list($file);
+    $this->assertEqual($references['file']['file'][$file->fid], 1, 'File usage recorded for the file within the block.');
+    $this->assertEqual($file->status, 1, 'File has been marked permanent by its file usage.');
 
     // Check whether the block can be moved to all available regions.
     $layout = layout_load('default');
@@ -68,6 +83,9 @@ class BlockTestCase extends BackdropWebTestCase {
     $this->backdropPost('admin/structure/block/manage/' . $custom_block['delta'] . '/delete', array(), 'Delete');
     $this->assertRaw(t('The block %title has been removed.', array('%title' => $custom_block['info'])), 'Custom block successfully deleted.');
     $this->assertNoText(t($custom_block['title']), 'Custom block no longer appears on page.');
+
+    // Note that file usages are NOT removed after a block has been deleted.
+    // See https://github.com/backdrop/backdrop-issues/issues/2137.
   }
 
   /**

--- a/core/modules/ckeditor/js/plugins/backdropimage/plugin.js
+++ b/core/modules/ckeditor/js/plugins/backdropimage/plugin.js
@@ -200,8 +200,14 @@ CKEDITOR.plugins.add('backdropimage', {
       modes: {wysiwyg: 1},
       canUndo: true,
       exec: function (editor, data) {
+        // Default to uploads being enabled, unless specifically requested not
+        // to be. Access permission is checked in the back-end form itself, this
+        // is just to prevent UX confusion from allowing uploads but then having
+        // them cleaned up by Backdrop's temporary file cleanup.
+        var uploadsEnabled = editor.element.$.getAttribute('data-editor-uploads') === 'false' ? 0 : 1;
         var dialogSettings = {
           title: data.dialogTitle,
+          uploads: uploadsEnabled,
           dialogClass: 'editor-image-dialog'
         };
         Backdrop.ckeditor.openDialog(editor, editor.config.backdrop.imageDialogUrl, data.existingValues, data.saveCallback, dialogSettings);

--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -534,6 +534,7 @@ function text_field_widget_form(&$form, &$form_state, $field, $instance, $langco
       $element = $main_widget;
       $element['#type'] = 'text_format';
       $element['#format'] = isset($items[$delta]['format']) ? $items[$delta]['format'] : NULL;
+      $element['#editor_uploads'] = TRUE;
       $element['#base_type'] = $main_widget['#type'];
     }
     else {

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -1503,7 +1503,7 @@ function _filter_tips($format_id, $long = FALSE) {
  * @param $text
  *   The partial (X)HTML snippet to load. Invalid mark-up will be corrected on
  *   import.
- * @return
+ * @return DOMDocument
  *   A DOMDocument that represents the loaded (X)HTML snippet.
  */
 function filter_dom_load($text) {
@@ -1722,10 +1722,10 @@ function _filter_get_file_ids_by_field(EntityInterface $entity) {
       foreach ($entity->$processed_text_field as $langcode => $values) {
         foreach ($values as $delta => $text) {
           if (isset($text['value'])) {
-            $fids[$processed_text_field] = array_merge($fids[$processed_text_field], _filter_parse_file_fids($text['value']));
+            $fids[$processed_text_field] = array_merge($fids[$processed_text_field], filter_parse_file_fids($text['value']));
           }
           if (isset($text['summary'])) {
-            $fids[$processed_text_field] = array_merge($fids[$processed_text_field], _filter_parse_file_fids($text['summary']));
+            $fids[$processed_text_field] = array_merge($fids[$processed_text_field], filter_parse_file_fids($text['summary']));
           }
         }
       }
@@ -1765,7 +1765,7 @@ function _filter_get_processed_text_fields(EntityInterface $entity) {
  * @return array
  *   An array of all found FIDs.
  */
-function _filter_parse_file_fids($text) {
+function filter_parse_file_fids($text) {
   $dom = filter_dom_load($text);
   $xpath = new DOMXPath($dom);
   $fids = array();

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -45,6 +45,12 @@ function filter_theme() {
  */
 function filter_element_info() {
   $type['text_format'] = array(
+    // The text format selected by default for this element.
+    '#format' => NULL,
+    // Whether file uploads are permitted through the editor (if supported).
+    // Disable by default, modules must specifically implement saving files as
+    // permanent when they save their text data. See filter_entity_insert().
+    '#editor_uploads' => FALSE,
     '#process' => array('filter_process_format'),
     '#base_type' => 'textarea',
     '#theme_wrappers' => array('text_format_wrapper'),
@@ -1208,6 +1214,9 @@ function filter_process_format($element) {
   else {
     $element['#attached'] = filter_get_attached($formats);
   }
+
+  // Specify if uploads are allowed by using a data attribute.
+  $element['value']['#attributes']['data-editor-uploads'] = empty($element['#editor_uploads']) ? 'false' : 'true';
 
   // Use the default format for this user if none was selected.
   if (!isset($element['#format'])) {

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -87,6 +87,9 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     $form_state['storage']['dialog_selector'] = $form_state['input']['dialogOptions']['target'];
   }
 
+  // Record if image uploading is requested by the calling element.
+  $element_supports_uploads = !isset($form_state['input']['dialogOptions']['uploads']) || (bool) $form_state['input']['dialogOptions']['uploads'];
+
   // Pull in any default values set by the editor.
   $values = array();
   if (isset($form_state['input']['editor_object'])) {
@@ -137,7 +140,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     ),
     '#parents' => array('fid'),
     '#weight' => -10,
-    '#access' => $upload_settings['status'] && user_access('upload editor images'),
+    '#access' => $element_supports_uploads && $upload_settings['status'] && user_access('upload editor images'),
   );
 
   // Use a "textfield" rather than "url" to allow relative paths.

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -64,6 +64,7 @@ class BlockText extends Block {
       '#title' => t('Block content'),
       '#default_value' => $this->settings['content'],
       '#format' => $this->settings['format'],
+      '#editor_uploads' => TRUE,
       '#rows' => 5,
     );
 

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -269,6 +269,27 @@ class Layout {
       ->setData($data)
       ->save();
 
+    // Parse each BlockText block for file IDs.
+    $fids = array();
+    foreach ($this->content as $content) {
+      if (is_a($content, 'BlockText')) {
+        $block_content = $content->settings['content'];
+        $block_fids = filter_parse_file_fids($block_content);
+        if (isset($block_fids)) {
+          $fids = array_merge($fids, $block_fids);
+        }
+      }
+    }
+    $files = file_load_multiple($fids);
+    foreach ($files as $fid => $file) {
+      if ($file && $file->status !== FILE_STATUS_PERMANENT) {
+        // This makes the file "self-referencing", so it will never be deleted.
+        // File usages are not removed for text blocks currently.
+        // See https://github.com/backdrop/backdrop-issues/issues/2137.
+        file_usage_add($file, 'file', 'file', $file->fid);
+      }
+    }
+
     if (!empty($this->is_new)) {
       $this->invokeHook('insert');
     }

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -1513,6 +1513,85 @@ class LayoutSelectionTest extends BackdropWebTestCase {
 }
 
 /**
+ * Tests the BlockTest (custom text) block functionality.
+ */
+class LayoutBlockTextTest extends BackdropWebTestCase {
+  protected $profile = 'testing';
+  protected $admin_user;
+
+  function setUp() {
+    parent::setUp(array('layout', 'block'));
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access content',
+      'access administration pages',
+      'administer layouts',
+      'view the administration theme',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
+
+  /**
+   * Tests the BlockText class functionality.
+   */
+  function testBlockText() {
+    // Save a file to test file usage saving.
+    $files = $this->backdropGetTestFiles('image');
+    $file_info = (array) array_pop($files);
+    $file_info['status'] = 0;
+    $file = new File($file_info);
+    $file->save();
+    $file_info['attributes']['data-file-id'] = $file->fid;
+    $image_string = theme('image', $file_info);
+
+    $this->backdropGet('admin/structure/layouts/manage/default/add-block/editor/sidebar');
+    $this->clickLink(t('Add a custom block'));
+    $this->backdropPost(NULL, array(
+      'title' => 'Custom block test',
+      'content[value]' => $this->randomString(32) . $image_string,
+    ), t('Add block'));
+
+    // Get the block UUID.
+    $last_block = $this->xpath('(//*[contains(@class,:region)]//*[@data-block-id])[last()]', array(
+      ':region' => 'l-sidebar',
+    ));
+    $block_uuid = (string) $last_block[0]['data-block-id'];
+
+    // Check that file usage is not added by the act of adding the block, as the
+    // layout has not yet been saved.
+    $usage = file_usage_list($file);
+    $this->assertEqual($usage, array(), 'No file usages recorded (as correct) when adding block to layout.');
+
+    $this->backdropPost(NULL, array(), t('Save layout'));
+
+    // Check that a file usage was recorded for the file within the block.
+    $file = file_load($file->fid);
+    $references = file_usage_list($file);
+    $this->assertEqual($references['file']['file'][$file->fid], 1, 'File usage recorded for the file within the block.');
+    $this->assertEqual($file->status, 1, 'File has been marked permanent by its file usage.');
+
+    // Visit the front-end and check the block is displayed.
+    $this->backdropGet('user');
+    $this->assertRaw('Custom block test', 'Custom block found on front-end.');
+
+    // Removing the block.
+    $this->backdropGet('admin/structure/layouts/manage/default');
+    $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
+      ':uuid' => $block_uuid,
+    ));
+    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
+    $this->backdropPost(NULL, array(), t('Save layout'));
+
+    // Check the file usage is left in place.
+    $file = file_load($file->fid);
+    $references = file_usage_list($file);
+    $this->assertEqual($references['file']['file'][$file->fid], 1, 'File usage is unaffected by removing the block from the layout.');
+    $this->assertEqual($file->status, 1, 'File still exists and is marked as permanent after removing the block from the layout.');
+  }
+}
+
+/**
  * Tests the upgrade path from block-based regions to layouts.
  */
 class LayoutUpgradePathTest extends UpgradePathTestCase {

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -4,6 +4,12 @@ description = Tests the interface for adding, removing, and moving blocks.
 group = Layout
 file = layout.test
 
+[LayoutBlockTextTest]
+name = Layout BlockText Test
+description = Tests the custom text block (BlockText) saving and converting to reusable blocks.
+group = Layout
+file = layout.test
+
 [LayoutSelectionTest]
 name = Layout Selection Test
 description = Tests that the correct layout is used in various situations.

--- a/core/modules/views/handlers/views_handler_area_text.inc
+++ b/core/modules/views/handlers/views_handler_area_text.inc
@@ -28,7 +28,6 @@ class views_handler_area_text extends views_handler_area {
       '#default_value' => $this->options['content'],
       '#rows' => 6,
       '#format' => isset($this->options['format']) ? $this->options['format'] : filter_default_format(),
-      '#wysiwyg' => FALSE,
     );
 
     // @TODO: Refactor token handling into a base class.

--- a/core/modules/views/plugins/views_plugin_exposed_form_input_required.inc
+++ b/core/modules/views/plugins/views_plugin_exposed_form_input_required.inc
@@ -29,7 +29,6 @@ class views_plugin_exposed_form_input_required extends views_plugin_exposed_form
       '#description' => t('Text to display instead of results until the user selects and applies an exposed filter.'),
       '#default_value' => $this->options['text_input_required'],
       '#format' => isset($this->options['text_input_required_format']) ? $this->options['text_input_required_format'] : filter_default_format(),
-      '#wysiwyg' => FALSE,
     );
   }
 


### PR DESCRIPTION
One of the options for https://github.com/backdrop/backdrop-issues/issues/1373. Disables uploading through CKEditor on a per-field basis by setting `$element['#editor_uploads'] = FALSE`. Still defaults to TRUE by default in this version.

This does not affect the block uploads currently, so uploads are still allowed even though they get cleaned up. IMO it might be better to reverse the default and have it be FALSE by default and only allow uploads if set to TRUE, so we use the more conservative approach unless uploads are specifically requested.
