### PR TITLE
Issue #2693: Fixing tablesort error on install caused by status report.

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -248,6 +248,7 @@ function install_begin_request(&$install_state) {
   include_once BACKDROP_ROOT . '/core/includes/module.inc';
   include_once BACKDROP_ROOT . '/core/includes/session.inc';
   require_once BACKDROP_ROOT . '/core/includes/theme.inc';
+  require_once BACKDROP_ROOT . '/core/includes/tablesort.inc';
 
   require_once BACKDROP_ROOT . '/core/includes/ajax.inc';
   $module_list['system']['filename'] = 'core/modules/system/system.module';

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -284,9 +284,6 @@ function theme_status_report($variables) {
   $infos = array();
   $okays = array();
   foreach ($requirements as $requirement) {
-    if ($requirement['title'] == 'hash') {
-      dpm($requirement);
-    }
     if (!isset($requirement['severity'])) {
       $requirement['severity'] = REQUIREMENT_OK;
     }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2683.