### PR TITLE
Issue #2478: Fix inconsistent naming of the setting that enables user configurable timezones.

### DIFF
--- a/core/modules/date/date.inc
+++ b/core/modules/date/date.inc
@@ -791,7 +791,7 @@ function date_timezone_is_valid($timezone) {
  */
 function date_default_timezone($check_user = TRUE) {
   global $user;
-  if ($check_user && config_get('system.date','user_timezone_configurable') && !empty($user->timezone)) {
+  if ($check_user && config_get('system.date','user_configurable_timezones') && !empty($user->timezone)) {
     return $user->timezone;
   }
   else {

--- a/core/modules/system/config/system.date.json
+++ b/core/modules/system/config/system.date.json
@@ -3,7 +3,7 @@
     "first_day": 0,
     "default_country": "",
     "default_timezone": "UTC",
-    "user_timezone_configurable": 1,
+    "user_configurable_timezones": 1,
     "user_timezone_default": 0,
     "user_timezone_warn": 0,
     "formats": {

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1912,11 +1912,10 @@ function system_regional_settings($form, &$form_state) {
     '#options' => $zones,
   );
 
-  $configurable_timezones = $system_date->get('user_configurable_timezones');
-  $form['timezone']['configurable_timezones'] = array(
+  $form['timezone']['user_configurable_timezones'] = array(
     '#type' => 'checkbox',
     '#title' => t('Users may set their own time zone.'),
-    '#default_value' => $configurable_timezones,
+    '#default_value' => $system_date->get('user_configurable_timezones'),
   );
 
   $form['timezone']['configurable_timezones_wrapper'] =  array(
@@ -1925,7 +1924,7 @@ function system_regional_settings($form, &$form_state) {
       // Hide the user configured timezone settings when users are forced to use
       // the default setting.
       'invisible' => array(
-        'input[name="configurable_timezones"]' => array('checked' => FALSE),
+        'input[name="user_configurable_timezones"]' => array('checked' => FALSE),
       ),
     ),
   );


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2478.

Change all references to `user_configurable_timezones`.