### PR TITLE
Issue #2478: revert forms with form element / settings name mismatches

### DIFF
--- a/core/modules/date/date.inc
+++ b/core/modules/date/date.inc
@@ -791,7 +791,7 @@ function date_timezone_is_valid($timezone) {
  */
 function date_default_timezone($check_user = TRUE) {
   global $user;
-  if ($check_user && config_get('system.date','user_timezone_configurable') && !empty($user->timezone)) {
+  if ($check_user && config_get('system.date','user_configurable_timezones') && !empty($user->timezone)) {
     return $user->timezone;
   }
   else {

--- a/core/modules/dblog/dblog.module
+++ b/core/modules/dblog/dblog.module
@@ -150,7 +150,16 @@ function dblog_form_system_logging_settings_alter(&$form, $form_state) {
     '#title' => t('Database log messages to keep'),
     '#default_value' => config_get('system.core', 'log_row_limit'),
     '#options' => array(0 => t('All')) + backdrop_map_assoc(array(100, 1000, 10000, 100000, 1000000)),
-    '#description' => t('The maximum number of messages to keep in the database log. Requires a <a href="@cron">cron maintenance task</a>.', array('@cron' => url('admin/reports/status'))),
-    '#config' => 'system.core',
+    '#description' => t('The maximum number of messages to keep in the database log. Requires a <a href="@cron">cron maintenance task</a>.', array('@cron' => url('admin/reports/status')))
   );
+  $form['#submit'][] = 'dblog_logging_settings_submit';
+}
+
+/**
+ * Form submission handler for system_logging_settings().
+ *
+ * @see dblog_form_system_logging_settings_alter()
+ */
+function dblog_logging_settings_submit($form, &$form_state) {
+  config_set('system.core', 'log_row_limit', $form_state['values']['dblog_row_limit']);
 }

--- a/core/modules/simpletest/simpletest.pages.inc
+++ b/core/modules/simpletest/simpletest.pages.inc
@@ -288,10 +288,10 @@ function simpletest_result_status_image($status) {
  *
  * @ingroup forms
  * @see simpletest_settings_form_validate()
+ * @see simpletest_settings_form_submit()
  */
 function simpletest_settings_form($form, &$form_state) {
   $config = config('simpletest.settings');
-  $form['#config'] = 'simpletest.settings';
   $form['general'] = array(
     '#type' => 'fieldset',
     '#title' => t('General'),
@@ -347,7 +347,25 @@ function simpletest_settings_form($form, &$form_state) {
     $form['httpauth']['simpletest_httpauth_password']['#description'] = t('To change the password, enter the new password here.');
   }
 
-  return system_settings_form($form);
+  $form['actions']['#type'] = 'actions';
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration')
+  );
+  return $form;
+}
+
+/**
+ * Form submission handler for simpletest_settings_form().
+ */
+function simpletest_settings_form_submit($form, &$form_state) {
+  config('simpletest.settings')
+    ->set('simpletest_clear_results', $form_state['values']['simpletest_clear_results'])
+    ->set('simpletest_verbose', $form_state['values']['simpletest_verbose'])
+    ->set('simpletest_method', $form_state['values']['simpletest_httpauth_method'])
+    ->set('simpletest_username', $form_state['values']['simpletest_httpauth_username'])
+    ->set('simpletest_password', $form_state['values']['simpletest_httpauth_password'])
+    ->save();
 }
 
 /**

--- a/core/modules/simpletest/simpletest.pages.inc
+++ b/core/modules/simpletest/simpletest.pages.inc
@@ -366,6 +366,7 @@ function simpletest_settings_form_submit($form, &$form_state) {
     ->set('simpletest_username', $form_state['values']['simpletest_httpauth_username'])
     ->set('simpletest_password', $form_state['values']['simpletest_httpauth_password'])
     ->save();
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**

--- a/core/modules/system/config/system.date.json
+++ b/core/modules/system/config/system.date.json
@@ -3,9 +3,9 @@
     "first_day": 0,
     "default_country": "",
     "default_timezone": "UTC",
-    "user_timezone_configurable": 1,
-    "user_timezone_default": 0,
-    "user_timezone_warn": 0,
+    "user_configurable_timezones": 1,
+    "user_default_timezone": 0,
+    "user_empty_timezone_message": 0,
     "formats": {
         "long": {
             "label": "Long Date",

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1877,7 +1877,6 @@ function system_regional_settings($form, &$form_state) {
   // Date settings:
   $zones = system_time_zones();
 
-  $form['#config'] = 'system.date';
   $form['locale'] = array(
     '#type' => 'fieldset',
     '#title' => t('Locale'),
@@ -1948,7 +1947,31 @@ function system_regional_settings($form, &$form_state) {
     '#description' => t('Only applied if users may set their own time zone.')
   );
 
-  return system_settings_form($form);
+  $form['actions']['#type'] = 'actions';
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+  );
+  return $form;
+}
+
+/**
+ * Form submission handler for regional settings.
+ *
+ * @ingroup forms
+ * @see system_regional_settings()
+ */
+function system_regional_settings_submit($form, &$form_state) {
+  config('system.date')
+    ->set('default_country', $form_state['values']['site_default_country'])
+    ->set('first_day', $form_state['values']['date_first_day'])
+    ->set('default_timezone', $form_state['values']['date_default_timezone'])
+    ->set('user_configurable_timezones', $form_state['values']['configurable_timezones'])
+    ->set('user_empty_timezone_message', $form_state['values']['empty_timezone_message'])
+    ->set('user_default_timezone', $form_state['values']['user_default_timezone'])
+    ->save();
+  // Display status messages for this form.
+  backdrop_set_message(t('The configuration options have been saved.'));
 }
 
 /**

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -568,7 +568,7 @@ function system_requirements($phase) {
       'description' => $description,
     );
   }
-  
+
   if ($phase == 'runtime') {
     // Inform the user if theme_debug is enabled.
     $theme_debug_enabled = config_get('system.core', 'theme_debug');
@@ -581,7 +581,7 @@ function system_requirements($phase) {
       );
     }
   }
-  
+
   return $requirements;
 }
 
@@ -3041,6 +3041,17 @@ function system_update_1061() {
   // Remove the entry for the entity_view_mode module in the system table. This
   // will "disable" the module if present.
   db_query("DELETE FROM {system} WHERE name = 'entity_view_mode' AND type = 'module'");
+}
+
+/**
+ * Remove configuration settings that were never used.
+ */
+function system_update_1062() {
+  $config = config('system.date');
+  $config->clear('user_timezone_configurable');
+  $config->clear('user_timezone_default');
+  $config->clear('user_timezone_warn');
+  $config->save();
 }
 
 /**


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2478.

* Reverts changes to three forms from #675.
* Changes the three `user_timezone_*` settings in system.date.json to the actually used names.
* Corrects a usage of `user_configurable_timezones` in date.inc.