### PR TITLE
Issue #2190: Add template files for layouts and the hero block to ach…

### DIFF
--- a/core/themes/basis/css/component/breadcrumb.css
+++ b/core/themes/basis/css/component/breadcrumb.css
@@ -4,7 +4,7 @@
  */
 .breadcrumb {
   overflow: hidden;
-  margin: 0 0 1em;
+  margin: 1em 0;
 }
 
 .breadcrumb ol,

--- a/core/themes/basis/css/layout.css
+++ b/core/themes/basis/css/layout.css
@@ -5,7 +5,6 @@
 
 .l-header {
   position: relative;
-  margin: 0 0 2rem;
 }
 
 .layout .l-messages {

--- a/core/themes/basis/template.php
+++ b/core/themes/basis/template.php
@@ -106,6 +106,11 @@ function basis_preprocess_block(&$variables) {
   if ($variables['block']->delta === 'hero') {
     backdrop_add_css($theme_path . '/css/component/hero.css', array('group' => CSS_THEME));
   }
+
+  // Add a container class to the breadcrumb block.
+  if ($variables['block']->delta === 'breadcrumb') {
+    $variables['classes'][] = 'container';
+  }
 }
 
 /**

--- a/core/themes/basis/templates/block--layout--hero.tpl.php
+++ b/core/themes/basis/templates/block--layout--hero.tpl.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Template for outputting the default block styling within a Layout.
+ *
+ * Variables available:
+ * - $classes: Array of classes that should be displayed on the block's wrapper.
+ * - $title: The title of the block.
+ * - $title_prefix/$title_suffix: A prefix and suffix for the title tag. This
+ *   is important to print out as administrative links to edit this block are
+ *   printed in these variables.
+ * - $content: The actual content of the block.
+ */
+?>
+<div class="<?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div class="container">
+    <?php print render($title_prefix); ?>
+    <?php if ($title): ?>
+      <h2 class="block-title"><?php print $title; ?></h2>
+    <?php endif;?>
+    <?php print render($title_suffix); ?>
+
+    <div class="block-content">
+      <?php print render($content); ?>
+    </div>
+  </div>
+</div>

--- a/core/themes/basis/templates/layout--boxton.tpl.php
+++ b/core/themes/basis/templates/layout--boxton.tpl.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @file
+ * Template for the Boxton layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--boxton <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-content" role="main" aria-label="<?php print t('Main content'); ?>">
+        <?php print $content['content']; ?>
+      </div>
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div><!-- /.container -->
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--boxton -->

--- a/core/themes/basis/templates/layout--geary.tpl.php
+++ b/core/themes/basis/templates/layout--geary.tpl.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @file
+ * Template for the Geary layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['third1']
+ *   - $content['third2']
+ *   - $content['third3']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--geary <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle l-thirds row">
+        <div class="l-thirds-region col-md-4">
+          <?php print $content['third1']; ?>
+        </div>
+        <div class="l-thirds-region col-md-4">
+          <?php print $content['third2']; ?>
+        </div>
+        <div class="l-thirds-region col-md-4">
+          <?php print $content['third3']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div><!-- /.container -->
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--geary -->

--- a/core/themes/basis/templates/layout--harris.tpl.php
+++ b/core/themes/basis/templates/layout--harris.tpl.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @file
+ * Template for the Harris layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['sidebar']
+ *   - $content['sidebar2']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--harris <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle row">
+        <main class="l-content col-md-6 col-md-push-3" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </main>
+        <div class="l-sidebar l-sidebar-first col-md-3 col-md-pull-6">
+          <?php print $content['sidebar']; ?>
+        </div>
+        <div class="l-sidebar l-sidebar-second col-md-3">
+          <?php print $content['sidebar2']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--harris -->

--- a/core/themes/basis/templates/layout--moscone-flipped.tpl.php
+++ b/core/themes/basis/templates/layout--moscone-flipped.tpl.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @file
+ * Template for the Moscone Flipped layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['sidebar']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--moscone-flipped <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle row">
+        <main class="l-content col-md-9" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </main>
+        <div class="l-sidebar l-sidebar-first col-md-3">
+          <?php print $content['sidebar']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--moscone-flipped -->

--- a/core/themes/basis/templates/layout--moscone.tpl.php
+++ b/core/themes/basis/templates/layout--moscone.tpl.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @file
+ * Template for the Moscone layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['sidebar']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--moscone <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle row">
+        <main class="l-content col-md-9 col-md-push-3" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </main>
+        <div class="l-sidebar l-sidebar-first col-md-3 col-md-pull-9">
+          <?php print $content['sidebar']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--moscone -->

--- a/core/themes/basis/templates/layout--rolph.tpl.php
+++ b/core/themes/basis/templates/layout--rolph.tpl.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @file
+ * Template for the Rolph layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['quarter1']
+ *   - $content['quarter2']
+ *   - $content['quarter3']
+ *   - $content['quarter4']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--rolph <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle l-quarters row">
+        <div class="l-quarters-region col-md-3">
+          <?php print $content['quarter1']; ?>
+        </div>
+        <div class="l-quarters-region col-md-3">
+          <?php print $content['quarter2']; ?>
+        </div>
+        <div class="l-quarters-region col-md-3">
+          <?php print $content['quarter3']; ?>
+        </div>
+        <div class="l-quarters-region col-md-3">
+          <?php print $content['quarter4']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--rolph -->

--- a/core/themes/basis/templates/layout--simmons.tpl.php
+++ b/core/themes/basis/templates/layout--simmons.tpl.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @file
+ * Template for the Simmons layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['sidebar']
+ *   - $content['sidebar2']
+ *   - $content['third1']
+ *   - $content['third2']
+ *   - $content['third3']
+ *   - $content['quarter1']
+ *   - $content['quarter2']
+ *   - $content['quarter3']
+ *   - $content['quarter4']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--simmons <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle row">
+        <main class="l-content col-md-6 col-md-push-3" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </main>
+        <div class="l-sidebar l-sidebar-first col-md-3 col-md-pull-6">
+          <?php print $content['sidebar']; ?>
+        </div>
+        <div class="l-sidebar l-sidebar-second col-md-3">
+          <?php print $content['sidebar2']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if ($content['third1'] || $content['third2'] || $content['third3']): ?>
+        <div class="l-thirds row">
+          <div class="l-thirds-region col-md-4">
+            <?php print $content['third1']; ?>
+          </div>
+          <div class="l-thirds-region col-md-4">
+            <?php print $content['third2']; ?>
+          </div>
+          <div class="l-thirds-region col-md-4">
+            <?php print $content['third3']; ?>
+          </div>
+        </div><!-- /.l-thirds -->
+      <?php endif; ?>
+
+      <?php if ($content['quarter1'] || $content['quarter2'] || $content['quarter3'] || $content['quarter4']): ?>
+        <div class="l-quarters row">
+          <div class="l-quarters-region col-md-3">
+            <?php print $content['quarter1']; ?>
+          </div>
+          <div class="l-quarters-region col-md-3">
+            <?php print $content['quarter2']; ?>
+          </div>
+          <div class="l-quarters-region col-md-3">
+            <?php print $content['quarter3']; ?>
+          </div>
+          <div class="l-quarters-region col-md-3">
+            <?php print $content['quarter4']; ?>
+          </div>
+        </div><!-- /.l-quarters -->
+      <?php endif; ?>
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--simmons -->

--- a/core/themes/basis/templates/layout--sutro.tpl.php
+++ b/core/themes/basis/templates/layout--sutro.tpl.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @file
+ * Template for the Sutro layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['half1']
+ *   - $content['half2']
+ *   - $content['bottom']
+ *   - $content['footer']
+ *
+ */
+?>
+<div class="layout--sutro <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <?php if (!empty($content['content'])): ?>
+        <div class="l-content" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-middle l-halves row">
+        <div class="l-halves-region col-md-6">
+          <?php print $content['half1']; ?>
+        </div>
+        <div class="l-halves-region col-md-6">
+          <?php print $content['half2']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--sutro -->

--- a/core/themes/basis/templates/layout--taylor-flipped.tpl.php
+++ b/core/themes/basis/templates/layout--taylor-flipped.tpl.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @file
+ * Template for the Taylor Flipped layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['sidebar']
+ *   - $content['sidebar2']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--taylor-flipped <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle row">
+        <main class="l-content col-md-6 col-md-push-6" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </main>
+        <div class="l-sidebar l-sidebar-first col-md-3 col-md-pull-6">
+          <?php print $content['sidebar']; ?>
+        </div>
+        <div class="l-sidebar l-sidebar-second col-md-3 col-md-pull-6">
+          <?php print $content['sidebar2']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--taylor-flipped -->

--- a/core/themes/basis/templates/layout--taylor.tpl.php
+++ b/core/themes/basis/templates/layout--taylor.tpl.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @file
+ * Template for the Taylor layout.
+ *
+ * Variables:
+ * - $title: The page title, for use in the actual HTML content.
+ * - $messages: Status and error messages. Should be displayed prominently.
+ * - $tabs: Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node.)
+ * - $action_links: Array of actions local to the page, such as 'Add menu' on
+ *   the menu administration interface.
+ * - $classes: Array of CSS classes to be added to the layout wrapper.
+ * - $attributes: Array of additional HTML attributes to be added to the layout
+ *     wrapper. Flatten using backdrop_attributes().
+ * - $content: An array of content, each item in the array is keyed to one
+ *   region of the layout. This layout supports the following sections:
+ *   - $content['header']
+ *   - $content['top']
+ *   - $content['content']
+ *   - $content['sidebar']
+ *   - $content['sidebar2']
+ *   - $content['bottom']
+ *   - $content['footer']
+ */
+?>
+<div class="layout--taylor <?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+  </div>
+
+  <?php if ($content['header']): ?>
+    <header class="l-header" role="banner" aria-label="<?php print t('Site header'); ?>">
+      <div class="l-header-inner container container-fluid">
+        <?php print $content['header']; ?>
+      </div>
+    </header>
+  <?php endif; ?>
+
+  <div class="l-wrapper">
+
+    <?php if (!empty($content['top'])): ?>
+      <div class="l-top">
+        <?php print $content['top']; ?>
+      </div>
+    <?php endif; ?>
+
+    <div class="l-wrapper-inner container container-fluid">
+
+      <?php if ($messages): ?>
+        <div class="l-messages" role="status" aria-label="<?php print t('Status messages'); ?>">
+          <?php print $messages; ?>
+        </div>
+      <?php endif; ?>
+
+      <div class="l-page-title">
+        <a id="main-content"></a>
+        <?php print render($title_prefix); ?>
+        <?php if ($title): ?>
+          <h1 class="page-title"><?php print $title; ?></h1>
+        <?php endif; ?>
+        <?php print render($title_suffix); ?>
+      </div>
+
+      <?php if ($tabs): ?>
+        <nav class="tabs" role="tablist" aria-label="<?php print t('Admin content navigation tabs.'); ?>">
+          <?php print $tabs; ?>
+        </nav>
+      <?php endif; ?>
+
+      <?php print $action_links; ?>
+
+      <div class="l-middle row">
+        <main class="l-content col-md-6" role="main" aria-label="<?php print t('Main content'); ?>">
+          <?php print $content['content']; ?>
+        </main>
+        <div class="l-sidebar l-sidebar-first col-md-3">
+          <?php print $content['sidebar']; ?>
+        </div>
+        <div class="l-sidebar l-sidebar-second col-md-3">
+          <?php print $content['sidebar2']; ?>
+        </div>
+      </div><!-- /.l-middle -->
+
+      <?php if (!empty($content['bottom'])): ?>
+        <div class="l-bottom">
+          <?php print $content['bottom']; ?>
+        </div>
+      <?php endif; ?>
+
+    </div><!-- /.l-wrapper-inner -->
+  </div><!-- /.l-wrapper -->
+
+  <?php if ($content['footer']): ?>
+    <footer class="l-footer"  role="footer">
+      <div class="l-footer-inner container container-fluid">
+        <?php print $content['footer']; ?>
+      </div>
+    </footer>
+  <?php endif; ?>
+</div><!-- /.layout--taylor -->


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2190#issuecomment-250643713. 

PR contains: 
- in every template file (yes, all 10) move the top region outside the fixed-width container, between `<div class="l-wrapper">` and `<div class="l-wrapper-inner container container-fluid">`
- on the hero, add an **inner** div with class `container` to center the content
- on the breadcrumbs, add an **outer** div with class `container` to center the content
- CSS fix to remove extra margin below header
- CSS fix to add extra margin above breadcrumbs

(Vetoed, but leaving here for posterity.)
