### PR TITLE
Issue #2968: Add an Export drop-button operation to the menu overview…

### DIFF
--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -28,6 +28,12 @@ function menu_overview_page() {
       'title' => t('Configure'),
       'href' => 'admin/structure/menu/manage/' . $menu['menu_name'] . '/configure',
     );
+    if (user_access('synchronize configuration')) {
+      $links['export'] = array(
+        'title' => t('Export'),
+        'href' => 'admin/config/development/configuration/single/export/Menus/menu.menu.' . $menu['menu_name'],
+      );
+    }
     $row[] = array(
       'data' => array(
         '#type' => 'operations',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2969