### PR TITLE
Issue #1703: [UX] All custom blocks with no display title have "Custo…

### DIFF
--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -37,16 +37,13 @@ class BlockText extends Block {
   function getAdminPreview() {
     // The admin preview for custom blocks and hero blocks will always fall back
     // to their description...
-    $block_description = layout_get_block_info($this->module)[$this->delta]['description'];
+    $block_description = layout_get_block_info(($this->module)[$this->delta]['description']);
     $admin_preview = $block_description;
     // ...but if they have content, then that will be used instead.
-    if (!isset($this->settings['content'])) {
-      $block_content = $this->settings['content'];
-      if (!empty($block_content)) {
-        $admin_preview = $block_content;
-      }
-      return $admin_preview;
+    if (!empty($this->settings['content'])) {
+      $admin_preview = $this->settings['content'];
     }
+    return $admin_preview;
   }
 
   /**

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -19,10 +19,32 @@ class BlockText extends Block {
   }
 
   /**
-   *  Sets title text on draggable block panel in Layout builder.
+   *  Sets the title text on the draggable block panel in the "Manage blocks"
+   *  page.
    */
   function getAdminTitle() {
-    return !empty($this->settings['title']) ? check_plain($this->settings['title']) : t('Custom block');
+    // The admin title text for custom blocks will always fall back to this...
+    $admin_title = t('Custom block');
+    // ...but if there is a display title, it will be appended to it. 
+    $admin_title .= !empty($this->settings['title']) ? ': ' . check_plain($this->settings['title']) : '';
+    return $admin_title;
+  }
+
+  /**
+   *  Returns a preview for this block to be used on the draggable block panel
+   *  in the "Manage blocks" form.
+   */
+  function getAdminPreview() {
+    // The admin preview for custom blocks and hero blocks will always fall back
+    // to their description...
+    $block_description = layout_get_block_info($this->module)[$this->delta]['description'];
+    $admin_preview = $block_description;
+    // ...but if they have content, then that will be used instead.
+    $block_content = $this->settings['content'];
+    if (!empty($block_content)) {
+      $admin_preview = $block_content;
+    }
+    return $admin_preview;
   }
 
   /**

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -37,8 +37,8 @@ class BlockText extends Block {
   function getAdminPreview() {
     // The admin preview for custom blocks and hero blocks will always fall back
     // to their description...
-    $block_description = layout_get_block_info(($this->module)[$this->delta]['description']);
-    $admin_preview = $block_description;
+    $block_info = layout_get_block_info($this->module, $this->delta);
+    $admin_preview = $block_info['description'];
     // ...but if they have content, then that will be used instead.
     if (!empty($this->settings['content'])) {
       $admin_preview = $this->settings['content'];

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -40,11 +40,13 @@ class BlockText extends Block {
     $block_description = layout_get_block_info($this->module)[$this->delta]['description'];
     $admin_preview = $block_description;
     // ...but if they have content, then that will be used instead.
-    $block_content = $this->settings['content'];
-    if (!empty($block_content)) {
-      $admin_preview = $block_content;
+    if (!isset($this->settings['content'])) {
+      $block_content = $this->settings['content'];
+      if (!empty($block_content)) {
+        $admin_preview = $block_content;
+      }
+      return $admin_preview;
     }
-    return $admin_preview;
   }
 
   /**


### PR DESCRIPTION
…m block" as admin title and no way to customize that.

Fixes https://github.com/backdrop/backdrop-issues/issues/1703