### PR TITLE
Issue #2722: Add description field to custom blocks.

### DIFF
--- a/core/modules/block/block.admin.inc
+++ b/core/modules/block/block.admin.inc
@@ -13,6 +13,7 @@ function block_admin_list() {
 
   $header = array(
     t('Block'),
+    t('Description'),
     t('Operations'),
   );
 
@@ -20,6 +21,7 @@ function block_admin_list() {
   foreach ($custom_blocks_info as $delta => $block_info) {
     $row = array();
     $row[] = check_plain($block_info['info']);
+    $row[] = check_plain($block_info['description']);
     $links = array();
     $links['configure'] = array(
       'title' => t('Configure'),

--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -89,7 +89,7 @@ function block_block_info() {
   foreach ($config_names as $config_name) {
     $block = config_get($config_name);
     $blocks[$block['delta']] = $block;
-    $blocks[$block['delta']]['description'] = t('A reusable custom block.');
+    $blocks[$block['delta']]['description'] = !empty($block['description']) ? $block['description'] : t('A reusable custom block.');
   }
   return $blocks;
 }
@@ -173,19 +173,17 @@ function block_custom_block_load($delta) {
  */
 function block_custom_block_form($edit = array(), $stand_alone = TRUE) {
   $edit += array(
+    'delta' => NULL,
     'info' => '',
     'title' => '',
+    'description' => '',
     'body' => array('value' => '', 'format' => NULL),
-    'delta' => NULL,
   );
-  $form['title'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Display title'),
-    '#default_value' => $edit['title'],
-    '#maxlength' => 255,
-    '#description' => t('The title of the block as shown to the user. This will affect all places where this block is used.'),
-    '#weight' => -18,
-  );
+  // If the description is the default from hook_block_info(), leave blank.
+  if ($edit['description'] === t('A reusable custom block.')) {
+    $edit['description'] = '';
+  }
+
   $form['info'] = array(
     '#type' => 'textfield',
     '#title' => t('Admin label'),
@@ -195,6 +193,15 @@ function block_custom_block_form($edit = array(), $stand_alone = TRUE) {
     '#required' => TRUE,
     '#weight' => -20,
     '#id' => 'block-info',
+  );
+  $form['description'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Block description'),
+    '#default_value' => $edit['description'],
+    '#maxlength' => 128,
+    '#description' => t('Used in administrative interfaces and not shown to end-users.'),
+    '#weight' => -18,
+    '#id' => 'block-description',
   );
   $form['delta'] = array(
     '#type' => 'machine_name',
@@ -208,6 +215,14 @@ function block_custom_block_form($edit = array(), $stand_alone = TRUE) {
     '#weight' => -19,
     '#disabled' => isset($edit['delta']),
   );
+  $form['title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Display title'),
+    '#default_value' => $edit['title'],
+    '#maxlength' => 255,
+    '#description' => t('The title of the block as shown to the user. This will affect all places where this block is used.'),
+    '#weight' => -17,
+  );
   $form['body'] = array(
     '#type' => 'text_format',
     '#title' => t('Block content'),
@@ -216,7 +231,7 @@ function block_custom_block_form($edit = array(), $stand_alone = TRUE) {
     '#editor_uploads' => TRUE,
     '#rows' => 8,
     '#required' => TRUE,
-    '#weight' => -17,
+    '#weight' => -16,
   );
 
   // When displaying as part of the Layout UI.
@@ -229,6 +244,7 @@ function block_custom_block_form($edit = array(), $stand_alone = TRUE) {
     $form['info']['#weight'] = 5;
     $form['delta']['#weight'] = 6;
     $form['delta']['#machine_name']['source'] = array('block_settings', 'info');
+    $form['description']['#weight'] = 7;
     $form['reusable'] = array(
       '#type' => 'checkbox',
       '#title' => t('Make this block reusable'),
@@ -266,6 +282,7 @@ function block_custom_block_save(array $edit, $delta = NULL) {
       'delta' => $delta,
       'info' => '',
       'title' => '',
+      'description' => '',
       'body' => array('value' => '', 'format' => ''),
     );
   }

--- a/core/modules/layout/includes/block.text.inc
+++ b/core/modules/layout/includes/block.text.inc
@@ -91,6 +91,18 @@ class BlockText extends Block {
           ),
         ),
       );
+      $form['convert']['description'] = array(
+       '#type' => 'textfield',
+       '#title' => t('Block description'),
+       '#maxlength' => 128,
+       '#description' => t('Used in administrative interfaces and not shown to end-users.'),
+       '#weight' => 4,
+        '#states' => array(
+          'visible' => array(
+            ':input[name="reusable"]' => array('checked' => TRUE),
+          ),
+        ),
+      );
       $form['convert']['delta'] = array(
         '#type' => 'machine_name',
         '#title' => t('Internal name'),
@@ -140,6 +152,7 @@ class BlockText extends Block {
       $edit = array(
         'info' => $form_state['values']['label'],
         'title' => $form_state['values']['title'],
+        'description' => $form_state['values']['description'],
         'body' => $form_state['values']['content'],
       );
       block_custom_block_save($edit, $delta);


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#2722: Add description field to custom blocks.

Replaces https://github.com/backdrop/backdrop/pull/1908. I didn't mean to permanently close out #1908, but GitHub will not let me reopen it. As such I'm just refiling that PR here.

I included 2 minor changes: The description `t('A custom reusable block.')` is now filtered out when editing an existing block so it maintains no description when saved. And I moved the description down below the machine name when editing a block in the layout UI. @Graham-72 maintains the commit credit.