### PR TITLE
Issue #2826: Fix jQuery version number to match.

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -1257,7 +1257,7 @@ function system_library_info() {
   $libraries['jquery'] = array(
     'title' => 'jQuery',
     'website' => 'http://jquery.com',
-    'version' => '1.11.0',
+    'version' => '1.12.4',
     'js' => array(
       'core/misc/jquery.js' => array('group' => JS_LIBRARY, 'weight' => -20),
     ),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2826.