### PR TITLE
Issue #1858: [UX] Project Browser should run some pre-flight checks

### DIFF
--- a/core/modules/installer/installer.browser.inc
+++ b/core/modules/installer/installer.browser.inc
@@ -573,3 +573,36 @@ function installer_browser_check_zip_loaded() {
   }
   return $zip_loaded;
 }
+
+/**
+ *
+ * Checks if relevant system folder is writable
+ *
+ * @param $type
+ *   Type of project to view. Must be one of 'module', 'theme' or 'layout'.
+ */
+function installer_browser_check_folder_writable($type) {
+  // luckily these are simple words to plural
+  $plural = "{$type}s";
+  $path = BACKDROP_ROOT."/{$plural}";
+  $test = $path.'/'.uniqid('test-');
+
+  if (backdrop_mkdir($test)){
+    backdrop_rmdir($test);
+  }
+  else {
+    backdrop_set_message(t('The following directory is not writable by the server: "@path" You may have trouble installing @plural', array('@plural' => $plural, '@path' => $path,)), 'warning', false);
+  }
+}
+
+/**
+ *
+ * Checks if the backdrop contrib repo is accessible
+ */
+function installer_browser_check_repo_accessible() {
+  $response = backdrop_http_request('http://example.com/', array('method' => 'HEAD'));
+
+  if (!$response || $response->code != '200'){
+    backdrop_set_message(t('Unable to access the internet. The installer is unlikely to work.'), 'warning', false);
+  }
+}

--- a/core/modules/installer/installer.pages.inc
+++ b/core/modules/installer/installer.pages.inc
@@ -20,6 +20,12 @@ function installer_browser_page($type) {
   // select to view available releases. Install blocked on select versions page.
   installer_browser_check_zip_loaded();
 
+  // Show a warning if provided backdrop repo is not accessible.
+  installer_browser_check_repo_accessible();
+
+  // Show a warning if the $type folder is not writable
+  installer_browser_check_folder_writable($type);
+
   // Show link to enable page if recently installed modules were not yet 
   // enabled.
   $recent_projects = installer_browser_get_installed_projects();


### PR DESCRIPTION
Fixes issue: https://github.com/backdrop/backdrop-issues/issues/1858

This could be better, but I avoided changing any core installer files.  

Ideally, there would be a way to get the project-type-relative install path from the `Updater` instance without having to construct it.  To construct an `Updater` class, it requires a legitimate project name. 

Ex: `$updater = new ModuleUpdater( $legitmate_project_name );`

With a working instance of an Updater, I could call `$updater->getInstallDirectory()`, it would fail to find a real backdrop module path, and it would return with `/path/to/backdrop/modules`.

But since the constructor executes `Updater::getProjectTitle()`, and that method throws an exception when it fails, I couldn't find a great way to get a system-provided install path for a project-type.

Additionally, with a fully-functioning `Updater` instance, I could `Updater::prepareInstallDirectory()` for a more accurate test of whether or not the directory can be created during project installation.

Long story short, this PR leverages the coincidence of all project type install directories being `BACKDROP_ROOT."/".$type."s"`, and some simple mkdir/rmdir functions to test if the install directory is writable.  If it fails to make the directory, it provides a UI warning to the user.

As a simple internet test, it attempts to get the headers for example.com, and provides a UI error in the case of failure.

I don't think this is testable on the CI server. You would need to be able to change some file permissions, and somehow disconnect the site from example.com.