### PR TITLE
Issue #2248: Clear the file stat cache after expanding project archives.

### DIFF
--- a/core/modules/installer/installer.manager.inc
+++ b/core/modules/installer/installer.manager.inc
@@ -991,6 +991,10 @@ function installer_manager_archive_extract($file, $directory) {
   }
 
   $archiver->extract($directory);
+
+  // Clear the file stat cache to ensure PHP picks up the new files.
+  clearstatcache();
+
   return $archiver;
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2248.
