### PR TITLE
Issue #2731: [UX] Manage blocks UI: No required indicator in "Admin l…

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -301,9 +301,9 @@
   margin: 1em 0;
   padding: 0 20px;
 }
-.form-item-reusable-admin-label {
+.form-item.form-item-reusable-admin-label {
   padding-left: 20px;
 }
-[dir="rtl"] .form-item-reusable-admin-label {
+[dir="rtl"] .form-item.form-item-reusable-admin-label {
   padding-right: 20px;
 }

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -301,9 +301,11 @@
   margin: 1em 0;
   padding: 0 20px;
 }
-.form-item.form-item-reusable-admin-label {
+.form-item.form-item-reusable-admin-label,
+.form-item.form-item-reusable-delta {
   padding-left: 20px;
 }
-[dir="rtl"] .form-item.form-item-reusable-admin-label {
+[dir="rtl"] .form-item.form-item-reusable-admin-label,
+[dir="rtl"] .form-item.form-item-reusable-delta {
   padding-right: 20px;
 }

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -301,3 +301,9 @@
   margin: 1em 0;
   padding: 0 20px;
 }
+.form-item-reusable-admin-label {
+  padding-left: 20px;
+}
+[dir="rtl"] .form-item-reusable-admin-label {
+  padding-right: 20px;
+}

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -76,7 +76,7 @@ class BlockText extends Block {
       $form['convert']['reusable'] = array(
         '#type' => 'checkbox',
         '#title' => t('Make this block reusable'),
-        '#description' => t('If enabled, this block will be made reusable across different layouts and will be listed in the !link page. <br><strong>Note</strong>: This option may not be unchecked once enabled!', array('!link' => l(t('Custom blocks'), 'admin/structure/block'))),
+        '#description' => t('If enabled, this block will be made reusable across different layouts and will be listed in the !link page. This option may not be unchecked once enabled.', array('!link' => l(t('Custom blocks'), 'admin/structure/block'))),
         '#weight' => 1,
       );
       $form['convert']['label'] = array(

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -139,7 +139,7 @@ class BlockText extends Block {
           form_error($form['convert']['label'], t('Admin label is required when making a block reusable.'));
         }
         elseif (empty($delta)) {
-          form_error($form['convert']['delta'], t('An internal name is required when making a block reusable.'));
+          form_error($form['convert']['delta'], t('A machine-readable name is required when making a block reusable.'));
         }
       }
     }

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -79,7 +79,7 @@ class BlockText extends Block {
         '#description' => t('If enabled, this block will be made reusable across different layouts and will be listed in the !link page. This option may not be unchecked once enabled.', array('!link' => l(t('Custom blocks'), 'admin/structure/block'))),
         '#weight' => 1,
       );
-      $form['convert']['label'] = array(
+      $form['convert']['reusable-admin-label'] = array(
         '#type' => 'textfield',
         '#title' => t('Admin label'),
         '#maxlength' => 64,

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -76,7 +76,7 @@ class BlockText extends Block {
       $form['convert']['reusable'] = array(
         '#type' => 'checkbox',
         '#title' => t('Make this block reusable'),
-        '#description' => t('If enabled, this block will be made reusable across different layouts and will be listed in the !link page. <br><strong>Note</strong>: Making a custom block reusable cannot be reverted!', array('!link' => l(t('Custom blocks'), 'admin/structure/block'))),
+        '#description' => t('If enabled, this block will be made reusable across different layouts and will be listed in the !link page. <br><strong>Note</strong>: This option may not be unchecked once enabled!', array('!link' => l(t('Custom blocks'), 'admin/structure/block'))),
         '#weight' => 1,
       );
       $form['convert']['label'] = array(

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -76,7 +76,7 @@ class BlockText extends Block {
       $form['convert']['reusable'] = array(
         '#type' => 'checkbox',
         '#title' => t('Make this block reusable'),
-        '#description' => t('If enabled, this block will be made reusable across different layouts and be listed in on the !block_link page.', array('!block_link' => l(t('Custom blocks'), 'admin/structure/block'))),
+        '#description' => t('If enabled, this block will be made reusable across different layouts and will be listed in the !link page. <br><strong>Note</strong>: Making a custom block reusable cannot be reverted!', array('!link' => l(t('Custom blocks'), 'admin/structure/block'))),
         '#weight' => 1,
       );
       $form['convert']['label'] = array(
@@ -89,11 +89,18 @@ class BlockText extends Block {
           'visible' => array(
             ':input[name="reusable"]' => array('checked' => TRUE),
           ),
+          // Workaround in order to make the field render as required, with a
+          // red asterisk. Actual form validation happens in formValidate()
+          // below.
+          // See https://github.com/backdrop/backdrop-issues/issues/2732
+          'required' => array(
+            'input[name="reusable"]' => array('checked' => TRUE),
+          ),
         ),
       );
       $form['convert']['delta'] = array(
         '#type' => 'machine_name',
-        '#title' => t('Internal name'),
+        '#title' => t('Machine-readable name'),
         '#maxlength' => 64,
         '#machine_name' => array(
           'source' => array('convert', 'label'),
@@ -101,6 +108,18 @@ class BlockText extends Block {
         ),
         '#description' => t('A unique machine-readable name containing letters, numbers, and underscores.'),
         '#weight' => 3,
+        // Workaround in order to make the field render as required, with a red
+        // asterisk (when one clicks the "edit" link). Actual form validation
+        // happens in formValidate() below.
+        // See https://github.com/backdrop/backdrop-issues/issues/2732
+        '#states' => array(
+          'required' => array(
+            'input[name="reusable"]' => array('checked' => TRUE),
+          ),
+        ),
+        // This line is still required in order to not throw form validation
+        // errors when the 'Make this block reusable' checkbox is not checked.
+        // See https://github.com/backdrop/backdrop-issues/issues/2732
         '#required' => FALSE,
       );
     }

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -103,7 +103,7 @@ class BlockText extends Block {
         '#title' => t('Machine-readable name'),
         '#maxlength' => 64,
         '#machine_name' => array(
-          'source' => array('convert', 'label'),
+          'source' => array('convert', 'reusable-admin-label'),
           'exists' => 'block_custom_block_load',
         ),
         '#description' => t('A unique machine-readable name containing letters, numbers, and underscores.'),
@@ -132,11 +132,11 @@ class BlockText extends Block {
     parent::formValidate($form, $form_state);
 
     if (module_exists('block')) {
-      $label = trim($form_state['values']['label']);
+      $reusable_admin_label = trim($form_state['values']['reusable-admin-label']);
       $delta = trim($form_state['values']['delta']);
       if ($form_state['values']['reusable']) {
-        if (empty($label)) {
-          form_error($form['convert']['label'], t('Admin label is required when making a block reusable.'));
+        if (empty($reusable_admin_label)) {
+          form_error($form['convert']['reusable-admin-label'], t('Admin label is required when making a block reusable.'));
         }
         elseif (empty($delta)) {
           form_error($form['convert']['delta'], t('A machine-readable name is required when making a block reusable.'));
@@ -157,7 +157,7 @@ class BlockText extends Block {
       $this->plugin = 'block:' . $delta;
 
       $edit = array(
-        'info' => $form_state['values']['label'],
+        'info' => $form_state['values']['reusable-admin-label'],
         'title' => $form_state['values']['title'],
         'body' => $form_state['values']['content'],
       );

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -98,7 +98,7 @@ class BlockText extends Block {
           ),
         ),
       );
-      $form['convert']['delta'] = array(
+      $form['convert']['reusable-delta'] = array(
         '#type' => 'machine_name',
         '#title' => t('Machine-readable name'),
         '#maxlength' => 64,
@@ -133,13 +133,13 @@ class BlockText extends Block {
 
     if (module_exists('block')) {
       $reusable_admin_label = trim($form_state['values']['reusable-admin-label']);
-      $delta = trim($form_state['values']['delta']);
+      $delta = trim($form_state['values']['reusable-delta']);
       if ($form_state['values']['reusable']) {
         if (empty($reusable_admin_label)) {
           form_error($form['convert']['reusable-admin-label'], t('Admin label is required when making a block reusable.'));
         }
         elseif (empty($delta)) {
-          form_error($form['convert']['delta'], t('A machine-readable name is required when making a block reusable.'));
+          form_error($form['convert']['reusable-delta'], t('A machine-readable name is required when making a block reusable.'));
         }
       }
     }

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -1369,7 +1369,7 @@ class LayoutBlockTest extends BackdropWebTestCase {
     $this->assertText(t('Admin label is required when making a block reusable.'));
     $edit['label'] = 'My custom block label';
     $this->backdropPost(NULL, $edit, t('Update block'));
-    $this->assertText(t('An internal name is required when making a block reusable.'));
+    $this->assertText(t('A machine-readable name is required when making a block reusable.'));
     $edit['delta'] = 'my_custom_block';
     $this->backdropPost(NULL, $edit, t('Update block'));
 


### PR DESCRIPTION
…abel" field for custom blocks.

Fixes https://github.com/backdrop/backdrop-issues/issues/2731