### PR TITLE
Issue #2151: Add searchable strings to simpletest results.

### DIFF
--- a/core/modules/simpletest/simpletest.pages.inc
+++ b/core/modules/simpletest/simpletest.pages.inc
@@ -123,7 +123,7 @@ function simpletest_result_form($form, &$form_state, $test_id) {
     $rows = array();
     foreach ($assertions as $assertion) {
       $row = array();
-      $row[] = $assertion->message;
+      $row[] = strtoupper(str_replace('simpletest-', '', $assertion->status)) . ': ' . $assertion->message;
       $row[] = $assertion->message_group;
       $row[] = backdrop_basename($assertion->file);
       $row[] = $assertion->line;

--- a/core/modules/simpletest/tests/simpletest.test
+++ b/core/modules/simpletest/tests/simpletest.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Tests for simpletest.module.
@@ -208,7 +207,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
    */
   function getTestIdFromResults() {
     foreach ($this->childTestResults['assertions'] as $assertion) {
-      if (preg_match('@^Test ID is ([0-9]*)\.$@', $assertion['message'], $matches)) {
+      if (preg_match('@^PASS: Test ID is ([0-9]*)\.$@', $assertion['message'], $matches)) {
         return $matches[1];
       }
     }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2151