### PR TITLE
Issue #2406 Basis: place footer region at foot.

### DIFF
--- a/core/themes/basis/css/layout.css
+++ b/core/themes/basis/css/layout.css
@@ -11,3 +11,30 @@
 .layout .l-messages {
   margin: 0 0 2rem;
 }
+
+/* Push the footer down to the bottom of the page. */
+.layout {
+  box-sizing: border-box;
+  height: 100vh;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+.admin-bar body .layout {
+  padding-top: 33px;
+  margin-top: -33px;
+}
+.l-wrapper {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+.l-header,
+.l-footer {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}


### PR DESCRIPTION
I think this fixes https://github.com/backdrop/backdrop-issues/issues/2406 and re-uses part of Bartik's style.css solution to push the footer down to the bottom of the page.