### PR TITLE
Issue #2744: Whitespace issue on 'Available updates' page.

### DIFF
--- a/core/modules/update/css/update.css
+++ b/core/modules/update/css/update.css
@@ -32,7 +32,8 @@ table.update {
   [dir="rtl"] .update .version-status {
     float: left;
   }
-  .update .versions {
+  .update .versions,
+  .update .info {
     clear: both;
   }
 }


### PR DESCRIPTION
Addresses backdrop/backdrop-issues/issues/2744