### PR TITLE
Issue #2787: NodeMultiByteUtf8Test checks the wrong xpath.

### DIFF
--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -2850,7 +2850,7 @@ class NodeMultiByteUtf8Test extends NodeWebTestCase {
     $this->assertTrue(backdrop_strlen($title) < strlen($title), 'Title has multi-byte characters.');
     $node = $this->backdropCreateNode(array('title' => $title));
     $this->backdropGet('node/' . $node->nid);
-    $result = $this->xpath('//h1[@id="page-title"]');
+    $result = $this->xpath('(//div[contains(@class, "l-page-title")])//h1');
     $this->assertEqual(trim((string) $result[0]), $title, 'The passed title was returned.');
   }
 


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2787