### PR TITLE
Issue  #3310: [UX] Use double underline for hover style of links within messages.

### DIFF
--- a/core/modules/system/css/messages.theme.css
+++ b/core/modules/system/css/messages.theme.css
@@ -108,7 +108,7 @@ div.info:before {
   text-decoration: underline;
 }
 .messages a:hover {
-  text-decoration: none;
+  text-decoration-style: double;
 }
 
 /* Desktop size icons */


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/3310