### PR TITLE
Issue #2594: Deleting a node should not validate the form

### DIFF
--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -84,7 +84,6 @@ function node_add($type) {
 /**
  * Form validation handler for node_form().
  *
- * @see node_form_delete_submit()
  * @see node_form_submit()
  * @see node_form_submit_build_node()
  */
@@ -103,7 +102,6 @@ function node_form_validate($form, &$form_state) {
 /**
  * Form constructor for the node add/edit form.
  *
- * @see node_form_delete_submit()
  * @see node_form_validate()
  * @see node_form_submit()
  * @see node_form_submit_build_node()
@@ -343,11 +341,22 @@ function node_form($form, &$form_state, Node $node) {
     '#submit' => array('node_form_submit'),
   );
   if (!empty($node->nid) && node_access('delete', $node)) {
+    $destination = array();
+    if (isset($_GET['destination'])) {
+      $destination = backdrop_get_destination();
+      unset($_GET['destination']);
+    }
+
+    // Use a link for the delete button so the form doesn't need to validate.
     $form['actions']['delete'] = array(
-      '#type' => 'submit',
-      '#value' => t('Delete'),
+      '#type' => 'link',
+      '#title' => t('Delete'),
+      '#href' => "node/{$node->nid}/delete",
+      '#options' => array(
+        'query' => $destination,
+        'attributes' => array('class' => array('button', 'button-secondary', 'form-delete'))
+      ),
       '#weight' => 15,
-      '#submit' => array('node_form_delete_submit'),
     );
   }
   $form['actions']['cancel'] = array(
@@ -374,26 +383,8 @@ function node_form($form, &$form_state, Node $node) {
 }
 
 /**
- * Form submission handler for the 'Delete' button for node_form().
- *
- * @see node_form_validate()
- * @see node_form_submit()
- * @see node_form_submit_build_node()
- */
-function node_form_delete_submit($form, &$form_state) {
-  $destination = array();
-  if (isset($_GET['destination'])) {
-    $destination = backdrop_get_destination();
-    unset($_GET['destination']);
-  }
-  $node = $form['#node'];
-  $form_state['redirect'] = array('node/' . $node->nid . '/delete', array('query' => $destination));
-}
-
-/**
  * Form submission handler that saves the node for node_form().
  *
- * @see node_form_delete_submit()
  * @see node_form_validate()
  * @see node_form_submit_build_node()
  */
@@ -435,7 +426,6 @@ function node_form_submit($form, &$form_state) {
  * entity with the current step's values before proceeding to the next step.
  *
  * @see node_form()
- * @see node_form_delete_submit()
  * @see node_form_validate()
  * @see node_form_submit()
  */


### PR DESCRIPTION
This PR changes the Delete button into a Delete link to `node/[nid]/delete`.  

The previous button effectively did the same thing, but used `$form_state['redirect']` to change the path during a `#submit` callback, which required the form to pass validation before the redirect would trigger.

Changing this button into a link should have no strange affects or security concerns, as the route is already protected by node_access.

After changing the button to a link, I searched the entire code base (core and whatever contrib modules I have) for usage of the `node_form_delete_submit()` function and found none. So I deleted that function and some comments related to it. 

I also styled the new link with the classes 'button' and 'button-secondary` to match the old button.

**Before (as a button)**
![delete button](https://cloud.githubusercontent.com/assets/1205329/25834211/65bccf16-3444-11e7-9b8c-cf8014e76052.png)

**After (as a link)**
![delete link](https://cloud.githubusercontent.com/assets/1205329/25834222/7203e3f4-3444-11e7-8ca2-da3d58c1f140.png)

