### PR TITLE
Fixes issue #2504

### DIFF
--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -459,6 +459,8 @@ function path_patterns_settings_form($form) {
   module_load_include('inc', 'path');
   $config = config('path.settings');
 
+  $form['#config'] = 'path.settings';
+  
   $form['verbose'] = array(
     '#type' => 'checkbox',
     '#title' => t('Verbose'),


### PR DESCRIPTION
Fixes issue #2504 "transliteration does not work backdrop 1.6". URL alias pattern settings form doesn't save values.