### PR TITLE
2369 menu toggle

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -7604,6 +7604,9 @@ function backdrop_common_theme() {
     'menu_local_tasks' => array(
       'variables' => array('primary' => array(), 'secondary' => array()),
     ),
+    'menu_toggle' => array(
+      'variables' => array('#enabled' => NULL, 'hash' => NULL),
+    ),
     // From form.inc.
     'select' => array(
       'render element' => 'element',

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -7605,7 +7605,7 @@ function backdrop_common_theme() {
       'variables' => array('primary' => array(), 'secondary' => array()),
     ),
     'menu_toggle' => array(
-      'variables' => array('#enabled' => NULL, 'hash' => NULL),
+      'variables' => array('enabled' => NULL, 'text' => 'Menu', 'hash' => NULL),
     ),
     // From form.inc.
     'select' => array(

--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -1849,15 +1849,12 @@ function theme_menu_local_actions($variables) {
  */
 function theme_menu_toggle($variables) {
   $output = '';
-  if ($variables['#enabled']) {
-    $output = '<input id="menu-toggle--state-' . $variables['hash'] . '" class="menu-toggle--state element-invisible" type="checkbox"  aria-controls="' . $variables['hash'] . '" />';
-    $output .= '<label class="menu-toggle__button" for="menu-toggle--state-' . $variables['hash'] . '">';
-    $output .= '<span class="menu-toggle__button-icon"></span><span class="menu-toggle__button-text">';
-    $output .= t('Menu');
-    $output .= '</span>';
-    $output .= '<span class="menu-toggle__assistive-text element-invisible">';
-    $output .= t('Toggle main menu visibility');
-    $output .= '</span></label>';
+  if ($variables['enabled']) {
+    $output  = '<input id="menu-toggle-state-' . $variables['hash'] . '" class="menu-toggle-state element-invisible" type="checkbox"  aria-controls="menu-toggle-state-' . $variables['hash'] . '" />';
+    $output .= '<label class="menu-toggle-button" for="menu-toggle-state-' . $variables['hash'] . '">';
+    $output .= '  <span class="menu-toggle-button-icon"></span><span class="menu-toggle-button-text">' . t($variables['text']) . '</span>';
+    $output .= '  <span class="menu-toggle-assistive-text element-invisible">' . t('Toggle menu visibility') . '</span>';
+    $output .= '</label>';
   }
   return $output;
 }

--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -1837,6 +1837,32 @@ function theme_menu_local_actions($variables) {
 }
 
 /**
+ * Returns rendered HTML for a menu toggle.
+ *
+ * @param $variables
+ *   An associative array containing:
+ *     - #enabled: A boolean indicating whether the menu toggle is active.
+ *     - hash: Unique string id to match the label to the input.
+ *
+ * @see theme_menu_toggle()
+ * @ingroup themeable
+ */
+function theme_menu_toggle($variables) {
+  $output = '';
+  if ($variables['#enabled']) {
+    $output = '<input id="menu-toggle--state-' . $variables['hash'] . '" class="menu-toggle--state element-invisible" type="checkbox"  aria-controls="' . $variables['hash'] . '" />';
+    $output .= '<label class="menu-toggle__button" for="menu-toggle--state-' . $variables['hash'] . '">';
+    $output .= '<span class="menu-toggle__button-icon"></span><span class="menu-toggle__button-text">';
+    $output .= t('Menu');
+    $output .= '</span>';
+    $output .= '<span class="menu-toggle__assistive-text element-invisible">';
+    $output .= t('Toggle main menu visibility');
+    $output .= '</span></label>';
+  }
+  return $output;
+}
+
+/**
  * Gets the custom theme for the current page, if there is one.
  *
  * @param $initialize

--- a/core/modules/system/css/menu-toggle.theme.css
+++ b/core/modules/system/css/menu-toggle.theme.css
@@ -1,117 +1,100 @@
-
-/**
+/*
  * @file
- * Responsive menu toggle button
+ * CSS for the responsive menu toggle checkbox / button.
  */
 
-.menu-toggle--state ~ .menu {
-  height: 0;
+ /**
+  * Menu toggle button
+  */
+.menu-toggle-button {
+  position: relative;
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  text-indent: 28px;
+  white-space: nowrap;
   overflow: hidden;
-  transition: height 0.25s ease-in-out;
-}
-
-.menu-toggle--state:checked ~ .menu {
-  height: 100vh;
-  height: calc(100vh - 2.8125em);
-  overflow-y: auto;
-}
-
-@media (min-width: 62em) {
-  .menu-toggle--state ~ .menu,
-  ul.menu,
-  .menu-toggle--state:checked ~ .menu {
-    height: auto;
-    overflow: visible;
-  }
-}
-
-.menu-toggle__button {
-  position: absolute;
-  top: 0;
-  right: 0;
-  display: block;
-  padding: 2.9375em 1.25em 1.75em 3em;
   cursor: pointer;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
-
-@media (min-width: 62em) {
-  .menu-toggle__button {
-    position: relative;
-    top: auto;
-    right: auto;
-    float: left;
-    -webkit-transform: none;
-    transform: none;
-    -webkit-transform: translate(0, 0.75em);
-    transform: translate(0, 0.75em);
-  }
-
-  .menu-toggle__button,
-  .menu-toggle__state {
-    display: none;
+@media (min-width: 48em) {  /* 768px @ 16px font size */
+  /* hide the button in desktop view */
+  .menu-toggle-button {
+    position: absolute;
+    top: -99999px;
   }
 }
 
-.menu-toggle__button-icon {
-  display: block;
+/**
+ * Hamburger icon
+ */
+.menu-toggle-button-icon,
+.menu-toggle-button-icon:before,
+.menu-toggle-button-icon:after {
   position: absolute;
   top: 50%;
-  left: 0.875em;
-  -webkit-transform: translate(0, 0.4375em) scale(0.6);
-  transform: translate(0, 0.4375em) scale(0.6);
+  left: 2px;
+  height: 2px;
+  width: 24px;
+  background: #bbb;
+  -webkit-transition: all 0.25s;
+  transition: all 0.25s;
 }
-
-.menu-toggle__button-icon:before,
-.menu-toggle__button-icon:after {
+.menu-toggle-button-icon:before {
   content: '';
-  position: absolute;
-  top: 0;
+  top: -7px;
   left: 0;
-  box-sizing: border-box;
-  display: block;
-  width: 2.5em;
+}
+.menu-toggle-button-icon:after {
+  content: '';
+  top: 7px;
+  left: 0
 }
 
-.menu-toggle__button-icon:before {
+/**
+ * X icon
+ */
+.menu-toggle-state:checked ~ .menu-toggle-button .menu-toggle-button-icon {
   height: 0;
-  border-top: 0.25em solid #fff;
-  background: #fff;
-  -webkit-transform: translate(0, -0.75em);
-  transform: translate(0, -0.75em);
-  -webkit-transform-origin: left top;
-  transform-origin: left top;
-  -webkit-transition: -webkit-transform 0.2s;
-  transition: -webkit-transform 0.2s;
-  transition: transform 0.2s;
-  transition: transform 0.2s, -webkit-transform 0.2s;
+  background: transparent;
+}
+.menu-toggle-state:checked ~ .menu-toggle-button .menu-toggle-button-icon:before {
+  top: 0;
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}
+.menu-toggle-state:checked ~ .menu-toggle-button .menu-toggle-button-icon:after {
+  top: 0;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
 }
 
-.menu-toggle--state:checked ~ .menu-toggle__button .menu-toggle__button-icon:before {
-  -webkit-transform: translate(0, -0.75em) rotate(45deg);
-  transform: translate(0, -0.75em) rotate(45deg);
-  -webkit-transform-origin: left top;
-  transform-origin: left top;
+/**
+ * Menu state checkbox
+ */
+.menu-toggle-state {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(1px,1px,1px,1px);
 }
-
-.menu-toggle__button-icon:after {
-  height: 1em;
-  border: 0.25em solid #fff;
-  border-width: 0.25em 0 0.25em 0;
-  -webkit-transition: border 0.2s, -webkit-transform 0.2s;
-  transition: border 0.2s, -webkit-transform 0.2s;
-  transition: border 0.2s, transform 0.2s;
-  transition: border 0.2s, transform 0.2s, -webkit-transform 0.2s;
+.menu-toggle-state ~ .menu {
+  display: none;
 }
-
-.menu-toggle--state:checked ~ .menu-toggle__button .menu-toggle__button-icon:after {
-  -webkit-transform: translate(0.375em, 0) rotate(-45deg);
-  transform: translate(0.375em, 0) rotate(-45deg);
-  border-top-color: transparent;
-  -webkit-transform-origin: left 1.5em;
-  transform-origin: left 1.5em;
+/* hide the menu in mobile view */
+.menu-toggle-state:not(:checked) ~ .menu {
+  display: none;
+}
+.menu-toggle-state:checked ~ .menu {
+  display: block;
+}
+@media (min-width: 48em) {  /* 768px @ 16px font size */
+  /* always show the menu in desktop view */
+  .menu-toggle-state:not(:checked) ~ .menu {
+    display: block;
+  }
 }

--- a/core/modules/system/css/menu-toggle.theme.css
+++ b/core/modules/system/css/menu-toggle.theme.css
@@ -1,0 +1,117 @@
+
+/**
+ * @file
+ * Responsive menu toggle button
+ */
+
+.menu-toggle--state ~ .menu {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.25s ease-in-out;
+}
+
+.menu-toggle--state:checked ~ .menu {
+  height: 100vh;
+  height: calc(100vh - 2.8125em);
+  overflow-y: auto;
+}
+
+@media (min-width: 62em) {
+  .menu-toggle--state ~ .menu,
+  ul.menu,
+  .menu-toggle--state:checked ~ .menu {
+    height: auto;
+    overflow: visible;
+  }
+}
+
+.menu-toggle__button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: block;
+  padding: 2.9375em 1.25em 1.75em 3em;
+  cursor: pointer;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (min-width: 62em) {
+  .menu-toggle__button {
+    position: relative;
+    top: auto;
+    right: auto;
+    float: left;
+    -webkit-transform: none;
+    transform: none;
+    -webkit-transform: translate(0, 0.75em);
+    transform: translate(0, 0.75em);
+  }
+
+  .menu-toggle__button,
+  .menu-toggle__state {
+    display: none;
+  }
+}
+
+.menu-toggle__button-icon {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 0.875em;
+  -webkit-transform: translate(0, 0.4375em) scale(0.6);
+  transform: translate(0, 0.4375em) scale(0.6);
+}
+
+.menu-toggle__button-icon:before,
+.menu-toggle__button-icon:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  box-sizing: border-box;
+  display: block;
+  width: 2.5em;
+}
+
+.menu-toggle__button-icon:before {
+  height: 0;
+  border-top: 0.25em solid #fff;
+  background: #fff;
+  -webkit-transform: translate(0, -0.75em);
+  transform: translate(0, -0.75em);
+  -webkit-transform-origin: left top;
+  transform-origin: left top;
+  -webkit-transition: -webkit-transform 0.2s;
+  transition: -webkit-transform 0.2s;
+  transition: transform 0.2s;
+  transition: transform 0.2s, -webkit-transform 0.2s;
+}
+
+.menu-toggle--state:checked ~ .menu-toggle__button .menu-toggle__button-icon:before {
+  -webkit-transform: translate(0, -0.75em) rotate(45deg);
+  transform: translate(0, -0.75em) rotate(45deg);
+  -webkit-transform-origin: left top;
+  transform-origin: left top;
+}
+
+.menu-toggle__button-icon:after {
+  height: 1em;
+  border: 0.25em solid #fff;
+  border-width: 0.25em 0 0.25em 0;
+  -webkit-transition: border 0.2s, -webkit-transform 0.2s;
+  transition: border 0.2s, -webkit-transform 0.2s;
+  transition: border 0.2s, transform 0.2s;
+  transition: border 0.2s, transform 0.2s, -webkit-transform 0.2s;
+}
+
+.menu-toggle--state:checked ~ .menu-toggle__button .menu-toggle__button-icon:after {
+  -webkit-transform: translate(0.375em, 0) rotate(-45deg);
+  transform: translate(0.375em, 0) rotate(-45deg);
+  border-top-color: transparent;
+  -webkit-transform-origin: left 1.5em;
+  transform-origin: left 1.5em;
+}

--- a/core/modules/system/js/menus.js
+++ b/core/modules/system/js/menus.js
@@ -41,6 +41,27 @@ Backdrop.menuStyles.dropdown = {
       subIndicatorsText: ''
     });
     $(element).addClass('sm').smartmenus(settings);
+
+    // Add gentle menu slide behavior.
+    $('.menu-toggle-state').once('smartmenus-behavior', function() {
+      var $mainMenuState = $(this);
+      // animate mobile menu
+      $mainMenuState.change(function(e) {
+        var $menu = $(element);
+        if (this.checked) {
+          $menu.hide().slideDown(250, function() { $menu.css('display', ''); });
+        }
+        else {
+          $menu.show().slideUp(250, function() { $menu.css('display', ''); });
+        }
+      });
+      // hide mobile menu beforeunload
+      $(window).bind('beforeunload unload', function() {
+        if ($mainMenuState[0].checked) {
+          $mainMenuState[0].click();
+        }
+      });
+    });
   }
 };
 

--- a/core/modules/system/system.menu.inc
+++ b/core/modules/system/system.menu.inc
@@ -19,12 +19,15 @@ function system_menu_block_defaults($menu_name) {
     'level' => 1,
     'menu_name' => $menu_name,
     'style' => NULL,
+    'menu_toggle_hash' => backdrop_random_key(),
   );
   if ($menu_name == 'main-menu') {
     $defaults['depth'] = 1;
+    $defaults['menu_toggle'] = 1;
   }
   else {
     $defaults['depth'] = 0;
+    $defaults['menu_toggle'] = 0;
   }
   return $defaults;
 }
@@ -101,6 +104,16 @@ function system_menu_block_form($config) {
       ),
     ),
   );
+  $form['menu_toggle'] = array(
+    '#type' => 'checkbox',
+    '#title' => 'Display menu toggle button on small screens',
+    '#default_value' => $config['menu_toggle'],
+    '#description' => t('When enabled, a menu toggle button—commonly known as a "hamburger" icon—will appear on small screens and allow the user to toggle the visibility of the menu.'),
+  );
+  $form['menu_toggle_hash'] = array(
+    '#type' => 'hidden',
+    '#default_value' => $config['menu_toggle_hash'],
+  );
 
   return $form;
 }
@@ -163,6 +176,10 @@ function system_menu_block_build(array $config) {
       if ($config['style'] === 'dropdown') {
         $data['content']['#attached']['library'][] = array('system', 'smartmenus');
       }
+    }
+    if (!empty($config['menu_toggle']) && $config['menu_toggle'] == TRUE) {
+      $data['content']['#attached']['css'][] = backdrop_get_path('module', 'system') . '/css/menu-toggle.theme.css';
+      $data['content']['#prefix'] = theme('menu_toggle', array('#enabled' => $config['menu_toggle'], 'hash' => $config['menu_toggle_hash']));
     }
     if (!empty($config['style_settings'])) {
       $data['content']['#wrapper_attributes']['data-menu-style'] = backdrop_json_encode($config['style_settings']);

--- a/core/modules/system/system.menu.inc
+++ b/core/modules/system/system.menu.inc
@@ -19,15 +19,15 @@ function system_menu_block_defaults($menu_name) {
     'level' => 1,
     'menu_name' => $menu_name,
     'style' => NULL,
-    'menu_toggle_hash' => backdrop_random_key(),
+    'hash' => backdrop_random_key(),
   );
   if ($menu_name == 'main-menu') {
     $defaults['depth'] = 1;
-    $defaults['menu_toggle'] = 1;
+    $defaults['toggle'] = TRUE;
   }
   else {
     $defaults['depth'] = 0;
-    $defaults['menu_toggle'] = 0;
+    $defaults['toggle'] = FALSE;
   }
   return $defaults;
 }
@@ -104,15 +104,15 @@ function system_menu_block_form($config) {
       ),
     ),
   );
-  $form['menu_toggle'] = array(
+  $form['toggle'] = array(
     '#type' => 'checkbox',
     '#title' => 'Display menu toggle button on small screens',
-    '#default_value' => $config['menu_toggle'],
-    '#description' => t('When enabled, a menu toggle button—commonly known as a "hamburger" icon—will appear on small screens and allow the user to toggle the visibility of the menu.'),
+    '#default_value' => $config['toggle'],
+    '#description' => t('A menu toggle button, commonly known as a hamburger icon, allows the menu to be hidden initially on devices with small screens, but then easily expanded.'),
   );
-  $form['menu_toggle_hash'] = array(
+  $form['hash'] = array(
     '#type' => 'hidden',
-    '#default_value' => $config['menu_toggle_hash'],
+    '#default_value' => $config['hash'],
   );
 
   return $form;
@@ -177,9 +177,10 @@ function system_menu_block_build(array $config) {
         $data['content']['#attached']['library'][] = array('system', 'smartmenus');
       }
     }
-    if (!empty($config['menu_toggle']) && $config['menu_toggle'] == TRUE) {
+    if (!empty($config['toggle']) && $config['toggle'] == TRUE) {
       $data['content']['#attached']['css'][] = backdrop_get_path('module', 'system') . '/css/menu-toggle.theme.css';
-      $data['content']['#prefix'] = theme('menu_toggle', array('#enabled' => $config['menu_toggle'], 'hash' => $config['menu_toggle_hash']));
+      $data['content']['#attached']['css'][] = backdrop_get_path('module', 'system') . '/js/menu-toggle.js';
+      $data['content']['#prefix'] = theme('menu_toggle', array('enabled' => $config['toggle'], 'text' => 'Menu', 'hash' => $config['hash']));
     }
     if (!empty($config['style_settings'])) {
       $data['content']['#wrapper_attributes']['data-menu-style'] = backdrop_json_encode($config['style_settings']);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2369
Replaces https://github.com/backdrop/backdrop/pull/1686

Changes: 
* fixed CSS names are all weird. Removed -- and __, replaced with -
* restored CSS to version recommended by smartmenus library
* organized the css into components within the same file
* moved media queries to relevant component sections
* tidied up markup in theme_menu_toggle(). Fixed indenting, spaces, and line breaks.
* removed # from enabled value in variables for theme_menu_toggle()
* added `text` variable for `Menu` for theme_menu_toggle()
* removed em-dashes in help text
* removed text calling the user a "user"
* removed 'menu_' from beginning of menu setting names.
* added back the recommended JS