### PR TITLE
Issue #2386: Conditionally load the contextmenu plugin to allow for spellcheck.

### DIFF
--- a/core/modules/ckeditor/ckeditor.api.php
+++ b/core/modules/ckeditor/ckeditor.api.php
@@ -52,6 +52,9 @@
  *   - required_html: If this button requires certain HTML tags or attributes
  *     to be allowed, specify an nested array for each set of tags that should
  *     be allowed. For example:
+ *   - dependencies: An array of other plugin names on which this button
+ *     depends. A common use is to add the "contextmenu" plugin, if the button
+ *     makes options available only via contextual menu.
  *
  *     @code
  *     array(
@@ -83,12 +86,16 @@ function hook_ckeditor_plugins() {
     'file' => 'plugin.js',
     'css' => array(backdrop_get_path('module', 'mymodule') . '/css/myplugin.css'),
     'enabled callback' => 'mymodule_myplugin_plugin_check',
-    'required_html' => array(
-      array(
-        'tags' => array('a'),
-        'attributes' => array('href', 'alt'),
-        'styles' => array('color', 'text-decoration'),
-        'classes' => array('external', 'internal'),
+    'buttons' => array(
+      'MyPlugin' => array(
+        'label' => t('My custom button'),
+        'required_html' => array(
+          'tags' => array('a'),
+          'attributes' => array('href', 'alt'),
+          'styles' => array('color', 'text-decoration'),
+          'classes' => array('external', 'internal'),
+        ),
+        'dependencies' => array('contextmenu'),
       ),
     ),
   );

--- a/core/modules/ckeditor/ckeditor.module
+++ b/core/modules/ckeditor/ckeditor.module
@@ -238,6 +238,7 @@ function ckeditor_ckeditor_plugins() {
     'Table' => array(
       'label' => t('Table'),
       'required_html' => array(array('tags' => array('table', 'thead', 'tbody', 'tr', 'td', 'th'))),
+      'dependencies' => array('contextmenu', 'tabletools', 'tableresize'),
     ),
     'Maximize' => array(
       'label' => t('Maximize'),
@@ -382,6 +383,7 @@ function ckeditor_get_settings($format, $existing_settings) {
   $external_plugins = array();
   $external_css = array();
   $all_buttons = array();
+  $dependencies = array();
   foreach ($plugin_info as $plugin_name => $plugin) {
     // Check if this plugin should be enabled.
     if (isset($plugin['enabled callback'])) {
@@ -432,6 +434,11 @@ function ckeditor_get_settings($format, $existing_settings) {
               $external_css = array_merge($external_css, $external_plugin['css']);
             }
           }
+
+          // Add in dependencies.
+          if (isset($all_buttons[$button_name]['dependencies'])) {
+            $dependencies = array_merge($dependencies, $all_buttons[$button_name]['dependencies']);
+          }
         }
       }
       $toolbar[] = $checked_group;
@@ -462,11 +469,21 @@ function ckeditor_get_settings($format, $existing_settings) {
     $css[$key] = base_path() . $css_path;
   }
 
+  // Default plugins that should be removed unless requested explicitly.
+  $excluded = array(
+    'image',
+    'tabletools',
+    'tableresize',
+    'contextmenu',
+  );
+  $excluded_plugins = array_diff($excluded, $dependencies);
+  $extra_plugins = array_unique(array_merge(array_keys($external_plugins), $dependencies));
+
   // Initialize reasonable defaults that provide expected basic behavior.
   $settings = array(
     'toolbar' => $toolbar,
-    'extraPlugins' => implode(',', array_keys($external_plugins)),
-    'removePlugins' => 'image',
+    'extraPlugins' => implode(',', $extra_plugins),
+    'removePlugins' => implode(',', $excluded_plugins),
     'removeButtons' => '',
     // Empty custom config must be a string.
     // See http://docs.ckeditor.com/#!/guide/dev_configuration.

--- a/core/modules/ckeditor/tests/ckeditor.test
+++ b/core/modules/ckeditor/tests/ckeditor.test
@@ -86,10 +86,26 @@ class CKEditorTestCase extends BackdropWebTestCase {
     $format_settings = $settings['filter']['formats']['ckeditor'];
     $this->assertEqual($format_settings['editorSettings']['toolbar'], $toolbar[0], 'CKEditor toolbar settings saved and added correctly.');
     $this->assertEqual($format_settings['editorSettings']['extraPlugins'], 'backdropimagecaption,backdropimage', 'Added custom plugins include custom image caption support.');
+    $this->assertEqual($format_settings['editorSettings']['removePlugins'], 'image,tabletools,tableresize,contextmenu');
     $style_list = array(
       array('name' => 'Title', 'element' => 'h1', 'attributes' => array('class' => 'title')),
       array('name' => 'Custom class', 'element' => 'p', 'attributes' => array('class' => 'custom-class')),
     );
     $this->assertEqual($format_settings['editorSettings']['stylesSet'], $style_list, 'Style list settings correct');
+
+    // Turn on the table plugin and check that the JavaScript is adjusted.
+    $toolbar[0][] = array(
+      'name' => 'Table',
+      'items' => array('Table'),
+    );
+    $this->backdropPost('admin/config/content/formats/ckeditor', array(
+      'editor_settings[toolbar]' => json_encode($toolbar),
+      'filters[filter_html][settings][allowed_html]' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h3> <h4> <h5> <p> <img> <figure> <figcaption> <table> <thead> <tbody> <tr> <td> <th>',
+    ), t('Save configuration'));
+    $this->backdropGet('node/add/article');
+    $settings = $this->backdropGetSettings();
+    $format_settings = $settings['filter']['formats']['ckeditor'];
+    $this->assertEqual($format_settings['editorSettings']['extraPlugins'], 'backdropimagecaption,backdropimage,contextmenu,tabletools,tableresize');
+    $this->assertEqual($format_settings['editorSettings']['removePlugins'], 'image');
   }
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2386.