### PR TITLE
Issue #2570: Remove ViewsTestCase and ViewsSqlTest entries that point to the wrong file from the autoloader.

### DIFF
--- a/core/modules/views/views.module
+++ b/core/modules/views/views.module
@@ -2186,9 +2186,5 @@ function views_autoload_info() {
     // Blocks.
     'ViewsBlock' => 'includes/views.block.inc',
     'ViewsSpecialBlock' => 'includes/views.special_block.inc',
-    // Tests. These are used as base classes so frequently its easiest to
-    // include them in the registry rather than include them manually.
-    'ViewsTestCase' => 'tests/views_query.inc',
-    'ViewsSqlTest' => 'tests/views_query.inc',
   );
 }


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#2530 per @quicksketch 's [comment](https://github.com/backdrop/backdrop-issues/issues/2530#issuecomment-297588133).