### PR TITLE
BD-2913/SSC-6: Convert blob fields in Locale and Database Log to text so PostgreSQL can search them.

### DIFF
--- a/core/modules/locale/locale.install
+++ b/core/modules/locale/locale.install
@@ -100,7 +100,7 @@ function locale_schema() {
         'description' => 'Backdrop path in case of online discovered translations or file path in case of imported strings.',
       ),
       'source' => array(
-        'type' => 'blob',
+        'type' => 'text',
         'not null' => TRUE,
         'description' => 'The original string in English.',
       ),
@@ -135,7 +135,7 @@ function locale_schema() {
         'description' => 'Source string ID. References {locales_source}.lid.',
       ),
       'translation' => array(
-        'type' => 'blob',
+        'type' => 'text',
         'not null' => TRUE,
         'description' => 'Translation string value in this language.',
       ),
@@ -339,6 +339,30 @@ function locale_update_1004() {
   // Moved to state:
   update_variable_del('locale_translation_plurals');
   update_variable_del('locale_translation_javascript');
+}
+
+/**
+ * Convert source and translation from blob to text.
+ */
+function locale_update_1005() {
+  db_drop_index('locales_source', 'source_context');
+  db_change_field('locales_source', 'source', 'source',
+    array(
+      'type' => 'text',
+      'not null' => TRUE,
+      'description' => 'The original string in English.',
+    ),
+    array('indexes' => array(
+      'source_context' => array(array('source', 30), 'context'),
+    )
+  ));
+  db_change_field('locales_target', 'translation', 'translation',
+    array(
+      'type' => 'text',
+      'not null' => TRUE,
+      'description' => 'Translation string value in this language.',
+    )
+  );
 }
 
 /**

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -518,8 +518,15 @@ class NodeCreationTestCase extends BackdropWebTestCase {
     }
 
     // Check that the rollback error was logged.
-    $records = db_query("SELECT wid FROM {watchdog} WHERE variables LIKE '%Test exception for rollback.%'")->fetchAll();
-    $this->assertTrue(count($records) > 0, 'Rollback explanatory error logged to watchdog.');
+    // The variables column is a blob, and therefore can't be searched with LIKE
+    $records = db_query("SELECT variables FROM {watchdog} WHERE type='node'")->fetchAll();
+    $count = 0;
+    foreach ($records as $row) {
+      if (strpos($row->variables, "Test exception for rollback")) {
+        $count++;
+      }
+    }
+    $this->assertTrue($count > 0, 'Rollback explanatory error logged to watchdog.');
   }
 
   /**


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2913