### PR TITLE
Issue #2683: Use relative file path for new site installs.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -688,7 +688,7 @@ function system_install() {
   backdrop_set_installed_schema_version('system', $version);
 
   // Set the public files path to the directory with the settings.php file.
-  config_set('system.core', 'file_public_path', conf_path() . '/files');
+  config_set('system.core', 'file_public_path', str_replace('./', '', conf_path() . '/files'));
 
   // Clear out module list and hook implementation statics before calling
   // system_rebuild_theme_data().


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop/pull/1892.