### PR TITLE
Issue #2210: Refer to "About us" page as "About" page and clean up pa…

### DIFF
--- a/profiles/standard/standard.install
+++ b/profiles/standard/standard.install
@@ -117,7 +117,7 @@ function standard_install() {
     array(
       'type' => 'page',
       'name' => st('Page'),
-      'description' => st("Add a page for static content, such as an 'About us' page."),
+      'description' => st("Add a page with static content, like the 'About' page."),
       'settings' => array(
         'status_default' => TRUE,
         'promote_enabled' => FALSE,


### PR DESCRIPTION
…ge content type description to match.

Fixes https://github.com/backdrop/backdrop-issues/issues/2210
