### PR TITLE
Fixes #3027: _menu_build_tree doesn't load include_file field from db…

### DIFF
--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -1516,6 +1516,7 @@ function _menu_build_tree($menu_name, array $parameters = array()) {
       'theme_arguments',
       'type',
       'description',
+      'include_file',
     ));
     for ($i = 1; $i <= MENU_MAX_DEPTH; $i++) {
       $query->orderBy('p' . $i, 'ASC');


### PR DESCRIPTION
…, resulting in include not being loaded.