### PR TITLE
Issue #2541: Project Installer: Modules "remembered” even if enabled

### DIFF
--- a/core/modules/installer/installer.browser.inc
+++ b/core/modules/installer/installer.browser.inc
@@ -108,6 +108,15 @@ function installer_browser_install_queue_remove($project_name) {
 }
 
 /**
+ * Removes a project from the list of recently installed projects.
+ */
+function installer_browser_installed_projects_remove($project_name) {
+  if (isset($_SESSION['installer_browser_installed_projects'][$project_name])) {
+    unset($_SESSION['installer_browser_installed_projects'][$project_name]);
+  }
+}
+
+/**
  * Clears the install queue.
  *
  * Removes all projects from the $_SESSION variables.

--- a/core/modules/installer/installer.browser.inc
+++ b/core/modules/installer/installer.browser.inc
@@ -109,10 +109,17 @@ function installer_browser_install_queue_remove($project_name) {
 
 /**
  * Removes a project from the list of recently installed projects.
+ *
+ * @param string[] $project_names
+ *   A list of projects to remove from the installed project list.
+ *
+ * @since 1.10.1
  */
-function installer_browser_installed_projects_remove($project_name) {
-  if (isset($_SESSION['installer_browser_installed_projects'][$project_name])) {
-    unset($_SESSION['installer_browser_installed_projects'][$project_name]);
+function installer_browser_installed_projects_remove($project_names) {
+  foreach ($project_names as $project_name) {
+    if (isset($_SESSION['installer_browser_installed_projects'][$project_name])) {
+      unset($_SESSION['installer_browser_installed_projects'][$project_name]);
+    }
   }
 }
 

--- a/core/modules/installer/installer.module
+++ b/core/modules/installer/installer.module
@@ -390,3 +390,26 @@ function installer_config_info() {
   );
   return $prefixes;
 }
+
+/**
+ * Implements hook_modules_enabled().
+ */
+function installer_modules_enabled($modules) {
+  module_load_include('inc', 'installer', 'installer.browser');
+
+  foreach ($modules as $module_name) {
+    installer_browser_installed_projects_remove($module_name);
+  }
+}
+
+/**
+ * Implements hook_themes_enabled().
+ */
+function installer_themes_enabled($theme_list) {
+  module_load_include('inc', 'installer', 'installer.browser');
+
+  foreach ($theme_list as $theme_name) {
+    installer_browser_installed_projects_remove($theme_name);
+  }
+}
+

--- a/core/modules/installer/installer.module
+++ b/core/modules/installer/installer.module
@@ -396,10 +396,7 @@ function installer_config_info() {
  */
 function installer_modules_enabled($modules) {
   module_load_include('inc', 'installer', 'installer.browser');
-
-  foreach ($modules as $module_name) {
-    installer_browser_installed_projects_remove($module_name);
-  }
+  installer_browser_installed_projects_remove($modules);
 }
 
 /**
@@ -407,9 +404,6 @@ function installer_modules_enabled($modules) {
  */
 function installer_themes_enabled($theme_list) {
   module_load_include('inc', 'installer', 'installer.browser');
-
-  foreach ($theme_list as $theme_name) {
-    installer_browser_installed_projects_remove($theme_name);
-  }
+  installer_browser_installed_projects_remove($theme_list);
 }
 


### PR DESCRIPTION
The problem is that the only time items are cleared from the `$_SESSION['installer_browser_installed_projects']` variable is when the user hits the route: `/admin/installer/reset/module/all`, which the user can easily avoid doing.

This PR hooks into `hook_themes_enabled` and `hook_modules_enabled` and removes newly enabled projects from `$_SESSION['installer_browser_installed_projects']` array.