### PR TITLE
Issue #2190: Add template files for layouts and the hero block to ach…

### DIFF
--- a/core/themes/basis/css/component/breadcrumb.css
+++ b/core/themes/basis/css/component/breadcrumb.css
@@ -4,7 +4,7 @@
  */
 .breadcrumb {
   overflow: hidden;
-  margin: 0 0 1em;
+  margin: 1em 0;
 }
 
 .breadcrumb ol,

--- a/core/themes/basis/css/layout.css
+++ b/core/themes/basis/css/layout.css
@@ -5,7 +5,6 @@
 
 .l-header {
   position: relative;
-  margin: 0 0 2rem;
 }
 
 .layout .l-messages {

--- a/core/themes/basis/template.php
+++ b/core/themes/basis/template.php
@@ -34,7 +34,12 @@ function basis_preprocess_page(&$variables) {
  */
 function basis_preprocess_layout(&$variables) {
   if ($variables['is_front']) {
+    // Add a special front-page class.
     $variables['classes'][] = 'layout-front';
+    // Add a special font-page template suggestion.
+    $original = $variables['theme_hook_original'];
+    $variables['theme_hook_suggestions'][] = $original . '__front';
+    $variables['theme_hook_suggestion'] = $original . '__front';
   }
 }
 

--- a/core/themes/basis/templates/block--layout--hero.tpl.php
+++ b/core/themes/basis/templates/block--layout--hero.tpl.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Template for outputting the default block styling within a Layout.
+ *
+ * Variables available:
+ * - $classes: Array of classes that should be displayed on the block's wrapper.
+ * - $title: The title of the block.
+ * - $title_prefix/$title_suffix: A prefix and suffix for the title tag. This
+ *   is important to print out as administrative links to edit this block are
+ *   printed in these variables.
+ * - $content: The actual content of the block.
+ */
+?>
+<div class="<?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div class="container">
+    <?php print render($title_prefix); ?>
+    <?php if ($title): ?>
+      <h2 class="block-title"><?php print $title; ?></h2>
+    <?php endif;?>
+    <?php print render($title_suffix); ?>
+
+    <div class="block-content">
+      <?php print render($content); ?>
+    </div>
+  </div>
+</div>

--- a/core/themes/basis/templates/layout--boxton--front.tpl.php
+++ b/core/themes/basis/templates/layout--boxton--front.tpl.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @file
+ * Template for the Boxton layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--boxton <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-content" role="main" aria-label="<?php print t('Main content'); ?>">
+        <?php print $content['content']; ?>
+      </div>
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div><!-- /.container -->
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--boxton -->


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2190

PR contains: 
- new theme hook suggestion for front page layout template.
- override for front page (boxton) layout template.
- on the hero, add an **inner** div with class `container` to center the content (NW)
- on the breadcrumbs, add an **outer** div with class `container` to center the content
- CSS fix to remove extra margin below header (NW)
- CSS fix to add extra margin above breadcrumbs (NW)
