### PR TITLE
Issue #2209: Installer: Empty " | " in <title> tag while site name no…

### DIFF
--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2655,7 +2655,7 @@ function template_preprocess_page(&$variables) {
   backdrop_add_html_head_link(array('rel' => 'shortcut icon', 'href' => $favicon['path'], 'type' => $favicon['type']));
 
   $site_config = config('system.core');
-  // Construct page title.
+  // Construct head <title>.
   if (backdrop_get_title()) {
     $head_title = array(
       'title' => strip_tags(backdrop_get_title()),
@@ -2771,18 +2771,14 @@ function template_preprocess_maintenance_page(&$variables) {
   $favicon = backdrop_get_favicon();
   backdrop_add_html_head_link(array('rel' => 'shortcut icon', 'href' => $favicon['path'], 'type' => $favicon['type']));
 
-  // Construct page title
+  // Construct head <title>.
+  $head_title = array();
   if (backdrop_get_title()) {
-    $head_title = array(
-      'title' => strip_tags(backdrop_get_title()),
-      'name' => $site_name,
-    );
+    $head_title['title'] = strip_tags(backdrop_get_title());
   }
-  else {
-    $head_title = array('name' => $site_name);
-    if ($site_slogan) {
-      $head_title['slogan'] = $site_slogan;
-    }
+  $head_title['name'] = $site_name ? $site_name : 'Backdrop CMS';
+  if ($site_slogan) {
+    $head_title['slogan'] = $site_slogan;
   }
 
   // Set the default language if necessary.

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -1035,7 +1035,7 @@ class CommentPreviewTest extends CommentHelperCase {
     $this->backdropPost('node/' . $this->node->nid, $edit, t('Preview'));
 
     // Check that the preview is displaying the title and body.
-    $this->assertTitle(t('Preview comment | Backdrop'), 'Page title is "Preview comment".');
+    $this->assertTitle(t('Preview comment | Backdrop CMS'), 'Page title is "Preview comment".');
     $this->assertText($edit['subject'], 'Title displayed.');
     $this->assertText($edit['comment_body[' . $langcode . '][0][value]'], 'Comment displayed.');
 
@@ -1074,7 +1074,7 @@ class CommentPreviewTest extends CommentHelperCase {
     $this->backdropPost('comment/' . $comment->id . '/edit', $edit, t('Preview'));
 
     // Check that the preview is displaying the subject, comment, author and date correctly.
-    $this->assertTitle(t('Preview comment | Backdrop'), 'Page title is "Preview comment".');
+    $this->assertTitle(t('Preview comment | Backdrop CMS'), 'Page title is "Preview comment".');
     $this->assertText($edit['subject'], 'Title displayed.');
     $this->assertText($edit['comment_body[' . $langcode . '][0][value]'], 'Comment displayed.');
     $this->assertText($edit['name'], 'Author displayed.');

--- a/core/modules/language/tests/language.test
+++ b/core/modules/language/tests/language.test
@@ -82,7 +82,7 @@ class LanguageListTest extends BackdropWebTestCase {
 
     // Ensure 'edit' link works.
     $this->clickLink(t('Edit'));
-    $this->assertTitle(t('Edit language | Backdrop'), t('Page title is "Edit language".'));
+    $this->assertTitle(t('Edit language | Backdrop CMS'), t('Page title is "Edit language".'));
     // Edit a language.
     $name = $this->randomName(16);
     $edit = array(

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2275,7 +2275,7 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
 
     // Check that URLs are rewritten using the given browser language.
     $fields = $this->xpath('//*[contains(@class,"site-name")]//a[@rel="home" and @href=:url]//span', $args);
-    $this->assertTrue($fields[0] == 'Backdrop', 'URLs are rewritten using the browser language.');
+    $this->assertTrue($fields[0] == 'Backdrop CMS', 'URLs are rewritten using the browser language.');
   }
 
   /**

--- a/core/modules/menu/tests/menu.test
+++ b/core/modules/menu/tests/menu.test
@@ -89,7 +89,7 @@ class MenuTestCase extends BackdropWebTestCase {
     $this->assertNoTitle('Home | Backdrop');
     $this->backdropLogout();
     $this->backdropGet('user/register');
-    $this->assertTitle($item['link_title'] . ' | Backdrop');
+    $this->assertTitle($item['link_title'] . ' | Backdrop CMS');
     $this->backdropGet('user');
     $this->assertNoTitle('Home | Backdrop');
   }
@@ -391,7 +391,7 @@ class MenuTestCase extends BackdropWebTestCase {
       // Verify menu link.
       $this->clickLink($title);
       $title = $parent_node->title;
-      $this->assertTitle(t("@title | Backdrop", array('@title' => $title)), 'Parent menu link link target was correct');
+      $this->assertTitle(t("@title | Backdrop CMS", array('@title' => $title)), 'Parent menu link link target was correct');
     }
 
     // Verify menu link.
@@ -401,7 +401,7 @@ class MenuTestCase extends BackdropWebTestCase {
     // Verify menu link link.
     $this->clickLink($title);
     $title = $item_node->title;
-    $this->assertTitle(t("@title | Backdrop", array('@title' => $title)), 'Menu link link target was correct');
+    $this->assertTitle(t("@title | Backdrop CMS", array('@title' => $title)), 'Menu link link target was correct');
   }
 
   /**

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -637,7 +637,7 @@ class NodeTitleXSSTestCase extends BackdropWebTestCase {
 
     $this->backdropGet('node/' . $node->nid);
     // assertTitle() decodes HTML-entities inside the <title> element.
-    $this->assertTitle($edit["title"] . ' | Backdrop', 'Title is displayed when viewing a node.');
+    $this->assertTitle($edit["title"] . ' | Backdrop CMS', 'Title is displayed when viewing a node.');
     $this->assertNoRaw($xss, 'Harmful tags are escaped when viewing a node.');
 
     $this->backdropGet('node/' . $node->nid . '/edit');

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -1787,7 +1787,7 @@ class NodeTitleTestCase extends BackdropWebTestCase {
     // Test <title> tag.
     $this->backdropGet("node/$node->nid");
     $xpath = '//title';
-    $this->assertEqual(current($this->xpath($xpath)), $node->title .' | Backdrop', 'Page title is equal to node title.', 'Node');
+    $this->assertEqual(current($this->xpath($xpath)), $node->title .' | Backdrop CMS', 'Page title is equal to node title.', 'Node');
 
     // Test breadcrumb in comment preview.
     $this->backdropGet("comment/reply/$node->nid");

--- a/core/modules/search/tests/search.test
+++ b/core/modules/search/tests/search.test
@@ -255,7 +255,7 @@ class SearchPageText extends BackdropWebTestCase {
     $this->backdropGet('search/node');
     $this->assertText(t('Enter your keywords'));
     $this->assertText(t('Search'));
-    $title = t('Search') . ' | Backdrop';
+    $title = t('Search') . ' | Backdrop CMS';
     $this->assertTitle($title, 'Search page title is correct');
 
     $edit = array();

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -55,7 +55,7 @@ class MenuWebTestCase extends BackdropWebTestCase {
 
     // Additionally assert page title, if given.
     if (isset($page_title)) {
-      $this->assertTitle(strtr('@title | Backdrop', array('@title' => $page_title)));
+      $this->assertTitle(strtr('@title | Backdrop CMS', array('@title' => $page_title)));
     }
 
     // Additionally assert active trail in a menu tree output, if given.
@@ -514,7 +514,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
       $this->backdropGet('menu-title-test/case' . $case_no);
       $this->assertResponse(200);
       $asserted_title = 'Alternative example title - Case ' . $case_no;
-      $this->assertTitle($asserted_title . ' | Backdrop', 'Menu title is: ' . $asserted_title, 'Menu');
+      $this->assertTitle($asserted_title . ' | Backdrop CMS', 'Menu title is: ' . $asserted_title, 'Menu');
     }
   }
 

--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -82,7 +82,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
     // Check if the token is recognized in each of the contexts.
     foreach ($tests as $test) {
       $input = $test['prefix'] . '[site:name]' . $test['suffix'];
-      $expected = $test['prefix'] . 'Backdrop' . $test['suffix'];
+      $expected = $test['prefix'] . 'Backdrop CMS' . $test['suffix'];
       $output = token_replace($input, array(), array('language' => $language));
       $this->assertTrue($output == $expected, format_string('Token recognized in string %string', array('%string' => $input)));
     }

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -54,7 +54,7 @@
     "site_favicon_path": "core/misc/favicon.ico",
     "site_favicon_mimetype": "image/vnd.microsoft.icon",
     "site_frontpage": "node",
-    "site_name": "Backdrop",
+    "site_name": "Backdrop CMS",
     "site_logo_theme": 0,
     "site_logo_path": "",
     "site_mail": "",

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -2356,7 +2356,7 @@ class SystemAuthorizeCase extends BackdropWebTestCase {
   function testFileTransferHooks() {
     $page_title = $this->randomName(16);
     $this->backdropGetAuthorizePHP($page_title);
-    $this->assertTitle(strtr('@title | Backdrop', array('@title' => $page_title)), 'authorize.php page title is correct.');
+    $this->assertTitle(strtr('@title | Backdrop CMS', array('@title' => $page_title)), 'authorize.php page title is correct.');
     $this->assertNoText('It appears you have reached this page in error.');
     $this->assertText('To continue, provide your server connection details');
     // Make sure we see the new connection method added by system_test.


### PR DESCRIPTION
…t defined yet.

Fixes https://github.com/backdrop/backdrop-issues/issues/2209