### PR TITLE
Issue #2211: Manage blocks page: Clear the "Layout content saved" mes…

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -1469,6 +1469,7 @@ function layout_block_configure_ajax_update($form, $form_state) {
 
   // Update the messages area.
   if ($message = layout_locked_message($layout, 'layout')) {
+    backdrop_get_messages();
     backdrop_set_message($message, 'warning');
   }
   $commands[] = ajax_command_remove('#messages');


### PR DESCRIPTION
…sage before showing the "dirty form" message.

Fixes https://github.com/backdrop/backdrop-issues/issues/2211
