### PR TITLE
Issue #2930: Respect language weight order.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -3319,11 +3319,11 @@ function language_multilingual() {
  *   (optional) Whether to return only enabled languages.
  * @param $option_list
  *   (optional) Whether to return a list of options instead of objects. This
- *   list is suitable for use in a select list #options array.
+ *   list is suitable for use in a select list #options array. This list is
+ *   ordered by weight and then language name.
  *
- * @return stdClass[]
- *   An associative array of languages, keyed by the language code, ordered by
- *   weight ascending and name ascending.
+ * @return (stdClass|string)[]
+ *   An associative array of languages, keyed by the language code.
  */
 function language_list($only_enabled = FALSE, $option_list = FALSE) {
   $languages = &backdrop_static(__FUNCTION__);
@@ -3379,6 +3379,10 @@ function language_list($only_enabled = FALSE, $option_list = FALSE) {
   if ($option_list) {
     $list = array();
     $this_list = $only_enabled ? $languages['enabled'] : $languages['all'];
+    // backdrop_sort() needed for ordering, but common.inc may not be loaded
+    // in very early bootstrap. Include only if returning an option list.
+    require_once __DIR__ . '/common.inc';
+    backdrop_sort($this_list, array('weight' => SORT_NUMERIC, 'name' => SORT_STRING));
     foreach ($this_list as $language) {
       $list[$language->langcode] = $language->name;
     }

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -360,14 +360,14 @@ function locale_language_url_fallback($languages = NULL, $language_type = LANGUA
  */
 function locale_language_switcher_url($type, $path) {
   // Get the enabled languages only.
-  $languages = language_list(TRUE);
+  $language_list = language_list(TRUE, TRUE);
   $links = array();
 
-  foreach ($languages as $language) {
-    $links[$language->langcode] = array(
+  foreach ($language_list as $langcode => $label) {
+    $links[$langcode] = array(
       'href'       => $path,
-      'title'      => $language->name,
-      'language'   => $language,
+      'title'      => $label,
+      'language'   => language_load($langcode),
       'attributes' => array('class' => array('language-link')),
     );
   }
@@ -385,17 +385,16 @@ function locale_language_switcher_session($type, $path) {
   $language_query = isset($_SESSION[$param]) ? $_SESSION[$param] : $GLOBALS[$type]->langcode;
 
   // Get the enabled languages only.
-  $languages = language_list(TRUE);
+  $language_list = language_list(TRUE, TRUE);
   $links = array();
 
   $query = $_GET;
   unset($query['q']);
 
-  foreach ($languages as $language) {
-    $langcode = $language->langcode;
+  foreach ($language_list as $langcode => $label) {
     $links[$langcode] = array(
       'href'       => $path,
-      'title'      => $language->name,
+      'title'      => $label,
       'attributes' => array('class' => array('language-link')),
       'query'      => $query,
     );

--- a/core/modules/locale/locale.admin.inc
+++ b/core/modules/locale/locale.admin.inc
@@ -185,7 +185,7 @@ function language_negotiation_configure_url_form($form, &$form_state) {
   );
 
   // Get the enabled languages only.
-  $languages = language_list(TRUE);
+  $language_list = language_list(TRUE, TRUE);
   $prefixes = locale_language_negotiation_url_prefixes();
   $domains = locale_language_negotiation_url_domains();
 
@@ -194,17 +194,17 @@ function language_negotiation_configure_url_form($form, &$form_state) {
   $mock_language = (object)(array(
     'langcode' => '',
   ));
-  foreach ($languages as $langcode => $language) {
+  foreach ($language_list as $langcode => $label) {
     $form['prefix'][$langcode] = array(
       '#type' => 'textfield',
-      '#title' => t('%language (%langcode) path prefix', array('%language' => $language->name, '%langcode' => $language->langcode)),
+      '#title' => t('%language (%langcode) path prefix', array('%language' => $label, '%langcode' => $langcode)),
       '#maxlength' => 64,
       '#default_value' => isset($prefixes[$langcode]) ? $prefixes[$langcode] : '',
       '#field_prefix' => url('', array('absolute' => TRUE, 'language' => $mock_language)) . (config_get('system.core', 'clean_url') ? '' : '?q=')
     );
     $form['domain'][$langcode] = array(
       '#type' => 'textfield',
-      '#title' => t('%language (%langcode) domain', array('%language' => $language->name, '%langcode' => $language->langcode)),
+      '#title' => t('%language (%langcode) domain', array('%language' => $label, '%langcode' => $langcode)),
       '#maxlength' => 128,
       '#default_value' => isset($domains[$langcode]) ? $domains[$langcode] : '',
     );
@@ -229,7 +229,6 @@ function language_negotiation_configure_url_form($form, &$form_state) {
 function language_negotiation_configure_url_form_validate($form, &$form_state) {
   // Get the enabled languages only.
   $languages = language_list(TRUE);
-  $default = language_default();
 
   // Count repeated values for uniqueness check.
   $count = array_count_values($form_state['values']['prefix']);

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -168,15 +168,11 @@ function locale_config_info() {
 function locale_language_selector_form($user) {
   global $language;
   // Get list of enabled languages only.
-  $languages = language_list(TRUE);
+  $language_options = language_list(TRUE, TRUE);
 
   // If the user is being created, we set the user language to the page language.
   $user_preferred_language = $user->uid ? user_preferred_language($user) : $language;
 
-  $names = array();
-  foreach ($languages as $langcode => $item) {
-    $names[$langcode] = $item->name;
-  }
   // Get language negotiation settings.
   $mode = language_negotiation_get(LANGUAGE_TYPE_INTERFACE) != LANGUAGE_NEGOTIATION_DEFAULT;
   $form['locale'] = array(
@@ -185,10 +181,10 @@ function locale_language_selector_form($user) {
     '#weight' => 1,
   );
   $form['locale']['language'] = array(
-    '#type' => (count($names) <= 5 ? 'radios' : 'select'),
+    '#type' => (count($language_options) <= 5 ? 'radios' : 'select'),
     '#title' => t('Language'),
     '#default_value' => $user_preferred_language->langcode,
-    '#options' => $names,
+    '#options' => $language_options,
     '#description' => $mode ? t("This account's default language for e-mails, and preferred language for site presentation.") : t("This account's default language for e-mails."),
   );
   return $form;

--- a/core/modules/locale/locale.pages.inc
+++ b/core/modules/locale/locale.pages.inc
@@ -172,12 +172,9 @@ function locale_translation_filters() {
 
   // Get all languages, except English
   backdrop_static_reset('language_list');
-  $languages = language_list(TRUE);
-  $language_options = array();
-  foreach ($languages as $langcode => $language) {
-    if ($langcode != 'en' || locale_translate_english()) {
-      $language_options[$langcode] = $language->name;
-    }
+  $language_options = language_list(TRUE, TRUE);
+  if (!locale_translate_english() && isset($language_options['en'])) {
+    unset($language_options['en']);
   }
 
   $filters['string'] = array(

--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -166,11 +166,7 @@ function node_form($form, &$form_state, Node $node) {
   $form['#node'] = $node;
 
   if ($node_type->settings['language'] && module_exists('language')) {
-    $languages = language_list(TRUE);
-    $language_options = array();
-    foreach ($languages as $langcode => $language) {
-      $language_options[$langcode] = $language->name;
-    }
+    $language_options = language_list(TRUE, TRUE);
     $form['langcode'] = array(
       '#type' => 'select',
       '#title' => t('Language'),

--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -143,11 +143,7 @@ function path_admin_form($form, &$form_state, $path = array('source' => '', 'ali
 
   // A hidden value unless language.module is enabled.
   if (module_exists('language')) {
-    $languages = language_list(TRUE);
-    foreach ($languages as $langcode => $language) {
-      $language_options[$langcode] = $language->name;
-    }
-
+    $language_options = language_list(TRUE, TRUE);
     $form['langcode'] = array(
       '#type' => 'select',
       '#title' => t('Language'),

--- a/core/modules/translation/translation.pages.inc
+++ b/core/modules/translation/translation.pages.inc
@@ -32,10 +32,10 @@ function translation_node_overview(Node $node) {
 
   $type = config_get('translation.settings', 'language_type');
   $header = array(t('Language'), t('Title'), t('Status'), t('Operations'));
+  $rows = array();
 
-  foreach (language_list() as $langcode => $language) {
+  foreach (language_list(TRUE, TRUE) as $langcode => $language_name) {
     $options = array();
-    $language_name = $language->name;
     if (isset($translations[$langcode])) {
       // Existing translation in the translation set: display status.
       // We load the full node to check whether the user can edit it.

--- a/core/modules/views/views.module
+++ b/core/modules/views/views.module
@@ -750,7 +750,7 @@ function views_language_list($field = 'name', $all = FALSE) {
     $languages = language_list();
   }
   else {
-    $languages = language_list('enabled');
+    $languages = language_list(TRUE);
   }
   $list = array();
   foreach ($languages as $language) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2930.

This PR does not order all return types of `language_list()`, but rather only if the second parameter is TRUE (returning as a list of $langcode => $language_name). This is because backdrop_sort() may not be available in early bootstrap, such as when the language URL is being parsed.