### PR TITLE
Issue #3123: Hide the langcode markup if language module is not enabled.

### DIFF
--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -151,6 +151,7 @@ function _menu_overview_tree_form($tree, $langcode = NULL) {
       $form[$mlid]['langcode'] = array(
         '#type' => 'markup',
         '#markup' => check_plain($langcode_label),
+        '#access' => module_exists('language'),
       );
       $form[$mlid]['hidden'] = array(
         '#type' => 'checkbox',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3123.