### PR TITLE
Issue #2757: Removed "Provide markup text for the area." text in views

### DIFF
--- a/core/modules/views/includes/views.views.inc
+++ b/core/modules/views/includes/views.views.inc
@@ -51,7 +51,6 @@ function views_views_data() {
 
   $data['views']['area'] = array(
     'title' => t('Text area'),
-    'help' => t('Provide markup text for the area.'),
     'area' => array(
       'handler' => 'views_handler_area_text',
     ),


### PR DESCRIPTION
This solves: https://github.com/backdrop/backdrop-issues/issues/2757