### PR TITLE
Issue #2694, Add easy-to-enable HTTPS redirect rules in .htaccess.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -51,13 +51,6 @@ DirectoryIndex index.php index.html index.htm
 <IfModule mod_rewrite.c>
   RewriteEngine on
 
-  # Set "protossl" to "s" if we were accessed via https://.  This is used later
-  # if you enable "www." stripping or enforcement, in order to ensure that
-  # you don't bounce between http and https.
-  RewriteRule ^ - [E=protossl]
-  RewriteCond %{HTTPS} on
-  RewriteRule ^ - [E=protossl:s]
-
   # Make sure Authorization HTTP header is available to PHP
   # even when running as CGI or FastCGI.
   RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
@@ -79,6 +72,11 @@ DirectoryIndex index.php index.html index.htm
   # downloaded.
   RewriteCond %{REQUEST_URI} !^/\.well-known
   RewriteRule "(^|/)\." - [F]
+
+  # To redirect all users to access the site using a SSL/https certificate,
+  # uncomment the following:
+  # RewriteCond %{HTTPS} !=on
+  # RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
   # If your site can be accessed both with and without the 'www.' prefix, you
   # can use one of the following settings to redirect users to your preferred


### PR DESCRIPTION
opiniated change included, I remove the directive that define the `[E=protossl]` env variable, unused since https://github.com/backdrop/backdrop/commit/2f9a04eb03066c24852c5564fae6482d8770ec80#diff-8052c42ab3b8aa06a3f5f788a4ddccc2