### PR TITLE
315 view modes single table

### DIFF
--- a/core/modules/entity/config/entity.view_modes.json
+++ b/core/modules/entity/config/entity.view_modes.json
@@ -1,0 +1,4 @@
+{
+    "_config_name": "entity.view_modes",
+    "view_modes": []
+}

--- a/core/modules/entity/entity.admin.inc
+++ b/core/modules/entity/entity.admin.inc
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * List all custom view modes.
+ */
+function entity_view_mode_list() {
+  $custom_view_modes = config_get('entity.view_modes', 'view_modes');
+  $entity_info = entity_get_info();
+
+  $build = array(
+    '#prefix' => '<div id="view-modes-accordion">',
+    '#suffix' => '</div>',
+    '#attached' => array(
+      'library' => array(
+        //array('system', 'ui.accordion'),
+      ),
+      'js' => array(
+        //backdrop_get_path('module', 'entity_view_mode') . '/entity_view_mode.admin.js',
+      ),
+    ),
+  );
+
+  foreach (array_keys($entity_info) as $entity_type) {
+    if (empty($entity_info[$entity_type]['view modes'])) {
+      continue;
+    }
+
+    $build[$entity_type] = array(
+      '#type' => 'fieldset',
+      '#title' => $entity_info[$entity_type]['label'],
+      '#collapsible' => TRUE,
+    );
+
+    // Sort view modes by machine name.
+    ksort($entity_info[$entity_type]['view modes']);
+
+    $rows = array();
+    foreach ($entity_info[$entity_type]['view modes'] as $view_mode => $view_mode_info) {
+      $rows[$view_mode]['label'] = check_plain($view_mode_info['label']);
+      $rows[$view_mode]['type'] = !empty($custom_view_modes[$entity_type][$view_mode]) ? t('In configuration') : t('In code');
+      $rows[$view_mode]['custom_settings'] = !empty($view_mode_info['custom settings']) ? t('Yes') : t('No');
+
+      $operations = array();
+      if (isset($custom_view_modes[$entity_type][$view_mode])) {
+        $operations['edit'] = array(
+          'title' => t('Edit'),
+          'href' => "admin/config/system/view-modes/edit/{$entity_type}/{$view_mode}",
+        );
+        $operations['delete'] = array(
+          'title' => t('Delete'),
+          'href' => "admin/config/system/view-modes/delete/{$entity_type}/{$view_mode}",
+        );
+      }
+      if (!empty($operations)) {
+        $rows[$view_mode]['operations'] = array(
+          'data' => array(
+            '#theme' => 'links',
+            '#links' => $operations,
+            '#attributes' => array('class' => array('links', 'inline')),
+          ),
+        );
+      }
+      else {
+        $rows[$view_mode]['operations'] = t('None (view mode locked)');
+      }
+    }
+
+    $rows['_add_new'][] = array(
+      'data' => l(t('Add new view mode'), "admin/config/system/view-modes/add/{$entity_type}"),
+      'colspan' => 4,
+    );
+
+    $build[$entity_type]['view_modes'] = array(
+      '#theme' => 'table',
+      '#header' => array(
+        t('View mode'),
+        t('Type'),
+        t('Custom settings'),
+        t('Operations'),
+      ),
+      '#rows' => $rows,
+    );
+  }
+
+  return $build;
+}
+
+/**
+ * Form builder; edit a custom view mode.
+ */
+function entity_view_mode_edit_form($form, &$form_state, $entity_type, $machine_name = NULL) {
+  $form['#entity_type'] = $entity_type;
+  $form['#entity_info'] = $entity_info = entity_get_info($entity_type);
+  $view_mode = entity_view_mode_load($entity_type, $machine_name);
+
+  if (empty($entity_info['view modes']) || (isset($machine_name) && empty($view_mode))) {
+    backdrop_not_found();
+    backdrop_exit();
+  }
+
+  $form['entity_type'] = array(
+    '#type' => 'item',
+    '#title' => t('Entity type'),
+    '#markup' => $entity_info['label'],
+  );
+
+  $form['label'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Label'),
+    '#default_value' => isset($view_mode['label']) ? $view_mode['label'] : '',
+    '#required' => TRUE,
+  );
+
+  $form['machine_name'] = array(
+    '#type' => 'machine_name',
+    '#machine_name' => array(
+      'source' => array('label'),
+      'exists' => 'entity_view_mode_exists',
+    ),
+    '#default_value' => $machine_name,
+    '#entity_type' => $entity_type,
+  );
+
+  if (isset($machine_name)) {
+    $form['old_machine_name'] = array(
+      '#type' => 'value',
+      '#value' => $machine_name,
+    );
+  }
+
+  $form['custom_settings'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use custom display settings'),
+    '#description' => t('Unchecking this will delete all the display settings for this view mode.'),
+    '#default_value' => isset($entity_info['view modes'][$machine_name]['custom settings']) ? $entity_info['view modes'][$machine_name]['custom settings'] : TRUE,
+  );
+
+  $bundle_options = entity_view_mode_get_possible_bundles($entity_type);
+  $bundle_values = !empty($machine_name) ? array_keys(entity_view_mode_get_enabled_bundles($entity_type, $machine_name)) : array_keys($bundle_options);
+
+  $form['enabled_bundles'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Enable this view mode for the following types'),
+    '#description' => t('Unchecking a type that has already been configured will delete the display settings for this view mode.'),
+    '#options' => $bundle_options,
+    '#default_value' => $bundle_values,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="custom_settings"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
+
+  $form['actions'] = array('#type' => 'actions');
+  $form['actions']['save'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
+
+  return $form;
+}
+
+function entity_view_mode_exists($machine_name, $element, $form_state) {
+  $entity_info = entity_get_info($element['#entity_type']);
+  return !empty($entity_info['view modes'][$machine_name]);
+}
+
+function entity_view_mode_edit_form_submit($form, &$form_state) {
+  // Save the view mode.
+  form_state_values_clean($form_state);
+  $view_mode = $form_state['values'];
+  entity_view_mode_save($form['#entity_type'], $view_mode);
+
+  backdrop_set_message(t('Saved the %view-mode @entity-type view mode.', array(
+    '@entity-type' => backdrop_strtolower($form['#entity_info']['label']),
+    '%view-mode' => $view_mode['label'],
+  )));
+  $form_state['redirect'] = 'admin/config/system/view-modes';
+}
+
+function entity_view_mode_delete_form(array $form, $form_state, $entity_type, $machine_name) {
+  $form['#entity_type'] = $entity_type;
+  $form['#entity_info'] = $entity_info = entity_get_info($entity_type);
+  $form['#view_mode'] = $view_mode = entity_view_mode_load($entity_type, $machine_name);
+
+  if (empty($form['#view_mode'])) {
+    backdrop_not_found();
+    backdrop_exit();
+  }
+
+  $form['machine_name'] = array(
+    '#type' => 'value',
+    '#value' => $machine_name,
+  );
+
+  return confirm_form(
+    $form,
+    t('Are you sure you want to delete the %view-mode @entity-type view mode?', array(
+      '@entity-type' => backdrop_strtolower($entity_info['label']),
+      '%view-mode' => $view_mode['label'],
+    )),
+    'admin/config/system/view-modes',
+    t('Deleting a view mode will cause any output still requesting to use that view mode to use the default display settings.'),
+    t('Delete'),
+    t('Cancel')
+  );
+}
+
+function entity_view_mode_delete_form_submit($form, &$form_state) {
+  entity_view_mode_delete($form['#entity_type'], $form_state['values']['machine_name']);
+
+  backdrop_set_message(t('Deleted the %view-mode @entity-type view mode.', array(
+    '@entity-type' => backdrop_strtolower($form['#entity_info']['label']),
+    '%view-mode' => $form['#view_mode']['label'],
+  )));
+  $form_state['redirect'] = 'admin/config/system/view-modes';
+}

--- a/core/modules/entity/entity.admin.inc
+++ b/core/modules/entity/entity.admin.inc
@@ -1,115 +1,122 @@
 <?php
+/**
+ * @file
+ * Administration pages and forms for entity module.
+ */
 
 /**
- * List all custom view modes.
+ * Admin listing page for entity view modes.
  */
 function entity_view_mode_list() {
   $custom_view_modes = config_get('entity.view_modes', 'view_modes');
   $entity_info = entity_get_info();
 
-  $build = array(
-    '#prefix' => '<div id="view-modes-accordion">',
-    '#suffix' => '</div>',
-    '#attached' => array(
-      'library' => array(
-        //array('system', 'ui.accordion'),
-      ),
-      'js' => array(
-        //backdrop_get_path('module', 'entity_view_mode') . '/entity_view_mode.admin.js',
-      ),
-    ),
-  );
-
+  $rows = array();
   foreach (array_keys($entity_info) as $entity_type) {
     if (empty($entity_info[$entity_type]['view modes'])) {
       continue;
     }
 
-    $build[$entity_type] = array(
-      '#type' => 'fieldset',
-      '#title' => $entity_info[$entity_type]['label'],
-      '#collapsible' => TRUE,
-    );
-
     // Sort view modes by machine name.
     ksort($entity_info[$entity_type]['view modes']);
 
-    $rows = array();
     foreach ($entity_info[$entity_type]['view modes'] as $view_mode => $view_mode_info) {
-      $rows[$view_mode]['label'] = check_plain($view_mode_info['label']);
-      $rows[$view_mode]['type'] = !empty($custom_view_modes[$entity_type][$view_mode]) ? t('In configuration') : t('In code');
-      $rows[$view_mode]['custom_settings'] = !empty($view_mode_info['custom settings']) ? t('Yes') : t('No');
+      $rows[$entity_type . '-' . $view_mode]['label'] = check_plain($view_mode_info['label']);
+      $rows[$entity_type . '-' . $view_mode]['entity'] = $entity_info[$entity_type]['label'];
+      $rows[$entity_type . '-' . $view_mode]['type'] = !empty($custom_view_modes[$entity_type][$view_mode]) ? t('In configuration') : t('In code');
+      $rows[$entity_type . '-' . $view_mode]['custom_settings'] = !empty($view_mode_info['custom settings']) ? t('Yes') : t('No');
 
       $operations = array();
       if (isset($custom_view_modes[$entity_type][$view_mode])) {
         $operations['edit'] = array(
           'title' => t('Edit'),
-          'href' => "admin/config/system/view-modes/edit/{$entity_type}/{$view_mode}",
+          'href' => "admin/structure/view-modes/edit/{$entity_type}/{$view_mode}",
         );
         $operations['delete'] = array(
           'title' => t('Delete'),
-          'href' => "admin/config/system/view-modes/delete/{$entity_type}/{$view_mode}",
+          'href' => "admin/structure/view-modes/delete/{$entity_type}/{$view_mode}",
         );
       }
       if (!empty($operations)) {
-        $rows[$view_mode]['operations'] = array(
+        $rows[$entity_type . '-' . $view_mode]['operations'] = array(
           'data' => array(
-            '#theme' => 'links',
+            '#type' => 'dropbutton',
             '#links' => $operations,
-            '#attributes' => array('class' => array('links', 'inline')),
           ),
         );
       }
       else {
-        $rows[$view_mode]['operations'] = t('None (view mode locked)');
+        $rows[$entity_type . '-' . $view_mode]['operations'] = t('<em>locked</em>');
       }
     }
-
-    $rows['_add_new'][] = array(
-      'data' => l(t('Add new view mode'), "admin/config/system/view-modes/add/{$entity_type}"),
-      'colspan' => 4,
-    );
-
-    $build[$entity_type]['view_modes'] = array(
-      '#theme' => 'table',
-      '#header' => array(
-        t('View mode'),
-        t('Type'),
-        t('Custom settings'),
-        t('Operations'),
-      ),
-      '#rows' => $rows,
-    );
   }
+
+  $build['view_modes'] = array(
+    '#theme' => 'table',
+    '#header' => array(
+      array('data' => t('View mode')),
+      array('data' => t('Entity')),
+      array('data' => t('Storage state')),
+      array('data' => t('Custom settings')),
+      array(
+        'data' => t('Operations'),
+        'class' => array('class' => 'operations'),
+      ),
+    ),
+    '#rows' => $rows,
+  );
 
   return $build;
 }
 
 /**
- * Form builder; edit a custom view mode.
+ * Form builder: edit a custom view mode.
  */
-function entity_view_mode_edit_form($form, &$form_state, $entity_type, $machine_name = NULL) {
-  $form['#entity_type'] = $entity_type;
-  $form['#entity_info'] = $entity_info = entity_get_info($entity_type);
+function entity_view_mode_edit_form($form, &$form_state, $entity_type = NULL, $machine_name = NULL) {
   $view_mode = entity_view_mode_load($entity_type, $machine_name);
-
-  if (empty($entity_info['view modes']) || (isset($machine_name) && empty($view_mode))) {
-    backdrop_not_found();
-    backdrop_exit();
-  }
-
-  $form['entity_type'] = array(
-    '#type' => 'item',
-    '#title' => t('Entity type'),
-    '#markup' => $entity_info['label'],
-  );
-
   $form['label'] = array(
     '#type' => 'textfield',
     '#title' => t('Label'),
     '#default_value' => isset($view_mode['label']) ? $view_mode['label'] : '',
     '#required' => TRUE,
   );
+
+  $entity_info = entity_get_info($entity_type);
+  if ($entity_type === NULL) {
+
+    // Get the type from form state (for ajax).
+    $entity_type = !empty($form_state['values']['entity_type']) ? $form_state['values']['entity_type'] : 'node';
+
+    // Only offer entity options with view modes.
+    $options = array();
+    foreach ($entity_info as $machine => $info) {
+      if (!empty($info['view modes'])) {
+        $options[$machine] = t($info['label']);
+      }
+    }
+    $form['entity_type'] = array(
+      '#type' => 'select',
+      '#title' => t('Entity type'),
+      '#options' => $options,
+      '#default_value' => array_key_exists($entity_type, $options)? $entity_type : '',
+      '#ajax' => array(
+        'wrapper' => 'ajax-bundles',
+        'callback' => 'entity_view_mode_ajax_update',
+        'method' => 'replace',
+        'effect' => 'fade',
+       ),
+    );
+  }
+  else {
+    $form['entity_type'] = array(
+      '#type' => 'item',
+      '#title' => t('Entity type'),
+      '#markup' => $entity_info['label'],
+    );
+  }
+
+  $form['#entity_type'] = $entity_type;
+  $form['#entity_info'] = $entity_info[$entity_type];
 
   $form['machine_name'] = array(
     '#type' => 'machine_name',
@@ -131,7 +138,6 @@ function entity_view_mode_edit_form($form, &$form_state, $entity_type, $machine_
   $form['custom_settings'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use custom display settings'),
-    '#description' => t('Unchecking this will delete all the display settings for this view mode.'),
     '#default_value' => isset($entity_info['view modes'][$machine_name]['custom settings']) ? $entity_info['view modes'][$machine_name]['custom settings'] : TRUE,
   );
 
@@ -141,15 +147,22 @@ function entity_view_mode_edit_form($form, &$form_state, $entity_type, $machine_
   $form['enabled_bundles'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Enable this view mode for the following types'),
-    '#description' => t('Unchecking a type that has already been configured will delete the display settings for this view mode.'),
     '#options' => $bundle_options,
     '#default_value' => $bundle_values,
+    '#prefix' => '<div id="ajax-bundles">',
+    '#suffix' => '</div>',
     '#states' => array(
       'visible' => array(
         ':input[name="custom_settings"]' => array('checked' => TRUE),
       ),
     ),
   );
+
+  if (isset($machine_name)) {
+    // Add some extra help text for existing view modes.
+    $form['custom_settings']['#description'] = t('Unchecking this will delete all the display settings for this view mode.');
+    $form['enabled_bundles']['#description'] = t('Unchecking a type that has already been configured will delete the display settings for this view mode.');
+  }
 
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['save'] = array(
@@ -160,11 +173,24 @@ function entity_view_mode_edit_form($form, &$form_state, $entity_type, $machine_
   return $form;
 }
 
+/**
+ * Ajax callback to update bundle checkbox options.
+ */
+function entity_view_mode_ajax_update($form, $form_state) {
+  return $form['enabled_bundles'];
+}
+
+/**
+ * Helper function: checks if the view mode exists.
+ */
 function entity_view_mode_exists($machine_name, $element, $form_state) {
   $entity_info = entity_get_info($element['#entity_type']);
   return !empty($entity_info['view modes'][$machine_name]);
 }
 
+/**
+ * Submit hanlder for entity_view_mode_edit_form().
+ */
 function entity_view_mode_edit_form_submit($form, &$form_state) {
   // Save the view mode.
   form_state_values_clean($form_state);
@@ -175,9 +201,12 @@ function entity_view_mode_edit_form_submit($form, &$form_state) {
     '@entity-type' => backdrop_strtolower($form['#entity_info']['label']),
     '%view-mode' => $view_mode['label'],
   )));
-  $form_state['redirect'] = 'admin/config/system/view-modes';
+  $form_state['redirect'] = 'admin/structure/view-modes';
 }
 
+/**
+ * Form builder: delete a view mode.
+ */
 function entity_view_mode_delete_form(array $form, $form_state, $entity_type, $machine_name) {
   $form['#entity_type'] = $entity_type;
   $form['#entity_info'] = $entity_info = entity_get_info($entity_type);
@@ -199,13 +228,16 @@ function entity_view_mode_delete_form(array $form, $form_state, $entity_type, $m
       '@entity-type' => backdrop_strtolower($entity_info['label']),
       '%view-mode' => $view_mode['label'],
     )),
-    'admin/config/system/view-modes',
+    'admin/structure/view-modes',
     t('Deleting a view mode will cause any output still requesting to use that view mode to use the default display settings.'),
     t('Delete'),
     t('Cancel')
   );
 }
 
+/**
+ * Submit handler for entity_view_mode_delete_form().
+ */
 function entity_view_mode_delete_form_submit($form, &$form_state) {
   entity_view_mode_delete($form['#entity_type'], $form_state['values']['machine_name']);
 
@@ -213,5 +245,5 @@ function entity_view_mode_delete_form_submit($form, &$form_state) {
     '@entity-type' => backdrop_strtolower($form['#entity_info']['label']),
     '%view-mode' => $form['#view_mode']['label'],
   )));
-  $form_state['redirect'] = 'admin/config/system/view-modes';
+  $form_state['redirect'] = 'admin/structure/view-modes';
 }

--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -423,3 +423,157 @@ function hook_entity_prepare_view($entities, $type) {
     }
   }
 }
+
+/**
+ * Describe the view modes for entity types.
+ *
+ * View modes let entities be displayed differently depending on the context.
+ * For instance, a node can be displayed differently on its own page ('full'
+ * mode), on the home page or taxonomy listings ('teaser' mode), or in an RSS
+ * feed ('rss' mode). Modules taking part in the display of the entity (notably
+ * the Field API) can adjust their behavior depending on the requested view
+ * mode. An additional 'default' view mode is available for all entity types.
+ * This view mode is not intended for actual entity display, but holds default
+ * display settings. For each available view mode, administrators can configure
+ * whether it should use its own set of field display settings, or just
+ * replicate the settings of the 'default' view mode, thus reducing the amount
+ * of display configurations to keep track of.
+ *
+ * Note: This hook is invoked inside an implementation of
+ * hook_entity_info_alter() so care must be taken not to call anything that
+ * will result in an additional, and hence recurisve call to entity_get_info().
+ *
+ * @return array
+ *   An associative array of all entity view modes, keyed by the entity
+ *   type name, and then the view mode name, with the following keys:
+ *   - label: The human-readable name of the view mode.
+ *   - custom_settings: A boolean specifying whether the view mode should by
+ *     default use its own custom field display settings. If FALSE, entities
+ *     displayed in this view mode will reuse the 'default' display settings
+ *     by default (e.g. right after the module exposing the view mode is
+ *     enabled), but administrators can later use the Field UI to apply custom
+ *     display settings specific to the view mode.
+ *
+ * @see entity_view_mode_entity_info_alter()
+ * @see hook_entity_view_mode_info_alter()
+ */
+function hook_entity_view_mode_info() {
+  $view_modes['user']['full'] = array(
+    'label' => t('User account'),
+  );
+  $view_modes['user']['compact'] = array(
+    'label' => t('Compact'),
+    'custom_settings' => TRUE,
+  );
+  return $view_modes;
+}
+
+/**
+ * Alter the view modes for entity types.
+ *
+ * Note: This hook is invoked inside an implementation of
+ * hook_entity_info_alter() so care must be taken not to call anything that
+ * will result in an additional, and hence recurisve call to entity_get_info().
+ *
+ * @param array $view_modes
+ *   An array of view modes, keyed first by entity type, then by view mode name.
+ *
+ * @see entity_view_mode_entity_info_alter()
+ * @see hook_entity_view_mode_info()
+ */
+function hook_entity_view_mode_info_alter(&$view_modes) {
+  $view_modes['user']['full']['custom_settings'] = TRUE;
+}
+
+/**
+ * Change the view mode of an entity that is being displayed.
+ *
+ * @param string $view_mode
+ *   The view_mode that is to be used to display the entity.
+ * @param array $context
+ *   Array with contextual information, including:
+ *   - entity_type: The type of the entity that is being viewed.
+ *   - entity: The entity object.
+ *   - langcode: The langcode the entity is being viewed in.
+ */
+function hook_entity_view_mode_alter(&$view_mode, $context) {
+  // For nodes, change the view mode when it is teaser.
+  if ($context['entity_type'] == 'node' && $view_mode == 'teaser') {
+    $view_mode = 'my_custom_view_mode';
+  }
+}
+
+/**
+ * Act on a view mode before it is created or updated.
+ *
+ * @param string $view_mode
+ *   The view_mode that is to be used to display the entity.
+ * @param $entity_type
+ *   The type of entity being saved (i.e. node, user, comment).
+ */
+function hook_entity_view_mode_presave($view_mode, $entity_type) {
+  // Force all view modes to be saved with custom settings.
+  $view_mode['custom settings'] = TRUE;
+  return $view_mode;
+}
+
+/**
+ * Respond to creation of a new view mode.
+ *
+ * @param string $view_mode
+ *   The view_mode that is to be used to display the entity.
+ * @param $entity_type
+ *   The type of entity being saved (i.e. node, user, comment).
+ */
+function hook_entity_view_mode_insert($view_mode, $entity_type) {
+  config_set('my_module.view_modes', 'view_mode_list', array($entity_type => $view_mode);
+}
+
+/**
+ * Respond to update of a view mode.
+ *
+ * @param string $view_mode
+ *   The view_mode that is to be used to display the entity.
+ * @param $entity_type
+ *   The type of entity being saved (i.e. node, user, comment).
+ */
+function hook_entity_view_mode_update($view_mode, $entity_type) {
+  config_set('my_module.view_modes', 'view_mode_list', array($entity_type => $view_mode);
+}
+
+/**
+ * Respond to deletion of a view mode.
+ *
+ * @param string $view_mode
+ *   The view_mode that is to be used to display the entity.
+ * @param $entity_type
+ *   The type of entity being saved (i.e. node, user, comment).
+ */
+function hook_entity_view_mode_delete($view_mode, $entity_type) {
+  $config = config('my_module.view_modes');
+  $view_mode_list = $config->get('view_mode_list');
+  unset($view_mode_list[$view_mode['machine_name']]);
+  $config->set('view_mode_list', $view_mode_list);
+  $config->save();
+}
+
+/**
+ * Act on a view mode which is being renamed.
+ *
+ * @param $entity_type
+ *   The type of entity being saved (i.e. node, user, comment).
+ * @param string $old_view_mode_name
+ *   The name of the view_mode before it is renamed.
+ * @param string $new_view_mode_name
+ *   The name of the view_mode after it is renamed.
+ */
+function hook_entity_view_mode_rename($entity_type, $old_view_mode_name, $new_view_mode_name) {
+  $config = config('my_module.view_modes');
+  $view_mode_list = $config->get('view_mode_list');
+  if (isset($view_mode_list[$old_view_mode_name]) {
+    $view_mode_list[$new_view_mode_name] = $view_mode_list[$old_view_mode_name];
+    unset($view_mode_list[$old_view_mode_name]);
+  }
+  $config->set('view_mode_list', $view_mode_list);
+  $config->save();
+}

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -152,7 +152,10 @@ function entity_view_mode_save($entity_type, $view_mode) {
   }
 
   // Let modules modify the view mode before it is saved.
-  $view_mode = module_invoke_all('entity_view_mode_presave', $view_mode, $entity_type);
+  $view_mode_invoke = module_invoke_all('entity_view_mode_presave', $view_mode, $entity_type);
+  if (isset($view_mode_invoke)) {
+    $view_mode = array_merge($view_mode, $view_mode_invoke);
+  }
 
   // Save the view mode.
   $view_modes = config_get('entity.view_modes', 'view_modes');
@@ -480,7 +483,10 @@ function entity_get_info($entity_type = NULL) {
         backdrop_alter('entity_view_mode_info', $view_mode_info);
 
         // Add in the variable entity view modes which override hook-provided.
-        $view_mode_info = backdrop_array_merge_deep($view_mode_info, config_get('entity.view_modes', 'view_modes'));
+        $config = config_get('entity.view_modes', 'view_modes');
+        if ($config) {
+          $view_mode_info = backdrop_array_merge_deep($view_mode_info, $config);
+        }
 
         // Add in the combined custom entity view modes which override the existing
         // view modes in the entity information.

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -77,29 +77,31 @@ function entity_menu_local_tasks_alter(&$data, $router_item, $root_path) {
   // replace the load argument in the admin paths with a '%' and append
   // '/display' and check if this matches the current $root_path.
   $display = FALSE;
-  foreach (entity_get_info() as $entity_type => $entity_info) {
-    if ($entity_info['fieldable']) {
-      foreach ($entity_info['bundles'] as $bundle_name => $bundle_info) {
-        if (isset($bundle_info['admin'])) {
-          $path = $bundle_info['admin']['path'];
-          $root_path_string = '';
-          if (isset($bundle_info['admin']['bundle argument'])) {
-            $bundle_arg = $bundle_info['admin']['bundle argument'];
-            $parts = explode('/', $path);
-            $load_arg = $parts[$bundle_arg];
-            $root_path_string = str_replace($load_arg, '%', $path) . '/display';
-          }
-          else {
-            $root_path_string = $path . '/display';
-          }
-          if ($root_path_string == $root_path){
-            $display = TRUE;
+  // Only check if the $root_path ends in '/display'.
+  if (substr_compare($root_path, '/display', strlen($root_path)-8, 8) === 0) {
+    foreach (entity_get_info() as $entity_type => $entity_info) {
+      if (!empty($entity_info['fieldable'])) {
+        foreach ($entity_info['bundles'] as $bundle_name => $bundle_info) {
+          if (isset($bundle_info['admin'])) {
+            $path = $bundle_info['admin']['path'];
+            $root_path_string = '';
+            if (isset($bundle_info['admin']['bundle argument'])) {
+              $bundle_arg = $bundle_info['admin']['bundle argument'];
+              $parts = explode('/', $path);
+              $load_arg = $parts[$bundle_arg];
+              $root_path_string = str_replace($load_arg, '%', $path) . '/display';
+            }
+            else {
+              $root_path_string = $path . '/display';
+            }
+            if ($root_path_string == $root_path){
+              $display = TRUE;
+            }
           }
         }
       }
     }
   }
-  
   if ($display) {
     $item = menu_get_item('admin/config/system/view-modes');
     if ($item['access']) {
@@ -490,14 +492,15 @@ function entity_get_info($entity_type = NULL) {
 
         // Add in the combined custom entity view modes which override the existing
         // view modes in the entity information.
-        foreach ($view_mode_info as $entity_type => $view_modes) {
-          if (isset($entity_info[$entity_type])) {
-            if (!isset($entity_info[$entity_type]['view modes'])) {
-              $entity_info[$entity_type]['view modes'] = array();
+        foreach ($view_mode_info as $type => $view_modes) {
+          if (isset($entity_info[$type])) {
+            if (!isset($entity_info[$type]['view modes'])) {
+              $entity_info[$type]['view modes'] = array();
             }
-            $entity_info[$entity_type]['view modes'] = $entity_info[$entity_type]['view modes'] + $view_modes;
+            $entity_info[$type]['view modes'] = $entity_info[$type]['view modes'] + $view_modes;
           }
         }
+
         foreach ($entity_info[$name]['view modes'] as $view_mode => $view_mode_info) {
           $entity_info[$name]['view modes'][$view_mode] += array(
             'custom settings' => FALSE,
@@ -939,6 +942,22 @@ function entity_autoload_info() {
     'EntityFieldQueryException' => 'entity.query.inc',
     'EntityFieldQuery' => 'entity.query.inc',
   );
+}
+
+/**
+ * Implements hook_hook_info().
+ */
+function entity_hook_info() {
+  $hooks = array(
+    'entity_view_mode_info',
+    'entity_view_mode_info_alter',
+    'entity_view_mode_presave',
+    'entity_view_mode_insert',
+    'entity_view_mode_update',
+    'entity_view_mode_delete',
+  );
+
+  return array_fill_keys($hooks, array('group' => 'entity'));
 }
 
 /**

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -20,6 +20,401 @@ function entity_modules_disabled() {
 }
 
 /**
+ * Implements hook_permission().
+ */
+function entity_permission() {
+  return array(
+    'administer view modes' => array(
+      'title' => t('Add, edit and delete custom view modes.'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function entity_menu() {
+  $items['admin/config/system/view-modes'] = array(
+    'title' => 'View modes',
+    'description' => 'Create new custom view modes for content.',
+    'page callback' => 'entity_view_mode_list',
+    'access arguments' => array('administer view modes'),
+    'file' => 'entity.admin.inc',
+  );
+  $items['admin/config/system/view-modes/add/%'] = array(
+    'title' => 'Add view mode',
+    'page callback' => 'backdrop_get_form',
+    'page arguments' => array('entity_view_mode_edit_form', 5),
+    'access arguments' => array('administer view modes'),
+    'file' => 'entity.admin.inc',
+  );
+  $items['admin/config/system/view-modes/edit/%/%'] = array(
+    'title' => 'Edit view mode',
+    'page callback' => 'backdrop_get_form',
+    'page arguments' => array('entity_view_mode_edit_form', 5, 6),
+    'access arguments' => array('administer view modes'),
+    'file' => 'entity.admin.inc',
+  );
+  $items['admin/config/system/view-modes/delete/%/%'] = array(
+    'title' => 'Edit view mode',
+    'page callback' => 'backdrop_get_form',
+    'page arguments' => array('entity_view_mode_delete_form', 5, 6),
+    'access arguments' => array('administer view modes'),
+    'file' => 'entity.admin.inc',
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function entity_menu_local_tasks_alter(&$data, $router_item, $root_path) {
+  // On entity "Manage display" pages, $root_path is in the format 
+  // 'admin/structure/types/manage/%/display' whereas entity admin paths are in
+  // the format'admin/structure/types/manage/%node_type'. To determine if this
+  // is a display page for an entity we loop through all available entities and
+  // replace the load argument in the admin paths with a '%' and append
+  // '/display' and check if this matches the current $root_path.
+  $display = FALSE;
+  foreach (entity_get_info() as $entity_type => $entity_info) {
+    if ($entity_info['fieldable']) {
+      foreach ($entity_info['bundles'] as $bundle_name => $bundle_info) {
+        if (isset($bundle_info['admin'])) {
+          $path = $bundle_info['admin']['path'];
+          $root_path_string = '';
+          if (isset($bundle_info['admin']['bundle argument'])) {
+            $bundle_arg = $bundle_info['admin']['bundle argument'];
+            $parts = explode('/', $path);
+            $load_arg = $parts[$bundle_arg];
+            $root_path_string = str_replace($load_arg, '%', $path) . '/display';
+          }
+          else {
+            $root_path_string = $path . '/display';
+          }
+          if ($root_path_string == $root_path){
+            $display = TRUE;
+          }
+        }
+      }
+    }
+  }
+  
+  if ($display) {
+    $item = menu_get_item('admin/config/system/view-modes');
+    if ($item['access']) {
+      $item['title'] = t('Add view mode');
+      $data['actions']['output'][] = array(
+        '#theme' => 'menu_local_action',
+        '#link' => $item,
+      );
+    }
+  }
+}
+
+/**
+ * Load a custom entity view mode by entity type and machine name.
+ */
+function entity_view_mode_load($entity_type, $machine_name) {
+  $view_modes = config_get('entity.view_modes', 'view_modes');
+
+  if (!empty($view_modes[$entity_type][$machine_name])) {
+    // Ensure that the machine name is always available.
+    return $view_modes[$entity_type][$machine_name] + array('machine_name' => $machine_name);
+  }
+
+  return FALSE;
+}
+
+/**
+ * Save a custom view mode.
+ */
+function entity_view_mode_save($entity_type, $view_mode) {
+  $existing_view_mode_name = !empty($view_mode['old_machine_name']) ? $view_mode['old_machine_name'] : $view_mode['machine_name'];
+  $view_mode_name = $view_mode['machine_name'];
+
+  // Load the original, unchanged view mode, if it exists.
+  if ($original = entity_view_mode_load($entity_type, $existing_view_mode_name)) {
+    $view_mode['original'] = $original;
+    unset($view_mode['old_machine_name']);
+  }
+
+  // The key value for custom settings needs to be converted from
+  // 'custom_settings' to 'custom settings' before saving.
+  if (isset($view_mode['custom_settings'])) {
+    $view_mode['custom settings'] = (bool) $view_mode['custom_settings'];
+    unset($view_mode['custom_settings']);
+  }
+
+  // Determine if we will be inserting a new view mode.
+  if (!isset($view_mode['is_new'])) {
+    $view_mode['is_new'] = empty($view_mode['original']);
+  }
+
+  // Let modules modify the view mode before it is saved.
+  $view_mode = module_invoke_all('entity_view_mode_presave', $view_mode, $entity_type);
+
+  // Save the view mode.
+  $view_modes = config_get('entity.view_modes', 'view_modes');
+  unset($view_modes[$entity_type][$existing_view_mode_name]);
+  $view_modes[$entity_type][$view_mode_name] = array_intersect_key($view_mode, backdrop_map_assoc(array('label', 'custom settings')));
+  $view_modes[$entity_type][$view_mode_name] += array('custom settings' => TRUE);
+  config_set('entity.view_modes', 'view_modes', $view_modes);
+
+  // Allow modules to respond after the view mode is saved.
+  if ($view_mode['is_new']) {
+    module_invoke_all('entity_view_mode_insert', $view_mode, $entity_type);
+  }
+  else {
+    // If the view mode's machine name has changed, invoke a separate hook
+    // before running the update hook.
+    if ($view_mode_name != $existing_view_mode_name) {
+      module_invoke_all('entity_view_mode_rename', $entity_type, $existing_view_mode_name, $view_mode_name);
+    }
+    module_invoke_all('entity_view_mode_update', $view_mode, $entity_type);
+  }
+
+  // Clear internal properties.
+  unset($view_mode['original']);
+  unset($view_mode['is_new']);
+
+  // Clear the static entity info cache and rebuild the menu.
+  entity_info_cache_clear();
+  state_set('menu_rebuild_needed', TRUE);
+}
+
+/**
+ * Delete a custom view mode.
+ */
+function entity_view_mode_delete($entity_type, $machine_name) {
+  if ($view_mode = entity_view_mode_load($entity_type, $machine_name)) {
+    module_invoke_all('entity_view_mode_delete', $view_mode, $entity_type);
+
+    $config = config('entity.view_modes');
+    $view_modes = $config->get('entity_view_modes');
+    unset($view_modes[$entity_type][$machine_name]);
+    $config->set('view_modes', $view_modes);
+    $config->save();
+
+    // Clear the static entity info cache and rebuild the menu.
+    entity_info_cache_clear();
+    state_set('menu_rebuild_needed', TRUE);
+  }
+}
+
+/**
+ * Implements hook_entity_view_mode_insert() on behalf of core field module.
+ */
+function field_entity_view_mode_insert($view_mode, $entity_type) {
+  field_entity_view_mode_update($view_mode, $entity_type);
+}
+
+/**
+ * Implements hook_entity_view_mode_rename() on behalf of core field module.
+ */
+function field_entity_view_mode_rename($entity_type, $view_mode_old, $view_mode_new) {
+  $entity_info = entity_get_info($entity_type);
+
+  foreach (array_keys($entity_info['bundles']) as $bundle) {
+    // Update all field bundle settings for the renamed view mode.
+    $settings = field_bundle_settings($entity_type, $bundle);
+    $changed = FALSE;
+    if (isset($settings['view_modes'][$view_mode_old])) {
+      $settings['view_modes'][$view_mode_new] = $settings['view_modes'][$view_mode_old];
+      unset($settings['view_modes'][$view_mode_old]);
+      $changed = TRUE;
+    }
+    if (isset($settings['extra_fields']['display'][$view_mode_old])) {
+      $settings['extra_fields']['display'][$view_mode_new] = $settings['extra_fields']['display'][$view_mode_old];
+      unset($settings['extra_fields']['display'][$view_mode_old]);
+      $changed = TRUE;
+    }
+    if ($changed) {
+      field_bundle_settings($entity_type, $bundle, $settings);
+    }
+
+    // Update all field instance display settings for the renamed view mode.
+    $instances = field_read_instances(array('entity_type' => $entity_type, 'bundle' => $bundle));
+    foreach ($instances as $instance) {
+      // Remove the view mode settings from all configured field instances.
+      if (isset($instance['display'][$view_mode_old])) {
+        $instance['display'][$view_mode_new] = $instance['display'][$view_mode_old];
+        field_update_instance($instance);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_view_mode_update() on behalf of core field module.
+ */
+function field_entity_view_mode_update($view_mode, $entity_type) {
+  module_load_include('inc', 'field_ui', 'field_ui.admin');
+  $entity_info = entity_get_info($entity_type);
+  $view_mode_name = $view_mode['machine_name'];
+
+  // If custom settings is set to false, then we should be disabling this view
+  // view mode for all bundles.
+  //if (empty($view_mode['custom settings'])) {
+  //  $view_mode['enabled_bundles'] = array_fill_keys(array_keys($entity_info['bundles']), 0);
+  //}
+
+  if (!empty($view_mode['enabled_bundles'])) {
+    foreach ($view_mode['enabled_bundles'] as $bundle => $value) {
+      $bundle_settings = field_bundle_settings($entity_type, $bundle);
+
+      // Display a message for each view mode newly configured to use custom
+      // settings.
+      $view_mode_settings = field_view_mode_settings($entity_type, $bundle);
+      if (!empty($value) && empty($view_mode_settings[$view_mode_name]['custom_settings'])) {
+        $path = _field_ui_bundle_admin_path($entity_type, $bundle) . "/display/$view_mode_name";
+        backdrop_set_message(t('The %view_mode @entity_type @bundle view mode now uses custom display settings copied from the default view mode. You might want to <a href="@url">configure them</a>.', array(
+          '%view_mode' => $view_mode['label'],
+          '@entity_type' => $entity_info['label'],
+          '@bundle' => $entity_info['bundles'][$bundle]['label'],
+          '@url' => url($path, array('query' => backdrop_get_destination())),
+        )));
+        // Initialize the newly customized view mode with the display settings
+        // from the default view mode.
+        _field_ui_add_default_view_mode_settings($entity_type, $bundle, $view_mode_name, $bundle_settings);
+      }
+
+      // Save updated bundle settings.
+      $bundle_settings['view_modes'][$view_mode_name]['custom_settings'] = !empty($value);
+      field_bundle_settings($entity_type, $bundle, $bundle_settings);
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_view_mode_delete() on behalf of core field module.
+ */
+function field_entity_view_mode_delete($view_mode, $entity_type) {
+  $entity_info = entity_get_info($entity_type);
+  $view_mode_name = $view_mode['machine_name'];
+
+  foreach (array_keys($entity_info['bundles']) as $bundle) {
+    // Remove all field bundle settings for the deleted view mode.
+    $settings = field_bundle_settings($entity_type, $bundle);
+    if (isset($settings['view_modes'][$view_mode_name]) || isset($settings['extra_fields']['display'][$view_mode_name])) {
+      unset($settings['view_modes'][$view_mode_name]);
+      unset($settings['extra_fields']['display'][$view_mode_name]);
+      field_bundle_settings($entity_type, $bundle, $settings);
+    }
+
+    // Remove all field instance display settings for the deleted view mode.
+    $instances = field_read_instances(array('entity_type' => $entity_type, 'bundle' => $bundle));
+    foreach ($instances as $instance) {
+      // Remove the view mode settings from all configured field instances.
+      if (isset($instance['display'][$view_mode_name])) {
+        unset($instance['display'][$view_mode_name]);
+        field_update_instance($instance);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_view().
+ *
+ * @see entity_preprocess()
+ */
+function entity_entity_view($entity, $entity_type, $view_mode, $langcode) {
+  // Add context and variables necessary to entity_preprocess().
+  list($id, $vid, $bundle) = entity_extract_ids($entity_type, $entity);
+  $entity->content['#entity_view_mode'] = array(
+    'entity_type' => $entity_type,
+    'id' => $id,
+    'bundle' => $bundle,
+    'view_mode' => $view_mode,
+    'langcode' => $langcode,
+    'has_bundles' => TRUE,
+  );
+  if ($entity_type == $bundle) {
+    $info = entity_get_info($entity_type);
+    if (empty($info['entity keys']['bundle'])) {
+      $entity->content['#entity_view_mode']['has_bundles'] = FALSE;
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess().
+ *
+ * Add template suggestions for an entity based on view modes if they do not
+ * already exist.
+ *
+ * The eventual order of the entity's theme suggestions are:
+ * - entity-type__bundle (lowest priority = first in the array)
+ * - entity-type__bundle__view-mode
+ * - entity-type__id
+ * - entity-type__id__view-mode (highest priority = last in the array)
+ *
+ * @see entity_view_mode_entity_view()
+ */
+function entity_preprocess(&$variables, $hook) {
+  // Check for the context provided in entity_view_mode_entity_view().
+  if (!empty($variables['elements']['#entity_view_mode'])) {
+
+    // Sometimes a rendered entity is passed into another theme function, in
+    // which case we should not process. But also account that #theme may be a
+    // hook suggestion itself. For example. #theme = 'comment__node_type'
+    // and $hook = 'comment'.
+    if ($variables['elements']['#theme'] != $hook && strpos($variables['elements']['#theme'], $hook . '__') !== 0) {
+      return;
+    }
+
+    extract($variables['elements']['#entity_view_mode']);
+    $suggestions = &$variables['theme_hook_suggestions'];
+
+    // Ensure the base suggestions exist and if not, add them.
+    if ($has_bundles && !in_array("{$entity_type}__{$bundle}", $suggestions)) {
+      // The entity-type__bundle suggestion is typically "first".
+      array_unshift($suggestions, "{$entity_type}__{$bundle}");
+    }
+    if (!in_array("{$entity_type}__{$id}", $suggestions)) {
+      // The entity-type__id suggestion is always "last".
+      array_push($suggestions, "{$entity_type}__{$id}");
+    }
+
+    // Add view mode suggestions based on the location of the base suggestions.
+    if ($has_bundles && !in_array("{$entity_type}__{$bundle}__{$view_mode}", $suggestions)) {
+      $index = array_search("{$entity_type}__{$bundle}", $suggestions);
+      array_splice($suggestions, $index + 1, 0, "{$entity_type}__{$bundle}__{$view_mode}");
+    }
+    if (!in_array("{$entity_type}__{$id}__{$view_mode}", $suggestions)) {
+      $index = array_search("{$entity_type}__{$id}", $suggestions);
+      array_splice($suggestions, $index + 1, 0, "{$entity_type}__{$id}__{$view_mode}");
+    }
+  }
+}
+
+function entity_view_mode_get_enabled_bundles($entity_type, $view_mode_name) {
+  $bundles = array();
+
+  $entity_info = entity_get_info($entity_type);
+  foreach ($entity_info['bundles'] as $bundle => $bundle_info) {
+    $view_mode_settings = field_view_mode_settings($entity_type, $bundle);
+    if (!empty($view_mode_settings[$view_mode_name]['custom_settings'])) {
+      $bundles[$bundle] = $bundle_info['label'];
+    }
+  }
+
+  return $bundles;
+}
+
+function entity_view_mode_get_possible_bundles($entity_type) {
+  $bundles = array();
+
+  $entity_info = entity_get_info($entity_type);
+  foreach ($entity_info['bundles'] as $bundle => $bundle_info) {
+    $bundles[$bundle] = $bundle_info['label'];
+  }
+
+  return $bundles;
+}
+
+/**
  * Gets the entity info array of an entity type.
  *
  * @param $entity_type
@@ -67,11 +462,6 @@ function entity_get_info($entity_type = NULL) {
           'revision' => '',
           'bundle' => '',
         );
-        foreach ($entity_info[$name]['view modes'] as $view_mode => $view_mode_info) {
-          $entity_info[$name]['view modes'][$view_mode] += array(
-            'custom settings' => FALSE,
-          );
-        }
         // If no bundle key is provided, assume a single bundle, named after
         // the entity type.
         if (empty($entity_info[$name]['entity keys']['bundle']) && empty($entity_info[$name]['bundles'])) {
@@ -84,6 +474,28 @@ function entity_get_info($entity_type = NULL) {
           if (isset($entity_info[$name]['revision table'])) {
             $entity_info[$name]['schema_fields_sql']['revision table'] = backdrop_schema_fields_sql($entity_info[$name]['revision table']);
           }
+        }
+
+        $view_mode_info = module_invoke_all('entity_view_mode_info');
+        backdrop_alter('entity_view_mode_info', $view_mode_info);
+
+        // Add in the variable entity view modes which override hook-provided.
+        $view_mode_info = backdrop_array_merge_deep($view_mode_info, config_get('entity.view_modes', 'view_modes'));
+
+        // Add in the combined custom entity view modes which override the existing
+        // view modes in the entity information.
+        foreach ($view_mode_info as $entity_type => $view_modes) {
+          if (isset($entity_info[$entity_type])) {
+            if (!isset($entity_info[$entity_type]['view modes'])) {
+              $entity_info[$entity_type]['view modes'] = array();
+            }
+            $entity_info[$entity_type]['view modes'] = $entity_info[$entity_type]['view modes'] + $view_modes;
+          }
+        }
+        foreach ($entity_info[$name]['view modes'] as $view_mode => $view_mode_info) {
+          $entity_info[$name]['view modes'][$view_mode] += array(
+            'custom settings' => FALSE,
+          );
         }
       }
       // Let other modules alter the entity info.
@@ -521,4 +933,15 @@ function entity_autoload_info() {
     'EntityFieldQueryException' => 'entity.query.inc',
     'EntityFieldQuery' => 'entity.query.inc',
   );
+}
+
+/**
+ * Implements hook_config_info().
+ */
+function entity_config_info() {
+  $prefixes['entity.view_modes'] = array(
+    'label' => t('View mode settings'),
+    'group' => t('Entity'),
+  );
+  return $prefixes;
 }

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -34,31 +34,38 @@ function entity_permission() {
  * Implements hook_menu().
  */
 function entity_menu() {
-  $items['admin/config/system/view-modes'] = array(
+  $items['admin/structure/view-modes'] = array(
     'title' => 'View modes',
     'description' => 'Create new custom view modes for content.',
     'page callback' => 'entity_view_mode_list',
     'access arguments' => array('administer view modes'),
     'file' => 'entity.admin.inc',
   );
-  $items['admin/config/system/view-modes/add/%'] = array(
+  $items['admin/structure/view-modes/add'] = array(
     'title' => 'Add view mode',
     'page callback' => 'backdrop_get_form',
-    'page arguments' => array('entity_view_mode_edit_form', 5),
+    'page arguments' => array('entity_view_mode_edit_form'),
     'access arguments' => array('administer view modes'),
     'file' => 'entity.admin.inc',
   );
-  $items['admin/config/system/view-modes/edit/%/%'] = array(
-    'title' => 'Edit view mode',
+  $items['admin/structure/view-modes/add/%'] = array(
+    'title' => 'Add view mode',
     'page callback' => 'backdrop_get_form',
-    'page arguments' => array('entity_view_mode_edit_form', 5, 6),
+    'page arguments' => array('entity_view_mode_edit_form', 4),
     'access arguments' => array('administer view modes'),
     'file' => 'entity.admin.inc',
   );
-  $items['admin/config/system/view-modes/delete/%/%'] = array(
+  $items['admin/structure/view-modes/edit/%/%'] = array(
     'title' => 'Edit view mode',
     'page callback' => 'backdrop_get_form',
-    'page arguments' => array('entity_view_mode_delete_form', 5, 6),
+    'page arguments' => array('entity_view_mode_edit_form', 4, 5),
+    'access arguments' => array('administer view modes'),
+    'file' => 'entity.admin.inc',
+  );
+  $items['admin/structure/view-modes/delete/%/%'] = array(
+    'title' => 'Edit view mode',
+    'page callback' => 'backdrop_get_form',
+    'page arguments' => array('entity_view_mode_delete_form', 4, 5),
     'access arguments' => array('administer view modes'),
     'file' => 'entity.admin.inc',
   );
@@ -70,42 +77,9 @@ function entity_menu() {
  * Implements hook_menu_local_tasks_alter().
  */
 function entity_menu_local_tasks_alter(&$data, $router_item, $root_path) {
-  // On entity "Manage display" pages, $root_path is in the format 
-  // 'admin/structure/types/manage/%/display' whereas entity admin paths are in
-  // the format'admin/structure/types/manage/%node_type'. To determine if this
-  // is a display page for an entity we loop through all available entities and
-  // replace the load argument in the admin paths with a '%' and append
-  // '/display' and check if this matches the current $root_path.
-  $display = FALSE;
-  // Only check if the $root_path ends in '/display'.
-  if (substr_compare($root_path, '/display', strlen($root_path)-8, 8) === 0) {
-    foreach (entity_get_info() as $entity_type => $entity_info) {
-      if (!empty($entity_info['fieldable'])) {
-        foreach ($entity_info['bundles'] as $bundle_name => $bundle_info) {
-          if (isset($bundle_info['admin'])) {
-            $path = $bundle_info['admin']['path'];
-            $root_path_string = '';
-            if (isset($bundle_info['admin']['bundle argument'])) {
-              $bundle_arg = $bundle_info['admin']['bundle argument'];
-              $parts = explode('/', $path);
-              $load_arg = $parts[$bundle_arg];
-              $root_path_string = str_replace($load_arg, '%', $path) . '/display';
-            }
-            else {
-              $root_path_string = $path . '/display';
-            }
-            if ($root_path_string == $root_path){
-              $display = TRUE;
-            }
-          }
-        }
-      }
-    }
-  }
-  if ($display) {
-    $item = menu_get_item('admin/config/system/view-modes');
+  if ($root_path == 'admin/structure/view-modes') {
+    $item = menu_get_item('admin/structure/view-modes/add');
     if ($item['access']) {
-      $item['title'] = t('Add view mode');
       $data['actions']['output'][] = array(
         '#theme' => 'menu_local_action',
         '#link' => $item,
@@ -408,6 +382,9 @@ function entity_view_mode_get_enabled_bundles($entity_type, $view_mode_name) {
   return $bundles;
 }
 
+/**
+ * Helper function. Returns bundles in format suitable for form checlist.
+ */
 function entity_view_mode_get_possible_bundles($entity_type) {
   $bundles = array();
 

--- a/core/modules/entity/tests/entity.test
+++ b/core/modules/entity/tests/entity.test
@@ -95,3 +95,302 @@ class EntityAPIInfoTestCase extends BackdropWebTestCase  {
     $this->assertEqual($info['controller class'], 'DefaultEntityController', 'Entity controller class info is correct.');
   }
 }
+
+
+/**
+ * Helper class for testing view mode functionality.
+ */
+class EntityViewModeTestHelper extends BackdropWebTestCase {
+  /**
+   * Overrides BackdropWebTestCase::setUp().
+   */
+  public function setUp(array $modules = array()) {
+    $modules[] = 'entity_view_mode_test';
+    parent::setUp($modules);
+
+    // Create an administrative user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'administer view modes',
+      'administer content types',
+    ));
+  }
+
+  /**
+   * Overrides BackdropWebTestCase::refreshVariables().
+   *
+   * Ensures that the entity and field view mode caches are cleared so they
+   * can be reliably checked in the test.
+   */
+  protected function refreshVariables() {
+    parent::refreshVariables();
+
+    // Clear the entity and display caches.
+    backdrop_static_reset('field_view_mode_settings');
+    entity_info_cache_clear();
+  }
+
+  public function assertViewModeExists($entity_type, $view_mode) {
+    $info = entity_get_info($entity_type);
+    return $this->assertTrue(!empty($info['view modes'][$view_mode]), "View mode $view_mode found for entity type $entity_type.");
+  }
+
+  public function assertNoViewModeExists($entity_type, $view_mode) {
+    $info = entity_get_info($entity_type);
+    return $this->assertTrue(!isset($info['view modes'][$view_mode]), "View mode $view_mode not found for entity type $entity_type.");
+  }
+
+  public function getActualViewMode($entity_type, $bundle, $view_mode) {
+    $view_mode_settings = field_view_mode_settings($entity_type, $bundle);
+    return (!empty($view_mode_settings[$view_mode]['custom_settings']) ? $view_mode : 'default');
+  }
+
+  public function assertActualViewMode($entity_type, $bundle, $view_mode, $expected_view_mode) {
+    $actual_view_mode = $this->getActualViewMode($entity_type, $bundle, $view_mode);
+    return $this->assertIdentical($expected_view_mode, $actual_view_mode, "View mode $view_mode for entity type $entity_type and bundle $bundle actually uses view mode $actual_view_mode, expected $expected_view_mode.");
+  }
+
+  public function assertViewModeDefaultDisplay($entity_type, $bundle, $view_mode) {
+    return $this->assertActualViewMode($entity_type, $bundle, $view_mode, 'default');
+  }
+
+  public function assertViewModeCustomDisplay($entity_type, $bundle, $view_mode) {
+    return $this->assertActualViewMode($entity_type, $bundle, $view_mode, $view_mode);
+  }
+}
+
+/**
+ * Tests view mode functionality.
+ */
+class EntityViewModeFunctionalTest extends EntityViewModeTestHelper {
+  /**
+   * Tests view mode functionality.
+   */
+  public function testEntityViewModes() {
+    $this->backdropLogin($this->admin_user);
+    $this->backdropGet('admin/config/system/view-modes');
+    $this->assertLinkByHref('admin/config/system/view-modes/add/node');
+    $this->backdropGet('admin/config/system/view-modes/add/node');
+
+    // @todo Set some 'default' settings under a field instance display and
+    // view mode settings to test that the default settings are applied to
+    // custom view modes.
+    //$settings = field_bundle_settings('node', 'post');
+    //$settings['extra_fields']['display']['test']['default']['testing'] = TRUE;
+    //field_bundle_settings('node', 'post', $settings);
+    //$settings = field_bundle_settings('node', 'page');
+    //$settings['extra_fields']['display']['test']['default']['testing'] = TRUE;
+    //field_bundle_settings('node', 'page', $settings);
+
+    // Attempt to create a view mode that already is provided by core.
+    $edit = array(
+      'label' => 'Custom teaser',
+      'machine_name' => 'teaser',
+    );
+    $this->backdropPost(NULL, $edit, 'Save');
+    $this->assertText('The machine-readable name is already in use. It must be unique.');
+
+    // Save a new view mode for real.
+    $edit['label'] = 'Custom 1';
+    $edit['machine_name'] = 'custom_1';
+    $edit['enabled_bundles[post]'] = TRUE;
+    $edit['enabled_bundles[page]'] = FALSE;
+    $this->backdropPost(NULL, $edit, 'Save');
+    $this->assertViewModeExists('node', 'custom_1');
+    $this->assertViewModeCustomDisplay('node', 'post', 'custom_1');
+    $this->assertViewModeDefaultDisplay('node', 'page', 'custom_1');
+
+    // Switch the view mode from posts to pages.
+    $edit = array(
+      'enabled_bundles[post]' => FALSE,
+      'enabled_bundles[page]' => TRUE,
+    );
+    $this->backdropPost('admin/config/system/view-modes/edit/node/custom_1', $edit, 'Save');
+    $this->assertText('Saved the Custom 1 node view mode.');
+    $this->assertViewModeExists('node', 'custom_1');
+    $this->assertViewModeDefaultDisplay('node', 'post', 'custom_1');
+    $this->assertViewModeCustomDisplay('node', 'page', 'custom_1');
+
+    // Save a custom value into the view mode settings to check that when a
+    // view mode's machine name is changed, that the display settings are
+    // changed as well.
+    //$settings = field_bundle_settings('node', 'page');
+    //$settings['view_modes']['custom_1']['testing'] = TRUE;
+    //$settings['extra_fields']['display']['testing']['custom_1']['custom_1']['testing'] = TRUE;
+    //field_bundle_settings('node', 'page', $settings);
+
+    // Rename the view mode's label and machine name.
+    $edit = array(
+      'label' => 'Custom 2',
+      'machine_name' => 'custom_2',
+    );
+    $this->backdropPost('admin/config/system/view-modes/edit/node/custom_1', $edit, 'Save');
+    $this->assertText('Saved the Custom 2 node view mode.');
+    $this->assertNoViewModeExists('node', 'custom_1');
+    $this->assertViewModeDefaultDisplay('node', 'post', 'custom_1');
+    $this->assertViewModeDefaultDisplay('node', 'page', 'custom_1');
+    $this->assertViewModeExists('node', 'custom_2');
+    $this->assertViewModeDefaultDisplay('node', 'post', 'custom_2');
+    $this->assertViewModeCustomDisplay('node', 'page', 'custom_2');
+
+    // Check that our custom value was transferred to the new view mode
+    // settings.
+    //$settings = field_bundle_settings('node', 'page');
+    //$this->assertTrue(!isset($settings['view_modes']['custom_1']) && !isset($settings['extra_fields']['display']['custom_1']));
+    //$this->assertTrue(!empty($settings['view_modes']['custom_2']['testing']) && !empty($settings['extra_fields']['display']['custom_2']['testing']));
+
+    // Delete the view mode.
+    $this->backdropPost('admin/config/system/view-modes/delete/node/custom_2', array(), 'Delete');
+    $this->assertText('Deleted the Custom 2 node view mode.');
+    $this->assertNoViewModeExists('node', 'custom_2');
+    $this->assertViewModeDefaultDisplay('node', 'post', 'custom_2');
+    $this->assertViewModeDefaultDisplay('node', 'page', 'custom_2');
+  }
+
+  /**
+   * Test the new entity view mode hooks.
+   */
+  public function testInfoHooks() {
+    config_set('entity.view_modes', 'view_modes', array(
+      'node' => array(
+        'info_3' => array(
+          'label' => t('Variable-altered view mode'),
+          'custom settings' => TRUE,
+        ),
+      ),
+      'taxonomy_term' => array(),
+    ));
+    $this->refreshVariables();
+
+    $info = entity_get_info();
+
+    // An invalid entity type in hook_entity_view_mode_info() does not pass
+    // into the entity info array.
+    $this->assertTrue(!isset($info['invalid-type']));
+
+    // Test hook-provided view modes.
+    $this->assertIdentical($info['node']['view modes']['info_1'], array(
+      'label' => t('Hook-defined view mode #1'),
+      'custom settings' => FALSE,
+    ));
+    $this->assertIdentical($info['node']['view modes']['info_2'], array(
+      'label' => t('Hook-altered view mode'),
+      'custom settings' => TRUE,
+    ));
+    $this->assertIdentical($info['node']['view modes']['info_3'], array(
+      'label' => t('Variable-altered view mode'),
+      'custom settings' => TRUE,
+    ));
+    $this->assertIdentical($info['taxonomy_term']['view modes']['info_1'], array(
+      'label' => t('Hook-defined view mode #1'),
+      'custom settings' => TRUE,
+    ));
+
+    // Test that entity view modes defined in hook_entity_info() are never
+    // overridden by custom view modes.
+    $this->assertIdentical($info['node']['view modes']['full'], array(
+      'label' => 'Full content',
+      'custom settings' => FALSE,
+    ));
+  }
+}
+
+/**
+ * Tests view mode altering theme suggestions.
+ */
+class EntityViewModeSuggestionsTest extends EntityViewModeTestHelper {
+  /**
+   * Overrides EntityViewModeTestHelper::setUp().
+   */
+  public function setUp(array $modules = array()) {
+    parent::setUp($modules);
+
+    // Core RDF module causes PHP notices with entity rendering.
+    module_disable(array('rdf'));
+
+    backdrop_static_reset('theme_get_registry');
+  }
+
+  public function testEntityTemplateSuggestions() {
+    $node = $this->backdropCreateNode();
+    $build = node_view($node, 'node_test');
+    $actual_suggestions = theme($build['#theme'], $build);
+    $expected_suggestions = array(
+      'node__' . $node->nid . '__node_test',
+      'node__' . $node->nid,
+      'node__' . $node->type . '__node_test',
+      'node__' . $node->type,
+    );
+    $this->assertIdentical($actual_suggestions, $expected_suggestions);
+
+    // Rendering comments uses '#theme' => 'comment__node_type'.
+    $comment = (object) array(
+      'cid' => NULL,
+      'nid' => $node->nid,
+      'pid' => 0,
+      'uid' => 0,
+      'status' => COMMENT_PUBLISHED,
+      'subject' => $this->randomName(),
+      'language' => LANGUAGE_NONE,
+      'comment_body' => array(LANGUAGE_NONE => array($this->randomName())),
+    );
+    comment_save($comment);
+    $build = comment_view($comment, $node, 'comment_test');
+    $actual_suggestions = theme($build['#theme'], $build);
+    $expected_suggestions = array(
+      'comment__' . $comment->cid . '__comment_test',
+      'comment__' . $comment->cid,
+      'comment__' . 'comment_node_' . $node->type . '__comment_test',
+      'comment__' . 'comment_node_' . $node->type,
+    );
+    $this->assertIdentical($actual_suggestions, $expected_suggestions);
+
+    // Users have no bundles.
+    $account = $this->admin_user;
+    $build = user_view($this->admin_user, 'user_test');
+    $actual_suggestions = theme($build['#theme'], $build);
+    $expected_suggestions = array(
+      'user__' . $account->uid . '__user_test',
+      'user__' . $account->uid,
+    );
+    $this->assertIdentical($actual_suggestions, $expected_suggestions);
+
+    $term = (object) array(
+      'name' => $this->randomName(),
+      'vocabulary_machine_name' => 'tags',
+    );
+    taxonomy_term_save($term);
+    $build = taxonomy_term_view($term, 'term_test');
+    $actual_suggestions = theme($build['#theme'], $build);
+    $expected_suggestions = array(
+      'taxonomy_term__' . $term->tid . '__term_test',
+      'taxonomy_term__' . $term->tid,
+      'taxonomy_term__' . $term->vocabulary_machine_name . '__term_test',
+      'taxonomy_term__' . $term->vocabulary_machine_name,
+    );
+    $this->assertIdentical($actual_suggestions, $expected_suggestions);
+
+    // Test the proper ordering of suggestions using the custom testing
+    // theme function.
+    $build = array(
+      '#theme' => 'entity_view_mode_test',
+      '#entity_view_mode' => array(
+        'entity_type' => 'test',
+        'id' => 'id',
+        'bundle' => 'bundle',
+        'view_mode' => 'view_mode',
+        'langcode' => 'xx-test',
+        'has_bundles' => TRUE,
+      ),
+    );
+    $actual_suggestions = theme($build['#theme'], $build);
+    $expected_suggestions = array(
+      'test__first',
+      'test__id__view_mode',
+      'test__id',
+      'test__bundle__view_mode',
+      'test__bundle',
+      'test__last',
+    );
+    $this->assertIdentical($actual_suggestions, $expected_suggestions);
+  }
+}

--- a/core/modules/entity/tests/entity.test
+++ b/core/modules/entity/tests/entity.test
@@ -304,9 +304,8 @@ class EntityViewModeSuggestionsTest extends EntityViewModeTestHelper {
   public function setUp(array $modules = array()) {
     parent::setUp($modules);
 
-    // Core RDF module causes PHP notices with entity rendering.
-    module_disable(array('rdf'));
-
+    state_set('entity_view_mode_theme_output_suggestions', array('comment', 'node', 'taxonomy_term', 'user_profile'));
+    backdrop_theme_rebuild();
     backdrop_static_reset('theme_get_registry');
   }
 
@@ -323,7 +322,8 @@ class EntityViewModeSuggestionsTest extends EntityViewModeTestHelper {
     $this->assertIdentical($actual_suggestions, $expected_suggestions);
 
     // Rendering comments uses '#theme' => 'comment__node_type'.
-    $comment = (object) array(
+    $comment_body = $this->randomName();
+    $comment = entity_create('comment', array(
       'cid' => NULL,
       'nid' => $node->nid,
       'pid' => 0,
@@ -331,9 +331,14 @@ class EntityViewModeSuggestionsTest extends EntityViewModeTestHelper {
       'status' => COMMENT_PUBLISHED,
       'subject' => $this->randomName(),
       'language' => LANGUAGE_NONE,
-      'comment_body' => array(LANGUAGE_NONE => array($this->randomName())),
-    );
+      'comment_body' => array(LANGUAGE_NONE => array($comment_body)),
+    ));
+
     comment_save($comment);
+    $comment->comment_body[LANGUAGE_NONE][0] = array(
+      'value' => $comment_body,
+      'format' => 'filtered_html',
+    );
     $build = comment_view($comment, $node, 'comment_test');
     $actual_suggestions = theme($build['#theme'], $build);
     $expected_suggestions = array(
@@ -354,18 +359,18 @@ class EntityViewModeSuggestionsTest extends EntityViewModeTestHelper {
     );
     $this->assertIdentical($actual_suggestions, $expected_suggestions);
 
-    $term = (object) array(
+    $term = entity_create('taxonomy_term',  array(
       'name' => $this->randomName(),
-      'vocabulary_machine_name' => 'tags',
-    );
+      'vocabulary' => 'tags',
+    ));
     taxonomy_term_save($term);
     $build = taxonomy_term_view($term, 'term_test');
     $actual_suggestions = theme($build['#theme'], $build);
     $expected_suggestions = array(
       'taxonomy_term__' . $term->tid . '__term_test',
       'taxonomy_term__' . $term->tid,
-      'taxonomy_term__' . $term->vocabulary_machine_name . '__term_test',
-      'taxonomy_term__' . $term->vocabulary_machine_name,
+      'taxonomy_term__' . $term->vocabulary . '__term_test',
+      'taxonomy_term__' . $term->vocabulary,
     );
     $this->assertIdentical($actual_suggestions, $expected_suggestions);
 

--- a/core/modules/entity/tests/entity.tests.info
+++ b/core/modules/entity/tests/entity.tests.info
@@ -27,3 +27,15 @@ name = Entity loading
 description = Tests the entity_load() function.
 group = Entity API
 file = entity_crud.test
+
+[EntityViewModeFunctionalTest]
+name = View modes
+description = Tests view mode functionality.
+group = Entity API
+file = entity.test
+
+[EntityViewModeSuggestionsTest]
+name = View mode suggestions
+description = Tests view mode altering theme suggestions.
+group = Entity API
+file = entity.test

--- a/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.entity.inc
+++ b/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.entity.inc
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Entity view mode integration for the entity_view_mode_test module.
+ */
+
+/**
+ * Implements hook_entity_view_mode_info().
+ */
+function entity_view_mode_test_entity_view_mode_info() {
+  $info['node']['info_1'] = array(
+    'label' => t('Hook-defined view mode #1'),
+  );
+  $info['node']['info_2'] = array(
+    'label' => t('Hook-defined view mode #2'),
+    'custom settings' => FALSE,
+  );
+  $info['node']['info_3'] = array(
+    'label' => t('Hook-defined view mode #3'),
+  );
+  $info['node']['full'] = array(
+    'label' => t('Full view mode already defined by core.'),
+    'custom settings' => TRUE,
+  );
+
+  $info['taxonomy_term']['info_1'] = array(
+    'label' => t('Hook-defined view mode #1'),
+    'custom settings' => TRUE,
+  );
+
+  // Invalid entity type.
+  $info['invalid-type']['test'] = array(
+    'label' => t('Test view mode'),
+  );
+
+  // Call entity_get_info() from inside this hook to test recursion prevention.
+  foreach (entity_get_info() as $entity_type => $entity_info) {
+    $info[$entity_type]['recursion'] = array(
+      'label' => t('Recursion'),
+    );
+  }
+
+  return $info;
+}
+
+/**
+ * Implements hook_entity_view_mode_info_alter().
+ */
+function entity_view_mode_test_entity_view_mode_info_alter(&$info) {
+  $info['node']['info_2']['label'] = t('Hook-altered view mode');
+  $info['node']['info_2']['custom settings'] = TRUE;
+}

--- a/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.info
+++ b/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.info
@@ -1,0 +1,5 @@
+name = Entity view mode test
+description = Testing module.
+core = 7.x
+hidden = TRUE
+type = module

--- a/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.module
+++ b/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.module
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Test module for the entity_view_mode module.
+ */
+
+/**
+ * Implements hook_theme().
+ */
+function entity_view_mode_test_theme() {
+  $info = array();
+
+  $info['entity_view_mode_test'] = array(
+    'render element' => 'elements',
+    // Template needs to be set in order to actually have preprocess functions
+    // added to its registry.
+    'template' => 'does-not-exist',
+    'function' => 'entity_view_mode_test_return_suggestions',
+  );
+
+  return $info;
+}
+
+function template_preprocess_entity_view_mode_test(&$variables) {
+  $variables['theme_hook_suggestions'][] = 'test__last';
+  $variables['theme_hook_suggestions'][] = 'test__bundle';
+  $variables['theme_hook_suggestions'][] = 'test__id';
+  $variables['theme_hook_suggestions'][] = 'test__first';
+}
+
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function entity_view_mode_test_theme_registry_alter(&$registry) {
+  if ($hooks = variable_get('entity_view_mode_theme_output_suggestions', array())) {
+    foreach ($hooks as $hook) {
+      if (isset($registry[$hook])) {
+        $registry[$hook]['function'] = 'entity_view_mode_test_return_suggestions';
+      }
+    }
+  }
+}
+
+function entity_view_mode_test_return_suggestions(array $variables) {
+  $suggestions = array();
+  if (!empty($variables['theme_hook_suggestions'])) {
+    $suggestions = $variables['theme_hook_suggestions'];
+  }
+  if (!empty($variables['theme_hook_suggestion'])) {
+    $suggestions[] = $variables['theme_hook_suggestion'];
+  }
+  return array_reverse($suggestions);
+}

--- a/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.module
+++ b/core/modules/entity/tests/entity_view_mode_test/entity_view_mode_test.module
@@ -33,7 +33,7 @@ function template_preprocess_entity_view_mode_test(&$variables) {
  * Implements hook_theme_registry_alter().
  */
 function entity_view_mode_test_theme_registry_alter(&$registry) {
-  if ($hooks = variable_get('entity_view_mode_theme_output_suggestions', array())) {
+  if ($hooks = state_get('entity_view_mode_theme_output_suggestions', array())) {
     foreach ($hooks as $hook) {
       if (isset($registry[$hook])) {
         $registry[$hook]['function'] = 'entity_view_mode_test_return_suggestions';

--- a/core/modules/field_ui/field_ui.admin.inc
+++ b/core/modules/field_ui/field_ui.admin.inc
@@ -1109,7 +1109,7 @@ function field_ui_display_overview_form($form, &$form_state, $entity_type, $bund
 
   $form['fields'] = $table;
 
-  // Custom display settings.
+  // View modes.
   if ($view_mode == 'default') {
     $form['modes'] = array(
       '#type' => 'fieldset',
@@ -1132,10 +1132,15 @@ function field_ui_display_overview_form($form, &$form_state, $entity_type, $bund
     }
     $form['modes']['view_modes_custom'] = array(
       '#type' => 'checkboxes',
-      '#title' => t('Use custom display settings for the following view modes'),
       '#options' => $options,
       '#default_value' => $default,
     );
+    if (user_access('administer view modes')) {
+      $form['modes']['add'] = array(
+        '#type' => 'markup',
+        '#markup' => l(t('+ Add view mode'), 'admin/structure/view-modes/add/' . $entity_type),
+      );
+    }
   }
 
   // In overviews involving nested rows from contributed modules (i.e

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -59,24 +59,6 @@ function hook_hook_info_alter(&$hooks) {
 }
 
 /**
- * Change the view mode of an entity that is being displayed.
- *
- * @param string $view_mode
- *   The view_mode that is to be used to display the entity.
- * @param array $context
- *   Array with contextual information, including:
- *   - entity_type: The type of the entity that is being viewed.
- *   - entity: The entity object.
- *   - langcode: The langcode the entity is being viewed in.
- */
-function hook_entity_view_mode_alter(&$view_mode, $context) {
-  // For nodes, change the view mode when it is teaser.
-  if ($context['entity_type'] == 'node' && $view_mode == 'teaser') {
-    $view_mode = 'my_custom_view_mode';
-  }
-}
-
-/**
  * Define administrative paths.
  *
  * Modules may specify whether or not the paths they define in hook_menu() are


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/315

Replaces https://github.com/backdrop/backdrop/pull/1645 (and includes the commits)

Also includes:
* a single table of view mode info
* action link to add a new view mode on view modes page
* removed action link to add view modes on manage display pages (see next)
* added "Add view mode" link into view mode section on manage display pages
* changed the "Type" column to "Storage state" to be consistent with the rest of core.
* moved the settings page under 'structure'
* hid the descriptions about un-checking when adding a new view mode
* added AJAX on the add form for entity/bundle selection