### PR TITLE
Fix issue #2903 by modifying example date.

### DIFF
--- a/core/modules/date/date.module
+++ b/core/modules/date/date.module
@@ -815,20 +815,11 @@ function date_format_type_options() {
 }
 
 /**
- * Creates an example date.
+ * Creates an example date object.
  *
  * This ensures a clear difference between month and day, and 12 and 24 hours.
  */
 function date_example_date() {
-  $now = date_now();
-  if (date_format($now, 'M') == date_format($now, 'F')) {
-    date_modify($now, '+1 month');
-  }
-  if (date_format($now, 'm') == date_format($now, 'd')) {
-    date_modify($now, '+1 day');
-  }
-  if (date_format($now, 'H') == date_format($now, 'h')) {
-    date_modify($now, '+12 hours');
-  }
-  return $now;
+  // use a fixed unambiguous date and time.
+  return new BackdropDateTime('2099-12-31 23:59:00');
 }


### PR DESCRIPTION
This uses a fixed example date and time that gives the user an unambiguous example in all formats and avoids possible confusion caused by showing a modified version of the current date and time.