### PR TITLE
commenting out ini_set('session.use_trans_sid', '0')

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -739,7 +739,7 @@ function backdrop_environment_initialize() {
   // the query string.
   ini_set('session.use_cookies', '1');
   ini_set('session.use_only_cookies', '1');
-  ini_set('session.use_trans_sid', '0');
+  // ini_set('session.use_trans_sid', '0');
   // Don't send HTTP headers using PHP's session handler.
   // An empty string is used here to disable the cache limiter.
   ini_set('session.cache_limiter', '');


### PR DESCRIPTION
This is mandatory for sites running CiviCRM on top of backdropCMS but it also it also matches PHP defaults and it prevent the function to invoke the watchdog to write a message because cron was manipulating session when it shouldn't. 