### PR TITLE
Issue #3237: Wrong radio(s) checked when having #default_value to 0 and having at least one alpha key

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -2980,7 +2980,18 @@ function theme_radio($variables) {
   $element['#attributes']['type'] = 'radio';
   element_set_attributes($element, array('id', 'name', '#return_value' => 'value'));
 
-  if (isset($element['#return_value']) && $element['#value'] !== FALSE && $element['#value'] == $element['#return_value']) {
+  // To avoid auto-casting during '==' we convert $element['#value'] and
+  // $element['#return_value'] to strings. It will prevent wrong true-checking
+  // for both cases: 0 == 'string' and 'string' == 0, this will occur because
+  // all numeric array values will be integers and all submitted values will
+  // be strings. Array values are never valid for radios and are skipped. To
+  // account for FALSE and empty string values in the #return_value, we will
+  // consider any #value that evaluates to empty to be the same as any
+  // #return_value that evaluates to empty.
+  if (isset($element['#return_value']) &&
+    $element['#value'] !== FALSE &&
+    !is_array($element['#value']) &&
+    ((empty($element['#value']) && empty($element['#return_value'])) || (string) $element['#value'] === (string) $element['#return_value'])) {
     $element['#attributes']['checked'] = 'checked';
   }
   _form_set_class($element, array('form-radio'));


### PR DESCRIPTION
[does not include tests]