### PR TITLE
Issue #984: [UX] New layout templates *installed manually* are only a…

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -252,7 +252,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
 
   // Get the list of layout template options. The list needs to be rebuilt (see
   // https://github.com/backdrop/backdrop-issues/issues/984)
-  $all_template_info = layout_get_layout_template_info(NULL, $rebuild = TRUE);
+  $all_template_info = layout_get_layout_template_info(NULL, TRUE);
   $excluded = config_get('layout.settings', 'excluded_templates');
   foreach ($all_template_info as $template_name => $template_info) {
     if (!in_array($template_name, $excluded)) {
@@ -2624,7 +2624,7 @@ function layout_settings_page($form, &$form_state) {
 
   // Get the list of layout template options. The list needs to be rebuilt (see
   // https://github.com/backdrop/backdrop-issues/issues/984)
-  $all_template_info = layout_get_layout_template_info(NULL, $rebuild = TRUE);
+  $all_template_info = layout_get_layout_template_info(NULL, TRUE);
   $options = array();
   $default = array();
   $form_state['hidden_templates'] = array();

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2624,11 +2624,11 @@ function layout_settings_page($form, &$form_state) {
 
   // Get the list of layout template options. The list needs to be rebuilt (see
   // https://github.com/backdrop/backdrop-issues/issues/984)
-  $all_layout_info = layout_get_layout_template_info(NULL, $rebuild = TRUE);
+  $all_template_info = layout_get_layout_template_info(NULL, $rebuild = TRUE);
   $options = array();
   $default = array();
   $form_state['hidden_templates'] = array();
-  foreach ($all_layout_info as $template_name => $template_info) {
+  foreach ($all_template_info as $template_name => $template_info) {
     // Build the default values list.
     if (!in_array($template_name, $excluded)) {
       $default[] = $template_name;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -250,8 +250,9 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#required' => TRUE,
   );
 
-  // Get the list of layout template options.
-  $all_template_info = layout_get_layout_template_info();
+  // Get the list of layout template options. The list needs to be rebuilt (see
+  // https://github.com/backdrop/backdrop-issues/issues/984)
+  $all_template_info = layout_get_layout_template_info(NULL, $rebuild = TRUE);
   $excluded = config_get('layout.settings', 'excluded_templates');
   foreach ($all_template_info as $template_name => $template_info) {
     if (!in_array($template_name, $excluded)) {
@@ -2621,8 +2622,9 @@ function layout_settings_page($form, &$form_state) {
   $form['#attached']['css'][] = backdrop_get_path('module', 'layout') . '/css/layout.admin.css';
   $form['#attributes']['class'] = array('layout-settings-page');
 
-  // Get the list of layout template options.
-  $all_layout_info = layout_get_layout_template_info();
+  // Get the list of layout template options. The list needs to be rebuilt (see
+  // https://github.com/backdrop/backdrop-issues/issues/984)
+  $all_layout_info = layout_get_layout_template_info(NULL, $rebuild = TRUE);
   $options = array();
   $default = array();
   $form_state['hidden_templates'] = array();

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1169,30 +1169,43 @@ function _layout_get_all_info($data_type, $init = array()) {
 }
 
 /**
- * Load the layout template information for a single layout template name.
+ * Load the information of either a single layout template or all available
+ * layout templates.
  *
  * @param string $template_name
- *   The name of the layout template, e.g. "boxton" or "simmons". If no layout
- *   template is specified, all layout info will be returned.
+ *   Optionally specify a name of a single layout template, e.g. "boxton" or
+ *   "simmons". If no layout template name is specified, information for all
+ *   layout templates will be returned.
+ * 
+ * @param boolean $rebuild
+ *   Whether or not the list of layout template info needs to be rebuilt (see
+ *   https://github.com/backdrop/backdrop-issues/issues/984). The rebuilt is
+ *   required only on specific cases, so this defaults to FALSE. That way, the
+ *   rest of the times the layout cache is used (when available) for performance
+ *   reasons.
+ * 
  * @return array|boolean
  *   The layout template information, as returned by either a stand-alone
  *   template .info file, or through a module's hook_layout_info().
  *
  * @see hook_layout_info()
  */
-function layout_get_layout_template_info($template_name = NULL) {
+function layout_get_layout_template_info($template_name = NULL, $rebuild = FALSE) {
   $info = &backdrop_static(__FUNCTION__);
 
-  // Try getting a cached list of layout info.
-  if (!isset($info)) {
+  // Try getting a cached list of layout info. Skip this if the optional
+  // $rebuild argument has been passed to the function.
+  if (!isset($info) && !$rebuild) {
     $cache = cache('cache')->get('layout_info');
     if ($cache && $cache->data) {
       $info = $cache->data;
     }
   }
 
-  // Rebuild the list.
-  if (!isset($info)) {
+  // Rebuild the list of layout info in the following two cases:
+  // - If trying to get a list of layout info from cache did not work.
+  // - If the optional $rebuild argument has been passed to the function.
+  if (!isset($info) || $rebuild) {
     $files = backdrop_system_listing('/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.info$/', 'layouts', 'name', 0);
     $init = array();
     foreach ($files as $name => $file) {

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1179,7 +1179,7 @@ function _layout_get_all_info($data_type, $init = array()) {
  * 
  * @param boolean $rebuild
  *   Whether or not the list of layout template info needs to be rebuilt (see
- *   https://github.com/backdrop/backdrop-issues/issues/984). The rebuilt is
+ *   https://github.com/backdrop/backdrop-issues/issues/984). The rebuild is
  *   required only on specific cases, so this defaults to FALSE. That way, the
  *   rest of the times the layout cache is used (when available) for performance
  *   reasons.
@@ -1193,8 +1193,7 @@ function _layout_get_all_info($data_type, $init = array()) {
 function layout_get_layout_template_info($template_name = NULL, $rebuild = FALSE) {
   $info = &backdrop_static(__FUNCTION__);
 
-  // Try getting a cached list of layout info. Skip this if the optional
-  // $rebuild argument has been passed to the function.
+  // Try getting a cached list of layout info.
   if (!isset($info) && !$rebuild) {
     $cache = cache('cache')->get('layout_info');
     if ($cache && $cache->data) {
@@ -1202,9 +1201,7 @@ function layout_get_layout_template_info($template_name = NULL, $rebuild = FALSE
     }
   }
 
-  // Rebuild the list of layout info in the following two cases:
-  // - If trying to get a list of layout info from cache did not work.
-  // - If the optional $rebuild argument has been passed to the function.
+  // Rebuild the list of layout info.
   if (!isset($info) || $rebuild) {
     $files = backdrop_system_listing('/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.info$/', 'layouts', 'name', 0);
     $init = array();


### PR DESCRIPTION
…vailable after layout cache clear.

Fixes https://github.com/backdrop/backdrop-issues/issues/984

Alternative to https://github.com/backdrop/backdrop/pull/1717