### PR TITLE
Issue: #1437 [DX] Add field_info_field_map() - solved (approximation)-2

### DIFF
--- a/core/modules/field/field.info.inc
+++ b/core/modules/field/field.info.inc
@@ -614,6 +614,60 @@ function field_info_bundles($entity_type = NULL) {
 }
 
 /**
+ * Returns a cached lightweight map of fields across bundles.
+ *
+ * The function only returns active, non deleted fields.
+ *
+ * @return
+ *   An array keyed by field name. Each value is an array with two entries:
+ *   - type: The field type.
+ *   - bundles: The bundles in which the field appears, as an array with entity
+ *     types as keys and the array of bundle names as values.
+ * Example:
+ * @code
+ * array(
+ *   'body' => array(
+ *     'bundles' => array(
+ *       'node' => array('page', 'article'),
+ *     ),
+ *     'type' => 'text_with_summary',
+ *   ),
+ * );
+ * @endcode
+ */
+function field_info_field_map() {
+  // Read from the "static" cache.
+  static $field_info_cache = NULL;
+
+  if (!empty($field_info_cache)) {
+    return $field_info_cache;
+  }
+
+  // Read from persistent cache.
+  if ($cached = cache_get('field_info:field_map', 'cache_field')) {
+    $field_info_cache = $cached->data;
+    return $field_info_cache;
+  }
+
+  // Rebuild static cache
+  $field_info_cache = array();
+  $field_info_fields = field_info_fields();
+
+  foreach($field_info_fields as $field_name => $field_info){
+    $field_info_cache[$field_name]['type'] = $field_info['type'];
+    $field_info_cache[$field_name]['bundles'] = $field_info['bundles'];
+  }
+
+  // Save in persistent caches.
+  if (lock_acquire('field_info:field_map')) {
+    cache_set('field_info:field_map', $field_info_cache, 'cache_field');
+    lock_release('field_info:field_map');
+  }
+
+  return $field_info_cache;
+}
+
+/**
  * Returns all field definitions.
  *
  * @return


### PR DESCRIPTION
Second attempt- now with DB persistent cache---

I was testing the portability of a module and ran into this issue. The changes that occurred in Drupal 7.22 around field info caching are significant; multiple new db tables, new php class, and a few new functions.

Rather that duplicating all of that for the sake of a function that no currently-ported backdrop module is using, I've written this function as a simple static cache for field_info_fields(), backed up by a row in the cache table. This will provided the same information Drupal modules are looking for with their calls to field_info_field_map().

