### PR TITLE
Issue #297: Separate password confirm from strength indicator. Add show/hide password.

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -2997,6 +2997,9 @@ function form_process_password_confirm($element) {
     '#value' => empty($element['#value']) ? NULL : $element['#value']['pass1'],
     '#required' => $element['#required'],
     '#attributes' => array('class' => array('password-field')),
+    '#password_strength' => TRUE,
+    '#password_shown' => FALSE,
+    '#password_toggle' => FALSE,
   );
   $element['pass2'] =  array(
     '#type' => 'password',
@@ -3004,6 +3007,9 @@ function form_process_password_confirm($element) {
     '#value' => empty($element['#value']) ? NULL : $element['#value']['pass2'],
     '#required' => $element['#required'],
     '#attributes' => array('class' => array('password-confirm')),
+    '#password_strength' => FALSE,
+    '#password_shown' => FALSE,
+    '#password_toggle' => FALSE,
   );
   $element['#element_validate'] = array('password_confirm_validate');
   $element['#tree'] = TRUE;

--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1851,9 +1851,12 @@ function _install_configure_form($form, &$form_state, &$install_state) {
     '#weight' => -5,
   );
   $form['admin_account']['account']['pass'] = array(
-    '#type' => 'password_confirm',
+    '#title' => st('Password'),
+    '#type' => 'password',
     '#required' => TRUE,
     '#weight' => 0,
+    '#password_toggle' => TRUE,
+    '#password_strength' => TRUE,
   );
 
   $form['server_settings'] = array(

--- a/core/modules/dblog/tests/dblog.test
+++ b/core/modules/dblog/tests/dblog.test
@@ -198,8 +198,7 @@ class DBLogTestCase extends BackdropWebTestCase {
     $edit = array();
     $edit['name'] = $name;
     $edit['mail'] = $name . '@example.com';
-    $edit['pass[pass1]'] = $pass;
-    $edit['pass[pass2]'] = $pass;
+    $edit['pass'] = $pass;
     $edit['status'] = 1;
     $this->backdropPost('admin/people/create', $edit, t('Create new account'));
     $this->assertResponse(200);

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -1636,8 +1636,7 @@ class LocaleUserCreationTest extends BackdropWebTestCase {
     $edit = array(
       'name' => $username,
       'mail' => $this->randomName(4) . '@example.com',
-      'pass[pass1]' => $username,
-      'pass[pass2]' => $username,
+      'pass' => $username,
     );
 
     $this->backdropPost($langcode . '/admin/people/create', $edit, t('Create new account'));
@@ -1673,8 +1672,7 @@ class LocaleUserCreationTest extends BackdropWebTestCase {
     // Set pass_raw so we can login the new user.
     $user->pass_raw = $this->randomName(10);
     $edit = array(
-      'pass[pass1]' => $user->pass_raw,
-      'pass[pass2]' => $user->pass_raw,
+      'pass' => $user->pass_raw,
     );
 
     $this->backdropPost($user_edit, $edit, t('Save'));

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -373,6 +373,10 @@ function system_element_info() {
     '#process' => array('ajax_process_form'),
     '#theme' => 'password',
     '#theme_wrappers' => array('form_element'),
+    '#password_strength' => FALSE,
+    '#password_toggle' => FALSE,
+    '#password_shown' => FALSE,
+    '#process' => array('user_form_process_password'),
   );
   $types['password_confirm'] = array(
     '#input' => TRUE,

--- a/core/modules/user/css/user.css
+++ b/core/modules/user/css/user.css
@@ -36,9 +36,24 @@
 }
 
 /**
+ * Password toggle.
+ */
+.password-toggle-wrapper {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+}
+.password-toggle {
+  right: 0;
+  position: absolute;
+  font-size: 80%;
+  top: -2em;
+}
+
+/**
  * Password strength indicator.
  */
-.password-confirm-wrapper {
+.password-strength-wrapper {
   position: relative;
   display: inline-block;
   max-width: 100%;
@@ -96,6 +111,10 @@
 .password-strength.strong .password-strength-text {
   color: #008000;
 }
+
+/**
+ * Password confirmation field.
+ */
 .password-match {
   display: block;
 }

--- a/core/modules/user/js/user.js
+++ b/core/modules/user/js/user.js
@@ -1,44 +1,113 @@
 (function ($) {
 
 /**
- * Attach handlers to evaluate the strength of any password fields and to check
- * that its confirmation is correct.
+ * Attach handlers to evaluate the strength of any password fields.
  */
-Backdrop.behaviors.password = {
+Backdrop.behaviors.passwordStrength = {
   attach: function (context, settings) {
-    var translate = settings.password;
-    $('input.password-field', context).once('password', function () {
+    $('input[data-password-strength]', context).once('password-strength', function () {
       var $passwordInput = $(this);
-      var $innerWrapper = $(this).parent();
-      var $outerWrapper = $(this).parent().parent();
-
-      // Add identifying class to password element parent.
-      $innerWrapper.addClass('password-parent');
-
-      // Add the password confirmation layer.
-      $outerWrapper.find('input.password-confirm').wrap('<span class="password-confirm-wrapper"></span>').after('<span class="password-match"><span class="password-match-title">' + translate.confirmTitle + '</span><span class="password-match-text"></span></span>').addClass('confirm-parent');
-      var $confirmInput = $outerWrapper.find('input.password-confirm');
-      var $matchResult = $outerWrapper.find('span.password-match');
-      var passwordMeter = '<span class="password-strength"><span class="password-strength-title">' + translate.strengthTitle + '</span><span class="password-strength-text" aria-live="assertive"></span><span class="password-indicator"><span class="indicator"></span></span></span>';
-      $passwordInput.wrap('<span class="password-confirm-wrapper"></span>').after(passwordMeter);
+      var passwordStrengthSettings = $passwordInput.data('passwordStrength');
+      var passwordMeter = '<span class="password-strength"><span class="password-strength-title">' + passwordStrengthSettings.strengthTitle + '</span><span class="password-strength-text" aria-live="assertive"></span><span class="password-indicator"><span class="indicator"></span></span></span>';
+      $passwordInput.wrap('<span class="password-strength-wrapper"></span>').after(passwordMeter);
+      var $innerWrapper = $passwordInput.parent();
+      var $indicatorBar = $innerWrapper.find('.indicator');
+      var $strengthText = $innerWrapper.find('.password-strength-text');
+      var $strengthWrapper = $innerWrapper.find('.password-strength');
 
       // Check the password strength.
       var passwordCheck = function () {
-
         // Evaluate the password strength.
-        var result = Backdrop.evaluatePasswordStrength($passwordInput.val(), translate.username);
+        var result = Backdrop.evaluatePasswordStrength($passwordInput.val(), passwordStrengthSettings.username);
 
         // Adjust the length of the strength indicator.
-        $innerWrapper.find('.indicator').css('width', result.strength + '%');
+        $indicatorBar.css('width', result.strength + '%');
 
         // Update the strength indication text.
-        $innerWrapper.find('.password-strength-text').html(translate[result.level]);
+        $strengthText.html(passwordStrengthSettings[result.level]);
 
         // Give a class to the strength.
-        $innerWrapper.find('.password-strength').attr('class', 'password-strength ' + result.level);
-
-        passwordCheckMatch();
+        $strengthWrapper.attr('class', 'password-strength ' + result.level);
       };
+
+      // Monitor keyup and blur events.
+      // Blur must be used because a mouse paste does not trigger keyup.
+      $passwordInput.on('keyup focus blur', passwordCheck).triggerHandler('blur');
+    });
+  }
+};
+
+/**
+ * Attach handlers to evaluate the strength of any password fields.
+ */
+Backdrop.behaviors.passwordToggle = {
+  attach: function (context, settings) {
+    $('input[data-password-toggle]', context).once('password-toggle', function () {
+      var $passwordInput = $(this);
+      var passwordToggleSettings = $passwordInput.data('passwordToggle');
+      var $passwordToggle = $('<a href="#" class="password-toggle" />').text(passwordToggleSettings.toggleShowTitle);
+
+      // Use the same wrapper as the password strength indicator, if it's
+      // already been added by the above behavior.
+      if ($passwordInput.parent().is('.password-strength-wrapper')) {
+        var $passwordWrapper = $passwordInput.parent().addClass('password-toggle-wrapper');
+      }
+      else {
+        var $passwordWrapper = $passwordInput.wrap('<span class="password-toggle-wrapper"></span>').parent();
+      }
+
+      $passwordWrapper.addClass('password-hidden');
+      $passwordInput.before($passwordToggle);
+
+      var passwordToggle = function (e) {
+        var showPassword = $passwordWrapper.is('.password-hidden');
+        if (showPassword) {
+          // Set the element to text and set the toggle to be "Hide".
+          $passwordInput.attr('type', 'text');
+          $passwordWrapper.removeClass('password-hidden').addClass('password-shown');
+          $passwordToggle.text(passwordToggleSettings.toggleHideTitle);
+        }
+        else {
+          // Set the element to password and set the toggle to be "Show".
+          $passwordInput.attr('type', 'password');
+          $passwordWrapper.removeClass('password-shown').addClass('password-hidden');
+          $passwordToggle.text(passwordToggleSettings.toggleShowTitle);
+        }
+        e.preventDefault();
+      };
+
+      $passwordToggle.on('click', passwordToggle);
+      if (passwordToggleSettings.toggleDefault === 'show') {
+        $passwordToggle.triggerHandler('click');
+      }
+
+      // When submitting the form, convert back to a password field for the
+      // sake of password managers.
+      $($passwordInput[0].form).submit(function() {
+        if ($passwordWrapper.is('.password-shown')) {
+          $passwordToggle.triggerHandler('click');
+        }
+      });
+    });
+
+  }
+};
+
+/**
+ * Attach handlers to password confirmation elements.
+ */
+Backdrop.behaviors.passwordConfirm = {
+  attach: function (context, settings) {
+    $('input[data-password-confirm]', context).once('password-confirm', function () {
+      var $confirmInput = $(this);
+      var $innerWrapper = $confirmInput.parent();
+      var $outerWrapper = $innerWrapper.parent();
+      var passwordConfirmSettings = $confirmInput.data('passwordConfirm');
+
+      // Add the password confirmation layer.
+      $outerWrapper.find('input.password-confirm').wrap('<span class="password-confirm-wrapper"></span>').after('<span class="password-match"><span class="password-match-title">' + passwordConfirmSettings.confirmTitle + '</span><span class="password-match-text"></span></span>').addClass('confirm-parent');
+      var $passwordInput = $outerWrapper.find('input.password-field');
+      var $matchResult = $outerWrapper.find('span.password-match');
 
       // Check that password and confirmation inputs match.
       var passwordCheckMatch = function () {
@@ -53,7 +122,7 @@ Backdrop.behaviors.password = {
 
           // Fill in the success message and set the class accordingly.
           this.confirmClass = success ? 'match' : 'mismatch';
-          $matchResult.addClass(this.confirmClass).find('.password-match-text').html(translate['confirm' + (success ? 'Success' : 'Failure')]);
+          $matchResult.addClass(this.confirmClass).find('.password-match-text').html(passwordConfirmSettings['confirm' + (success ? 'Success' : 'Failure')]);
         }
         else {
           this.confirmClass = 'empty';
@@ -63,8 +132,8 @@ Backdrop.behaviors.password = {
 
       // Monitor keyup and blur events.
       // Blur must be used because a mouse paste does not trigger keyup.
-      $passwordInput.bind('keyup focus blur', passwordCheck).triggerHandler('keyup');
-      $confirmInput.bind('keyup blur', passwordCheckMatch);
+      $passwordInput.on('keyup blur', passwordCheckMatch);
+      $confirmInput.on('keyup blur', passwordCheckMatch).triggerHandler('blur');
     });
   }
 };

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -119,16 +119,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $edit = array();
     $edit['name'] = $name = $this->randomName();
     $edit['mail'] = $mail = $edit['name'] . '@example.com';
-
-    // Try entering a mismatching password.
-    $edit['pass[pass1]'] = '99999.0';
-    $edit['pass[pass2]'] = '99999';
-    $this->backdropPost('user/register', $edit, t('Create new account'));
-    $this->assertText(t('The specified passwords do not match.'), 'Typing mismatched passwords displays an error message.');
-
-    // Enter a correct password.
-    $edit['pass[pass1]'] = $new_pass = $this->randomName();
-    $edit['pass[pass2]'] = $new_pass;
+    $edit['pass'] = $new_pass = $this->randomName();
     $this->backdropPost('user/register', $edit, t('Create new account'));
     $accounts = user_load_multiple(array(), array('name' => $name, 'mail' => $mail));
     $new_user = reset($accounts);
@@ -140,8 +131,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $edit = array();
     $edit['name'] = $name = $this->randomName();
     $edit['mail'] = $mail = $edit['name'] . '@example.com';
-    $edit['pass[pass1]'] = $pass = $this->randomName();
-    $edit['pass[pass2]'] = $pass;
+    $edit['pass'] = $pass = $this->randomName();
     $this->backdropPost('user/register', $edit, t('Create new account'));
     $this->assertText(t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.'), 'Users are notified of pending approval');
 
@@ -219,8 +209,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $edit = array();
     $edit['name'] = $name = $this->randomName();
     $edit['mail'] = $mail = $edit['name'] . '@example.com';
-    $edit['pass[pass1]'] = $new_pass = $this->randomName();
-    $edit['pass[pass2]'] = $new_pass;
+    $edit['pass'] = $new_pass = $this->randomName();
     $this->backdropPost(NULL, $edit, t('Create new account'));
 
     // Check user fields.
@@ -342,7 +331,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $edit = array();
     $edit['mail'] = $mail;
     $edit['name'] = $different;
-    $edit['pass[pass1]'] = $edit['pass[pass2]'] = $this->randomName();
+    $edit['pass'] = $this->randomName();
 
     // Attempt to create an account using an email that doesn't match the name.
     $this->backdropPost('user/register', $edit, t('Create new account'));
@@ -376,7 +365,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $edit = array();
     $edit['mail'] = $mail;
     $edit['name'] = $different;
-    $edit['pass[pass1]'] = $edit['pass[pass2]'] = $this->randomName();
+    $edit['pass'] = $this->randomName();
 
     // Attempt to create an account using an email that doesn't match the name.
     // This should be OK, as 'user_email_match' is disabled.
@@ -1777,8 +1766,7 @@ class UserCreateTestCase extends BackdropWebTestCase {
       $edit = array(
         'name' => $name,
         'mail' => $this->randomName() . '@example.com',
-        'pass[pass1]' => $pass = $this->randomString(),
-        'pass[pass2]' => $pass,
+        'pass' => $pass = $this->randomString(),
         'notify' => $notify,
       );
       $this->backdropPost('admin/people/create', $edit, t('Create new account'));
@@ -1803,8 +1791,7 @@ class UserCreateTestCase extends BackdropWebTestCase {
     $edit = array(
       'name' => $name,
       'mail' => $name . '@example.com',
-      'pass[pass1]' => 0,
-      'pass[pass2]' => 0,
+      'pass' => 0,
       'notify' => FALSE,
     );
     $this->backdropPost('admin/people/create', $edit, t('Create new account'));
@@ -1841,18 +1828,6 @@ class UserEditTestCase extends BackdropWebTestCase {
     $this->backdropPost("user/$user1->uid/edit", $edit, t('Save'));
     $this->assertRaw(t('The name %name is already taken.', array('%name' => $edit['name'])));
 
-    // Check that filling out a single password field does not validate.
-    $edit = array();
-    $edit['pass[pass1]'] = '';
-    $edit['pass[pass2]'] = $this->randomName();
-    $this->backdropPost("user/$user1->uid/edit", $edit, t('Save'));
-    $this->assertText(t("The specified passwords do not match."), 'Typing mismatched passwords displays an error message.');
-
-    $edit['pass[pass1]'] = $this->randomName();
-    $edit['pass[pass2]'] = '';
-    $this->backdropPost("user/$user1->uid/edit", $edit, t('Save'));
-    $this->assertText(t("The specified passwords do not match."), 'Typing mismatched passwords displays an error message.');
-
     // Test that the error message appears when attempting to change the mail or
     // pass without the current password.
     $edit = array();
@@ -1866,8 +1841,7 @@ class UserEditTestCase extends BackdropWebTestCase {
 
     // Test that the user must enter current password before changing passwords.
     $edit = array();
-    $edit['pass[pass1]'] = $new_pass = $this->randomName();
-    $edit['pass[pass2]'] = $new_pass;
+    $edit['pass'] = $new_pass = $this->randomName();
     $this->backdropPost("user/$user1->uid/edit", $edit, t('Save'));
     $this->assertRaw(t("Your current password is missing or incorrect; it's required to change the %name.", array('%name' => t('Password'))));
 
@@ -1895,7 +1869,7 @@ class UserEditTestCase extends BackdropWebTestCase {
     // Create a regular user.
     $user1 = $this->backdropCreateUser(array());
 
-    $edit = array('pass[pass1]' => '0', 'pass[pass2]' => '0');
+    $edit = array('pass' => '0');
     $this->backdropPost("user/" . $user1->uid . "/edit", $edit, t('Save'));
     $this->assertRaw(t("The changes have been saved."));
 
@@ -2360,8 +2334,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
     $edit = array(
       'name' => $this->randomName(),
       'mail' => $this->randomName() . '@example.com',
-      'pass[pass1]' => $pass = $this->randomString(),
-      'pass[pass2]' => $pass,
+      'pass' => $pass = $this->randomString(),
       "roles[$role_name]" => $role_name,
     );
     $this->backdropPost('admin/people/create', $edit, t('Create new account'));
@@ -2428,10 +2401,24 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
   function testUserValidateCurrentPassCustomForm() {
     $this->backdropLogin($this->adminUser);
 
+    // Check that filling out a single password field does not validate.
+    $edit = array();
+    $edit['password_confirm[pass1]'] = '';
+    $edit['password_confirm[pass2]'] = $this->randomName();
+    $this->backdropPost('user_form_test_current_password/' . $this->accessUser->uid, $edit, t('Test'));
+    $this->assertText(t("The specified passwords do not match."), 'Typing mismatched passwords displays an error message.');
+
+    $edit['password_confirm[pass1]'] = $new_pass = $this->randomName();
+    $edit['password_confirm[pass2]'] = '';
+    $this->backdropPost('user_form_test_current_password/' . $this->accessUser->uid, $edit, t('Test'));
+    $this->assertText(t("The specified passwords do not match."), 'Typing mismatched passwords displays an error message.');
+
     // Submit the custom form with the admin user using the access user's password.
     $edit = array();
     $edit['user_form_test_field'] = $this->accessUser->name;
     $edit['current_pass'] = $this->accessUser->pass_raw;
+    $edit['password_confirm[pass1]'] = $new_pass;
+    $edit['password_confirm[pass2]'] = $new_pass;
     $this->backdropPost('user_form_test_current_password/' . $this->accessUser->uid, $edit, t('Test'));
     $this->assertText(t('The password has been validated and the form submitted successfully.'));
   }

--- a/core/modules/user/tests/user_form_test/user_form_test.module
+++ b/core/modules/user/tests/user_form_test/user_form_test.module
@@ -47,6 +47,10 @@ function user_form_test_current_password($form, &$form_state, $account) {
     '#value' => array('user_form_test_field' => t('Test field')),
   );
 
+  $form['password_confirm'] = array(
+    '#type' => 'password_confirm',
+  );
+
   $form['#validate'][] = 'user_validate_current_pass';
   $form['submit'] = array(
     '#type' => 'submit',

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -742,8 +742,11 @@ function user_account_form(&$form, &$form_state) {
   // assign a password during registration.
   if (!$register) {
     $form['account']['pass'] = array(
-      '#type' => 'password_confirm',
-      '#description' => t('To change the current user password, enter the new password in both fields.'),
+      '#title' => t('New password'),
+      '#type' => 'password',
+      '#description' => t('Current password must be entered to set a new password.'),
+      '#password_toggle' => TRUE,
+      '#password_strength' => TRUE,
     );
     // To skip the current password field, the user must have logged in via a
     // one-time link and have the token in the URL. Store this in $form_state
@@ -773,6 +776,7 @@ function user_account_form(&$form, &$form_state) {
         '#access' => !empty($protected_values),
         '#description' => $current_pass_description,
         '#weight' => -5,
+        '#password_toggle' => TRUE,
         // Do not let web browsers remember this password, since we are
         // trying to confirm that the person submitting the form actually
         // knows the current one.
@@ -783,8 +787,10 @@ function user_account_form(&$form, &$form_state) {
   }
   elseif (!config_get('system.core', 'user_email_verification') || $admin) {
     $form['account']['pass'] = array(
-      '#type' => 'password_confirm',
-      '#description' => t('Provide a password for the new account in both fields.'),
+      '#type' => 'password',
+      '#description' => t('Provide a password for the new account.'),
+      '#password_toggle' => TRUE,
+      '#password_strength' => TRUE,
       '#required' => TRUE,
     );
   }
@@ -2652,6 +2658,42 @@ function _user_mail_notify($op, $account, $language = NULL) {
 }
 
 /**
+ * Form element process handler for client-side password hide/show and strength.
+ * @param $element
+ */
+function user_form_process_password($element) {
+  global $user;
+
+  if ($element['#password_strength']) {
+    $strength_settings = array(
+      'strengthTitle' => t('Password strength: '),
+      'weak' => t('poor'),
+      'fair' => t('fair'),
+      'good' => t('good'),
+      'strong' => t('excellent'),
+      'username' => (isset($user->name) ? $user->name : ''),
+    );
+
+    $element['#attributes']['data-password-strength'] = backdrop_json_encode($strength_settings, FALSE);
+  }
+
+  if ($element['#password_toggle']) {
+    $toggle_settings = array(
+      'toggleShowTitle' => t('Show password'),
+      'toggleHideTitle' => t('Hide password'),
+      'toggleDefault' => $element['#password_shown'] ? 'show' : 'hide',
+    );
+
+    $element['#attributes']['data-password-toggle'] = backdrop_json_encode($toggle_settings, FALSE);
+  }
+
+  if ($element['#password_strength'] || $element['#password_toggle']) {
+    $element['#attached']['js'][] = backdrop_get_path('module', 'user') . '/js/user.js';
+  }
+  return $element;
+}
+
+/**
  * Form element process handler for client-side password validation.
  *
  * This #process handler is automatically invoked for 'password_confirm' form
@@ -2661,24 +2703,14 @@ function _user_mail_notify($op, $account, $language = NULL) {
  * @see system_element_info()
  */
 function user_form_process_password_confirm($element) {
-  global $user;
-
-  $js_settings = array(
-    'password' => array(
-      'strengthTitle' => t('Password strength: '),
-      'confirmTitle' => t('Passwords match: '),
-      'confirmSuccess' => t('yes'),
-      'confirmFailure' => t('no'),
-      'weak' => t('poor'),
-      'fair' => t('fair'),
-      'good' => t('good'),
-      'strong' => t('excellent'),
-      'username' => (isset($user->name) ? $user->name : ''),
-    ),
+  $confirm_settings = array(
+    'confirmTitle' => t('Passwords match: '),
+    'confirmSuccess' => t('yes'),
+    'confirmFailure' => t('no'),
   );
 
   $element['#attached']['js'][] = backdrop_get_path('module', 'user') . '/js/user.js';
-  $element['#attached']['js'][] = array('data' => $js_settings, 'type' => 'setting');
+  $element['pass2']['#attributes']['data-password-confirm'] = backdrop_json_encode($confirm_settings, FALSE);
 
   return $element;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/297.

Replaces https://github.com/backdrop/backdrop/pull/735.