### PR TITLE
Issue #2758: [UX] If none of the admin bar components is enabled, dis…

### DIFF
--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -675,7 +675,7 @@ function admin_bar_empty_message() {
     ),
   );
 
-  $message = t('All admin bar components have been disabled. You can re-enable them <a href="@admin_bar_config">here</a>.', array('@admin_bar_config' => url('admin/config/administration/admin-bar')));
+  $message = t('All Administration bar components have been disabled. You can re-enable them <a href="@admin_bar_config">here</a>.', array('@admin_bar_config' => url('admin/config/administration/admin-bar')));
 
   $empty_message['message'] = array(
     '#title' => $message,

--- a/core/modules/admin_bar/admin_bar.inc
+++ b/core/modules/admin_bar/admin_bar.inc
@@ -63,24 +63,30 @@ function admin_bar_output($complete = FALSE) {
       $content['menu']['menu']['#title'] = t('Admin bar');
     }
 
-    // Check for status report errors.
+    // Add alert badge if there are status report errors.
     if (user_access('administer site configuration')) {
       $content['alert'] = admin_bar_links_alert();
     }
 
-    // Add menu additions.
-    $content['extra']['extra'] = array();
-    if (in_array('admin_bar.icon', $components) || $complete) {
-      $content['icon'] = admin_bar_links_icon();
+    // Add enabled components to the admin bar menu.
+    if (!empty($components)) {
+      $content['extra']['extra'] = array();
+      if (in_array('admin_bar.icon', $components) || $complete) {
+        $content['icon'] = admin_bar_links_icon();
+      }
+      if (in_array('admin_bar.search', $components) || $complete) {
+        $content['extra']['extra'] += admin_bar_links_search();
+      }
+      if (in_array('admin_bar.account', $components) || $complete) {
+        $content['extra']['extra'] += admin_bar_links_account();
+      }
+      if (in_array('admin_bar.users', $components) || $complete) {
+        $content['extra']['extra'] += admin_bar_links_users();
+      }
     }
-    if (in_array('admin_bar.search', $components) || $complete) {
-      $content['extra']['extra'] += admin_bar_links_search();
-    }
-    if (in_array('admin_bar.account', $components) || $complete) {
-      $content['extra']['extra'] += admin_bar_links_account();
-    }
-    if (in_array('admin_bar.users', $components) || $complete) {
-      $content['extra']['extra'] += admin_bar_links_users();
+    else {
+      // Show help text when all components are disabled.
+      $content['empty'] = admin_bar_empty_message();
     }
 
     // Allow modules to enhance the menu.
@@ -656,6 +662,31 @@ function admin_bar_links_search() {
     ),
   );
   return $search;
+}
+
+/**
+ * Build empty admin bar message.
+ */
+function admin_bar_empty_message() {
+  $empty_message = array(
+    '#theme' => 'admin_bar_links',
+    '#wrapper_attributes' => array(
+      'id' => 'admin-bar-empty-message',
+    ),
+  );
+
+  $message = t('All admin bar components have been disabled. You can re-enable them <a href="@admin_bar_config">here</a>.', array('@admin_bar_config' => url('admin/config/administration/admin-bar')));
+
+  $empty_message['message'] = array(
+    '#title' => $message,
+    '#attributes' => array(
+      'class' => 'admin-bar-empty-message',
+    ),
+    '#access' => user_access('administer site configuration'),
+    '#options' => array('html' => TRUE),
+  );
+
+  return $empty_message;
 }
 
 /**


### PR DESCRIPTION
…play some help text and a link to its config page.

Fixes https://github.com/backdrop/backdrop-issues/issues/2758

Unconditionally adds the "You can re-enable them [here](url)" part of the message.