### PR TITLE
Issue #2187: Prevent PHP notice in Seven's maintenance page template.

### DIFF
--- a/core/themes/seven/templates/maintenance-page.tpl.php
+++ b/core/themes/seven/templates/maintenance-page.tpl.php
@@ -26,10 +26,5 @@
       <?php print $content; ?>
     </main>
   </div>
-
-  <footer role="contentinfo">
-    <?php print $footer; ?>
-  </footer>
-
   </body>
 </html>


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2187
