### PR TITLE
Issue #2665: [UX] Display the "Default" block title

### DIFF
--- a/core/modules/layout/includes/block.class.inc
+++ b/core/modules/layout/includes/block.class.inc
@@ -128,6 +128,19 @@ class Block extends LayoutHandler {
   }
 
   /**
+   * Attempt to get a default title for this block for administrators
+   *
+   * @return string
+   */
+  function getDefaultTitle(){
+    $block_view = module_invoke($this->module, 'block_view', $this->delta);
+    if (!empty($block_view['subject'])){
+      return $block_view['subject'];
+    }
+    return '';
+  }
+
+  /**
    * Return an administrative title that will always have a value.
    */
   function getAdminTitle() {
@@ -216,6 +229,7 @@ class Block extends LayoutHandler {
     $layout = $form_state['layout'];
     $contexts = $layout->getContexts();
     $block_info = $this->getBlockInfo();
+    $default_title = $this->getDefaultTitle();
     $current_context_settings = isset($this->settings['contexts']) ? $this->settings['contexts'] : array();
 
     $form['contexts'] = layout_contexts_form_element($contexts, $current_context_settings, $block_info);
@@ -230,6 +244,18 @@ class Block extends LayoutHandler {
         LAYOUT_TITLE_NONE => t('None'),
       ),
       '#default_value' => $this->settings['title_display'],
+    );
+    $form['title_display']['default_title'] = array(
+      '#type' => 'textfield',
+      '#default_value' => $default_title,
+      '#title' => t('Default title'),
+      '#disabled' => TRUE,
+      '#states' => array(
+        'visible' => array(
+          'form.layout-block-configure-form :input[name="title_display"]' => array('value' => LAYOUT_TITLE_DEFAULT),
+        ),
+      ),
+      '#maxlength' => 255,
     );
     $form['title_display']['title'] = array(
       '#type' => 'textfield',


### PR DESCRIPTION
This approach provides a disabled text field, identical to the Custom Title field, that shows the default block title. This field, like Custom Title, disappears based on the selection of the Block title type field.

**Block title type - Default**
![default title selected](https://cloud.githubusercontent.com/assets/1205329/25765723/6ad0dfe0-31bc-11e7-9505-c8d64e1de395.png)

**Block title type - Custom**
![custom title selected](https://cloud.githubusercontent.com/assets/1205329/25765770/ab9192e0-31bc-11e7-8964-acb38dd74856.png)

**Block title type - None**
![screen shot 2017-05-05 at 5 57 41 pm](https://cloud.githubusercontent.com/assets/1205329/25765782/ba94c4f6-31bc-11e7-9b5f-9fcc7e57922b.png)


