### PR TITLE
Issue #3313: Suppress "Go online" message on maintenance mode settings page when clearing caches.

### DIFF
--- a/core/includes/menu.inc
+++ b/core/includes/menu.inc
@@ -4034,8 +4034,12 @@ function _menu_site_status($path = NULL, $display_messages = FALSE) {
     if (user_access('access site in maintenance mode')) {
       // Ensure that the maintenance mode message is displayed only once
       // (allowing for page redirects) and specifically suppress its display on
-      // the batch and maintenance mode settings pages.
-      if ($display_messages && !in_array(current_path(), array('batch', 'admin/config/development/maintenance'))) {
+      // the batch and maintenance mode settings pages. 'admin_bar/flush-cache'
+      // has been added to the list of excluded paths in order to suppress the
+      // warning on the maintenance mode settings page when clearing caches (see
+      // https://github.com/backdrop/backdrop-issues/issues/3313).
+      $excluded_paths = array('batch', 'admin/config/development/maintenance', 'admin_bar/flush-cache');
+      if ($display_messages && !in_array(current_path(), $excluded_paths)) {
         $message = t('The site is currently in maintenance mode.');
         if (user_access('administer site configuration')) {
           $message .= ' ' . l(t('Go online.'), 'admin/config/development/maintenance', array('query' => backdrop_get_destination()));


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3313