### PR TITLE
Issue #2175: Allow nav tags as wrapper tags around blocks.

### DIFF
--- a/core/modules/layout/plugins/styles/layout_style_dynamic.inc
+++ b/core/modules/layout/plugins/styles/layout_style_dynamic.inc
@@ -29,6 +29,7 @@ class LayoutStyleDynamic extends LayoutStyle {
         'div' => 'DIV',
         'aside' => 'ASIDE',
         'section' => 'SECTION',
+        'nav' => 'NAV',
         'p' => 'P',
         '' => t('No wrapper'),
       );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2175