### PR TITLE
Issue #2386: Enable browser spellcheck on ckeditor fields.

### DIFF
--- a/core/modules/ckeditor/ckeditor.module
+++ b/core/modules/ckeditor/ckeditor.module
@@ -484,6 +484,7 @@ function ckeditor_get_settings($format, $existing_settings) {
     //'format_tags' => implode(';', $format->editor_settings['format_list']),
     'language' => isset($language->language) ? $language->language : '',
     'resize_dir' => 'vertical',
+    'disableNativeSpellChecker' => FALSE,
   );
 
   // Add the allowedContent setting, which ensures CKEditor only allows tags


### PR DESCRIPTION
This fixes #2386 