### PR TITLE
Issue #2085: Tableselect.js affects checkboxes that should not be selected.

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -3588,6 +3588,7 @@ function form_process_tableselect($element) {
             '#ajax' => isset($element['#ajax']) ? $element['#ajax'] : NULL,
           );
         }
+        $element[$key]['#attributes']['data-tableselect-id'] = implode('-', $element['#parents']);
         if (isset($element['#options'][$key]['#weight'])) {
           $element[$key]['#weight'] = $element['#options'][$key]['#weight'];
         }

--- a/core/misc/tableselect.js
+++ b/core/misc/tableselect.js
@@ -25,7 +25,7 @@ Backdrop.tableSelect = function () {
   };
 
   // Find all <th> with class select-all, and insert the check all checkbox.
-  $('th.select-all', table).prepend($('<input type="checkbox" class="form-checkbox" />').attr('title', strings.selectAll)).click(function (event) {
+  $('th.select-all', table).prepend($('<input type="checkbox" class="form-checkbox" />').attr('title', strings.selectAll)).on('click', function (event) {
     if ($(event.target).is('input[type="checkbox"]')) {
       // Loop through all checkboxes and set their state to the select all checkbox' state.
       checkboxes.each(function () {
@@ -39,7 +39,8 @@ Backdrop.tableSelect = function () {
   });
 
   // For each of the checkboxes within the table that are not disabled.
-  checkboxes = $('td input[type="checkbox"]:enabled', table).click(function (e) {
+  checkboxes = $('td input[data-tableselect-id]:enabled');
+  $(table).on('click', checkboxes, function (e) {
     // Either add or remove the selected class based on the state of the check all checkbox.
     $(this).closest('tr').toggleClass('selected', this.checked);
 

--- a/core/modules/views/handlers/views_handler_field_bulk_form.inc
+++ b/core/modules/views/handlers/views_handler_field_bulk_form.inc
@@ -106,6 +106,7 @@ class views_handler_field_bulk_form extends views_handler_field {
         '#title_display' => 'invisible',
         '#return_value' => $row->{$this->field_alias},
         '#default_value' => !empty($form_state['values'][$this->options['id']][$row_index]) ? 1 : NULL,
+        '#attributes' => array('data-tableselect-id' => $this->options['id'])
       );
     }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2085.

Replaces https://github.com/backdrop/backdrop/pull/1761.