### PR TITLE
remove ['taxonomy_vocabulary'] from taxonomy_schema()

### DIFF
--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -311,6 +311,7 @@ function taxonomy_update_1005() {
   if (db_table_exists('taxonomy_vocabulary')) {
     db_drop_table('taxonomy_vocabulary');
   }
+}
 
 /**
  * @} End of "addtogroup updates-7.x-to-1.x"

--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -305,7 +305,7 @@ function taxonomy_update_1004() {
 }
 
 /**
- * Drop the old taxonomy vocabulary table for new Backdrop installations.
+ * Drop the old taxonomy vocabulary table for existing Backdrop installations.
  */
 function taxonomy_update_1005() {
   if (db_table_exists('taxonomy_vocabulary')) {

--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -305,6 +305,14 @@ function taxonomy_update_1004() {
 }
 
 /**
+ * Drop the old taxonomy vocabulary table for new Backdrop installations.
+ */
+function taxonomy_update_1005() {
+  if (db_table_exists('taxonomy_vocabulary')) {
+    db_drop_table('taxonomy_vocabulary');
+  }
+
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -102,62 +102,7 @@ function taxonomy_schema() {
     ),
     'primary key' => array('tid', 'parent'),
   );
-
-  $schema['taxonomy_vocabulary'] = array(
-    'description' => 'Stores vocabulary information.',
-    'fields' => array(
-      'vid' => array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'description' => 'Primary Key: Unique vocabulary ID.',
-      ),
-      'name' => array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => TRUE,
-        'default' => '',
-        'description' => 'Name of the vocabulary.',
-        'translatable' => TRUE,
-      ),
-      'machine_name' => array(
-        'type' => 'varchar',
-        'length' => 255,
-        'not null' => TRUE,
-        'default' => '',
-        'description' => 'The vocabulary machine name.',
-      ),
-      'description' => array(
-        'type' => 'text',
-        'not null' => FALSE,
-        'size' => 'big',
-        'description' => 'Description of the vocabulary.',
-        'translatable' => TRUE,
-      ),
-      'hierarchy' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-        'size' => 'tiny',
-        'description' => 'The type of hierarchy allowed within the vocabulary. (0 = disabled, 1 = single, 2 = multiple)',
-      ),
-      'weight' => array(
-        'type' => 'int',
-        'not null' => TRUE,
-        'default' => 0,
-        'description' => 'The weight of this vocabulary in relation to other vocabularies.',
-      ),
-    ),
-    'primary key' => array('vid'),
-    'indexes' => array(
-      'list' => array('weight', 'name'),
-    ),
-    'unique keys' => array(
-      'machine_name' => array('machine_name'),
-    ),
-  );
-
+  
   $schema['taxonomy_index'] = array(
     'description' => 'Maintains denormalized information about node/term relationships.',
     'fields' => array(


### PR DESCRIPTION
 Removes taxonomy_vocabulary table from new Backdrop installations. Resolves Issue #3012.