### PR TITLE
Issue #2939: Fix update tests. Use state instead of config where appropriate.

### DIFF
--- a/core/modules/installer/tests/installer.test
+++ b/core/modules/installer/tests/installer.test
@@ -258,7 +258,7 @@ class InstallerTestUploadCase extends BackdropWebTestCase {
     );
     $config->set('update_system_info', $setting)->save();
     $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
-    $config->set('update_xml_map', array('backdrop' => '2-sec'))->save();
+    state_set('update_test_xml_map', array('backdrop' => '2-sec'));
     // Initialize the update status.
     $this->backdropGet('admin/reports/updates');
 

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -2073,7 +2073,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
     $this->assertText('This is a requirements error provided by the update_script_test module.');
 
     // Check if the optional 'value' key displays without a notice.
-    $config->set('update_script_test_requirement_type', REQUIREMENT_INFO)->save();
+    $config->set('update_requirement_type', REQUIREMENT_INFO)->save();
     $this->backdropGet($this->update_url, array('external' => TRUE));
     $this->assertText('This is a requirements info provided by the update_script_test module.');
     $this->assertNoText('Notice: Undefined index: value in theme_status_report()');

--- a/core/modules/update/config/update.settings.json
+++ b/core/modules/update/config/update.settings.json
@@ -11,8 +11,6 @@
     "update_emails": [],
     "update_threshold": 0,
     "update_requirement_type": 0,
-    "update_system_info": [],
     "update_status": [],
-    "update_xml_map": 0,
     "update_projects": []
 }

--- a/core/modules/update/tests/update.test
+++ b/core/modules/update/tests/update.test
@@ -12,8 +12,8 @@
  * (specified via hook_system_info_alter() in the update_test helper module)
  * describing what's currently installed. Each test case defines a set of
  * projects to install, their current state (via the 'update_test_system_info'
- * variable) and the desired available update data (via the
- * 'update_test_xml_map' variable), and then performs a series of assertions
+ * state value) and the desired available update data (via the
+ * 'update_test_xml_map' state value), and then performs a series of assertions
  * that the report matches our expectations given the specific initial state and
  * availability scenario.
  */
@@ -42,7 +42,7 @@ class UpdateTestHelper extends BackdropWebTestCase {
     // update_test module.
     $config->set('update_url', url($url, array('absolute' => TRUE)))->save();
     // Save the map for update_test_mock_page() to use.
-    $config->set('update_xml_map', $xml_map)->save();
+    state_set('update_test_xml_map', $xml_map);
     // Manually check the update status.
     $this->backdropGet('admin/reports/updates/check');
   }
@@ -125,7 +125,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
         'datestamp' => '1000000000',
       ),
     );
-    config_set('update.settings', 'update_system_info', $system_info);
+    state_set('update_test_system_info', $system_info);
     $this->refreshUpdateStatus(array('backdrop' => 'dev'));
     $this->assertNoText(t('2001-Sep-'));
     $this->assertText(t('Up to date'));
@@ -140,7 +140,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
     $config = config('update.settings');
     $this->setSystemInfo1_0();
     $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
-    $config->set('update_xml_map', array('backdrop' => '0'))->save();
+    state_set('update_test_xml_map', array('backdrop' => '0'));
 
     $this->cronRun();
     $this->backdropGet('admin/modules');
@@ -155,7 +155,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
     $config = config('update.settings');
     // Instead of using refreshUpdateStatus(), set these manually.
     $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
-    $config->set('update_xml_map', array('backdrop' => '0'))->save();
+    state_set('update_test_xml_map', array('backdrop' => '0'));
 
     $this->backdropGet('admin/reports/updates');
     $this->clickLink(t('Check manually'));
@@ -173,7 +173,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
     $config = config('update.settings');
     // Instead of using refreshUpdateStatus(), set these manually.
     $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
-    $config->set('update_xml_map', array('backdrop' => '1'))->save();
+    state_set('update_test_xml_map', array('backdrop' => '1'));
 
     $this->backdropGet('admin/reports/updates');
     $this->clickLink(t('Check manually'));
@@ -191,7 +191,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
     $config = config('update.settings');
     // Instead of using refreshUpdateStatus(), set these manually.
     $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
-    $config->set('update_xml_map', array('backdrop' => '2-sec'))->save();
+    state_set('update_test_xml_map', array('backdrop' => '2-sec'));
 
     $this->backdropGet('admin/reports/updates');
     $this->clickLink(t('Check manually'));
@@ -285,7 +285,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
         'version' => '1.0',
       ),
     );
-    config_set('update.settings', 'update_system_info', $setting);
+    state_set('update_test_system_info', $setting);
   }
 
 }
@@ -314,7 +314,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    config_set('update.settings', 'update_system_info', $system_info);
+    state_set('update_test_system_info', $system_info);
     $this->refreshUpdateStatus(array('backdrop' => '0', 'aaa_update_test' => 'no-releases'));
     $this->backdropGet('admin/reports/updates');
     // Cannot use $this->assertStandardTests() because we need to check for the
@@ -342,7 +342,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    config_set('update.settings', 'update_system_info', $system_info);
+    state_set('update_test_system_info', $system_info);
     $this->refreshUpdateStatus(
       array(
         'backdrop' => '0',
@@ -401,7 +401,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    config_set('update.settings', 'update_system_info', $system_info);
+    state_set('update_test_system_info', $system_info);
     $this->refreshUpdateStatus(array('backdrop' => '0', '#all' => '1_0'));
     // We're expecting the report to say all projects are up to date.
     $this->assertText(t('Up to date'));
@@ -457,7 +457,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    config_set('update.settings', 'update_system_info', $system_info);
+    state_set('update_test_system_info', $system_info);
     $xml_mapping = array(
       'backdrop' => '0',
       'update_test_subtheme' => '1_0',
@@ -502,8 +502,8 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    config_set('system.core', 'update_test_system_info', $system_info);
-    config_set('system.core', 'update_check_disabled', FALSE);
+    state_set('update_test_system_info', $system_info);
+    config_set('update.settings', 'update_check_disabled', FALSE);
     $xml_mapping = array(
       // This is enough because we don't check the update status of the admin
       // theme. We want to check that the admin theme is included in the list.
@@ -553,7 +553,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
     // of update_max_fetch_attempts. Therefore this variable is set very high
     // to avoid test failures in those cases.
     $config->set('update_max_attempts', 99999)->save();
-    $config->set('update_system_info', $system_info)->save();
+    state_set('update_test_system_info', $system_info);
     $xml_mapping = array(
       'backdrop' => '0',
       'update_test_subtheme' => '1_0',
@@ -603,7 +603,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    config_set('update.settings', 'update_system_info', $system_info);
+    state_set('update_test_system_info',  $system_info);
 
     $xml_mapping = array(
       'backdrop' => '0',
@@ -663,7 +663,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
         'hidden' => FALSE,
       ),
     );
-    $config->set('update_system_info', $system_info)->save();
+    state_set('update_test_system_info', $system_info);
     $update_status = array(
       'aaa_update_test' => array(
         'status' => UPDATE_NOT_SECURE,

--- a/core/modules/update/tests/update_test/themes/update_test_basetheme/update_test_basetheme.info
+++ b/core/modules/update/tests/update_test/themes/update_test_basetheme/update_test_basetheme.info
@@ -1,4 +1,5 @@
 name = Update test base theme
 description = Test theme which acts as a base theme for other test subthemes.
+type = theme
 backdrop = 1.x
 hidden = TRUE

--- a/core/modules/update/tests/update_test/themes/update_test_subtheme/update_test_subtheme.info
+++ b/core/modules/update/tests/update_test/themes/update_test_subtheme/update_test_subtheme.info
@@ -1,5 +1,6 @@
 name = Update test subtheme
 description = Test theme which uses update_test_basetheme as the base theme.
+type = theme
 backdrop = 1.x
 base theme = update_test_basetheme
 hidden = TRUE

--- a/core/modules/update/tests/update_test/update_test.module
+++ b/core/modules/update/tests/update_test/update_test.module
@@ -39,7 +39,7 @@ function update_test_menu() {
 /**
  * Implements hook_system_info_alter().
  *
- * Checks the 'update.settings:update_system_info' configuration and sees if we
+ * Checks the 'update_test_system_info' state value and sees if we
  * need to alter the system info for the given $file based on the setting. The
  * setting is expected to be a nested associative array. If the key '#all' is
  * defined, its subarray will include .info keys and values for all modules and
@@ -48,7 +48,7 @@ function update_test_menu() {
  * that module, theme, or layout.
  */
 function update_test_system_info_alter(&$info, $file) {
-  $setting = config_get('update.settings', 'update_system_info');
+  $setting = state_get('update_test_system_info', array());
   foreach (array('#all', $file->name) as $id) {
     if (!empty($setting[$id])) {
       foreach ($setting[$id] as $key => $value) {
@@ -101,7 +101,7 @@ function update_test_update_status_alter(&$projects) {
  * @see update_test_menu()
  */
 function update_test_mock_page($project_name) {
-  $xml_map = config_get('update.settings', 'update_xml_map');
+  $xml_map = state_get('update_test_xml_map');
   if (isset($xml_map[$project_name])) {
     $availability_scenario = $xml_map[$project_name];
   }

--- a/core/modules/update/update.install
+++ b/core/modules/update/update.install
@@ -218,6 +218,16 @@ function update_update_1002() {
 }
 
 /**
+ * Removes the testing-only values from the update.settings config.
+ */
+function update_update_1003() {
+  $config = config('update.settings');
+  $config->clear('update_xml_map');
+  $config->clear('update_system_info');
+  $config->save();
+}
+
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2939.

This also switches some of our testing values from using config to using state, as these values would never be used in a production site; there's no need to track them in config.