### PR TITLE
 Issue #2880

### DIFF
--- a/core/modules/update/update.install
+++ b/core/modules/update/update.install
@@ -155,7 +155,7 @@ function _update_requirement_check($project, $type) {
       else {
         $version_available = t('Updates available');
       }
-      if (update_manager_access()) {
+      if (update_manager_access() && module_exists('project_installer')) {
         $requirement_label .= ' (' . l($version_available, 'admin/modules/update') . ')';
       }
       else {

--- a/core/modules/update/update.theme.inc
+++ b/core/modules/update/update.theme.inc
@@ -111,7 +111,7 @@ function theme_update_report($variables) {
     if (empty($status_label)) {
       $status_label = check_plain($project['reason']);
     }
-    if ($update_link) {
+    if ($update_link && module_exists('project_installer')) {
       switch ($project['project_type']) {
         case 'theme':
           $updatepath = 'admin/appearance/update';


### PR DESCRIPTION
'Status report' and 'Available updates' pages link to '/admin/modules/update' even when 'Project Installer' module isn't enabled.