### PR TITLE
Issue #2447: [UX] Admin bar: expose the "Manage fields" and "Manage display" for vocabularies

### DIFF
--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -100,7 +100,7 @@ function taxonomy_entity_info() {
     $return['taxonomy_term']['bundles'][$machine_name] = array(
       'label' => $vocabulary->name,
       'admin' => array(
-        'path' => 'admin/structure/taxonomy/%taxonomy_vocabulary_machine_name',
+        'path' => 'admin/structure/taxonomy/%taxonomy_vocabulary',
         'real path' => 'admin/structure/taxonomy/' . $machine_name,
         'bundle argument' => 3,
         'access arguments' => array('administer taxonomy'),


### PR DESCRIPTION
[UX] Admin bar: expose the "Manage fields" and "Manage display" for vocabularies.