### PR TITLE
Issue #2468: Views UI: title missing from the "Access" box.

### DIFF
--- a/core/modules/views/plugins/views_plugin_display.inc
+++ b/core/modules/views/plugins/views_plugin_display.inc
@@ -1077,13 +1077,20 @@ class views_plugin_display extends views_plugin {
         'title' => t('Format'),
         'column' => 'first',
       ),
+      'fields' => array(
+        'title' => t('Fields'),
+        'column' => 'first',
+      ),
       'filters' => array(
         'title' => t('Filters'),
         'column' => 'first',
       ),
-      'fields' => array(
-        'title' => t('Fields'),
-        'column' => 'first',
+      'access' => array(
+        'title' => 'Access',
+        'column' => 'second',
+        'build' => array(
+          '#weight' => -5,
+        ),
       ),
       'pager' => array(
         'title' => t('Pager'),
@@ -1094,13 +1101,6 @@ class views_plugin_display extends views_plugin {
         'column' => 'third',
         'build' => array(
           '#weight' => 1,
-        ),
-      ),
-      'access' => array(
-        'title' => 'Access',
-        'column' => 'second',
-        'build' => array(
-          '#weight' => -5,
         ),
       ),
       'other' => array(

--- a/core/modules/views/plugins/views_plugin_display.inc
+++ b/core/modules/views/plugins/views_plugin_display.inc
@@ -1097,7 +1097,7 @@ class views_plugin_display extends views_plugin {
         ),
       ),
       'access' => array(
-        'title' => '',
+        'title' => 'Access',
         'column' => 'second',
         'build' => array(
           '#weight' => -5,

--- a/core/modules/views/plugins/views_plugin_display.inc
+++ b/core/modules/views/plugins/views_plugin_display.inc
@@ -1086,7 +1086,7 @@ class views_plugin_display extends views_plugin {
         'column' => 'first',
       ),
       'access' => array(
-        'title' => 'Access',
+        'title' => t('Access'),
         'column' => 'second',
         'build' => array(
           '#weight' => -5,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2468

Note : the only actual change in this PR is the one-liner `'title' => '',` -> `'title' => 'Access',`. The rest of the changes is simply re-ordering things to match their order in the UI.