### PR TITLE
Fix two regressions in install

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -248,6 +248,7 @@ function install_begin_request(&$install_state) {
   include_once BACKDROP_ROOT . '/core/includes/module.inc';
   include_once BACKDROP_ROOT . '/core/includes/session.inc';
   require_once BACKDROP_ROOT . '/core/includes/theme.inc';
+  require_once BACKDROP_ROOT . '/core/includes/tablesort.inc';
 
   require_once BACKDROP_ROOT . '/core/includes/ajax.inc';
   $module_list['system']['filename'] = 'core/modules/system/system.module';

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -689,7 +689,7 @@ function system_install() {
 
   // Set the public files path to the directory with the settings.php file.
   $public_path_match = array();
-  preg_match("/(\.\/|\/)?(.*)/", conf_path() . '/files', $public_path_match);
+  preg_match("/^(\.\/)?(.*)/", conf_path() . '/files', $public_path_match);
   config_set('system.core', 'file_public_path', $public_path_match[2]);
 
   // Clear out module list and hook implementation statics before calling

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -688,7 +688,9 @@ function system_install() {
   backdrop_set_installed_schema_version('system', $version);
 
   // Set the public files path to the directory with the settings.php file.
-  config_set('system.core', 'file_public_path', conf_path() . '/files');
+  $public_path_match = array();
+  preg_match("/(\.\/|\/)?(.*)/", conf_path() . '/files', $public_path_match);
+  config_set('system.core', 'file_public_path', $public_path_match[2]);
 
   // Clear out module list and hook implementation statics before calling
   // system_rebuild_theme_data().


### PR DESCRIPTION
Issue backdrop/backdrop-issues#2683 is for the first commit, where `./` in the beginning of the path causes issues later on when generating URLs.

During testing, I found I couldn't complete an install through the browser because `theme_table()` calls `tablesort_cell()` (see core/includes/theme.inc:2200), but `tablesort.inc` wasn't included yet.

Still need to write some unit tests for this.