### PR TITLE
Issue #2784: Don't have Backdrop handle all 404 errors by default.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,9 +15,6 @@
 # Don't show directory listings for URLs which map to a directory.
 Options -Indexes
 
-# Make Backdrop handle any 404 errors.
-ErrorDocument 404 /index.php
-
 # Set the default handler.
 DirectoryIndex index.php index.html index.htm
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2784