### PR TITLE
Issue #1037: [UX] Token browser dialog: make token names clickable.

### DIFF
--- a/core/modules/system/css/token.css
+++ b/core/modules/system/css/token.css
@@ -31,6 +31,10 @@
   padding-left: 20px;
   padding-right: 20px;
 }
+.token-tree .branch.collapsed .token-name,
+.token-tree .branch.expanded .token-name {
+  cursor: pointer;
+}
 .token-tree .token-name {
   width: 30%;
   white-space: nowrap;

--- a/core/modules/system/js/token.js
+++ b/core/modules/system/js/token.js
@@ -9,7 +9,8 @@ Backdrop.behaviors.tokenTree = {
   attach: function (context, settings) {
     $(context).find('table.token-tree').once('token-tree', function () {
       $(this).treetable({
-        'expandable': true
+        'expandable': true,
+        'clickableNodeNames': true
       });
     });
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1037