### PR TITLE
Issue #2952: Move core layout contexts into their respective modules.

### DIFF
--- a/core/modules/layout/includes/layout.layout.inc
+++ b/core/modules/layout/includes/layout.layout.inc
@@ -6,45 +6,12 @@
 
 /**
  * Implements hook_layout_context_info().
+ *
+ * @see node_layout_context_info().
+ * @see user_layout_context_info().
+ * @see taxonomy_layout_context_info().
  */
 function layout_layout_context_info() {
-  $info['node'] = array(
-    'title' => t('Node'),
-    // Define the class which is used to handle this context.
-    'class' => 'EntityLayoutContext',
-    // Define menu paths where the node ID is a "known" context.
-    'menu paths' => array(
-      'node/%node',
-      'node/%node/view',
-    ),
-    // Given the menu paths defined above, identify the part of the path that
-    // is needed to generate this context.
-    'path placeholder' => '%node',
-
-    // Given an argument, the callback that will be responsible for loading the
-    // main context data.
-    'load callback' => 'node_load',
-  );
-  $info['user'] = array(
-    'title' => t('User'),
-    'class' => 'EntityLayoutContext',
-    'menu paths' => array(
-      'user/%user',
-      'user/%user/view',
-    ),
-    'path placeholder' => '%user',
-    'load callback' => 'user_load',
-  );
-  $info['taxonomy_term'] = array(
-    'title' => t('Term'),
-    'class' => 'EntityLayoutContext',
-    'menu paths' => array(
-      'taxonomy/term/%term',
-      'taxonomy/term/%term/view',
-    ),
-    'path placeholder' => '%term',
-    'load callback' => 'taxonomy_term_load',
-  );
   $info['overrides_path'] = array(
     'title' => t('Overrides path'),
     'description' => t('Layout overrides existing path provided by another module.'),

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -1584,6 +1584,30 @@ function _node_add_access() {
 }
 
 /**
+ * Implements hook_layout_context_info().
+ */
+function node_layout_context_info() {
+  $info['node'] = array(
+    'title' => t('Content (node)'),
+    // Define the class which is used to handle this context.
+    'class' => 'EntityLayoutContext',
+    // Define menu paths where the node ID is a "known" context.
+    'menu paths' => array(
+      'node/%node',
+      'node/%node/view',
+      'node/%node/edit',
+    ),
+    // Given the menu paths defined above, identify the part of the path that
+    // is needed to generate this context.
+    'path placeholder' => '%node',
+    // Given an argument, define the callback that will be responsible for
+    // loading the main context data.
+    'load callback' => 'node_load',
+  );
+  return $info;
+}
+
+/**
  * Implements hook_menu().
  */
 function node_menu() {

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -112,6 +112,30 @@ function taxonomy_entity_info() {
 }
 
 /**
+ * Implements hook_layout_context_info().
+ */
+function taxonomy_layout_context_info() {
+  $info['taxonomy_term'] = array(
+    'title' => t('Taxonomy Term'),
+    // Define the class which is used to handle this context.
+    'class' => 'EntityLayoutContext',
+    // Define menu paths where the term ID is a "known" context.
+    'menu paths' => array(
+      'taxonomy/term/%taxonomy_term',
+      'taxonomy/term/%taxonomy_term/view',
+      'taxonomy/term/%taxonomy_term/edit',
+    ),
+    // Given the menu paths defined above, identify the part of the path that
+    // is needed to generate this context.
+    'path placeholder' => '%taxonomy_term',
+    // Given an argument, the callback that will be responsible for loading the
+    // main context data.
+    'load callback' => 'taxonomy_term_load',
+  );
+  return $info;
+}
+
+/**
  * Implements hook_views_api().
  */
 function taxonomy_views_api() {

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -137,6 +137,30 @@ function user_entity_info() {
 }
 
 /**
+ * Implements hook_layout_context_info().
+ */
+function user_layout_context_info() {
+  $info['user'] = array(
+    'title' => t('User account'),
+    // Define the class which is used to handle this context.
+    'class' => 'EntityLayoutContext',
+    // Define menu paths where the user ID is a "known" context.
+    'menu paths' => array(
+      'user/%user',
+      'user/%user/view',
+      'user/%user/edit',
+    ),
+    // Given the menu paths defined above, identify the part of the path that
+    // is needed to generate this context.
+    'path placeholder' => '%user',
+    // Given an argument, define the callback that will be responsible for
+    // loading the main context data.
+    'load callback' => 'user_load',
+  );
+  return $info;
+}
+
+/**
  * Implements hook_field_info_alter().
  */
 function user_field_info_alter(&$info) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2952
Replaces https://github.com/backdrop/backdrop/pull/2080