### PR TITLE
Issue #2448

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1335,8 +1335,11 @@ function user_menu_alter(&$items) {
     // Provide a parent menu item for managing fields.
     $items['admin/config/people/manage'] = $items['admin/config/people/manage/fields'];
     $items['admin/config/people/manage']['type'] = MENU_NORMAL_ITEM;
-    $items['admin/config/people/manage']['weight'] = 1;
+    $items['admin/config/people/manage']['weight'] = 10;
     $items['admin/config/people/manage']['description'] = 'Configure fields and display of fields on user accounts.';
+
+    $items['admin/config/people/manage/fields']['weight'] = 10;
+    $items['admin/config/people/manage/display']['weight'] = 20;
 
     // Set "Manage fields" tab as the default tab.
     $items['admin/config/people/manage/fields']['type'] = MENU_DEFAULT_LOCAL_TASK;
@@ -1346,11 +1349,11 @@ function user_menu_alter(&$items) {
 /**
  * Implements hook_admin_menu_output_alter().
  */
-function user_admin_menu_output_alter(&$content) {
+function user_admin_bar_output_alter(&$content) {
   // Admin menu shows both the parent menu item and its children, remove the
   // duplicate child element show "Manage fields" doesn't show up twice.
-  if (isset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage/fields'])) {
-    unset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage/fields']);
+  if (isset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage'])) {
+    unset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage']);
   }
 }
 


### PR DESCRIPTION
[UX] Admin bar: "Manage fields" and "Manage display" items for user accounts unnecessarily nested under an extra "Manage fields" item.