### PR TITLE
Issue #2860: Removing description on "Menu style"

### DIFF
--- a/core/modules/system/system.menu.inc
+++ b/core/modules/system/system.menu.inc
@@ -56,7 +56,6 @@ function system_menu_block_form($config) {
       'tree' => t('Hierarchical tree'),
     ),
     '#default_value' => empty($config['style']) ? 'tree' : $config['style'],
-    '#description' => t('The menu style may adjust how a menu is displayed, such as a tree of links or a dropdown.'),
   );
 
   $form['level'] = array(


### PR DESCRIPTION
Removed unnecessary description text on Menu Block "Menu style".
This solves: https://github.com/backdrop/backdrop-issues/issues/2860