### PR TITLE
Issue #1052: Document theme_debug and show warnings if it is enabled.

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -104,6 +104,12 @@ function system_admin_index() {
  * Menu callback; displays a listing of all themes.
  */
 function system_themes_page() {
+  // Inform the user if theme_debug is enabled.
+  $theme_debug_enabled = config_get('system.core', 'theme_debug');
+  if ($theme_debug_enabled) {
+    backdrop_set_message(t('Theme debugging is enabled. See the <a href="!url">Status report</a> page for more info.', array('!url' => url('admin/reports/status'))), 'warning', FALSE);
+  }
+
   // Get current list of themes.
   $themes = system_rebuild_theme_data();
   uasort($themes, 'system_sort_modules_by_info_name');
@@ -217,6 +223,7 @@ function system_themes_page() {
   backdrop_alter('system_themes_page', $theme_groups);
 
   $admin_form = backdrop_get_form('system_themes_admin_form', $admin_theme_options);
+
   return theme('system_themes_page', array('theme_groups' => $theme_groups, 'theme_group_titles' => $theme_group_titles)) . backdrop_render($admin_form);
 }
 
@@ -365,6 +372,12 @@ function system_theme_default() {
  */
 function system_theme_settings($form, &$form_state, $key) {
   $themes = list_themes();
+
+  // Inform the user if theme_debug is enabled.
+  $theme_debug_enabled = config_get('system.core', 'theme_debug');
+  if ($theme_debug_enabled) {
+    backdrop_set_message(t('Theme debugging is enabled. See the <a href="!url">Status report</a> page for more info.', array('!url' => url('admin/reports/status'))), 'warning', FALSE);
+  }
 
   $form['theme'] = array(
     '#type' => 'value',

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -568,7 +568,20 @@ function system_requirements($phase) {
       'description' => $description,
     );
   }
-
+  
+  if ($phase == 'runtime') {
+    // Inform the user if theme_debug is enabled.
+    $theme_debug_enabled = config_get('system.core', 'theme_debug');
+    if ($theme_debug_enabled) {
+      $requirements['theme_debug'] = array(
+        'title' => $t('Theme debug'),
+        'value' => $t('Enabled'),
+        'severity' => REQUIREMENT_WARNING,
+        'description' => $t('Theme debugging is currently enabled, and should be disabled on a live site. This setting can be changed using the <a href="!url">Devel module</a>.', array('!url' => module_exists('devel') ? url('admin/config/development/devel') : 'https://backdropcms.org/project/devel')),
+      );
+    }
+  }
+  
   return $requirements;
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1052.

Replaces https://github.com/backdrop/backdrop/pull/1583.