### PR TITLE
Issue #2529: [UX] Maintenance mode: Do not render the "Create new acc…

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -2008,6 +2008,10 @@ function system_site_maintenance_mode($form, &$form_state) {
 function system_site_maintenance_mode_submit($form, &$form_state) {
   state_set('maintenance_mode', (bool) $form_state['values']['maintenance_mode']);
   config_set('system.core', 'maintenance_mode_message', $form_state['values']['maintenance_mode_message']);
+  // Rebuild menus so that certain items that are hidden when in maintenance
+  // mode (like the "Create new account" form for example) are immediately
+  // hidden/shown when switching to/from maintenance mode.
+  menu_rebuild();
 
   // Give specific messages on the primary action for this form.
   if ($form_state['values']['maintenance_mode']) {

--- a/core/modules/system/system.menu.inc
+++ b/core/modules/system/system.menu.inc
@@ -134,55 +134,59 @@ function system_menu_block_form($config) {
  *   - subject_array: The title as a renderable array.
  */
 function system_menu_block_build(array $config) {
-  if (module_exists('menu')) {
-    $menu_names = menu_get_menus();
-  }
-  else {
-    $menu_names = menu_list_system_menus();
-  }
-
-  // Set defaults.
-  $config += array(
-    'style' => 'tree',
-    'level' => 1,
-    'depth' => 3,
-  );
-
-  // Get the default block name.
-  backdrop_static_reset('menu_block_set_title');
-  $menu_name = str_replace('_', '-', $config['menu_name']);
-  system_menu_block_set_title($menu_names[$menu_name]);
-
-  // Get the raw menu tree data.
-  $tree = system_menu_tree_block_data($config);
-  $title = system_menu_block_get_title();
-
+  // Build menu blocks only if the site is not in maintenance mode or the
+  // logged in user has the 'access site in maintenance mode' permission.
   $data = array();
-  $data['subject'] = $title;
-  $data['content'] = array();
-  // Create a renderable tree.
-  if (!empty($tree) && $output = menu_tree_output($tree)) {
-    $data['content'] = $output;
-    // Add any menu style (currently always "dropdown" if any).
-    if (!empty($config['style'])) {
-      $data['content']['#wrapper_attributes']['class'][] = 'menu-' . str_replace('_', '-', $config['style']);
-      $data['content']['#wrapper_attributes']['data-menu-style'] = $config['style'];
-      $data['content']['#attached']['library'][] = array('system', 'backdrop.menus');
-      if ($config['style'] === 'dropdown') {
-        $data['content']['#attached']['library'][] = array('system', 'smartmenus');
+  if (!state_get('maintenance_mode', FALSE) || user_access('access site in maintenance mode')) {
+    if (module_exists('menu')) {
+      $menu_names = menu_get_menus();
+    }
+    else {
+      $menu_names = menu_list_system_menus();
+    }
+
+    // Set defaults.
+    $config += array(
+      'style' => 'tree',
+      'level' => 1,
+      'depth' => 3,
+    );
+
+    // Get the default block name.
+    backdrop_static_reset('menu_block_set_title');
+    $menu_name = str_replace('_', '-', $config['menu_name']);
+    system_menu_block_set_title($menu_names[$menu_name]);
+
+    // Get the raw menu tree data.
+    $tree = system_menu_tree_block_data($config);
+    $title = system_menu_block_get_title();
+
+    $data['subject'] = $title;
+    $data['content'] = array();
+    // Create a renderable tree.
+    if (!empty($tree) && $output = menu_tree_output($tree)) {
+      $data['content'] = $output;
+      // Add any menu style (currently always "dropdown" if any).
+      if (!empty($config['style'])) {
+        $data['content']['#wrapper_attributes']['class'][] = 'menu-' . str_replace('_', '-', $config['style']);
+        $data['content']['#wrapper_attributes']['data-menu-style'] = $config['style'];
+        $data['content']['#attached']['library'][] = array('system', 'backdrop.menus');
+        if ($config['style'] === 'dropdown') {
+          $data['content']['#attached']['library'][] = array('system', 'smartmenus');
+        }
+      }
+      if (!empty($config['toggle']) && $config['toggle'] == TRUE) {
+        $id = backdrop_html_id('menu-toggle-state');
+        $data['content']['#wrapper_attributes']['data-menu-toggle-id'] = $id;
+        $data['content']['#prefix'] = theme('menu_toggle', array('enabled' => $config['toggle'], 'id' => $id, 'text' => t('Menu')));
+        $data['content']['#attached']['css'][] = backdrop_get_path('module', 'system') . '/css/menu-toggle.theme.css';
+      }
+      if (!empty($config['style_settings'])) {
+        $data['content']['#wrapper_attributes']['data-menu-style'] = backdrop_json_encode($config['style_settings']);
       }
     }
-    if (!empty($config['toggle']) && $config['toggle'] == TRUE) {
-      $id = backdrop_html_id('menu-toggle-state');
-      $data['content']['#wrapper_attributes']['data-menu-toggle-id'] = $id;
-      $data['content']['#prefix'] = theme('menu_toggle', array('enabled' => $config['toggle'], 'id' => $id, 'text' => t('Menu')));
-      $data['content']['#attached']['css'][] = backdrop_get_path('module', 'system') . '/css/menu-toggle.theme.css';
-    }
-    if (!empty($config['style_settings'])) {
-      $data['content']['#wrapper_attributes']['data-menu-style'] = backdrop_json_encode($config['style_settings']);
-    }
   }
-
+  
   return $data;
 }
 

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3095,7 +3095,11 @@ function system_header_block($settings) {
     'site_slogan' => TRUE,
   );
 
-  $menu = $settings['menu'] ? menu_navigation_links($settings['menu']) : NULL;
+  // Render the header menu only if the site is not in maintenance mode or the
+  // logged in user has the 'access site in maintenance mode' permission.
+  if (!state_get('maintenance_mode', FALSE) || user_access('access site in maintenance mode')) {
+    $menu = $settings['menu'] ? menu_navigation_links($settings['menu']) : NULL;
+  }
   $site_config = config('system.core');
   $variables['logo']        = $settings['logo'] ? backdrop_get_logo() : NULL;
   $variables['logo_attributes'] = $settings['logo'] ? array_diff_key(backdrop_get_logo_info(), array('path' => '')) : array();
@@ -3112,12 +3116,19 @@ function system_header_block($settings) {
  * @see system_block_view()
  */
 function system_breadcrumb_block($settings = array()) {
-  $crumbs = backdrop_get_breadcrumb();
-  if (isset($settings['current']) && $settings['current'] == TRUE) {
-    $crumbs[] = '<span>' . backdrop_get_title() . '</span>';
-  }
+  // Render breadcrumbs only if the site is not in maintenance mode or the
+  // logged in user has the 'access site in maintenance mode' permission.
+  if (!state_get('maintenance_mode', FALSE) || user_access('access site in maintenance mode')) {
+    $crumbs = backdrop_get_breadcrumb();
+    if (isset($settings['current']) && $settings['current'] == TRUE) {
+      $crumbs[] = '<span>' . backdrop_get_title() . '</span>';
+    }
 
-  return theme('breadcrumb', array('breadcrumb' => $crumbs));
+    return theme('breadcrumb', array('breadcrumb' => $crumbs));
+  }
+  else {
+    return NULL;
+  }
 }
 
 /**

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1158,13 +1158,16 @@ function user_menu() {
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );
 
-  $items['user/register'] = array(
-    'title' => 'Create new account',
-    'page callback' => 'backdrop_get_form',
-    'page arguments' => array('user_register_form'),
-    'access callback' => 'user_register_access',
-    'type' => MENU_LOCAL_TASK,
-  );
+  // Do not render the registration tab if the site is in maintenance mode.
+  if (!state_get('maintenance_mode', FALSE)) {
+    $items['user/register'] = array(
+      'title' => 'Create new account',
+      'page callback' => 'backdrop_get_form',
+      'page arguments' => array('user_register_form'),
+      'access callback' => 'user_register_access',
+      'type' => MENU_LOCAL_TASK,
+    );
+  }
 
   $items['user/password'] = array(
     'title' => 'Reset password',


### PR DESCRIPTION
…ount" tab, the navigation menu and the account menu when in the "Log in" or "Reset password" pages.

Fixes https://github.com/backdrop/backdrop-issues/issues/2529