### PR TITLE
Issue #2578: Changed label for 'Administer users'

### DIFF
--- a/core/modules/user/config/views.view.user_admin.json
+++ b/core/modules/user/config/views.view.user_admin.json
@@ -7,7 +7,7 @@
     "tag": "default",
     "disabled": false,
     "base_table": "users",
-    "human_name": "Administer users",
+    "human_name": "Administer user accounts",
     "core": "1.0-dev",
     "display": {
         "default": {

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -170,7 +170,7 @@ function user_admin_settings($form, &$form_state) {
   $form['registration_cancellation']['user_cancel_method'] = array(
     '#type' => 'item',
     '#title' => t('When cancelling a user account'),
-    '#description' => t('Users with the %select-cancel-method or %administer-users <a href="@permissions-url">permissions</a> can override this default method.', array('%select-cancel-method' => t('Select method for cancelling account'), '%administer-users' => t('Administer users'), '@permissions-url' => url('admin/config/people/permissions'))),
+    '#description' => t('Users with the %select-cancel-method or %administer-users <a href="@permissions-url">permissions</a> can override this default method.', array('%select-cancel-method' => t('Select method for cancelling account'), '%administer-users' => t('Administer user accounts'), '@permissions-url' => url('admin/config/people/permissions'))),
   );
   $form['registration_cancellation']['user_cancel_method'] += user_cancel_methods();
   foreach (element_children($form['registration_cancellation']['user_cancel_method']) as $element) {

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -491,7 +491,7 @@ function user_update_1009() {
     'tag' => 'default',
     'disabled' => FALSE,
     'base_table' => 'users',
-    'human_name' => 'Administer users',
+    'human_name' => 'Administer user accounts',
     'core' => '1.0-dev',
     'display' => array(
       'default' => array(

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -494,7 +494,7 @@ function user_permission() {
       'restrict access' => TRUE,
     ),
     'administer users' => array(
-      'title' => t('Administer users'),
+      'title' => t('Administer user accounts'),
       'restrict access' => TRUE,
     ),
     'assign roles' => array(


### PR DESCRIPTION
Changed the friendly label from 'Administer users' to 'Administer user
accounts'