### PR TITLE
Issue #2072: Extend link dialogue to include a file upload option.

### DIFF
--- a/core/modules/ckeditor/ckeditor.admin.inc
+++ b/core/modules/ckeditor/ckeditor.admin.inc
@@ -39,6 +39,17 @@ function ckeditor_settings_form(&$form, $form_state, $format) {
     '#parents' => array('editor_settings', 'image_upload'),
   );
 
+  $elements['plugins']['file'] = filter_editor_file_upload_settings_form($format);
+  $elements['plugins']['file'] += array(
+    '#type' => 'fieldset',
+    '#title' => t('File uploading'),
+    '#attributes' => array(
+      'class' => array('ckeditor-plugin-backdropimage'),
+      'data-ckeditor-feature-dependency' => 'BackdropImage',
+    ),
+    '#parents' => array('editor_settings', 'file_upload'),
+  );
+
   $elements['plugins']['style'] = array(
     '#type' => 'fieldset',
     '#title' => t('Style list'),

--- a/core/modules/ckeditor/ckeditor.admin.inc
+++ b/core/modules/ckeditor/ckeditor.admin.inc
@@ -44,8 +44,8 @@ function ckeditor_settings_form(&$form, $form_state, $format) {
     '#type' => 'fieldset',
     '#title' => t('File uploading'),
     '#attributes' => array(
-      'class' => array('ckeditor-plugin-backdropimage'),
-      'data-ckeditor-feature-dependency' => 'BackdropImage',
+      'class' => array('ckeditor-plugin-backdroplink'),
+      'data-ckeditor-feature-dependency' => 'BackdropLink',
     ),
     '#parents' => array('editor_settings', 'file_upload'),
   );

--- a/core/modules/ckeditor/js/plugins/backdroplink/plugin.js
+++ b/core/modules/ckeditor/js/plugins/backdroplink/plugin.js
@@ -85,7 +85,7 @@ CKEDITOR.plugins.add('backdroplink', {
           existingValues = parseAttributes(editor, linkElement);
 
           // Update the displayed link text
-          existingValues.linktext = selectedText;
+          existingValues.text = selectedText;
         }
         // Or, if an image widget is focused, we're editing a link wrapping
         // an image widget.
@@ -94,7 +94,7 @@ CKEDITOR.plugins.add('backdroplink', {
         }
         // Or, if selected element is not an existing link or an image.
         else {
-          existingValues.linktext = selectedText;
+          existingValues.text = selectedText;
         }
 
         // Prepare a save callback to be used upon saving the dialog.
@@ -118,14 +118,14 @@ CKEDITOR.plugins.add('backdroplink', {
             // Get the text of the current selection.
             var oldtext = selection.getSelectedText();
             // And the replacement text.
-            var newtext = returnValues.attributes.linktext;
+            var newtext = returnValues.attributes.text;
             // Get the range of the selection.
             var range = selection.getRanges(1)[0];
 
             // If the selection is a link, replace the text
             var element = selection.getStartElement();
             this.element = element;
-            if(element.$.nodeName === "A") {
+            if (element.is('a')) {
               this.element.setText(newtext);
             }
           }
@@ -134,14 +134,14 @@ CKEDITOR.plugins.add('backdroplink', {
           if (!linkElement && returnValues.attributes.href) {
             // Use link URL as text with a collapsed cursor.
             if (range.collapsed) {
-
-              if(newtext != ""){
-                var text = new CKEDITOR.dom.text(newtext);
+              var text;
+              if (newtext) {
+                text = new CKEDITOR.dom.text(newtext);
               }
               else {
                 // Use href as link text
                 // Shorten mailto URLs to just the email address.
-                var text = new CKEDITOR.dom.text(returnValues.attributes.href.replace(/^mailto:/, ''), editor.document);
+                text = new CKEDITOR.dom.text(returnValues.attributes.href.replace(/^mailto:/, ''), editor.document);
               }
               range.insertNode(text);
               range.selectNodeContents(text);
@@ -149,10 +149,10 @@ CKEDITOR.plugins.add('backdroplink', {
 
             // Create the new link by applying a style to the new text.
             // Remove attributes that are not required.
-            if ( !(returnValues.attributes['data-file-id'] > 0)){
+            if (!returnValues.attributes['data-file-id']) {
               delete returnValues.attributes['data-file-id'];
             }
-            delete returnValues.attributes.linktext;
+            delete returnValues.attributes.text;
             var style = new CKEDITOR.style({element: 'a', attributes: returnValues.attributes});
             style.type = CKEDITOR.STYLE_INLINE;
             style.applyToRange(range);
@@ -177,7 +177,7 @@ CKEDITOR.plugins.add('backdroplink', {
                   linkElement.removeAttribute(attrName);
                 }
                 // Update the property if a value is specified.
-                else if ((returnValues.attributes[attrName].length > 0) && (attrName !== "linktext")) {
+                else if ((returnValues.attributes[attrName].length > 0) && (attrName !== "text")) {
                   linkElement.data('cke-saved-' + attrName, value);
                   linkElement.setAttribute(attrName, value);
                 }

--- a/core/modules/ckeditor/js/plugins/backdroplink/plugin.js
+++ b/core/modules/ckeditor/js/plugins/backdroplink/plugin.js
@@ -136,7 +136,7 @@ CKEDITOR.plugins.add('backdroplink', {
             if (range.collapsed) {
 
               if(newtext != ""){
-                var text = new CKEDITOR.dom.text( newtext );
+                var text = new CKEDITOR.dom.text(newtext);
               }
               else {
                 // Use href as link text

--- a/core/modules/filter/css/filter.css
+++ b/core/modules/filter/css/filter.css
@@ -37,7 +37,7 @@ input#edit-filters-filter-html-settings-allowed-html {
 
 .editor-dialog {
   width: 100%;
-  max-width: 500px;
+  max-width: 600px;
   z-index: 9996 !important; /* To come above the full-screen CKEditor button. */
 }
 .editor-dialog .form-managed-file .form-file,
@@ -86,4 +86,8 @@ input#edit-filters-filter-html-settings-allowed-html {
 }
 [dir="rtl"] .editor-image-toggle.last {
   border-left: none;
+}
+.form-item label.editor-image-toggle {
+  display: inline-block !important;
+  padding-bottom: 10px;
 }

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -617,3 +617,104 @@ function filter_editor_image_upload_settings_form($format) {
 
   return $form;
 }
+
+
+/**
+ * Subform constructor to configure the text editor's file upload settings.
+ *
+ * Each text editor plugin that is configured to offer the ability to insert
+ * images and uses EditorImageDialog for that, should use this form to update
+ * the text editor's configuration so that EditorImageDialog can also be used
+ * to upload files.
+ *
+ * @param $format
+ *   The text format that is being edited.
+ *
+ * @return array
+ *   The file upload settings form.
+ *
+ * @ingroup forms
+ */
+function filter_editor_file_upload_settings_form($format) {
+  // Defaults.
+  $settings = isset($format->editor_settings['file_upload']) ? $format->editor_settings['file_upload'] : array();
+  $settings += array(
+    'status' => FALSE,
+    'scheme' => file_default_scheme(),
+    'directory' => 'uploads',
+    'max_size' => '',
+    'file_extensions' => 'txt pdf',
+  );
+
+  $form['status'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable file uploads'),
+    '#default_value' => $settings['status'],
+    '#attributes' => array(
+      'data-editor-file-upload' => 'status',
+    ),
+  );
+  $show_if_file_uploads_enabled = array(
+    'visible' => array(
+      ':input[data-editor-file-upload="status"]' => array('checked' => TRUE),
+    ),
+  );
+
+  // Any visible, writable wrapper can potentially be used for uploads,
+  // including a remote file system that integrates with a CDN.
+  $stream_wrappers = file_get_stream_wrappers(STREAM_WRAPPERS_WRITE_VISIBLE);
+  foreach ($stream_wrappers as $scheme => $info) {
+    $options[$scheme] = $info['description'];
+  }
+  if (!empty($options)) {
+    $form['scheme'] = array(
+      '#type' => 'radios',
+      '#title' => t('File storage'),
+      '#default_value' => $settings['scheme'],
+      '#options' => $options,
+      '#states' => $show_if_file_uploads_enabled,
+      '#access' => count($options) > 1,
+    );
+  }
+  // Set data- attributes with human-readable names for all possible stream
+  // wrappers, so that drupal.ckeditor.drupalimage.admin's summary rendering
+  // can use that.
+  foreach ($stream_wrappers as $scheme => $info) {
+    $form['scheme'][$scheme]['#attributes']['data-label'] = t('Storage: @name', array('@name' => $info['name']));
+  }
+
+  $form['directory'] = array(
+    '#type' => 'textfield',
+    '#default_value' => $settings['directory'],
+    '#title' => t('Upload directory'),
+    '#description' => t("A directory relative to the files directory where uploaded files will be stored."),
+    '#states' => $show_if_file_uploads_enabled,
+  );
+
+  $default_max_size = format_size(file_upload_max_size());
+  $form['max_size'] = array(
+    '#type' => 'textfield',
+    '#default_value' => $settings['max_size'],
+    '#title' => t('Maximum file size'),
+    '#description' => t('If this is left empty, then the file size will be limited by the PHP maximum upload size of @size.', array('@size' => $default_max_size)),
+    '#maxlength' => 20,
+    '#size' => 10,
+    '#placeholder' => $default_max_size,
+    '#states' => $show_if_file_uploads_enabled,
+  );
+
+  $form['file_extensions'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Allowed file extensions'),
+    '#default_value' => $settings['file_extensions'],
+    '#description' => t('Separate extensions with a space or comma and do not include the leading dot.'),
+    '#element_validate' => array('_file_generic_settings_extensions'),
+    '#weight' => 1,
+    '#maxlength' => 256,
+    // By making this field required, we prevent a potential security issue
+    // that would allow files of any type to be uploaded.
+    '#required' => TRUE,
+  );
+
+  return $form;
+}

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -641,7 +641,7 @@ function filter_editor_file_upload_settings_form($format) {
   $settings += array(
     'status' => FALSE,
     'scheme' => file_default_scheme(),
-    'directory' => 'uploads',
+    'directory' => 'inline-files',
     'max_size' => '',
     'file_extensions' => 'txt pdf',
   );

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -714,6 +714,7 @@ function filter_editor_file_upload_settings_form($format) {
     // By making this field required, we prevent a potential security issue
     // that would allow files of any type to be uploaded.
     '#required' => TRUE,
+    '#states' => $show_if_file_uploads_enabled,
   );
 
   return $form;

--- a/core/modules/filter/filter.install
+++ b/core/modules/filter/filter.install
@@ -86,34 +86,6 @@ function filter_update_1001() {
 }
 
 /**
- * Add a separate permission for file upload access.
- */
-function filter_update_1002() {
-  user_role_grant_permissions(BACKDROP_AUTHENTICATED_ROLE, array('upload editor files'));
-
-  // Enable uploading on existing text formats for which
-  // image uploading is already enabled.
-  $format_configs = config_get_names_with_prefix('filter.format.');
-
-  foreach ($format_configs as $config_name) {
-    $config = config($config_name);
-    if ($config->get('editor')) {
-      $editor_settings = (array) $config->get('editor_settings');
-      if (isset($editor_settings['image_upload'])){
-        $upload_settings = array();
-        $upload_settings['status'] = 1;
-        $upload_settings['max_size'] = '';
-        $upload_settings['scheme'] = 'public';
-        $upload_settings['directory'] = 'inline-files';
-        $upload_settings['file_extensions'] = 'txt pdf';
-        $editor_settings['file_upload'] = $upload_settings;
-        $config->set('editor_settings', $editor_settings);
-        $config->save();
-      }
-    }
-  }
-}
-/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/filter/filter.install
+++ b/core/modules/filter/filter.install
@@ -86,6 +86,34 @@ function filter_update_1001() {
 }
 
 /**
+ * Add a separate permission for file upload access.
+ */
+function filter_update_1002() {
+  user_role_grant_permissions(BACKDROP_AUTHENTICATED_ROLE, array('upload editor files'));
+
+  // Enable uploading on existing text formats for which
+  // image uploading is already enabled.
+  $format_configs = config_get_names_with_prefix('filter.format.');
+
+  foreach ($format_configs as $config_name) {
+    $config = config($config_name);
+    if ($config->get('editor')) {
+      $editor_settings = (array) $config->get('editor_settings');
+      if (isset($editor_settings['image_upload'])){
+        $upload_settings = array();
+        $upload_settings['status'] = 1;
+        $upload_settings['max_size'] = '';
+        $upload_settings['scheme'] = 'public';
+        $upload_settings['directory'] = 'inline-files';
+        $upload_settings['file_extensions'] = 'txt pdf';
+        $editor_settings['file_upload'] = $upload_settings;
+        $config->set('editor_settings', $editor_settings);
+        $config->save();
+      }
+    }
+  }
+}
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -586,6 +586,11 @@ function filter_permission() {
     'description' => t('Allow users with access to image dialogs to upload files.'),
   );
 
+  $perms['upload editor files'] = array(
+    'title' => t('Upload files through editor dialogs'),
+    'description' => t('Allow users with access to editor dialogs to upload files.'),
+  );
+
   // Generate permissions for each text format. Warn the administrator that any
   // of them are potentially unsafe.
   foreach (filter_formats() as $format) {
@@ -1645,7 +1650,7 @@ function filter_entity_update(EntityInterface $entity) {
         $removed_files = array_diff($original_fids_by_field[$field], $fids_by_field[$field]);
         _filter_delete_file_usage($removed_files, $entity, 1);
       }
-    }  
+    }
   }
 }
 

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -24,7 +24,7 @@ function filter_tips_long($format = NULL) {
 }
 
 /**
- * Form callback: Display a form for inserting/editing a link.
+ * Form callback: Display a form for inserting/editing a link or uploading a file.
  */
 function filter_format_editor_link_form($form, &$form_state, $format) {
   $form_state['format'] = $format;
@@ -33,6 +33,9 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
   if (isset($form_state['input']['dialogOptions']['target'])) {
     $form_state['storage']['dialog_selector'] = $form_state['input']['dialogOptions']['target'];
   }
+
+  // Record if file uploading is requested by the calling element.
+  $element_supports_uploads = !isset($form_state['input']['dialogOptions']['uploads']) || (bool) $form_state['input']['dialogOptions']['uploads'];
 
   // Pull in any default values set by the editor.
   $values = array();
@@ -53,12 +56,58 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
     '#title' => t('URL'),
     '#type' => 'textfield',
     '#element_validate' => array('_filter_format_editor_link_url_validate'),
-    '#default_value' => isset($values['href']) ? $values['href'] : FALSE,
+    '#placeholder' => '/files/uploads/myfile.pdf',
+    '#default_value' => isset($values['href']) ? $values['href'] : NULL,
     '#parents' => array('attributes', 'href'),
+    '#wrapper_attributes' => array(
+      'data-editor-image-toggle' => t('Link URL'),
+    ),
+    '#weight' => -10,
     '#autocomplete_path' => 'filter-link/autocomplete',
     '#description' => t('Enter a known path, or start typing to get suggestions'),
-    '#maxlength' => 256,
   );
+
+
+  // Construct strings to use in the upload validators.
+  $upload_settings = isset($format->editor_settings['image_upload']) ? $format->editor_settings['image_upload'] : array();
+  $upload_settings += array(
+    'status' => 0,
+    'max_size' => NULL,
+    'scheme' => 'public',
+    'directory' => 'uploads',
+  );
+
+  $max_filesize = !empty($upload_settings['max_size']) ? min(parse_size($upload_settings['max_size']), file_upload_max_size()) : file_upload_max_size();
+  $existing_file = !empty($values['data-file-id']) ? file_load($values['data-file-id']) : NULL;
+  $fid = $existing_file ? $existing_file->fid : NULL;
+  $form['file']['fid'] = array(
+    '#title' => t('Upload file'),
+    '#type' => 'managed_file',
+    '#upload_location' => $upload_settings['scheme'] . '://uploads',
+    '#default_value' => $fid ? $fid : NULL,
+    '#upload_validators' => array(
+      'file_validate_extensions' => array('pdf doc docx txt'),
+      'file_validate_size' => array($max_filesize),
+    ),
+    '#wrapper_attributes' => array(
+      'data-editor-image-toggle' => t('Upload file'),
+    ),
+    '#parents' => array('fid'),
+    '#weight' => -2,
+    '#access' => $element_supports_uploads && $upload_settings['status'] && user_access('upload editor files'),
+  );
+
+
+  // If no current value or an existing file exists, default to showing
+  // the uploading interface.
+  if ($fid || empty($form['file']['src']['#default_value'])) {
+    $form['file']['fid']['#weight'] = -10;
+    $form['file']['src']['#default_value'] = '';
+  }
+  // Otherwise if editing an unmanaged file, show the raw URL field.
+  else {
+    $form['file']['src']['#weight'] = -10;
+  }
   $form['target'] = array(
     '#title' => t('Open in new window'),
     '#type' => 'checkbox',
@@ -361,6 +410,25 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
 
     $form_state['values']['attributes']['src'] = $url;
     $form_state['values']['attributes']['data-file-id'] = $fid;
+    unset($form_state['values']['fid']);
+  }
+}
+
+/**
+ * Submit handler for filter_format_editor_link_form().
+ */
+function filter_format_editor_link_form_submit($form, &$form_state) {
+
+  if (!empty($form_state['values']['fid'])) {
+    $fid = $form_state['values']['fid'];
+    $file = file_load($fid);
+
+    // Try to make a local path if possible for better portability.
+    $url = file_create_url($file->uri);
+    $url = str_replace($GLOBALS['base_url'], '', $url);
+
+    $form_state['values']['attributes']['data-file-id'] = $fid;
+    $form_state['values']['attributes']['href'] = $url;
     unset($form_state['values']['fid']);
   }
 }

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -59,7 +59,7 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
 
   // Use a "textfield" rather than "url" to allow relative paths.
   $form['href'] = array(
-    '#title' => t('Link to existing content'),
+    '#title' => t('Link value'),
     '#type' => 'textfield',
     '#element_validate' => array('_filter_format_editor_link_url_validate'),
     '#placeholder' => ' ',
@@ -110,6 +110,16 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
   else {
     $form['file']['src']['#weight'] = -10;
   }
+
+  $form['linktext'] = array(
+    '#title' => t('Link text'),
+    '#type' => 'textfield',
+    '#default_value' => isset($values['linktext']) ? $values['linktext'] : '',
+    '#parents' => array('attributes', 'linktext'),
+    '#description' => t('Default text is the link value. Enter some alternative link text here if preferred.'),
+  );
+
+
   $form['target'] = array(
     '#title' => t('Open in new window'),
     '#type' => 'checkbox',
@@ -447,21 +457,22 @@ function filter_format_editor_link_form_submit($form, &$form_state) {
       $uri = $form_state['values']['attributes']['href'];
       $fid = _filter_get_file_id($uri);
     }
-    // Value of fid is available in form values.
+    // Value of fid may be available in form values.
     else {$fid = $form_state['values']['fid'];}
+    if ($fid) {
+      // Get file details.
+      $file = file_load($fid);
 
-    // Get file details.
-    $file = file_load($fid);
+      // Try to make a local path if possible for better portability.
+      // Absolute path is needed if Backdrop is installed in subdirectory.
+      $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
+      $url = file_create_url($file->uri);
+      $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 
-    // Try to make a local path if possible for better portability.
-    // Absolute path is needed if Backdrop is installed in subdirectory.
-    $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
-    $url = file_create_url($file->uri);
-    $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
-
-    $form_state['values']['attributes']['data-file-id'] = $fid;
-    $form_state['values']['attributes']['href'] = $url;
-    unset($form_state['values']['fid']);
+      $form_state['values']['attributes']['data-file-id'] = $fid;
+      $form_state['values']['attributes']['href'] = $url;
+      unset($form_state['values']['fid']);
+    }
   }
 }
 

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -34,7 +34,6 @@ function filter_tips_long($format = NULL) {
  */
 function filter_format_editor_link_form($form, &$form_state, $format) {
   $form_state['format'] = $format;
-
   // Record the dialog selector that needs to be closed if present.
   if (isset($form_state['input']['dialogOptions']['target'])) {
     $form_state['storage']['dialog_selector'] = $form_state['input']['dialogOptions']['target'];
@@ -116,7 +115,7 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
     '#type' => 'textfield',
     '#default_value' => isset($values['linktext']) ? $values['linktext'] : '',
     '#parents' => array('attributes', 'linktext'),
-    '#description' => t('Default text is the link value. Enter some alternative link text here if preferred.'),
+    '#description' => t('Default is the link or file identifier. Enter some alternative link text here if needed.'),
   );
 
 
@@ -256,7 +255,6 @@ function _filter_link_autocomplete($string) {
   }
   // Allow modules to alter the matches.
   backdrop_alter('link_autocomplete', $matches, $string);
-
   backdrop_json_output($matches);
 }
 
@@ -450,29 +448,38 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
  * Submit handler for filter_format_editor_link_form().
  */
 function filter_format_editor_link_form_submit($form, &$form_state) {
-  if (isset($form_state['values']['fid'])) {
-    // Value of fid is zero for existing files so get it from href.
-    // This is to ensure that linked files get attribute 'data-file-id'.
-    if ($form_state['values']['fid'] == 0){
-      $uri = $form_state['values']['attributes']['href'];
-      $fid = _filter_get_file_id($uri);
-    }
-    // Value of fid may be available in form values.
-    else {$fid = $form_state['values']['fid'];}
-    if ($fid) {
-      // Get file details.
+  // Look for file and get fid from uri.
+  $fid = 0;
+  $uri = '';
+  if (isset($form_state['values']['attributes']['href']) && (strlen($form_state['values']['attributes']['href']) > 1)){
+    $uri = $form_state['values']['attributes']['href'];
+    // Check for FID for this URI.
+    $fid = _filter_get_file_id($uri);
+  }
+  // File upload will not have provided href but provides fid.
+  elseif (isset($form_state['values']['fid'])) {
+    $fid = $form_state['values']['fid'];
+  }
+  // If file is found get its URI.
+  if ($fid > 0) {
       $file = file_load($fid);
-
+      $uri = file_create_url($file->uri);
       // Try to make a local path if possible for better portability.
       // Absolute path is needed if Backdrop is installed in subdirectory.
       $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
-      $url = file_create_url($file->uri);
-      $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 
+      $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $uri);
       $form_state['values']['attributes']['data-file-id'] = $fid;
       $form_state['values']['attributes']['href'] = $url;
       unset($form_state['values']['fid']);
-    }
+  }
+  else {
+      // Modify references to other URIs.
+      $url = substr(base_path(), 0, -1) . $uri;
+      $form_state['values']['attributes']['href'] = $url;
+      // Remove any reference to a data file.
+      unset($form_state['values']['fid']);
+      $form_state['values']['attributes']['data-file-id'] = NULL;
   }
 }
 
@@ -529,10 +536,8 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
  */
 function _filter_get_file_id($href) {
   // Extract file name and directory from $href.
-  $public_path = config_get('system.core','file_public_path');
-  $pp_length = strlen($public_path);
-  $pos = strpos($href,$public_path);
-  $filename = substr($href,$pos + $pp_length);
+  $pos = strrpos($href, "/");
+  $filename = substr($href,$pos + 1);
   // Now find this file name in uri field to get fid.
   $results = db_select('file_managed')
     ->fields('file_managed', array('fid', 'uri'))
@@ -540,6 +545,7 @@ function _filter_get_file_id($href) {
     ->orderBy('fid', 'DESC')
     ->execute();
 
+  $result = 0;
   foreach ($results as $found) {
     $result = $found->fid;
   }

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -30,124 +30,6 @@ function filter_tips_long($format = NULL) {
 }
 
 /**
- * Form callback: Display a form for inserting/editing a link or uploading a file.
- */
-function filter_format_editor_link_form($form, &$form_state, $format) {
-  $form_state['format'] = $format;
-  // Record the dialog selector that needs to be closed if present.
-  if (isset($form_state['input']['dialogOptions']['target'])) {
-    $form_state['storage']['dialog_selector'] = $form_state['input']['dialogOptions']['target'];
-  }
-
-  // Record if file uploading is requested by the calling element.
-  $element_supports_uploads = !isset($form_state['input']['dialogOptions']['uploads']) || (bool) $form_state['input']['dialogOptions']['uploads'];
-
-  // Pull in any default values set by the editor.
-  $values = array();
-  if (isset($form_state['input']['editor_object'])) {
-    $values = $form_state['input']['editor_object'];
-  }
-
-  // Set the dialog title.
-  if (!empty($values['href'])) {
-    backdrop_set_title(t('Edit link'));
-  }
-  else {
-    backdrop_set_title(t('Insert link'));
-  }
-
-  // Use a "textfield" rather than "url" to allow relative paths.
-  $form['href'] = array(
-    '#title' => t('Link value'),
-    '#type' => 'textfield',
-    '#element_validate' => array('_filter_format_editor_link_url_validate'),
-    '#placeholder' => ' ',
-    '#default_value' => isset($values['href']) ? $values['href'] : NULL,
-    '#parents' => array('attributes', 'href'),
-    '#wrapper_attributes' => array(
-      'data-editor-image-toggle' => t('Link to existing content'),
-    ),
-    '#weight' => -10,
-    '#autocomplete_path' => 'filter-link/autocomplete',
-    '#description' => t('Enter a known path, or start typing to get suggestions'),
-  );
-
-
-  // Construct strings to use in the upload validators.
-
-  $upload_settings = isset($format->editor_settings['file_upload']) ? $format->editor_settings['file_upload'] : array();
-
-  $upload_settings += array(
-    'max_size' => file_upload_max_size(),
-    'file_extensions' => 'txt',
-    'directory' => 'inline-files',
-    'data-file-id' => NULL,
-  );
-
-  $max_filesize = $upload_settings['max_size'];
-  $file_extensions = $upload_settings['file_extensions'];
-  $file_directory = $upload_settings['directory'];
-  $existing_file = !empty($values['data-file-id']) ? file_load($values['data-file-id']) : NULL;
-  $fid = $existing_file ? $existing_file->fid : NULL;
-  $form['file']['fid'] = array(
-    '#title' => t('Upload a file and link to it'),
-    '#type' => 'managed_file',
-    '#upload_location' => $upload_settings['scheme'] . '://' . $file_directory,
-    '#default_value' => $fid ? $fid : NULL,
-    '#upload_validators' => array(
-      'file_validate_extensions' => array($file_extensions),
-      'file_validate_size' => array($max_filesize),
-    ),
-    '#wrapper_attributes' => array(
-      'data-editor-image-toggle' => t('Upload a file and link to it'),
-    ),
-    '#parents' => array('fid'),
-    '#weight' => -2,
-    '#access' => $element_supports_uploads && $upload_settings['status'] && user_access('upload editor files'),
-  );
-
-
-  // If no current value or an existing file exists, default to showing
-  // the uploading interface.
-  if ($fid || empty($form['file']['src']['#default_value'])) {
-    $form['file']['fid']['#weight'] = -10;
-    $form['file']['src']['#default_value'] = '';
-  }
-  // Otherwise if editing an unmanaged file, show the raw URL field.
-  else {
-    $form['file']['src']['#weight'] = -10;
-  }
-
-  $form['linktext'] = array(
-    '#title' => t('Link text'),
-    '#type' => 'textfield',
-    '#default_value' => isset($values['linktext']) ? $values['linktext'] : '',
-    '#parents' => array('attributes', 'linktext'),
-    '#description' => t('Default is the link or file identifier. Enter some alternative link text here if needed.'),
-  );
-
-
-  $form['target'] = array(
-    '#title' => t('Open in new window'),
-    '#type' => 'checkbox',
-    '#return_value' => '_blank',
-    '#default_value' => isset($values['target']) ? $values['target'] : FALSE,
-    '#parents' => array('attributes', 'target'),
-  );
-  $form['actions']['#type'] = 'actions';
-  $form['actions']['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Save'),
-    '#ajax' => array(
-      'callback' => 'filter_format_editor_dialog_save',
-      'event' => 'click',
-    ),
-  );
-
-  return $form;
-}
-
-/**
  * Autocomplete callback for link textfield.
  */
 function _filter_link_autocomplete($string) {
@@ -170,23 +52,25 @@ function _filter_link_autocomplete($string) {
     }
 
     // Get file matches.
-    $results = db_select('file_managed')
-      ->fields('file_managed', array('fid', 'filename', 'uri', 'filemime', 'status'))
-      ->condition('filename', db_like($string) . '%', 'LIKE')
-      ->condition('status', 1)
-      ->condition('filemime', 'image%', 'NOT LIKE')
-      ->orderBy('fid', 'DESC')
-      ->range(0, 10 - $match_count)
-      ->execute();
-    foreach ($results as $result) {
-      // Try to make a local path if possible for better portability.
-      $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
+    if (user_access('manage files') && $match_count < 10) {
+      $results = db_select('file_managed')
+        ->fields('file_managed', array('fid', 'filename', 'uri', 'filemime', 'status'))
+        ->condition('filename', db_like($string) . '%', 'LIKE')
+        ->condition('status', 1)
+        ->condition('filemime', 'image%', 'NOT LIKE')
+        ->orderBy('fid', 'DESC')
+        ->range(0, 10 - $match_count)
+        ->execute();
+      foreach ($results as $result) {
+        // Try to make a local path if possible for better portability.
+        $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
 
-      $url = file_create_url($result->uri);
-      $path = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
+        $url = file_create_url($result->uri);
+        $path = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 
-      $matches[$path] = check_plain($result->filename) . ' (' . t('File')  . ')';
-      $match_count++;
+        $matches[$path] = check_plain($result->filename) . ' (' . t('File')  . ')';
+        $match_count++;
+      }
     }
 
     // Get user matches.
@@ -453,6 +337,122 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
 }
 
 /**
+ * Form callback: Display a form for inserting/editing a link or uploading a file.
+ */
+function filter_format_editor_link_form($form, &$form_state, $format) {
+  $form_state['format'] = $format;
+  // Record the dialog selector that needs to be closed if present.
+  if (isset($form_state['input']['dialogOptions']['target'])) {
+    $form_state['storage']['dialog_selector'] = $form_state['input']['dialogOptions']['target'];
+  }
+
+  // Record if file uploading is requested by the calling element.
+  $element_supports_uploads = !isset($form_state['input']['dialogOptions']['uploads']) || (bool) $form_state['input']['dialogOptions']['uploads'];
+
+  // Pull in any default values set by the editor.
+  $values = array();
+  if (isset($form_state['input']['editor_object'])) {
+    $values = $form_state['input']['editor_object'];
+  }
+
+  // Set the dialog title.
+  if (!empty($values['href'])) {
+    backdrop_set_title(t('Edit link'));
+  }
+  else {
+    backdrop_set_title(t('Insert link'));
+  }
+
+  // Use a "textfield" rather than "url" to allow relative paths.
+  $form['href'] = array(
+    '#title' => t('Link value'),
+    '#type' => 'textfield',
+    '#element_validate' => array('_filter_format_editor_link_url_validate'),
+    '#placeholder' => ' ',
+    '#default_value' => isset($values['href']) ? $values['href'] : NULL,
+    '#parents' => array('attributes', 'href'),
+    '#wrapper_attributes' => array(
+      'data-editor-image-toggle' => t('Link to existing content'),
+    ),
+    '#weight' => -10,
+    '#autocomplete_path' => 'filter-link/autocomplete',
+    '#description' => t('Enter a known path, or start typing to get suggestions'),
+  );
+
+
+  // Construct strings to use in the upload validators.
+  $upload_settings = isset($format->editor_settings['file_upload']) ? $format->editor_settings['file_upload'] : array();
+
+  $upload_settings += array(
+    'max_size' => file_upload_max_size(),
+    'file_extensions' => 'txt',
+    'directory' => 'inline-files',
+    'data-file-id' => NULL,
+  );
+
+  $max_filesize = $upload_settings['max_size'];
+  $file_extensions = $upload_settings['file_extensions'];
+  $file_directory = $upload_settings['directory'];
+  $existing_file = !empty($values['data-file-id']) ? file_load($values['data-file-id']) : NULL;
+  $fid = $existing_file ? $existing_file->fid : NULL;
+  $form['file']['fid'] = array(
+    '#title' => t('Upload a file and link to it'),
+    '#type' => 'managed_file',
+    '#upload_location' => $upload_settings['scheme'] . '://' . $file_directory,
+    '#default_value' => $fid ? $fid : NULL,
+    '#upload_validators' => array(
+      'file_validate_extensions' => array($file_extensions),
+      'file_validate_size' => array($max_filesize),
+    ),
+    '#wrapper_attributes' => array(
+      'data-editor-image-toggle' => t('Upload a file and link to it'),
+    ),
+    '#parents' => array('fid'),
+    '#weight' => -2,
+    '#access' => $element_supports_uploads && $upload_settings['status'] && user_access('upload editor files'),
+  );
+
+
+  // If no current value or an existing file exists, default to showing
+  // the uploading interface.
+  if ($fid || empty($form['file']['src']['#default_value'])) {
+    $form['file']['fid']['#weight'] = -10;
+    $form['file']['src']['#default_value'] = '';
+  }
+  // Otherwise if editing an unmanaged file, show the raw URL field.
+  else {
+    $form['file']['src']['#weight'] = -10;
+  }
+
+  $form['text'] = array(
+    '#title' => t('Link text'),
+    '#type' => 'textfield',
+    '#default_value' => isset($values['text']) ? $values['text'] : '',
+    '#parents' => array('attributes', 'text'),
+    '#description' => t('Default is the link or file identifier. Enter some alternative link text here if needed.'),
+  );
+
+  $form['target'] = array(
+    '#title' => t('Open in new window'),
+    '#type' => 'checkbox',
+    '#return_value' => '_blank',
+    '#default_value' => isset($values['target']) ? $values['target'] : FALSE,
+    '#parents' => array('attributes', 'target'),
+  );
+  $form['actions']['#type'] = 'actions';
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+    '#ajax' => array(
+      'callback' => 'filter_format_editor_dialog_save',
+      'event' => 'click',
+    ),
+  );
+
+  return $form;
+}
+
+/**
  * Submit handler for filter_format_editor_link_form().
  */
 function filter_format_editor_link_form_submit($form, &$form_state) {
@@ -480,6 +480,12 @@ function filter_format_editor_link_form_submit($form, &$form_state) {
       $form_state['values']['attributes']['data-file-id'] = $fid;
       $form_state['values']['attributes']['href'] = $url;
       unset($form_state['values']['fid']);
+
+      // If no text was set, use the file name.
+      if (strlen($form_state['values']['attributes']['text']) === 0) {
+        $form_state['values']['attributes']['text'] = basename($url);
+      }
+
   }
   else {
       // Modify references to other URIs.

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -74,11 +74,19 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
 
 
   // Construct strings to use in the upload validators.
+
   $upload_settings = isset($format->editor_settings['file_upload']) ? $format->editor_settings['file_upload'] : array();
 
-  $max_filesize = !empty($upload_settings['max_size']) ? min(parse_size($upload_settings['max_size']), file_upload_max_size()) : file_upload_max_size();
-  $file_extensions = !empty($upload_settings['file_extensions']) ? $upload_settings['file_extensions'] : 'txt';
-  $file_directory = !empty($upload_settings['directory']) ? $upload_settings['directory'] : 'uploads';
+  $upload_settings += array(
+    'max_size' => file_upload_max_size(),
+    'file_extensions' => 'txt',
+    'directory' => 'inline-files',
+    'data-file-id' => NULL,
+  );
+
+  $max_filesize = $upload_settings['max_size'];
+  $file_extensions = $upload_settings['file_extensions'];
+  $file_directory = $upload_settings['directory'];
   $existing_file = !empty($values['data-file-id']) ? file_load($values['data-file-id']) : NULL;
   $fid = $existing_file ? $existing_file->fid : NULL;
   $form['file']['fid'] = array(

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -15,10 +15,16 @@
  */
 function filter_tips_long($format = NULL) {
   if (!empty($format)) {
-    $output = theme('filter_tips', array('tips' => _filter_tips($format->format, TRUE), 'long' => TRUE));
+    $output = theme('filter_tips', array(
+      'tips' => _filter_tips($format->format, TRUE),
+      'long' => TRUE
+    ));
   }
   else {
-    $output = theme('filter_tips', array('tips' => _filter_tips(-1, TRUE), 'long' => TRUE));
+    $output = theme('filter_tips', array(
+      'tips' => _filter_tips(-1, TRUE),
+      'long' => TRUE
+    ));
   }
   return $output;
 }
@@ -53,14 +59,14 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
 
   // Use a "textfield" rather than "url" to allow relative paths.
   $form['href'] = array(
-    '#title' => t('URL'),
+    '#title' => t('Link to existing content'),
     '#type' => 'textfield',
     '#element_validate' => array('_filter_format_editor_link_url_validate'),
-    '#placeholder' => '/files/uploads/myfile.pdf',
+    '#placeholder' => ' ',
     '#default_value' => isset($values['href']) ? $values['href'] : NULL,
     '#parents' => array('attributes', 'href'),
     '#wrapper_attributes' => array(
-      'data-editor-image-toggle' => t('Link URL'),
+      'data-editor-image-toggle' => t('Link to existing content'),
     ),
     '#weight' => -10,
     '#autocomplete_path' => 'filter-link/autocomplete',
@@ -69,28 +75,24 @@ function filter_format_editor_link_form($form, &$form_state, $format) {
 
 
   // Construct strings to use in the upload validators.
-  $upload_settings = isset($format->editor_settings['image_upload']) ? $format->editor_settings['image_upload'] : array();
-  $upload_settings += array(
-    'status' => 0,
-    'max_size' => NULL,
-    'scheme' => 'public',
-    'directory' => 'uploads',
-  );
+  $upload_settings = isset($format->editor_settings['file_upload']) ? $format->editor_settings['file_upload'] : array();
 
   $max_filesize = !empty($upload_settings['max_size']) ? min(parse_size($upload_settings['max_size']), file_upload_max_size()) : file_upload_max_size();
+  $file_extensions = !empty($upload_settings['file_extensions']) ? $upload_settings['file_extensions'] : 'txt';
+  $file_directory = !empty($upload_settings['directory']) ? $upload_settings['directory'] : 'uploads';
   $existing_file = !empty($values['data-file-id']) ? file_load($values['data-file-id']) : NULL;
   $fid = $existing_file ? $existing_file->fid : NULL;
   $form['file']['fid'] = array(
-    '#title' => t('Upload file'),
+    '#title' => t('Upload a file and link to it'),
     '#type' => 'managed_file',
-    '#upload_location' => $upload_settings['scheme'] . '://uploads',
+    '#upload_location' => $upload_settings['scheme'] . '://' . $file_directory,
     '#default_value' => $fid ? $fid : NULL,
     '#upload_validators' => array(
-      'file_validate_extensions' => array('pdf doc docx txt'),
+      'file_validate_extensions' => array($file_extensions),
       'file_validate_size' => array($max_filesize),
     ),
     '#wrapper_attributes' => array(
-      'data-editor-image-toggle' => t('Upload file'),
+      'data-editor-image-toggle' => t('Upload a file and link to it'),
     ),
     '#parents' => array('fid'),
     '#weight' => -2,
@@ -150,6 +152,26 @@ function _filter_link_autocomplete($string) {
       $match_count++;
     }
 
+    // Get file matches.
+    $results = db_select('file_managed')
+      ->fields('file_managed', array('fid', 'filename', 'uri', 'filemime', 'status'))
+      ->condition('filename', db_like($string) . '%', 'LIKE')
+      ->condition('status', 1)
+      ->condition('filemime', 'image%', 'NOT LIKE')
+      ->orderBy('fid', 'DESC')
+      ->range(0, 10 - $match_count)
+      ->execute();
+    foreach ($results as $result) {
+      // Try to make a local path if possible for better portability.
+      $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
+
+      $url = file_create_url($result->uri);
+      $path = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
+
+      $matches[$path] = check_plain($result->filename) . ' (' . t('File')  . ')';
+      $match_count++;
+    }
+
     // Get user matches.
     if (user_access('access user profiles') && $match_count < 10) {
       $results = db_select('users')
@@ -197,7 +219,7 @@ function _filter_link_autocomplete($string) {
           if ($view->access($display_id) && $display->display_plugin == 'page' && !empty($display->display_options['path'])) {
             $path = backdrop_get_path_alias($display->display_options['path']);
             if (!path_is_admin($path)) {
-              if (stripos($view->human_name, $string) !== false || (!empty($display->title) && stripos($display->title, $string) !== false)) {
+              if (stripos($view->human_name, $string) !== FALSE || (!empty($display->title) && stripos($display->title, $string) !== FALSE)) {
                 $view_display_title = (!empty($display->title)) ? $display->title : check_plain($view->human_name) . ' : ' . $display_id;
                 $matches['/' . $path] = $view_display_title . ' (' . t('Views page') . ')';
                 $match_count++;
@@ -215,7 +237,7 @@ function _filter_link_autocomplete($string) {
     if ($match_count < 10) {
       $menu_items = layout_get_all_configs('menu_item');
       foreach ($menu_items as $menu_item) {
-        if (stripos($menu_item['name'], $string) !== false && $match_count < 10) {
+        if (stripos($menu_item['name'], $string) !== FALSE && $match_count < 10) {
           $matches['/' . $menu_item['path']] = check_plain($menu_item['name']) . ' (' . t('Layout path') . ')';
           $match_count++;
         }
@@ -418,14 +440,24 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
  * Submit handler for filter_format_editor_link_form().
  */
 function filter_format_editor_link_form_submit($form, &$form_state) {
+  if (isset($form_state['values']['fid'])) {
+    // Value of fid is zero for existing files so get it from href.
+    // This is to ensure that linked files get attribute 'data-file-id'.
+    if ($form_state['values']['fid'] == 0){
+      $uri = $form_state['values']['attributes']['href'];
+      $fid = _filter_get_file_id($uri);
+    }
+    // Value of fid is available in form values.
+    else {$fid = $form_state['values']['fid'];}
 
-  if (!empty($form_state['values']['fid'])) {
-    $fid = $form_state['values']['fid'];
+    // Get file details.
     $file = file_load($fid);
 
     // Try to make a local path if possible for better portability.
+    // Absolute path is needed if Backdrop is installed in subdirectory.
+    $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
     $url = file_create_url($file->uri);
-    $url = str_replace($GLOBALS['base_url'], '', $url);
+    $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 
     $form_state['values']['attributes']['data-file-id'] = $fid;
     $form_state['values']['attributes']['href'] = $url;
@@ -478,4 +510,27 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
   if ($value !== '' && !valid_url($value, TRUE) && !valid_url($value, FALSE)) {
     form_error($element, t('The URL %url is not valid.', array('%url' => $value)));
   }
+}
+
+/**
+ * Find a managed file ID from a url.
+ *
+ */
+function _filter_get_file_id($href) {
+  // Extract file name and directory from $href.
+  $public_path = config_get('system.core','file_public_path');
+  $pp_length = strlen($public_path);
+  $pos = strpos($href,$public_path);
+  $filename = substr($href,$pos + $pp_length);
+  // Now find this file name in uri field to get fid.
+  $results = db_select('file_managed')
+    ->fields('file_managed', array('fid', 'uri'))
+    ->condition('uri', '%' . $filename, 'LIKE')
+    ->orderBy('fid', 'DESC')
+    ->execute();
+
+  foreach ($results as $found) {
+    $result = $found->fid;
+  }
+  return $result;
 }


### PR DESCRIPTION
This is ~~by way of a 'proof of concept'~~ now a working proposal and includes changes that
- use code based on that used for uploading and linking to images for selecting, uploading and linking to files within WYSIWYG.
- provide autocomplete for managed files previously uploaded.
- extend the WYSIWYG (CKEditor) admin to configure file uploads similarly to image uploads.
- add a user permission for allowing file uploads.
- adds script to enable the text of the link to be edited.

Updated 22 March 2018



