### PR TITLE
Issue #2142: Fix Backdrop link/unlink plugin buttons.

### DIFF
--- a/core/modules/ckeditor/ckeditor.module
+++ b/core/modules/ckeditor/ckeditor.module
@@ -22,7 +22,7 @@ function ckeditor_editor_info() {
           ),
           array(
             'name' => 'Linking',
-            'items' => array('Link', 'Unlink'),
+            'items' => array('BackdropLink', 'BackdropUnlink'),
           ),
           array(
             'name' => 'Alignment',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2142.
