### PR TITLE
Issue #3135: Fix version checking for dev releases and in installer.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -8456,7 +8456,7 @@ function backdrop_parse_dependency($dependency) {
   $parts = explode('(', $dependency, 2);
   $value['name'] = trim($parts[0]);
   if (isset($parts[1])) {
-    $value['original_version'] = ' (' . $parts[1];
+    $value['original_version'] = '(' . $parts[1];
     foreach (explode(',', $parts[1]) as $version) {
       if (preg_match("/^\s*$p_op\s*$p_core$p_major\.$p_minor/", $version, $matches)) {
         $op = !empty($matches['operation']) ? $matches['operation'] : '=';
@@ -8486,10 +8486,10 @@ function backdrop_parse_dependency($dependency) {
 /**
  * Checks whether a version is compatible with a given dependency.
  *
- * @param $v
+ * @param array $dependency_info
  *   The parsed dependency structure from backdrop_parse_dependency().
- * @param $current_version
- *   The version to check against (like 4.2).
+ * @param string $current_version
+ *   The version to check against (like 4.2 or 1.10.0-beta4).
  *
  * @return string|NULL
  *   NULL if compatible, otherwise the original dependency version string that
@@ -8497,16 +8497,49 @@ function backdrop_parse_dependency($dependency) {
  *
  * @see backdrop_parse_dependency()
  */
-function backdrop_check_incompatibility($v, $current_version) {
-  if (!empty($v['versions'])) {
-    foreach ($v['versions'] as $required_version) {
-      if ((isset($required_version['op']) && !version_compare($current_version, $required_version['version'], $required_version['op']))) {
-        return $v['original_version'];
+function backdrop_check_incompatibility(array $dependency_info, $current_version) {
+  $current_version = _backdrop_version_compare_convert($current_version);
+  if (!empty($dependency_info['versions'])) {
+    foreach ($dependency_info['versions'] as $required_version) {
+      if ((isset($required_version['op']) && !version_compare($current_version, _backdrop_version_compare_convert($required_version['version']), $required_version['op']))) {
+        return $dependency_info['original_version'];
       }
     }
   }
   // No incompatibilities.
   return NULL;
+}
+
+/**
+ * Converts a Backdrop version string into numeric-only version string.
+ *
+ * @param string $version_string
+ *   A version string such as 1.10.0-beta4 or 1.4.x-dev.
+ * @return string
+ *   A converted string only containing numbers, for use in PHP's
+ *   version_compare() function.
+ */
+function _backdrop_version_compare_convert($version_string) {
+  // Convert "dev" releases to be the highest possible version number. For
+  // example 1.5.x-dev should be considered higher than any other 1.5 release,
+  // so we replace .x with 99999.
+  $version_string = str_replace('.x-dev', '.99999', $version_string);
+
+  // Replace common indicators with numeric equivalents for version_compare().
+  $indicator_order = array(
+    1 => 'alpha',
+    2 => 'beta',
+    3 => 'preview',
+    4 => 'rc',
+  );
+  foreach ($indicator_order as $order => $indicator) {
+    // Replace both before and after the indicator with dots, so that multiple
+    // alphas, betas, etc. would be ordered properly. For example, version
+    // 1.5.0-beta9 and 1.5.0-beta10 would become 1.5.0.2.9 and 1.5.0.2.10.
+    $version_string = str_replace('-' . $indicator, '.' . $order . '.', $version_string);
+    $version_string .= substr($version_string, -1) === '.' ? '0' : '';
+  }
+  return $version_string;
 }
 
 /**

--- a/core/modules/installer/installer.pages.inc
+++ b/core/modules/installer/installer.pages.inc
@@ -653,13 +653,21 @@ function installer_browser_installation_enable_form($form, &$form_state, $projec
       $dependency_check = TRUE;
       $dependencies = array();
       if (isset($modules[$project['name']])) {
-        foreach ($modules[$project['name']]->info['dependencies'] as $dependency) {
-          if (isset($modules[$dependency])) {
-            $dependencies[] = $modules[$dependency]->info['name'] . ' (' . t('Installed') . ')';
+        foreach ($modules[$project['name']]->requires as $dependency_name => $dependency_info) {
+          if (isset($modules[$dependency_name])) {
+            $dependency_version = $modules[$dependency_name]->info['version'];
+            if (backdrop_check_incompatibility($dependency_info, $dependency_version)) {
+              $dependency_check = FALSE;
+              $dependency_version_string = trim($dependency_info['original_version'], '()');
+              $dependencies[] = $dependency_name . ' (' . t('Requires version @version', array('@version' => $dependency_version_string)) . ')';
+            }
+            else {
+              $dependencies[] = $modules[$dependency_name]->info['name'] . ' (' . t('Installed') . ')';
+            }
           }
           else {
             $dependency_check = FALSE;
-            $dependencies[] = $dependency . ' (' . t('Missing') . ')';
+            $dependencies[] = $dependency_name . ' (' . t('Missing') . ')';
           }
         }
         if ($dependency_check) {
@@ -690,10 +698,10 @@ function installer_browser_installation_enable_form($form, &$form_state, $projec
     array('data' => t('Dependencies'), 'class' => array('priority-low')),
   );
 
-  if(!empty($options) || !empty($missing)) {
+  if (!empty($options) || !empty($missing)) {
     $form['module_instructions'] = array(
-    '#type' => 'item',
-    '#markup' => t('You may enable modules using the form below or on the main !link page.', array('!link' => l(t('Modules'), 'admin/modules'))),
+      '#type' => 'item',
+      '#markup' => t('You may enable modules using the form below or on the main !link page.', array('!link' => l(t('Modules'), 'admin/modules'))),
     );
     if (!empty($options)) {
       $form['modules'] = array(

--- a/core/modules/simpletest/tests/system_test.module
+++ b/core/modules/simpletest/tests/system_test.module
@@ -325,18 +325,25 @@ function system_test_exit() {
  * Implements hook_system_info_alter().
  */
 function system_test_system_info_alter(&$info, $file, $type) {
-  // We need a static otherwise the last test will fail to alter common_test.
-  static $test;
-  if (($dependencies = state_get('system_test_dependencies', array())) || $test) {
+  if ($dependency = state_get('system_test_dependency')) {
     if ($file->name == 'module_test') {
       $info['hidden'] = FALSE;
-      $info['dependencies'][] = array_shift($dependencies);
-      state_set('system_test_dependencies', $dependencies);
-      $test = TRUE;
+      $info['dependencies'][] = $dependency;
     }
     if ($file->name == 'common_test') {
       $info['hidden'] = FALSE;
       $info['version'] = '1.x-2.4-beta3';
+    }
+  }
+
+  if ($dev_dependency = state_get('system_test_dev_dependency')) {
+    if ($file->name == 'module_test') {
+      $info['hidden'] = FALSE;
+      $info['dependencies'][] = $dev_dependency;
+    }
+    if ($file->name == 'common_test') {
+      $info['hidden'] = FALSE;
+      $info['version'] = '1.x-2.x-dev';
     }
   }
 

--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -86,6 +86,7 @@ small .admin-link:after {
 }
 #system-modules td.version {
   width: 70px;
+  white-space: nowrap;
 }
 #system-modules td.operations {
   width: 120px;

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -577,10 +577,11 @@ function system_modules($form, $form_state = array()) {
         $requires_name = $files[$requires]->info['name'];
 
         // Disable this module if it is incompatible with the dependency's version.
-        if ($incompatible_version = backdrop_check_incompatibility($v, str_replace(BACKDROP_CORE_COMPATIBILITY . '-', '', $files[$requires]->info['version']))) {
+        $version_string = preg_replace('/^' . preg_quote(BACKDROP_CORE_COMPATIBILITY, '/') . '-/', '', $files[$requires]->info['version']);
+        if ($incompatible_version = backdrop_check_incompatibility($v, $version_string)) {
           $extra['requires'][$requires] = t('@module (<span class="admin-missing">incompatible with</span> version @version)', array(
-            '@module' => $requires_name . $incompatible_version,
-            '@version' => $files[$requires]->info['version'],
+            '@module' => $requires_name . ' ' . $incompatible_version,
+            '@version' => $version_string,
           ));
           $extra['disabled'] = TRUE;
         }

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -447,7 +447,7 @@ function system_requirements($phase) {
         // Check for an incompatible version.
         $required_file = $files[$required_module];
         $required_name = $required_file->info['name'];
-        $version = str_replace(BACKDROP_CORE_COMPATIBILITY . '-', '', $required_file->info['version']);
+        $version = preg_replace('/^' . preg_quote(BACKDROP_CORE_COMPATIBILITY, '/') . '-/', '', $required_file->info['version']);
         $compatibility = backdrop_check_incompatibility($requirement, $version);
         if ($compatibility) {
           $compatibility = rtrim(substr($compatibility, 2), ')');

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2855,6 +2855,34 @@ function _system_rebuild_module_data() {
       $modules[$key]->info['hidden'] = TRUE;
     }
 
+    // Apply best guess version information if this is a Git checkout.
+    if (empty($modules[$key]->info['version'])) {
+      $module_base_path = BACKDROP_ROOT . '/' . preg_replace('!(.*modules/[^/]+).*!', '$1', $module->uri);
+      $git_version = FALSE;
+      if (file_exists($module_base_path . '/.git/HEAD')) {
+        // Branches names are directly in the HEAD file.
+        $git_head_contents = trim(file_get_contents($module_base_path . '/.git/HEAD'));
+        if (strpos($git_head_contents, 'ref') === 0) {
+          $git_version = trim(preg_replace('!^.*refs/heads/(.*)$!', '$1', $git_head_contents));
+        }
+        // Tags are named by sha1 hash, loop through each tag file to match it.
+        elseif (is_dir($module_base_path . '/.git/refs/tags')) {
+          $tag_files = file_scan_directory($module_base_path . '/.git/refs/tags', '/.*/', array('key' => 'filename', 'recurse' => FALSE));
+          $tag_files = array_reverse($tag_files, TRUE);
+          foreach ($tag_files as $tag_name => $tag_file) {
+            if (trim(file_get_contents($tag_file->uri)) == $git_head_contents) {
+              $git_version = $tag_name;
+              break;
+            }
+          }
+        }
+        if ($git_version) {
+          $git_version = preg_replace('/^' . preg_quote(BACKDROP_CORE_COMPATIBILITY, '/') . '-/', '', $git_version);
+          $modules[$key]->info['version'] = $git_version . '-dev';
+        }
+      }
+    }
+
     // Invoke hook_system_info_alter() to give installed modules a chance to
     // modify the data in the .info files if necessary.
     $type = 'module';

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -12,6 +12,7 @@ require_once BACKDROP_ROOT . '/core/modules/simpletest/tests/bootstrap.test';
  */
 class ModuleTestCase extends WatchdogTestCase {
   protected $admin_user;
+  protected $profile = 'testing';
 
   function setUp() {
     parent::setUp('system_test');
@@ -398,6 +399,11 @@ class ModuleDependencyTestCase extends ModuleTestCase {
    * Tests enabling a module that depends on a module which fails hook_requirements().
    */
   function testEnableRequirementsFailureDependency() {
+    // Enable comment module before testing the dependencies.
+    $edit = array();
+    $edit['modules[Comments][comment][enable]'] = TRUE;
+    $this->backdropPost('admin/modules', $edit, t('Save configuration'));
+
     $this->assertModules(array('requirements1_test'), FALSE);
     $this->assertModules(array('requirements2_test'), FALSE);
 
@@ -525,42 +531,85 @@ class ModuleVersionTestCase extends ModuleTestCase {
    */
   function testModuleVersions() {
     $dependencies = array(
-      // Alternating between being compatible and incompatible with 1.x-2.4-beta3.
-      // The first is always a compatible.
-      'common_test',
+      // All comparisons are done against 1.x-2.4-beta3.
+      'common_test' => TRUE,
       // Branch incompatibility.
-      'common_test (1.x)',
+      'common_test (1.x)' => FALSE,
       // Branch compatibility.
-      'common_test (2.x)',
+      'common_test (2.x)' => TRUE,
       // Another branch incompatibility.
-      'common_test (>2.x)',
+      'common_test (>2.x)' => FALSE,
       // Another branch compatibility.
-      'common_test (<=2.x)',
+      'common_test (<=2.x)' => TRUE,
       // Another branch incompatibility.
-      'common_test (<2.x)',
+      'common_test (<2.x)' => FALSE,
       // Another branch compatibility.
-      'common_test (>=2.x)',
+      'common_test (>=2.x)' => TRUE,
+      // Higher rc version. Incompatible.
+      'common_test (>=1.x-2.4-rc1)' => FALSE,
+      // Higher beta version. Incompatible.
+      'common_test (>=1.x-2.4-beta4)' => FALSE,
+      // Lower beta version. Compatible.
+      'common_test (>=1.x-2.4-beta2)' => TRUE,
+      // Lower alpha version. Compatible.
+      'common_test (>=1.x-2.4-alpha8)' => TRUE,
       // Nonsense, misses a dash. Incompatible with everything.
-      'common_test (=1.x2.x, >=2.4)',
+      'common_test (=1.x2.x, >=2.4)' => FALSE,
       // Core version is optional. Compatible.
-      'common_test (=1.x-2.x, >=2.4-alpha2)',
+      'common_test (=1.x-2.x, >=2.4-alpha2)' => TRUE,
       // Test !=, explicitly incompatible.
-      'common_test (=2.x, !=2.4-beta3)',
+      'common_test (=2.x, !=2.4-beta3)' => FALSE,
       // Three operations. Compatible.
-      'common_test (=2.x, !=2.3, <2.5)',
+      'common_test (=2.x, !=2.3, <2.5)' => TRUE,
       // Testing extra version. Incompatible.
-      'common_test (<=2.4-beta2)',
+      'common_test (<=2.4-beta2)' => FALSE,
       // Testing extra version. Compatible.
-      'common_test (>2.4-beta2)',
+      'common_test (>2.4-beta2)' => TRUE,
       // Testing extra version. Incompatible.
-      'common_test (>2.4-rc0)',
+      'common_test (>2.4-rc0)' => FALSE,
     );
-    state_set('system_test_dependencies', $dependencies);
-    $n = count($dependencies);
-    for ($i = 0; $i < $n; $i++) {
+    foreach ($dependencies as $version_string => $compatible) {
+      // Each request, one dependency is shifted off the front and added to
+      // module_test's dependencies. See system_test_system_info_alter().
+      state_set('system_test_dependency', $version_string);
       $this->backdropGet('admin/modules');
       $checkbox = $this->xpath('//input[@id="edit-modules-testing-module-test-enable"]');
-      $this->assertEqual(!empty($checkbox[0]['disabled']), $i % 2, $dependencies[$i]);
+      $this->assertEqual(empty($checkbox[0]['disabled']), $compatible, $version_string);
+    }
+
+    $dev_dependencies = array(
+      // Compare again against a the dev version 1.x-2.x-dev.
+      'common_test' => TRUE,
+      // Branch incompatibility.
+      'common_test (1.x)' => FALSE,
+      // Branch compatibility.
+      'common_test (2.x)' => TRUE,
+      // Another branch incompatibility.
+      'common_test (>2.x)' => FALSE,
+      // Any alpha version
+      'common_test (>=1.x-2.x-alpha4)' => TRUE,
+      // Any beta version
+      'common_test (>=1.x-2.x-beta4)' => TRUE,
+      // Any rc version
+      'common_test (>=1.x-2.x-rc4)' => TRUE,
+      // Any preview version
+      'common_test (>=1.x-2.x-preview)' => TRUE,
+      // Complex version string.
+      'common_test (>=1.x-2.4-beta2)' => TRUE,
+      // Dev versions are later than any minor number.
+      'common_test (>=2.4.0)' => TRUE,
+      // Next version is not compatible.
+      'common_test (>=3.0.0)' => FALSE,
+    );
+
+    // Same testing approach as above, only against a different version number.
+    foreach ($dev_dependencies as $version_string => $compatible) {
+      // Each request, one dependency is shifted off the front and added to
+      // module_test's dependencies. See system_test_system_info_alter().
+      state_set('system_test_dev_dependency', $version_string);
+      $this->backdropGet('admin/modules');
+      $checkbox = $this->xpath('//input[@id="edit-modules-testing-module-test-enable"]');
+      $this->assertEqual(empty($checkbox[0]['disabled']), $compatible, 'Dev dependency: ' . $version_string);
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3135.

- Adds support for properly checking `-dev` versions (assuming dev is always the latest).
- Adds support for comparing alphas, betas, previews, and rcs against each other.
- Makes installer.module support version checking in the built-in module enabling form.
- Adds support for checking Git checkout versions.
