### PR TITLE
Issue #2287: [UX] Add a link to the 'Site information' page from the …

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2991,9 +2991,6 @@ function _system_info_add_path($info, $path) {
 function system_header_block_form($settings) {
   $settings += array(
     'menu' => 'user-menu',
-    'site_info' => array(),
-  );
-  $settings['site_info'] += array(
     'logo' => TRUE,
     'site_name' => TRUE,
     'site_slogan' => TRUE,
@@ -3006,25 +3003,25 @@ function system_header_block_form($settings) {
     '#empty_option' => '- ' . t('None') . ' -',
     '#default_value' => $settings['menu'],
   );
-  $form['site_info'] = array(
+  $form = array(
     '#type' => 'fieldset',
     '#title' => t('Site information components'),
     '#description' => t('Here you can enable or disable the various components of the header of your site. To change the values of these components, use the !site_info page.', array('!site_info' => l(t('Site information'), 'admin/config/system/site-information'))),
   );
-  $form['site_info']['logo'] = array(
+  $form['logo'] = array(
     '#type' => 'checkbox',
     '#title' => t('Logo'),
-    '#default_value' => $settings['site_info']['logo'],
+    '#default_value' => $settings['logo'],
   );
-  $form['site_info']['site_name'] = array(
+  $form['site_name'] = array(
     '#type' => 'checkbox',
     '#title' => t('Site name'),
-    '#default_value' => $settings['site_info']['site_name'],
+    '#default_value' => $settings['site_name'],
   );
-  $form['site_info']['site_slogan'] = array(
+  $form['site_slogan'] = array(
     '#type' => 'checkbox',
     '#title' => t('Site slogan'),
-    '#default_value' => $settings['site_info']['site_slogan'],
+    '#default_value' => $settings['site_slogan'],
   );
   return $form;
 }
@@ -3037,9 +3034,6 @@ function system_header_block_form($settings) {
 function system_header_block($settings) {
   $settings += array(
     'menu' => 'user-menu',
-    'site_info' => array(),
-  );
-  $settings['site_info'] += array(
     'logo' => TRUE,
     'site_name' => TRUE,
     'site_slogan' => TRUE,
@@ -3047,9 +3041,9 @@ function system_header_block($settings) {
 
   $menu = $settings['menu'] ? menu_navigation_links($settings['menu']) : NULL;
   $site_config = config('system.core');
-  $variables['logo']        = $settings['site_info']['logo'] ? backdrop_get_logo() : NULL;
-  $variables['site_name']   = $settings['site_info']['site_name'] ? check_plain($site_config->get('site_name')) : '';
-  $variables['site_slogan'] = $settings['site_info']['site_slogan'] ? filter_xss_admin($site_config->get('site_slogan')) : '';
+  $variables['logo']        = $settings['logo'] ? backdrop_get_logo() : NULL;
+  $variables['site_name']   = $settings['site_name'] ? check_plain($site_config->get('site_name')) : '';
+  $variables['site_slogan'] = $settings['site_slogan'] ? filter_xss_admin($site_config->get('site_slogan')) : '';
   $variables['menu']        = $menu ? theme('links__header_menu', array('links' => $menu)) : NULL;
 
   return theme('header', $variables);

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2991,6 +2991,9 @@ function _system_info_add_path($info, $path) {
 function system_header_block_form($settings) {
   $settings += array(
     'menu' => 'user-menu',
+    'site_info' => array(),
+  );
+  $settings['site_info'] += array(
     'logo' => TRUE,
     'site_name' => TRUE,
     'site_slogan' => TRUE,
@@ -3003,20 +3006,25 @@ function system_header_block_form($settings) {
     '#empty_option' => '- ' . t('None') . ' -',
     '#default_value' => $settings['menu'],
   );
-  $form['logo'] = array(
+  $form['site_info'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Site information components'),
+    '#description' => t('Here you can enable or disable the various components of the header of your site. To change the values of these components, use the !site_info page.', array('!site_info' => l(t('Site information'), 'admin/config/system/site-information'))),
+  );
+  $form['site_info']['logo'] = array(
     '#type' => 'checkbox',
     '#title' => t('Logo'),
-    '#default_value' => $settings['logo'],
+    '#default_value' => $settings['site_info']['logo'],
   );
-  $form['site_name'] = array(
+  $form['site_info']['site_name'] = array(
     '#type' => 'checkbox',
     '#title' => t('Site name'),
-    '#default_value' => $settings['site_name'],
+    '#default_value' => $settings['site_info']['site_name'],
   );
-  $form['site_slogan'] = array(
+  $form['site_info']['site_slogan'] = array(
     '#type' => 'checkbox',
     '#title' => t('Site slogan'),
-    '#default_value' => $settings['site_slogan'],
+    '#default_value' => $settings['site_info']['site_slogan'],
   );
   return $form;
 }
@@ -3029,16 +3037,19 @@ function system_header_block_form($settings) {
 function system_header_block($settings) {
   $settings += array(
     'menu' => 'user-menu',
+    'site_info' => array(),
+  );
+  $settings['site_info'] += array(
     'logo' => TRUE,
-    'site_slogan' => TRUE,
     'site_name' => TRUE,
+    'site_slogan' => TRUE,
   );
 
   $menu = $settings['menu'] ? menu_navigation_links($settings['menu']) : NULL;
   $site_config = config('system.core');
-  $variables['logo']        = $settings['logo'] ? backdrop_get_logo() : NULL;
-  $variables['site_name']   = $settings['site_name'] ? check_plain($site_config->get('site_name')) : '';
-  $variables['site_slogan'] = $settings['site_slogan'] ? filter_xss_admin($site_config->get('site_slogan')) : '';
+  $variables['logo']        = $settings['site_info']['logo'] ? backdrop_get_logo() : NULL;
+  $variables['site_name']   = $settings['site_info']['site_name'] ? check_plain($site_config->get('site_name')) : '';
+  $variables['site_slogan'] = $settings['site_info']['site_slogan'] ? filter_xss_admin($site_config->get('site_slogan')) : '';
   $variables['menu']        = $menu ? theme('links__header_menu', array('links' => $menu)) : NULL;
 
   return theme('header', $variables);


### PR DESCRIPTION
…header block options for logo, site name, and site slogan.

Fixes https://github.com/backdrop/backdrop-issues/issues/2287
