### PR TITLE
Issue #2556: Admin bar: Cannot disable components.

### DIFF
--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -32,8 +32,14 @@ function admin_bar_output($complete = FALSE) {
 
   // Rebuild the output.
   if (!isset($content)) {
-    // Retrieve enabled components to display and make them available for others.
+    // Retrieve all admin bar components.
     $components = $config->get('components');
+    // Remove any disabled components.
+    foreach ($components as $component => $value) {
+      if ($value === 0) {
+        unset($components[$component]);
+      }
+    }
     $content['#components'] = $components;
     $content['#complete'] = $complete;
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2556

...does not fix saving enabled component values as `1` in config.