### PR TITLE
2776 drupal 2451449 users contact setting reverts to default when saving

### DIFF
--- a/core/modules/contact/contact.module
+++ b/core/modules/contact/contact.module
@@ -269,7 +269,12 @@ function contact_form_user_profile_form_alter(&$form, &$form_state) {
  */
 function contact_user_presave($account) {
   $config = config('contact.settings');
-  $account->data['contact'] = isset($account->contact) ? $account->contact : $config->get('contact_default_status');
+  if (isset($account->contact)) {
+    $account->data['contact'] = $account->contact;
+  }
+  elseif (!isset($account->data['contact'])) {
+    $account->data['contact'] = $config->get('contact_default_status');
+  }
 }
 
 /**

--- a/core/modules/contact/contact.module
+++ b/core/modules/contact/contact.module
@@ -249,6 +249,7 @@ function contact_mail($key, &$message, $params) {
  * @see user_profile_form()
  */
 function contact_form_user_profile_form_alter(&$form, &$form_state) {
+  $config = config('contact.settings');
   $form['contact'] = array(
     '#type' => 'fieldset',
     '#title' => t('Contact settings'),
@@ -259,7 +260,7 @@ function contact_form_user_profile_form_alter(&$form, &$form_state) {
   $form['contact']['contact'] = array(
     '#type' => 'checkbox',
     '#title' => t('Personal contact form'),
-    '#default_value' => !empty($account->data['contact']) ? $account->data['contact'] : FALSE,
+    '#default_value' => isset($account->data['contact']) ? $account->data['contact'] : $config->get('contact_default_status'),
     '#description' => t('Allow other users to contact you via a <a href="@url">personal contact form</a> which keeps your e-mail address hidden. Note that some privileged users such as site administrators are still able to contact you even if you choose to disable this feature.', array('@url' => url("user/$account->uid/contact"))),
   );
 }

--- a/core/modules/contact/tests/contact.test
+++ b/core/modules/contact/tests/contact.test
@@ -337,6 +337,28 @@ class ContactPersonalTestCase extends BackdropWebTestCase {
     $this->backdropGet('user/' . $this->contact_user->uid . '/contact');
     $this->assertResponse(200);
 
+    // Test that users can disable their contact form.
+    $this->backdropLogin($this->contact_user);
+    $edit = array('contact' => FALSE);
+    $this->backdropPost('user/' . $this->contact_user->uid . '/edit', $edit, 'Save');
+    $this->backdropLogout();
+    $this->backdropGet('user/' . $this->contact_user->uid . '/contact');
+    $this->assertResponse(403);
+
+    // Test that user's contact status stays disabled when saving.
+    $contact_user_temp = user_load($this->contact_user->uid, TRUE);
+    user_save($contact_user_temp);
+    $this->backdropGet('user/' . $this->contact_user->uid . '/contact');
+    $this->assertResponse(403);
+
+    // Test that users can enable their contact form.
+    $this->backdropLogin($this->contact_user);
+    $edit = array('contact' => TRUE);
+    $this->backdropPost('user/' . $this->contact_user->uid . '/edit', $edit, 'Save');
+    $this->backdropLogout();
+    $this->backdropGet('user/' . $this->contact_user->uid . '/contact');
+    $this->assertResponse(200);
+
     // Revoke the personal contact permission for the anonymous user.
     user_role_revoke_permissions(BACKDROP_ANONYMOUS_ROLE, array('access user contact forms'));
     $this->backdropGet('user/' . $this->contact_user->uid . '/contact');


### PR DESCRIPTION
[Issue #2451449 by drumm: User's contact setting reverts to default when saving](http://drupal.org/node/2451449)
Commit [ef9608dc1d](http://drupalcode.org/project/drupal.git/commit/ef9608dc1d8b7ef0eaa7b76b07b64a16f73e3bbe)
