### PR TITLE
Issue #2879: Fix dropdown menu elements

### DIFF
--- a/core/modules/system/system.menu.inc
+++ b/core/modules/system/system.menu.inc
@@ -19,7 +19,6 @@ function system_menu_block_defaults($menu_name) {
     'level' => 1,
     'menu_name' => $menu_name,
     'style' => NULL,
-    'expand_all' => FALSE,
   );
   if ($menu_name == 'main-menu') {
     $defaults['depth'] = 1;
@@ -158,8 +157,13 @@ function system_menu_block_build(array $config) {
     'style' => 'tree',
     'level' => 1,
     'depth' => 3,
-    'expand_all' => FALSE,
   );
+  
+  if ($config['style'] == 'tree') {
+    $config += array(
+      'expand_all' => FALSE,
+    );
+  }
 
   // Get the default block name.
   backdrop_static_reset('menu_block_set_title');


### PR DESCRIPTION
Fixes the regression from #1932, where adding expand_all = FALSE to ALL menu blocks prevented the "dropdown" menu style from displaying all links properly..