### PR TITLE
Issue 3001: option to automatically close comments

### DIFF
--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -150,6 +150,14 @@ function comment_schema() {
         'size' => 'tiny',
         'description' => 'The published status of a comment. (0 = Not Published, 1 = Published)',
       ),
+      'override_auto_closer' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+        'size' => 'tiny',
+        'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+      );
       'thread' => array(
         'type' => 'varchar',
         'length' => 255,
@@ -361,6 +369,25 @@ function comment_update_1003() {
       $config->save();
     }
   }
+}
+
+/**
+ * Add an Override column for automatic comment closing for individual nodes.
+ */
+function comment_update_1004() {
+  if (db_field_exists('comment', 'override_auto_closer')) {
+    return;
+  }
+
+  $schema = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'default' => 0,
+    'size' => 'tiny',
+    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+  );
+  db_add_field('comment', 'override_auto_closer', $schema);
 }
 
 /**

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -150,14 +150,6 @@ function comment_schema() {
         'size' => 'tiny',
         'description' => 'The published status of a comment. (0 = Not Published, 1 = Published)',
       ),
-      'override_auto_closer' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-        'size' => 'tiny',
-        'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
-      );
       'thread' => array(
         'type' => 'varchar',
         'length' => 255,
@@ -369,25 +361,6 @@ function comment_update_1003() {
       $config->save();
     }
   }
-}
-
-/**
- * Add an Override column for automatic comment closing for individual nodes.
- */
-function comment_update_1004() {
-  if (db_field_exists('comment', 'override_auto_closer')) {
-    return;
-  }
-
-  $schema = array(
-    'type' => 'int',
-    'unsigned' => TRUE,
-    'not null' => TRUE,
-    'default' => 0,
-    'size' => 'tiny',
-    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
-  );
-  db_add_field('comment', 'override_auto_closer', $schema);
 }
 
 /**

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -8,7 +8,7 @@
  * Implements hook_schema_alter().
  */
 function comment_schema_alter(&$schema) {
-  $schema['node']['fields']['comment_closer_override'] = array(
+  $schema['node']['fields']['comment_close_override'] = array(
     'type' => 'int',
     'unsigned' => TRUE,
     'not null' => TRUE,
@@ -22,10 +22,10 @@ function comment_schema_alter(&$schema) {
  * Implements hook_install().
  */
 function comment_install() {
-  if (!db_field_exists('node', 'comment_closer_override')) {
+  if (!db_field_exists('node', 'comment_close_override')) {
     $schema = array();
     comment_schema_alter($schema);
-    db_add_field('node', 'comment_closer_override', $schema['node']['fields']['comment_closer_override']);
+    db_add_field('node', 'comment_close_override', $schema['node']['fields']['comment_close_override']);
   }
 }
 
@@ -63,8 +63,8 @@ function comment_uninstall() {
   }
   
   // Remove comment closer override.
-  if (db_field_exists('node', 'comment_closer_override')) {
-    db_drop_field('node', 'comment_closer_override');
+  if (db_field_exists('node', 'comment_close_override')) {
+    db_drop_field('node', 'comment_close_override');
   }
 }
 
@@ -399,13 +399,13 @@ function comment_update_1003() {
  * Add an Override column for automatic comment closing for individual nodes.
  */
 function comment_update_1004() {
-  if (db_field_exists('node', 'comment_closer_override')) {
+  if (db_field_exists('node', 'comment_close_override')) {
     return;
   }
 
   $schema = array();
   comment_schema_alter($schema);
-  db_add_field('node', 'comment_closer_override', $schema['node']['fields']['comment_closer_override']);
+  db_add_field('node', 'comment_close_override', $schema['node']['fields']['comment_close_override']);
 }
 
 /**

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -5,6 +5,23 @@
  */
 
 /**
+ * Implements hook_install().
+ */
+function comment_install() {
+  if (!db_field_exists('node', 'comment_closer_override')) {
+    $schema = array(
+      'type' => 'int',
+      'unsigned' => TRUE,
+      'not null' => TRUE,
+      'default' => 0,
+      'size' => 'tiny',
+      'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+    );
+    db_add_field('node', 'comment_closer_override', $schema);
+  }
+}
+
+/**
  * Implements hook_uninstall().
  */
 function comment_uninstall() {
@@ -26,6 +43,8 @@ function comment_uninstall() {
       'comment_preview',
       'comment_subject_field',
       'comment_user_picture',
+      'comment_close_enabled',
+      'comment_close_days'
     );
     foreach ($comment_settings as $setting) {
       if (isset($node_type->settings[$setting])) {
@@ -33,6 +52,11 @@ function comment_uninstall() {
       }
     }
     node_type_save($node_type);
+  }
+  
+  // Remove comment closer override.
+  if (db_field_exists('node', 'comment_closer_override')) {
+    db_drop_field('node', 'comment_closer_override');
   }
 }
 
@@ -361,6 +385,25 @@ function comment_update_1003() {
       $config->save();
     }
   }
+}
+
+/**
+ * Add an Override column for automatic comment closing for individual nodes.
+ */
+function comment_update_1004() {
+  if (db_field_exists('node', 'comment_closer_override')) {
+    return;
+  }
+
+  $schema = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'default' => 0,
+    'size' => 'tiny',
+    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+  );
+  db_add_field('node', 'comment_closer_override', $schema);
 }
 
 /**

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -5,19 +5,27 @@
  */
 
 /**
+ * Implements hook_schema_alter().
+ */
+function comment_schema_alter(&$schema) {
+  $schema['node']['fields']['comment_closer_override'] = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'default' => 0,
+    'size' => 'tiny',
+    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+  );
+}
+
+/**
  * Implements hook_install().
  */
 function comment_install() {
   if (!db_field_exists('node', 'comment_closer_override')) {
-    $schema = array(
-      'type' => 'int',
-      'unsigned' => TRUE,
-      'not null' => TRUE,
-      'default' => 0,
-      'size' => 'tiny',
-      'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
-    );
-    db_add_field('node', 'comment_closer_override', $schema);
+    $schema = array();
+    comment_schema_alter($schema);
+    db_add_field('node', 'comment_closer_override', $schema['node']['fields']['comment_closer_override']);
   }
 }
 
@@ -395,15 +403,9 @@ function comment_update_1004() {
     return;
   }
 
-  $schema = array(
-    'type' => 'int',
-    'unsigned' => TRUE,
-    'not null' => TRUE,
-    'default' => 0,
-    'size' => 'tiny',
-    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
-  );
-  db_add_field('node', 'comment_closer_override', $schema);
+  $schema = array();
+  comment_schema_alter($schema);
+  db_add_field('node', 'comment_closer_override', $schema['node']['fields']['comment_closer_override']);
 }
 
 /**

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -403,9 +403,16 @@ function comment_update_1004() {
     return;
   }
 
-  $schema = array();
-  comment_schema_alter($schema);
-  db_add_field('node', 'comment_close_override', $schema['node']['fields']['comment_close_override']);
+  $comment_close_override_column = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'default' => 0,
+    'size' => 'tiny',
+    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+  );
+
+  db_add_field('node', 'comment_close_override', $comment_close_override_column);
 }
 
 /**

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -2420,20 +2420,6 @@ function _comment_close_all() {
 }
 
 /**
- * Implements hook_schema_alter().
- */
-function comment_schema_alter(&$schema) {
-  $schema['node']['fields']['comment_closer_override'] = array(
-    'type' => 'int',
-    'unsigned' => TRUE,
-    'not null' => TRUE,
-    'default' => 0,
-    'size' => 'tiny',
-    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
-  );
-}
-
-/**
  * Implements hook_autoload_info().
  */
 function comment_autoload_info() {

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1290,7 +1290,7 @@ function comment_form_node_form_alter(&$form, $form_state) {
     $form['comment_settings']['comment_closer_override'] = array(
       '#type' => 'checkbox',
       '#title' => t('Override the automatic closing of comments'),
-      '#description' => t('This content type is set to automatically disable commenting on old content. Override to leave commenting enabled on this item.'),
+      '#description' => t('This content type is set to automatically disable commenting on old content after !close-days days. Override to leave commenting enabled on this item.', array('!close-days' => $config->get('settings.comment_close_days'))),
       '#default_value' => isset($node->comment_closer_override) ? $node->comment_closer_override : 0,
     );
   }

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1281,6 +1281,11 @@ function comment_form_node_form_alter(&$form, $form_state) {
         ),
       ),
     );
+    $form['comment_settings']['comment_closer_override'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Override the automatic closing comments of old content'),
+      '#default_value' => isset($node->comment_closer_override) ? $node->comment_closer_override : 0,
+    );
   }
 }
 
@@ -2388,7 +2393,7 @@ function _comment_close_all() {
       $oldest_allowed = strtotime("-$days days", $now);
 
       // Fetch nodes that should have comments closed.
-      $result = db_query("SELECT nid FROM {node} WHERE created < :oldest AND type = :type AND comment = :comment",
+      $result = db_query("SELECT nid FROM {node} WHERE created < :oldest AND comment_closer_override = 0 AND type = :type AND comment = :comment",
         array(':oldest' => $oldest_allowed, ':type' => $type, ':comment' => COMMENT_NODE_OPEN)
       );
       $nids = $result->fetchCol();

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -308,6 +308,7 @@ function comment_node_type_load(&$types) {
       'comment_user_picture' => TRUE,
       'comment_form_location' => COMMENT_FORM_BELOW,
       'comment_preview' => BACKDROP_OPTIONAL,
+      'comment_close_enable' => FALSE,
       'comment_close_days' => 14
     );
   }
@@ -1206,11 +1207,20 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
         BACKDROP_REQUIRED => t('Required'),
       ),
     );
+    $form['comment']['comment_close_enable'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Automatically close comments on old content'),
+      '#default_value' => $node_type->settings['comment_close_enable'],
+    );
     $form['comment']['comment_close_days'] = array(
       '#type' => 'textfield',
-      '#title' => t('Automatically close comments on old content'),
-      '#size' => 5,
+      '#size' => 4,
       '#maxlength' => 4,
+      '#states' => array(
+        'invisible' => array(
+          ':input[name="comment_close_enable"]' => array('checked' => FALSE),
+        ),
+      ),
       '#field_prefix' => t('Close comments after'),
       '#default_value' => $node_type->settings['comment_close_days'],
       '#field_suffix' => t('days'),
@@ -2347,7 +2357,6 @@ function comment_file_download_access($field, $entity_type, $entity) {
   }
 }
 
-
 /**
  * Implements hook_cron().
  */
@@ -2371,9 +2380,10 @@ function _comment_close_all($now = NULL) {
     // Set it up.
     $config = config('node.type.' . $type);
     $days = $config->get('settings.comment_close_days');
+    $enable = $config->get('settings.comment_close_enable');
 
     // If a day is set, do this one.
-    if (!empty($days)) {
+    if (!empty($enable) && !empty($days)) {
       $oldest_allowed = _comment_closer_oldest_allowed($days, $now);
 
       // Fetch nodes that should have comments closed.
@@ -2424,7 +2434,7 @@ function _comment_closer_oldest_allowed($days, $now = NULL) {
 function _comment_close_days_validate($element, &$form_state) {
   $days = $element['#value'];
   if (!is_numeric($days) || $days < 0 || $days != intval($days)) {
-    form_error($element, t('The field "Automatically close comments on old content" should be a positive integer.'));
+    form_error($element, t('The "Close comments after" field should be a positive number.'));
   }
 }
 

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1283,15 +1283,15 @@ function comment_form_node_form_alter(&$form, $form_state) {
     );
   }
 
-  $config = config('node.type.' . $node->type);
-  $enable = $config->get('settings.comment_close_enabled');
+  $node_type = node_type_load($node->type);
+  $enable = $node_type->settings['comment_close_enabled'];
 
   if ($enable) {
-    $form['comment_settings']['comment_closer_override'] = array(
+    $form['comment_settings']['comment_close_override'] = array(
       '#type' => 'checkbox',
       '#title' => t('Override the automatic closing of comments'),
-      '#description' => t('This content type is set to automatically disable commenting on old content after !close-days days. Override to leave commenting enabled on this item.', array('!close-days' => $config->get('settings.comment_close_days'))),
-      '#default_value' => isset($node->comment_closer_override) ? $node->comment_closer_override : 0,
+      '#description' => t('This content type is set to automatically disable commenting on old content after @close-days days. Override to leave commenting enabled on this item.', array('@close-days' => $node_type->settings['comment_close_days'])),
+      '#default_value' => isset($node->comment_close_override) ? $node->comment_close_override : 0,
     );
   }
 }
@@ -2381,26 +2381,20 @@ function comment_cron() {
  * Close all comments that meet the current threshold.
  */
 function _comment_close_all() {
-  $now = REQUEST_TIME;
-
   $content_types = node_type_get_names();
 
   foreach ($content_types as $type => $name) {
     // Get the content type settings.
-    $config = config('node.type.' . $type);
-    $days = $config->get('settings.comment_close_days');
-    $enable = $config->get('settings.comment_close_enabled');
+    $node_type = node_type_load($type);
+    $days = $node_type->settings['comment_close_days'];
+    $enable = $node_type->settings['comment_close_enabled'];
 
     // If a day is set, do this one.
     if (!empty($enable) && !empty($days)) {
-      if (empty($now)) {
-        $now = isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIME'] : REQUEST_TIME;
-      }
-
-      $oldest_allowed = strtotime("-$days days", $now);
+      $oldest_allowed = strtotime("-$days days", REQUEST_TIME);
 
       // Fetch nodes that should have comments closed.
-      $result = db_query("SELECT nid FROM {node} WHERE created < :oldest AND comment_closer_override = 0 AND type = :type AND comment = :comment",
+      $result = db_query("SELECT nid FROM {node} WHERE created < :oldest AND comment_close_override = 0 AND type = :type AND comment = :comment",
         array(':oldest' => $oldest_allowed, ':type' => $type, ':comment' => COMMENT_NODE_OPEN)
       );
       $nids = $result->fetchCol();

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -308,7 +308,7 @@ function comment_node_type_load(&$types) {
       'comment_user_picture' => TRUE,
       'comment_form_location' => COMMENT_FORM_BELOW,
       'comment_preview' => BACKDROP_OPTIONAL,
-      'comment_close_enable' => FALSE,
+      'comment_close_enabled' => FALSE,
       'comment_close_days' => 14
     );
   }
@@ -1207,10 +1207,10 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
         BACKDROP_REQUIRED => t('Required'),
       ),
     );
-    $form['comment']['comment_close_enable'] = array(
+    $form['comment']['comment_close_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Automatically close comments on old content'),
-      '#default_value' => $node_type->settings['comment_close_enable'],
+      '#default_value' => $node_type->settings['comment_close_enabled'],
     );
     $form['comment']['comment_close_days'] = array(
       '#type' => 'number',
@@ -1220,7 +1220,7 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
       '#maxlength' => 4,
       '#states' => array(
         'invisible' => array(
-          ':input[name="comment_close_enable"]' => array('checked' => FALSE),
+          ':input[name="comment_close_enabled"]' => array('checked' => FALSE),
         ),
       ),
       '#field_prefix' => t('Close comments after'),
@@ -2377,7 +2377,7 @@ function _comment_close_all() {
     // Get the content type settings.
     $config = config('node.type.' . $type);
     $days = $config->get('settings.comment_close_days');
-    $enable = $config->get('settings.comment_close_enable');
+    $enable = $config->get('settings.comment_close_enabled');
 
     // If a day is set, do this one.
     if (!empty($enable) && !empty($days)) {

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -308,6 +308,7 @@ function comment_node_type_load(&$types) {
       'comment_user_picture' => TRUE,
       'comment_form_location' => COMMENT_FORM_BELOW,
       'comment_preview' => BACKDROP_OPTIONAL,
+      'comment_close_days' => 14
     );
   }
 }
@@ -1204,6 +1205,16 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
         BACKDROP_OPTIONAL => t('Optional'),
         BACKDROP_REQUIRED => t('Required'),
       ),
+    );
+    $form['comment']['comment_close_days'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Automatically close comments on old content'),
+      '#size' => 5,
+      '#maxlength' => 4,
+      '#field_prefix' => t('Close comments after'),
+      '#default_value' => $node_type->settings['comment_close_days'],
+      '#field_suffix' => t('days'),
+      '#element_validate' => array('_comment_close_days_validate'),
     );
   }
 }
@@ -2333,6 +2344,87 @@ function comment_file_download_access($field, $entity_type, $entity) {
       return node_access('view', $node);
     }
     return FALSE;
+  }
+}
+
+
+/**
+ * Implements hook_cron().
+ */
+function comment_cron() {
+  _comment_close_all();
+}
+
+/**
+ * Close all comments that meet the current threshold.
+ *
+ * @param $now
+ *  A UNIX timestamp for the expiration time.
+ */
+function _comment_close_all($now = NULL) {
+  if (is_null($now)) {
+    $now = REQUEST_TIME;
+  }
+  $content_types = node_type_get_names();
+
+  foreach ($content_types as $type => $name) {
+    // Set it up.
+    $config = config('node.type.' . $type);
+    $days = $config->get('settings.comment_close_days');
+
+    // If a day is set, do this one.
+    if (!empty($days)) {
+      $oldest_allowed = _comment_closer_oldest_allowed($days, $now);
+
+      // Fetch nodes that should have comments closed.
+      $result = db_query("SELECT nid FROM {node} WHERE created < :oldest AND type = :type AND comment = :comment",
+        array(':oldest' => $oldest_allowed, ':type' => $type, ':comment' => COMMENT_NODE_OPEN)
+      );
+      $nids = $result->fetchCol();
+
+      // Update those rows.
+      foreach($nids as $nid) {
+        $node = node_load($nid);
+        $node->comment = COMMENT_NODE_CLOSED;
+        node_save($node);
+      }
+
+      $count  = $result->rowCount();
+      if ($count) {
+        $vars = array(
+          '!count' => $count,
+          '@type' => $name,
+          '!date' => format_date($oldest_allowed),
+        );
+        $msg = 'Closed comments on !count @type posts created at, or before, !date.';
+        watchdog('comment', $msg, $vars, WATCHDOG_NOTICE);
+      }
+    }
+  }
+}
+
+/**
+ * Helper function for generating date from age interval.
+ */
+function _comment_closer_oldest_allowed($days, $now = NULL) {
+  if ($days == 0) {
+    return 0;
+  }
+
+  if (empty($now)) {
+    $now = isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIME'] : REQUEST_TIME;
+  }
+
+  return strtotime("-$days days", $now);
+}
+
+/**
+ * Form element validation to ensure proper data.
+ */
+function _comment_close_days_validate($element, &$form_state) {
+  $days = $element['#value'];
+  if (!is_numeric($days) || $days < 0 || $days != intval($days)) {
+    form_error($element, t('The field "Automatically close comments on old content" should be a positive integer.'));
   }
 }
 

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1213,7 +1213,9 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
       '#default_value' => $node_type->settings['comment_close_enable'],
     );
     $form['comment']['comment_close_days'] = array(
-      '#type' => 'textfield',
+      '#type' => 'number',
+      '#min' => 1,
+      '#step' => 1,
       '#size' => 4,
       '#maxlength' => 4,
       '#states' => array(
@@ -1224,7 +1226,6 @@ function comment_form_node_type_form_alter(&$form, $form_state) {
       '#field_prefix' => t('Close comments after'),
       '#default_value' => $node_type->settings['comment_close_days'],
       '#field_suffix' => t('days'),
-      '#element_validate' => array('_comment_close_days_validate'),
     );
   }
 }
@@ -2366,25 +2367,25 @@ function comment_cron() {
 
 /**
  * Close all comments that meet the current threshold.
- *
- * @param $now
- *  A UNIX timestamp for the expiration time.
  */
-function _comment_close_all($now = NULL) {
-  if (is_null($now)) {
-    $now = REQUEST_TIME;
-  }
+function _comment_close_all() {
+  $now = REQUEST_TIME;
+
   $content_types = node_type_get_names();
 
   foreach ($content_types as $type => $name) {
-    // Set it up.
+    // Get the content type settings.
     $config = config('node.type.' . $type);
     $days = $config->get('settings.comment_close_days');
     $enable = $config->get('settings.comment_close_enable');
 
     // If a day is set, do this one.
     if (!empty($enable) && !empty($days)) {
-      $oldest_allowed = _comment_closer_oldest_allowed($days, $now);
+      if (empty($now)) {
+        $now = isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIME'] : REQUEST_TIME;
+      }
+
+      $oldest_allowed = strtotime("-$days days", $now);
 
       // Fetch nodes that should have comments closed.
       $result = db_query("SELECT nid FROM {node} WHERE created < :oldest AND type = :type AND comment = :comment",
@@ -2393,7 +2394,7 @@ function _comment_close_all($now = NULL) {
       $nids = $result->fetchCol();
 
       // Update those rows.
-      foreach($nids as $nid) {
+      foreach ($nids as $nid) {
         $node = node_load($nid);
         $node->comment = COMMENT_NODE_CLOSED;
         node_save($node);
@@ -2410,31 +2411,6 @@ function _comment_close_all($now = NULL) {
         watchdog('comment', $msg, $vars, WATCHDOG_NOTICE);
       }
     }
-  }
-}
-
-/**
- * Helper function for generating date from age interval.
- */
-function _comment_closer_oldest_allowed($days, $now = NULL) {
-  if ($days == 0) {
-    return 0;
-  }
-
-  if (empty($now)) {
-    $now = isset($_SERVER['REQUEST_TIME']) ? $_SERVER['REQUEST_TIME'] : REQUEST_TIME;
-  }
-
-  return strtotime("-$days days", $now);
-}
-
-/**
- * Form element validation to ensure proper data.
- */
-function _comment_close_days_validate($element, &$form_state) {
-  $days = $element['#value'];
-  if (!is_numeric($days) || $days < 0 || $days != intval($days)) {
-    form_error($element, t('The "Close comments after" field should be a positive number.'));
   }
 }
 

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1281,9 +1281,16 @@ function comment_form_node_form_alter(&$form, $form_state) {
         ),
       ),
     );
+  }
+
+  $config = config('node.type.' . $node->type);
+  $enable = $config->get('settings.comment_close_enabled');
+
+  if ($enable) {
     $form['comment_settings']['comment_closer_override'] = array(
       '#type' => 'checkbox',
-      '#title' => t('Override the automatic closing comments of old content'),
+      '#title' => t('Override the automatic closing of comments'),
+      '#description' => t('This content type is set to automatically disable commenting on old content. Override to leave commenting enabled on this item.'),
       '#default_value' => isset($node->comment_closer_override) ? $node->comment_closer_override : 0,
     );
   }

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -2420,6 +2420,20 @@ function _comment_close_all() {
 }
 
 /**
+ * Implements hook_schema_alter().
+ */
+function comment_schema_alter(&$schema) {
+  $schema['node']['fields']['comment_closer_override'] = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'default' => 0,
+    'size' => 'tiny',
+    'description' => 'Override the automatic comment closer. (0 = Do not override, 1 = Override)',
+  );
+}
+
+/**
  * Implements hook_autoload_info().
  */
 function comment_autoload_info() {

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2237,12 +2237,12 @@ class CommentNodeAutoCloserTestCase extends CommentHelperCase {
     $this->backdropLogin($this->admin_user);
 
     $this->backdropGet('node/' . $this->node->nid . '/edit');
-    $this->assertNoField('edit-comment-closer-override', 'Comment auto closer override hidden when auto closer not enabled.');
+    $this->assertNoField('edit-comment-close-override', 'Comment auto closer override hidden when auto closer not enabled.');
 
     $this->setCommentSettings('comment_close_enabled', TRUE, 'Comment auto closer enabled.');
 
     $this->backdropGet('node/' . $this->node->nid . '/edit');
-    $this->assertField('edit-comment-closer-override', 'Comment auto closer override visible when auto closer enabled.');
+    $this->assertField('edit-comment-close-override', 'Comment auto closer override visible when auto closer enabled.');
 
     // Run cron
     $this->cronRun();
@@ -2264,7 +2264,7 @@ class CommentNodeAutoCloserTestCase extends CommentHelperCase {
     // Override the auto comment closer so the node can be kept open.
     $edit = array(
       'comment' => COMMENT_NODE_OPEN,
-      'comment_closer_override' => TRUE,
+      'comment_close_override' => TRUE,
     );
     $this->backdropPost('node/' . $this->node->nid . '/edit', $edit, t('Save'));
 

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2231,25 +2231,35 @@ class CommentNodeChangesTestCase extends CommentHelperCase {
  */
 class CommentNodeAutoCloserTestCase extends CommentHelperCase {
   /**
-   * Tests opening, closing, and hiding comments.
+   * Tests the auto closer node type setting and the override setting on individual nodes.
    */
   function testNodeCommentAutoCloserSettings() {
     $this->backdropLogin($this->admin_user);
 
-    $this->setCommentSettings('comment_close_enabled', TRUE, 'Comment auto closer enabled.');
-    // Set node created date to older than default 14 days
     $this->backdropGet('node/' . $this->node->nid . '/edit');
+    $this->assertNoField('edit-comment-closer-override', 'Comment auto closer override hidden when auto closer not enabled.');
 
-    $edit = array(
-      'created' => strtotime(now() - '15 days'),
-    );
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->setCommentSettings('comment_close_enabled', TRUE, 'Comment auto closer enabled.');
+
+    $this->backdropGet('node/' . $this->node->nid . '/edit');
+    $this->assertField('edit-comment-closer-override', 'Comment auto closer override visible when auto closer enabled.');
 
     // Run cron
     $this->cronRun();
 
     $this->backdropGet('node/' . $this->node->nid);
-    $this->assertEqual(count($this->xpath('//form[@id="comment-form"]')), 0, 'Comment form not on node page when comments are closed.');
+    $this->assertEqual(count($this->xpath('//form[@id="comment-form"]')), 1, 'Comment form visible on node page when created date is younger than comment auto closer default time span.');
+
+    // Set node created date to older than default 14 days
+    $comment_close_days = config_get('node.type.post','settings.comment_close_days');
+    $this->node->created = time() - strtotime($comment_close_days + 1 . ' days');
+    $this->node->save();
+
+    // Run cron
+    $this->cronRun();
+
+    $this->backdropGet('node/' . $this->node->nid);
+    $this->assertEqual(count($this->xpath('//form[@id="comment-form"]')), 0, 'Comment form not on node page when created date is older than the comment auto closer default time span.');
 
     // Override the auto comment closer so the node can be kept open.
     $edit = array(

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2225,3 +2225,43 @@ class CommentNodeChangesTestCase extends CommentHelperCase {
 
   }
 }
+
+/**
+ * Tests that comments behave correctly when the auto closer is enabled.
+ */
+class CommentNodeAutoCloserTestCase extends CommentHelperCase {
+  /**
+   * Tests opening, closing, and hiding comments.
+   */
+  function testNodeCommentAutoCloserSettings() {
+    $this->backdropLogin($this->admin_user);
+
+    $this->setCommentSettings('comment_close_enabled', TRUE, 'Comment auto closer enabled.');
+    // Set node created date to older than default 14 days
+    $this->backdropGet('node/' . $this->node->nid . '/edit');
+
+    $edit = array(
+      'created' => strtotime(now() - '15 days'),
+    );
+    $this->backdropPost(NULL, $edit, t('Save'));
+
+    // Run cron
+    $this->cronRun();
+
+    $this->backdropGet('node/' . $this->node->nid);
+    $this->assertEqual(count($this->xpath('//form[@id="comment-form"]')), 0, 'Comment form not on node page when comments are closed.');
+
+    // Override the auto comment closer so the node can be kept open.
+    $edit = array(
+      'comment' => COMMENT_NODE_OPEN,
+      'comment_closer_override' => TRUE,
+    );
+    $this->backdropPost('node/' . $this->node->nid . '/edit', $edit, t('Save'));
+
+    // Run cron
+    $this->cronRun();
+
+    $this->backdropGet('node/' . $this->node->nid);
+    $this->assertEqual(count($this->xpath('//form[@id="comment-form"]')), 1, 'Comment form visible on node page when comments auto closer is overridden for individual node.');
+  }
+}

--- a/core/modules/comment/tests/comment.tests.info
+++ b/core/modules/comment/tests/comment.tests.info
@@ -82,6 +82,12 @@ description = Tests that comments behave correctly when the node is changed.
 group = Comment
 file = comment.test
 
+[CommentNodeAutoCloserTestCase]
+name = Comment with auto closer
+description = Tests that comments behave correctly when the auto closer is enabled.
+group = Comment
+file = comment.test
+
 [CommentViewsHandlerArgumentUserUidTest]
 name = Tests handler argument_comment_user_uid
 description = Tests the user posted or commented argument Views handler.


### PR DESCRIPTION
Build something for issue https://github.com/backdrop/backdrop-issues/issues/3001. Might need some tweaks but it basically works.

It's a stripped down version of commentcloser module. It only has one option instead of a few: number of days before closing comments on content, configured per content type. It will close the comments regardless of published/unpublished state, which keeps it simple. Backdrop doesn't have a published date. If people want to leave them open longer then they can update the created date. It will check every cron run. If people don't like that they can install elysia cron for finer control.