### PR TITLE
Issue #2888: Use database independent calls to initialize the testing cache.

### DIFF
--- a/core/includes/database/mysql/schema.inc
+++ b/core/includes/database/mysql/schema.inc
@@ -124,6 +124,16 @@ class DatabaseSchema_mysql extends DatabaseSchema {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected function cloneTableSql($source, $target) {
+    $statements[] = 'CREATE TABLE ' . $target . ' LIKE ' . $source;
+    $statements[] = 'INSERT ' . $target . ' SELECT * FROM ' . $source;
+
+    return $statements;
+  }
+
+  /**
    * Create an SQL string for a field to be used in table creation or alteration.
    *
    * Before passing a field out of a schema definition into this function it has

--- a/core/includes/database/schema.inc
+++ b/core/includes/database/schema.inc
@@ -680,6 +680,39 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
   abstract protected function createTableSql($name, $table);
 
   /**
+   * Create an exact duplicate of an existing table, including all content.
+   *
+   * @param $source
+   *   The name of the table to be copied.
+   * @param $target
+   *   The name of the new table to be created and populated with data.
+   *
+   * @throws DatabaseSchemaObjectExistsException
+   *   If the new table specified already exists.
+   */
+  public function cloneTable($source, $target) {
+    if ($this->tableExists($target)) {
+      throw new DatabaseSchemaObjectExistsException(t('Table @name already exists.', array('@name' => $target)));
+    }
+    $statements = $this->cloneTableSql($source, $target);
+    foreach ($statements as $statement) {
+      $this->connection->query($statement);
+    }
+  }
+
+  /**
+   * Generate an array of query strings suitable for cloning a table.
+   *
+   * @param $source
+   *   The name of the table to be copied.
+   * @param $target
+   *   The name of the new table to be created and populated with data.
+   * @return
+   *   An array of SQL statements to clone the table, including inserting data.
+   */
+  abstract protected function cloneTableSql($source, $target);
+
+  /**
    * Return an array of field names from an array of key/index column specifiers.
    *
    * This is usually an identity function but if a key/index uses a column prefix

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1591,13 +1591,14 @@ class BackdropWebTestCase extends BackdropTestCase {
     $config_cache_dir = $this->originalFileDirectory . '/simpletest/simpletest_cache_' . $this->profile;
 
     if (is_dir($config_cache_dir)) {
+      $schema = self::getDatabaseConnection()->schema();
       $prefix = 'simpletest_cache_' . $this->profile . '_';
 
-      $tables = db_query("SHOW TABLES LIKE :prefix", array(':prefix' => db_like($prefix) . '%' ))->fetchCol();
+      $tables = $schema->findTables(db_like($prefix) . '%');
 
       foreach ($tables as $table_prefix) {
         $table = substr($table_prefix, strlen($prefix));
-        db_query('CREATE TABLE ' . $this->databasePrefix . $table . ' LIKE ' . $table_prefix);
+        db_query('CREATE TABLE ' . $this->databasePrefix . $table . ' LIKE ' . $table_prefix );
         db_query('INSERT ' . $this->databasePrefix . $table . ' SELECT * FROM ' . $table_prefix);
       }
 

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1598,8 +1598,7 @@ class BackdropWebTestCase extends BackdropTestCase {
 
       foreach ($tables as $table_prefix) {
         $table = substr($table_prefix, strlen($prefix));
-        db_query('CREATE TABLE ' . $this->databasePrefix . $table . ' LIKE ' . $table_prefix );
-        db_query('INSERT ' . $this->databasePrefix . $table . ' SELECT * FROM ' . $table_prefix);
+        $schema->cloneTable($table_prefix, $this->databasePrefix . $table);
       }
 
       $this->recursiveCopy($config_cache_dir, $this->public_files_directory);


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2888 by using the existing `DatabaseSchema::findTables()` member function and creating new `DatabaseSchema::cloneTable()` and abstract `DatabaseSchema::cloneTableSql()` member functions.