### PR TITLE
Issue #984: [UX] New layout templates *installed manually* are only a…

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1205,7 +1205,7 @@ function layout_get_layout_template_info($template_name = NULL) {
   }
 
   // Rebuild the list.
-  if (!isset($info)) {
+  if (!isset($info) || in_array($current_path, $paths)) {
     $files = backdrop_system_listing('/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.info$/', 'layouts', 'name', 0);
     $init = array();
     foreach ($files as $name => $file) {

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1183,14 +1183,6 @@ function _layout_get_all_info($data_type, $init = array()) {
 function layout_get_layout_template_info($template_name = NULL) {
   $info = &backdrop_static(__FUNCTION__);
 
-  // Try getting a cached list of layout info.
-  if (!isset($info)) {
-    $cache = cache('cache')->get('layout_info');
-    if ($cache && $cache->data) {
-      $info = $cache->data;
-    }
-  }
-
   $current_path = current_path();
   // List of paths that always require a rebuild of the list of layout
   // templates (see https://github.com/backdrop/backdrop-issues/issues/984).
@@ -1202,6 +1194,16 @@ function layout_get_layout_template_info($template_name = NULL) {
   $layouts = layout_load_all();
   foreach ($layouts as $layout) {
     $paths[] = 'admin/structure/layouts/manage/' . $layout->name . '/configure';
+  }
+
+  // Try getting a cached list of layout info and use that if set. Skip this for
+  // paths that always require a rebuild of the list of layout templates (since
+  // the layout info cache is being updated as part of the rebuild).
+  if (!isset($info) && !in_array($current_path, $paths)) {
+    $cache = cache('cache')->get('layout_info');
+    if ($cache && $cache->data) {
+      $info = $cache->data;
+    }
   }
 
   // Rebuild the list.

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1191,6 +1191,19 @@ function layout_get_layout_template_info($template_name = NULL) {
     }
   }
 
+  $current_path = current_path();
+  // List of paths that always require a rebuild of the list of layout
+  // templates (see https://github.com/backdrop/backdrop-issues/issues/984).
+  // This includes the "Layout settings" page...
+  $paths = array(
+    'admin/structure/layouts/settings',
+  );
+  // ...and all the "Configure layout" pages.
+  $layouts = layout_load_all();
+  foreach ($layouts as $layout) {
+    $paths[] = 'admin/structure/layouts/manage/' . $layout->name . '/configure';
+  }
+
   // Rebuild the list.
   if (!isset($info)) {
     $files = backdrop_system_listing('/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.info$/', 'layouts', 'name', 0);


### PR DESCRIPTION
…vailable after layout cache clear.

Fixes https://github.com/backdrop/backdrop-issues/issues/984