### PR TITLE
Issue #566: Making form-actions for long forms sticky

### DIFF
--- a/core/modules/views_ui/css/views_ui.admin.theme.css
+++ b/core/modules/views_ui/css/views_ui.admin.theme.css
@@ -957,7 +957,7 @@ td.group-title {
 
 /* @group Live preview elements */
 
-#views-preview-wrapper {
+[id="views-preview-wrapper"] {
   padding-bottom: 12px;
   padding-top: 20px;
   margin: 0 0 1em;

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -1716,3 +1716,99 @@ div.add-or-remove-shortcuts {
 @keyframes animate-stripes {
   0% { background-position: 0 0; } 100% { background-position: 50px 50px; }
 }
+
+/**
+ * Sticky submit buttons
+ */
+@media (min-height: 32em) {
+  .node-form,
+  .taxonomy-form-term,
+  .block-add-block-form,
+  .block-admin-configure,
+  [id="layout-edit"],
+  .system-modules,
+  .user-admin-permissions {
+    padding-bottom: 6em;
+  }
+
+  [id="views-preview-wrapper"] {
+    padding-bottom: 11em;
+  }
+
+  .node-form > div > .form-actions,
+  .taxonomy-form-term  > div > .form-actions,
+  .block-add-block-form > div > .form-actions,
+  .block-admin-configure > div > .form-actions,
+  [id="views-ui-edit-form"] > div > .form-actions,
+  [id="layout-edit"] > .form-actions,
+  .system-modules > div > .form-actions,
+  .user-admin-permissions > div > .form-actions {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    margin-bottom: 0;
+    padding-top: 1rem;
+    padding-left: 2.1875rem;
+    border-top: 0.125em solid #EAEAEA;
+    background: #fff;
+  }
+
+  .view-changed.messages {
+    position: fixed;
+    bottom: 5em;
+    z-index: 99;
+    width: calc(100% - 4.375rem);
+    max-width: 72.25rem;
+    margin-right: 2.1875rem;
+    margin-bottom: 0;
+    -webkit-animation-name: slideInUp;
+    animation-name: slideInUp;
+    animation-duration: 1s;
+  }
+}
+
+/* This magic number on min-width is "content area max-width" + "container padding" */
+@media (min-width: 74.4375em) and (min-height: 32em) {
+  .node-form > div > .form-actions,
+  .taxonomy-form-term  > div > .form-actions,
+  .block-add-block-form > div > .form-actions,
+  .block-admin-configure > div > .form-actions,
+  [id="views-ui-edit-form"] > div > .form-actions,
+  [id="layout-edit"] > .form-actions,
+  .system-modules > div > .form-actions,
+  .user-admin-permissions > div > .form-actions {
+    padding-right: calc(50vw - 578px);
+    padding-left: calc(50vw - 578px);
+  }
+}
+
+/**
+ * Slide In and Up Animation
+ * Originally from https://github.com/daneden/animate.css
+ */
+@-webkit-keyframes slideInUp {
+  from {
+    -webkit-transform: translate(0, 100%);
+    transform: translate(0, 100%);
+  }
+
+  to {
+    -webkit-transform: translate(0, 0);
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes slideInUp {
+  from {
+    -webkit-transform: translate(0, 100%);
+    transform: translate(0, 100%);
+    visibility: visible;
+  }
+
+  to {
+    -webkit-transform: translate(0, 0);
+    transform: translate(0, 0);
+  }
+}


### PR DESCRIPTION
Also decreased the specificity of views-preview of selector to avoid specificity wars.

Adds sticky `form-actions` to:
* Node Add/Edit
* Taxonomy Term Add/Edit
* Custom Block Add/Edit
* Views UI (also moved the "View is not saved yet" message to be near the save button)
* Modules Listing
* Permissions Listing

