### PR TITLE
Issue #2059 Add field prefix for "File directory" location.

### DIFF
--- a/core/modules/file/file.field.inc
+++ b/core/modules/file/file.field.inc
@@ -84,7 +84,7 @@ function file_field_instance_settings_form($field, $instance) {
     '#type' => 'textfield',
     '#title' => t('File directory'),
     '#default_value' => $settings['file_directory'],
-    '#field_prefix' => $field['settings']['uri_scheme'] == 'public' ? config_get('system.core', 'file_public_path') . '/' : config_get('system.core', 'file_private_path') . '/',
+    '#field_prefix' => $field['settings']['uri_scheme'] == 'public' ? config_get('system.core', 'file_public_path') . '/' : '',
     '#description' => t('Optional subdirectory within the upload destination where files will be stored. Do not include preceding or trailing slashes.'),
     '#element_validate' => array('_file_generic_settings_file_directory_validate'),
     '#weight' => 3,

--- a/core/modules/file/file.field.inc
+++ b/core/modules/file/file.field.inc
@@ -84,6 +84,7 @@ function file_field_instance_settings_form($field, $instance) {
     '#type' => 'textfield',
     '#title' => t('File directory'),
     '#default_value' => $settings['file_directory'],
+    '#field_prefix' => $field['settings']['uri_scheme'] == 'public' ? config_get('system.core', 'file_public_path') : config_get('system.core', 'file_private_path'). '/',
     '#description' => t('Optional subdirectory within the upload destination where files will be stored. Do not include preceding or trailing slashes.'),
     '#element_validate' => array('_file_generic_settings_file_directory_validate'),
     '#weight' => 3,

--- a/core/modules/file/file.field.inc
+++ b/core/modules/file/file.field.inc
@@ -84,7 +84,7 @@ function file_field_instance_settings_form($field, $instance) {
     '#type' => 'textfield',
     '#title' => t('File directory'),
     '#default_value' => $settings['file_directory'],
-    '#field_prefix' => $field['settings']['uri_scheme'] == 'public' ? config_get('system.core', 'file_public_path') : config_get('system.core', 'file_private_path'). '/',
+    '#field_prefix' => $field['settings']['uri_scheme'] == 'public' ? config_get('system.core', 'file_public_path') . '/' : config_get('system.core', 'file_private_path') . '/',
     '#description' => t('Optional subdirectory within the upload destination where files will be stored. Do not include preceding or trailing slashes.'),
     '#element_validate' => array('_file_generic_settings_file_directory_validate'),
     '#weight' => 3,


### PR DESCRIPTION
This PR addresses https://github.com/backdrop/backdrop-issues/issues/2059 and adds a field prefix to show the user exactly where the file will be placed, distinguishing between public and private file storage settings.