### PR TITLE
Issue #2249: Don't override background-size when no image is specified in hero.

### DIFF
--- a/core/themes/basis/css/component/hero.css
+++ b/core/themes/basis/css/component/hero.css
@@ -56,8 +56,11 @@
 }
 
 .block-hero-no-image {
-  background: #0074bd url(../../images/texture.png) no-repeat center center;
-  background-blend-mode: luminosity;
+  background-color: #0074bd;
+  background-image: url(../../images/texture.png);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-blend-mode: luminosity; /* Colorizes bg image */
 }
 
 .no-background-blend-mode .block-hero-no-image * {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2249.