### PR TITLE
Issue #2301: [UX] Rename "Admin content" and "Comments" to "Manage co…

### DIFF
--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -176,7 +176,7 @@ function comment_theme() {
  */
 function comment_menu() {
   $items['admin/content/comment'] = array(
-    'title' => 'Comments',
+    'title' => 'Manage comments',
     'description' => 'List and edit site comments and the comment approval queue.',
     'page callback' => 'comment_admin',
     'access arguments' => array('administer comments'),

--- a/core/modules/node/config/views.view.manage_content.json
+++ b/core/modules/node/config/views.view.manage_content.json
@@ -409,7 +409,7 @@
                         "ui_name": "",
                         "label": "",
                         "empty": true,
-                        "content": "No content available.",
+                        "content": "No content found.",
                         "tokenize": 0
                     }
                 },

--- a/core/modules/node/config/views.view.manage_content.json
+++ b/core/modules/node/config/views.view.manage_content.json
@@ -1,6 +1,6 @@
 {
-    "_config_name": "views.view.node_admin_content",
-    "name": "node_admin_content",
+    "_config_name": "views.view.manage_content",
+    "name": "manage_content",
     "description": "",
     "module": "node",
     "storage": 4,

--- a/core/modules/node/config/views.view.manage_content.json
+++ b/core/modules/node/config/views.view.manage_content.json
@@ -385,7 +385,7 @@
                         "order": "DESC"
                     }
                 },
-                "title": "Manage content",
+                "title": "Content",
                 "relationships": {
                     "uid": {
                         "id": "uid",

--- a/core/modules/node/config/views.view.manage_content.json
+++ b/core/modules/node/config/views.view.manage_content.json
@@ -7,7 +7,7 @@
     "tag": "default",
     "disabled": false,
     "base_table": "node",
-    "human_name": "Admin Content",
+    "human_name": "Manage content",
     "core": "1.0",
     "display": {
         "default": {
@@ -385,7 +385,7 @@
                         "order": "DESC"
                     }
                 },
-                "title": "Admin Content",
+                "title": "Manage content",
                 "relationships": {
                     "uid": {
                         "id": "uid",
@@ -506,7 +506,7 @@
                 "path": "admin/content/node",
                 "menu": {
                     "type": "default tab",
-                    "title": "Find content",
+                    "title": "Manage content",
                     "description": "",
                     "name": "management",
                     "weight": "-1",

--- a/core/modules/node/node.install
+++ b/core/modules/node/node.install
@@ -1095,6 +1095,27 @@ function node_update_1012() {
 }
 
 /**
+ * Replace the node_admin_content view config with a new manage_content config.
+ */
+function node_update_1013() {
+  // If the old node_admin_content view has not been customized, delete it.
+    if (config_get('views.view.node_admin_content', 'storage') === 4) {
+      $config_node_admin_content = config('views.view.node_admin_content');
+      $config_node_admin_content->delete();
+    }
+  // Check if there is already a manage_content view.
+  $config_manage_content = config('views.view.manage_content');
+  if ($config_manage_content->isNew()) {
+    // If not, create the new manage_content view.
+    $path = backdrop_get_path('module', 'node') . '/config/';
+    $contents = file_get_contents($path . 'views.view.manage_content.json');
+    $data = json_decode($contents, true);
+    $config_manage_content->setData($data);
+    $config_manage_content->save();
+  }
+}
+
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/node/node.install
+++ b/core/modules/node/node.install
@@ -1095,7 +1095,8 @@ function node_update_1012() {
 }
 
 /**
- * Replace the node_admin_content view config with a new manage_content config.
+ * Replace the node_admin_content view (if not customized) with the new
+ * manage_content view.
  */
 function node_update_1013() {
   // If the old node_admin_content view has not been customized, delete it.

--- a/core/modules/views/tests/views_ui.test
+++ b/core/modules/views/tests/views_ui.test
@@ -25,7 +25,7 @@ class ViewsUIWizardBasicTestCase extends ViewsUIWizardHelper {
   function testViewsWizardAndListing() {
     // Check if we can access the main views admin page.
     $this->backdropGet('admin/structure/views');
-    $this->assertLinkByHref(url('admin/config/development/configuration/single/export/Views/views.view.node_admin_content'));
+    $this->assertLinkByHref(url('admin/config/development/configuration/single/export/Views/views.view.manage_content'));
 
     $this->assertText(t('Add view'));
 


### PR DESCRIPTION
…ntent" and "Manage comments" respectively.

Fixes https://github.com/backdrop/backdrop-issues/issues/2301