### PR TITLE
Issue: #1437 [DX] Add field_info_field_map() - solved (approximation)

### DIFF
--- a/core/modules/field/field.info.inc
+++ b/core/modules/field/field.info.inc
@@ -614,6 +614,38 @@ function field_info_bundles($entity_type = NULL) {
 }
 
 /**
+ * Returns a cached lightweight map of fields across bundles.
+ *
+ * The function only returns active, non deleted fields.
+ *
+ * @return
+ *   An array keyed by field name. Each value is an array with two entries:
+ *   - type: The field type.
+ *   - bundles: The bundles in which the field appears, as an array with entity
+ *     types as keys and the array of bundle names as values.
+ * Example:
+ * @code
+ * array(
+ *   'body' => array(
+ *     'bundles' => array(
+ *       'node' => array('page', 'article'),
+ *     ),
+ *     'type' => 'text_with_summary',
+ *   ),
+ * );
+ * @endcode
+ */
+function field_info_field_map() {
+  static $field_info_cache = NULL;
+
+  if (empty($field_info_cache)){
+    $field_info_cache = field_info_fields();
+  }
+
+  return $field_info_cache;
+}
+
+/**
  * Returns all field definitions.
  *
  * @return


### PR DESCRIPTION
I was testing the portability of a module and ran into this issue.  The changes that occurred in Drupal 7.22 around field info caching are significant; multiple new db tables, new php class, and a few new functions.  

Rather that duplicating all of that for the sake of a function that no currently-ported backdrop module is using, I've written this function as a simple static cache for `field_info_fields()`.  This will provided the same information Drupal modules are looking for with their calls to `field_info_field_map()`, and though it probably isn't as performant as a database cache on the first call of this function during a request, it should be no-worse on second+ callings of this function than D core.
