### PR TITLE
Issue #2740: [UX] Align the operations dropbuttons to the left (right for RTL).

### DIFF
--- a/core/misc/dropbutton.css
+++ b/core/misc/dropbutton.css
@@ -26,11 +26,11 @@
 .js .dropbutton-widget {
   position: absolute;
   top: 0;
-  right: 0; /* LTR */
+  left: 0; /* LTR */
 }
 [dir="rtl"].js .dropbutton-widget {
-  left: 0;
-  right: auto;
+  right: 0;
+  left: auto;
 }
 /* UL styles are over-scoped in core, so this selector needs weight parity. */
 .js .dropbutton-widget .dropbutton {

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -14,9 +14,6 @@
 #layout-list td:last-child {
   min-width: 160px;
 }
-#layout-list th.layout-operations {
-  text-align: center;
-}
 
 @media (min-width: 768px) {
   #layout-list span.priority-low {

--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -88,7 +88,7 @@ small .admin-link:after {
   width: 70px;
 }
 #system-modules td.operations {
-  width: 105px;
+  width: 120px;
 }
 div.admin-requirements,
 div.admin-required {

--- a/core/modules/views_ui/css/views_ui.admin.theme.css
+++ b/core/modules/views_ui/css/views_ui.admin.theme.css
@@ -384,7 +384,7 @@ th.views-ui-path {
 }
 
 th.views-ui-operations {
-  width: 10%;
+  width: 15%;
 }
 
 /* @end */
@@ -1101,11 +1101,20 @@ div.messages {
 /* @group Drop buttons */
 .views-ui-display-tab-bucket .dropbutton-wrapper {
   position: absolute;
-  right: 12px; /* LTR */
   top: 8px;
 }
-[dir="rtl"] .views-ui-display-tab-bucket .dropbutton-wrapper {
-  left: 20px;
+.views-ui-display-tab-bucket .dropbutton-wrapper.dropbutton-multiple {
+  right: 80px; /* LTR */
+}
+.views-ui-display-tab-bucket .dropbutton-wrapper.dropbutton-single {
+  right: 55px; /* LTR */
+}
+[dir="rtl"] .views-ui-display-tab-bucket .dropbutton-wrapper.dropbutton-multiple {
+  left: 80px;
+  right: auto;
+}
+[dir="rtl"] .views-ui-display-tab-bucket .dropbutton-wrapper.dropbutton-single {
+  left: 55px;
   right: auto;
 }
 .views-ui-display-tab-bucket .dropbutton-wrapper,


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#2740

Replaces https://github.com/backdrop/backdrop/pull/1944.