### PR TITLE
Issue #2889: Tweak some tests to make them more robust

### DIFF
--- a/core/modules/file/tests/file.test
+++ b/core/modules/file/tests/file.test
@@ -1601,9 +1601,9 @@ class FileAdminTestCase extends FileFieldTestCase {
     $files['file_1'] = $this->getTestFile('text');
     $files['file_2'] = $this->getTestFile('text', 131072);
     $files['file_3'] = $this->getTestFile('text', 1310720);
-    $files['file_4'] = $this->getTestFile('image');
-    $files['file_5'] = $this->getTestFile('image');
-    $files['file_6'] = $this->getTestFile('image');
+    $files['file_4'] = $this->getTestFile('image', 125);
+    $files['file_5'] = $this->getTestFile('image', 183);
+    $files['file_6'] = $this->getTestFile('image', 1885);
 
     foreach ($files as $file) {
       // Create a new node with the file attached.

--- a/core/modules/node/tests/node_views_revision_relations.test
+++ b/core/modules/node/tests/node_views_revision_relations.test
@@ -109,6 +109,11 @@ class NodeViewsRevisionRelationsTestCase extends ViewsSqlTest {
     $handler->display->display_options['fields']['nid']['table'] = 'node';
     $handler->display->display_options['fields']['nid']['field'] = 'nid';
     $handler->display->display_options['fields']['nid']['relationship'] = 'nid';
+    /* Sort by VID */
+    $handler->display->display_options['sorts']['vid']['id'] = 'vid';
+    $handler->display->display_options['sorts']['vid']['table'] = 'node_revision';
+    $handler->display->display_options['sorts']['vid']['field'] = 'vid';
+    $handler->display->display_options['sorts']['vid']['relationship'] = 'none';
     /* Contextual filter: Content revision: Nid */
     $handler->display->display_options['arguments']['nid']['id'] = 'nid';
     $handler->display->display_options['arguments']['nid']['table'] = 'node_revision';

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -600,9 +600,9 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
 
     $edit = array(
       'action' => 'path_node_update_action',
-      "bulk_form[0]" => TRUE,
+      'bulk_form[1]' => TRUE,
     );
-    $this->backdropPost('admin/content', $edit, t('Execute'));
+    $this->backdropPost('admin/content', $edit, t('Execute'), array('query' => array('order' => 'type', 'sort' => 'asc')));
     $this->assertRaw(format_string('%action was applied to 1 item', array('%action' => 'Update content URL alias')));
 
     $this->assertEntityAlias('node', $node1, 'content/' . $node1->title);

--- a/core/modules/simpletest/backdrop_web_test_case_cache.php
+++ b/core/modules/simpletest/backdrop_web_test_case_cache.php
@@ -167,6 +167,9 @@ class BackdropWebTestCaseCache extends BackdropWebTestCase {
    * MyISAM is faster to delete and copy tables. It gives small adventage when /var/lib/mysql on SHM (memory) device, but much bigger when tests run on regular device.
    */
   protected function alterToMyISAM() {
+    if (Database::getConnection()->driver() != 'mysql') {
+      return;
+    }
     $skip_alter = array(
       'taxonomy_term_data',
       'node',

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1388,6 +1388,8 @@ class UserAdminTestCase extends BackdropWebTestCase {
   function testUserAdmin() {
     // Create admin user to delete registered user.
     $admin_user = $this->backdropCreateUser(array('administer users', 'access user profiles'));
+    $admin_user->created -= 2;
+    $admin_user->save();
 
     $user_a = $this->backdropCreateUser(array());
     $user_b = $this->backdropCreateUser(array('administer taxonomy'));


### PR DESCRIPTION
In three cases, FileAdminTestCase, NodeViewsRevisionRelationsTestCase and PathPatternFunctionalTestCase, the right data may be returned, but in the wrong order.  

For FileAdminTestCase, giving each file a unique size ensures they can be returned in the right order.  

For NodeViewsRevisionRelationsTestCase and PathPatternFunctionalTestCase, sorting the results by an existing field does the same.  PathPatternFunctionalTestCase needs an additional tweak to choose the right item, which now appears at a different index.

In UserAdminTestCase, a fast machine may set the created timestamps of all three users to the same second.  In the unit test that disables a user, pgsql returned the users in a different order, and the admin test account disabled itself, breaking the rest of the tests.  Artificially setting the admin user's created timestamp to 2 seconds earlier ensures correct sort order.

Finally, `alterToMyISAM()` is only valid for MySQL and friends.  Other drivers can safely skip this step.

Addresses backdrop/backdrop-issues#2889.