### PR TITLE
Issue #2234: [UX] Page title block: summary text not updated upon dialog save (plus better title summary format)

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2530,8 +2530,8 @@ function layout_ajax_form_save_title_dialog($form, $form_state) {
   }
   else {
     // Rebuild the title area description.
-    $description = '<div class="layout-editor-block-content">' . layout_get_title_description($layout) . '</div>';
-    $commands[] = ajax_command_replace("#layout-editor-title .layout-editor-block-content", $description);
+    $description = '<span class="description">' . layout_get_title_description($layout) . '</span>';
+    $commands[] = ajax_command_replace("#layout-editor-title .description", $description);
 
     // Clear out previous messages.
     if ($message = layout_locked_message($layout, 'layout')) {

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1727,8 +1727,8 @@ function layout_modules_uninstalled($modules) {
 function layout_get_title_description(Layout $layout) {
   $options = array(
     LAYOUT_TITLE_DEFAULT => t('Default page title'),
-    LAYOUT_TITLE_CUSTOM => t('Custom page title'),
-    LAYOUT_TITLE_BLOCK => t('Title copied from block'),
+    LAYOUT_TITLE_CUSTOM => t('Custom page title:'),
+    LAYOUT_TITLE_BLOCK => t('Title copied from the'),
     LAYOUT_TITLE_NONE => t('No title'),
   );
   $source = $layout->settings['title_display'];
@@ -1741,7 +1741,7 @@ function layout_get_title_description(Layout $layout) {
     if (!empty($layout->settings['title_block'])) {
       $uuid = $layout->settings['title_block'];
       $title_block = $layout->content[$uuid];
-      $description .= ' <em>' . $all_blocks[$title_block->module][$title_block->delta]['info'] . '</em>';
+      $description .= ' <em>' . $all_blocks[$title_block->module][$title_block->delta]['info'] . '</em>' . ' block';
     }
   }
 

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1745,6 +1745,6 @@ function layout_get_title_description(Layout $layout) {
       $description = t('No title');
       break;
   }
-  
+
   return $description;
 }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1725,25 +1725,26 @@ function layout_modules_uninstalled($modules) {
  *   Description of title source.
  */
 function layout_get_title_description(Layout $layout) {
-  $options = array(
-    LAYOUT_TITLE_DEFAULT => t('Default page title'),
-    LAYOUT_TITLE_CUSTOM => t('Custom page title:'),
-    LAYOUT_TITLE_BLOCK => t('Title copied from the'),
-    LAYOUT_TITLE_NONE => t('No title'),
-  );
   $source = $layout->settings['title_display'];
-  $description = $options[$source];
-  if ($layout->settings['title_display'] == LAYOUT_TITLE_CUSTOM) {
-    $description .= ' <em>' . check_plain($layout->settings['title']) . '</em>';
+  switch ($source) {
+    case LAYOUT_TITLE_DEFAULT:
+      $description = t('Default page title');
+      break;
+    case LAYOUT_TITLE_CUSTOM:
+      $description = t('Custom page title: @title', array('@title' => $layout->settings['title']));
+      break;
+    case LAYOUT_TITLE_BLOCK:
+      $all_blocks = layout_get_block_info();
+      if (!empty($layout->settings['title_block'])) {
+        $uuid = $layout->settings['title_block'];
+        $title_block = $layout->content[$uuid];
+        $description = t('Title copied from the @block block', array('@block' => $all_blocks[$title_block->module][$title_block->delta]['info']));
+      }
+      break;
+    case LAYOUT_TITLE_NONE:
+      $description = t('No title');
+      break;
   }
-  elseif ($layout->settings['title_display'] == LAYOUT_TITLE_BLOCK) {
-    $all_blocks = layout_get_block_info();
-    if (!empty($layout->settings['title_block'])) {
-      $uuid = $layout->settings['title_block'];
-      $title_block = $layout->content[$uuid];
-      $description .= ' <em>' . $all_blocks[$title_block->module][$title_block->delta]['info'] . '</em>' . ' block';
-    }
-  }
-
+  
   return $description;
 }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1731,14 +1731,14 @@ function layout_get_title_description(Layout $layout) {
       $description = t('Default page title');
       break;
     case LAYOUT_TITLE_CUSTOM:
-      $description = t('Custom page title: @title', array('@title' => $layout->settings['title']));
+      $description = t('Custom page title: %title', array('%title' => $layout->settings['title']));
       break;
     case LAYOUT_TITLE_BLOCK:
       $all_blocks = layout_get_block_info();
       if (!empty($layout->settings['title_block'])) {
         $uuid = $layout->settings['title_block'];
         $title_block = $layout->content[$uuid];
-        $description = t('Title copied from the @block block', array('@block' => $all_blocks[$title_block->module][$title_block->delta]['info']));
+        $description = t('Title copied from the %block block', array('%block' => $all_blocks[$title_block->module][$title_block->delta]['info']));
       }
       break;
     case LAYOUT_TITLE_NONE:


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2234
