### PR TITLE
Issue #1853: Create and use the 'files' directory in the conf_path().

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1742,7 +1742,7 @@ function install_check_requirements($install_state) {
         $writable = backdrop_verify_install_file($settings_file, FILE_READABLE|FILE_WRITABLE);
         $exists = TRUE;
       }
-      if ($settings_file !== './settings.php') {
+      elseif ($settings_file !== './settings.php') {
         if (copy('./settings.php', $settings_file) === TRUE) {
           $exists = TRUE;
           $writable = backdrop_verify_install_file($settings_file, FILE_READABLE|FILE_WRITABLE);

--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1298,7 +1298,7 @@ function install_find_translations() {
  * @see file_scan_directory()
  */
 function install_find_translation_files($langcode = NULL) {
-  $directory = settings_get('locale_translate_file_directory', 'files/translations');
+  $directory = settings_get('locale_translate_file_directory', conf_path() . '/files/translations');
   // @todo: Remove the "drupal" check in 2.x (assuming we have a localization
   //   server by then).
   $files = file_scan_directory($directory, '!(install|drupal-\d+\.\d+)\.' . (!empty($langcode) ? preg_quote($langcode, '!') : '[^\.]+') . '\.po$!', array('recurse' => FALSE));
@@ -1343,7 +1343,7 @@ function install_select_language(&$install_state) {
     // is doing.
     if (count($files) == 1) {
       if ($install_state['interactive']) {
-        $directory = settings_get('locale_translate_file_directory', 'files/translations');
+        $directory = settings_get('locale_translate_file_directory', conf_path() . '/files/translations');
 
         backdrop_set_title(st('Choose language'));
         if (!empty($install_state['parameters']['translate'])) {
@@ -1741,6 +1741,12 @@ function install_check_requirements($install_state) {
         // If it does, make sure it is writable.
         $writable = backdrop_verify_install_file($settings_file, FILE_READABLE|FILE_WRITABLE);
         $exists = TRUE;
+      }
+      if ($settings_file !== './settings.php') {
+        if (copy('./settings.php', $settings_file) === TRUE) {
+          $exists = TRUE;
+          $writable = backdrop_verify_install_file($settings_file, FILE_READABLE|FILE_WRITABLE);
+        }
       }
     }
 

--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -665,7 +665,8 @@ function backdrop_install_config_directories() {
   $config_directories = array();
 
   // Include the current settings file to check the current database string.
-  $settings_file = conf_path(FALSE) . '/settings.php';
+  $conf_path = conf_path(FALSE);
+  $settings_file = $conf_path . '/settings.php';
   include $settings_file;
 
   $is_empty = empty($config_directories['active']);
@@ -676,11 +677,11 @@ function backdrop_install_config_directories() {
   if ($is_empty || $is_default) {
     $config_directories_hash = md5(backdrop_random_bytes(55));
     $update_settings["config_directories['active']"] = array(
-      'value' => 'files/config_' . $config_directories_hash . '/active',
+      'value' => $conf_path . '/files/config_' . $config_directories_hash . '/active',
       'required' => TRUE,
     );
     $update_settings["config_directories['staging']"] = array(
-      'value' => 'files/config_' . $config_directories_hash . '/staging',
+      'value' => $conf_path . '/files/config_' . $config_directories_hash . '/staging',
       'required' => TRUE,
     );
 

--- a/core/modules/locale/locale.bulk.inc
+++ b/core/modules/locale/locale.bulk.inc
@@ -205,7 +205,7 @@ function locale_translate_add_language_set_batch($langcode) {
  *   See http://drupal.org/node/1191488.
  */
 function locale_translate_batch_import_files($langcode = NULL, $finish_feedback = FALSE) {
-  $directory = settings_get('locale_translate_file_directory', 'files/translations');
+  $directory = settings_get('locale_translate_file_directory', conf_path() . '/files/translations');
   $files = array();
   if (!empty($langcode)) {
     $langcodes = array($langcode);

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -752,7 +752,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
 
     // Set the translation file directory.
     $source = backdrop_get_path('module', 'locale_test');
-    $destination = settings_get('locale_translate_file_directory', 'files/translations');
+    $destination = settings_get('locale_translate_file_directory', conf_path() . '/files/translations');
     file_prepare_directory($destination);
     foreach (file_scan_directory($source, '/.*\.po/') as $file) {
       file_unmanaged_copy($file->uri, $destination . '/' . $file->filename, FILE_EXISTS_REPLACE);

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -315,7 +315,7 @@ function system_requirements($phase) {
     $directories[] = file_directory_temp();
   }
   else {
-    $directories[] = 'files';
+    $directories[] = conf_path() . '/files';
   }
 
   $requirements['file system'] = array(
@@ -682,6 +682,9 @@ function system_install() {
   $versions = backdrop_get_schema_versions('system');
   $version = $versions ? max($versions) : SCHEMA_INSTALLED;
   backdrop_set_installed_schema_version('system', $version);
+
+  // Set the public files path to the directory with the settings.php file.
+  config_set('system.core', 'file_public_path', conf_path() . '/files');
 
   // Clear out module list and hook implementation statics before calling
   // system_rebuild_theme_data().


### PR DESCRIPTION
Almost addresses backdrop/backdrop-issues#1853. 

This patch works if you copy the `settings.php` to the `sites/example.com/settings.php` and set the `$database` string.  

If you don't set the `$database` string, then it fails to install the modules defined in the profile and returns: 

     The requested page "/" could not be found. 

I've run out of time trying to find out why.