### PR TITLE
Issue #1612: Move cursor after link element when creating a link.

### DIFF
--- a/core/modules/ckeditor/js/plugins/backdroplink/plugin.js
+++ b/core/modules/ckeditor/js/plugins/backdroplink/plugin.js
@@ -72,6 +72,12 @@ CKEDITOR.plugins.add('backdroplink', {
 
             // Set the link so individual properties may be set below.
             linkElement = getSelectedLink(editor);
+
+            // Move the selection to after the link so the user may continue
+            // typing outside of the link element itself.
+            range.setStartAfter(linkElement);
+            range.setEndAfter(linkElement);
+            range.select();
           }
           // Update the link properties.
           else if (linkElement) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1612.