### PR TITLE
Issue #2688: Date Popup does not handle the S (English ordinal suffix for the day of the month) properly

### DIFF
--- a/core/modules/date/date.elements.inc
+++ b/core/modules/date/date.elements.inc
@@ -1381,6 +1381,7 @@ function _date_popup_datepicker_format_replacements() {
     'M' => 'M',
     'Y' => 'yy',
     'y' => 'y',
+    'S' => '',
   );
 }
 


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/2688