### PR TITLE
Issue #2891: Check for php-curl before running tests.

### DIFF
--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -129,7 +129,13 @@ abstract class BackdropTestCase {
    *   Array of errors containing a list of unmet requirements.
    */
   protected function checkRequirements() {
-    return array();
+    $errors = array();
+
+    if (!extension_loaded('curl')) {
+      $errors[] = 'PHP curl extension is not present.';
+    }
+
+    return $errors;
   }
 
   /**


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2891 by checking for the php-curl library in BackdropTestCase.