### PR TITLE
Issue #2108: [UX] Better messages for user creation/deletion/rename.

### DIFF
--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2071,7 +2071,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     $role_name = '123';
     $edit = array('name' => $role_name, 'label' => $role_name);
     $this->backdropPost('admin/config/people/roles', $edit, t('Add role'));
-    $this->assertText(t('The role has been added.'), 'The role has been added.');
+    $this->assertText(t('The 123 role has been added.'), 'The role has been added.');
     backdrop_static_reset('user_roles');
     $role = user_role_load($role_name);
     $this->assertTrue(is_object($role), 'The role was successfully loaded from config.');
@@ -2085,7 +2085,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     $new_label = '456';
     $edit = array('label' => $new_label);
     $this->backdropPost("admin/config/people/roles/edit/$role_name", $edit, t('Save role'));
-    $this->assertText(t('The role has been renamed.'), 'The role has been renamed.');
+    $this->assertText(t('The 123 role has been renamed to 456.'), 'The role has been renamed.');
     backdrop_static_reset('user_roles');
     $role = user_role_load($role_name);
     $this->assertFalse($role->label === $old_label, 'The role has had its label changed.');
@@ -2119,7 +2119,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     $role_name = 'administrator';
     $role = user_role_load($role_name);
     $this->backdropPost("admin/config/people/roles/delete/$role_name", array(), t('Delete'));
-    $this->assertText(t('The role has been deleted.'), 'The role has been deleted');
+    $this->assertText(t('The administrator role has been deleted.'), 'The role has been deleted');
     $this->assertNoLinkByHref("admin/config/people/roles/edit/$role_name", 'Role edit link removed.');
     backdrop_static_reset('user_roles');
     $this->assertFalse(user_role_load($role_name), 'A deleted role can no longer be loaded.');

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -628,8 +628,9 @@ function user_admin_role_delete_confirm($form, &$form_state, $role) {
  */
 function user_admin_role_delete_confirm_submit($form, &$form_state) {
   $role = $form_state['role'];
+  $deleted_role = $role->label;
   user_role_delete($form_state['values']['role_name']);
-  backdrop_set_message(t('The %role role has been deleted.', array('%role' => $role->label)));
+  backdrop_set_message(t('The %role role has been deleted.', array('%role' => $deleted_role)));
   $form_state['redirect'] = 'admin/config/people/roles';
 }
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -627,10 +627,9 @@ function user_admin_role_delete_confirm($form, &$form_state, $role) {
  * Form submit handler for user_admin_role_delete_confirm().
  */
 function user_admin_role_delete_confirm_submit($form, &$form_state) {
-  $role = $form_state['role'];
-  $deleted_role = $role->label;
-  user_role_delete($form_state['values']['role_name']);
-  backdrop_set_message(t('The %role role has been deleted.', array('%role' => $deleted_role)));
+  $role = $form_state['values']['role_name'];
+  user_role_delete($role);
+  backdrop_set_message(t('The %role role has been deleted.', array('%role' => $role)));
   $form_state['redirect'] = 'admin/config/people/roles';
 }
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -553,7 +553,7 @@ function user_admin_roles_add_submit($form, &$form_state) {
     'label' => $form_state['values']['label'],
   );
   user_role_save($role);
-  backdrop_set_message(t('The role has been added.'));
+  backdrop_set_message(t('The %role role has been added.', array('%role' => $role->label)));
   $form_state['redirect'] = 'admin/config/people/roles';
 }
 
@@ -604,9 +604,11 @@ function user_admin_role($form, &$form_state, $role) {
  */
 function user_admin_role_submit($form, &$form_state) {
   $role = $form_state['role'];
+  $old_role = $role->label;
   $role->label = $form_state['values']['label'];
   user_role_save($role);
-  backdrop_set_message(t('The role has been renamed.'));
+  $new_role = $role->label;
+  backdrop_set_message(t('The %old_role role has been renamed to %new_role.', array('%old_role' => $old_role, '%new_role' => $new_role)));
   $form_state['redirect'] = 'admin/config/people/roles';
 }
 
@@ -618,7 +620,7 @@ function user_admin_role_delete_confirm($form, &$form_state, $role) {
     '#type' => 'value',
     '#value' => $role->name,
   );
-  return confirm_form($form, t('Are you sure you want to delete the role %name ?', array('%name' => $role->label)), 'admin/config/people/roles', t('This action cannot be undone.'), t('Delete'));
+  return confirm_form($form, t('Are you sure you want to delete the %role role?', array('%role' => $role->label)), 'admin/config/people/roles', t('This action cannot be undone.'), t('Delete'));
 }
 
 /**
@@ -626,7 +628,7 @@ function user_admin_role_delete_confirm($form, &$form_state, $role) {
  */
 function user_admin_role_delete_confirm_submit($form, &$form_state) {
   user_role_delete($form_state['values']['role_name']);
-  backdrop_set_message(t('The role has been deleted.'));
+  backdrop_set_message(t('The %role role has been deleted.', array('%role' => $role->label)));
   $form_state['redirect'] = 'admin/config/people/roles';
 }
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -627,6 +627,7 @@ function user_admin_role_delete_confirm($form, &$form_state, $role) {
  * Form submit handler for user_admin_role_delete_confirm().
  */
 function user_admin_role_delete_confirm_submit($form, &$form_state) {
+  $role = $form_state['role'];
   user_role_delete($form_state['values']['role_name']);
   backdrop_set_message(t('The %role role has been deleted.', array('%role' => $role->label)));
   $form_state['redirect'] = 'admin/config/people/roles';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2108 , replaces https://github.com/backdrop/backdrop/pull/1504
