### PR TITLE
Issue #3325: Use WATCHDOG_* contants instead of numerical value.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -2220,7 +2220,17 @@ function watchdog_severity_enabled($severity = WATCHDOG_NOTICE) {
   // This may be called before system.core, such as when running update.php or
   // the initial installation. As such we provide the defaults if needed.
   if (!isset($enabled_severity_levels)) {
-    $enabled_severity_levels = array(0, 1, 2, 3, 4, 5, 6);
+    $enabled_severity_levels = array(
+      WATCHDOG_EMERGENCY,
+      WATCHDOG_ALERT,
+      WATCHDOG_CRITICAL,
+      WATCHDOG_ERROR,
+      WATCHDOG_WARNING,
+      WATCHDOG_NOTICE,
+      WATCHDOG_INFO,
+      // WATCHDOG_DEBUG,
+      // WATCHDOG_DEPRECATED,
+    );
   }
 
   // Return TRUE if the severity level is enabled.

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -2851,7 +2851,17 @@ function system_update_1056() {
  */
 function system_update_1057() {
   $config = config('system.core');
-  $config->set('watchdog_enabled_severity_levels', array(0, 1, 2, 3, 4, 5, 6));
+  $config->set('watchdog_enabled_severity_levels', array(
+    WATCHDOG_EMERGENCY,
+    WATCHDOG_ALERT,
+    WATCHDOG_CRITICAL,
+    WATCHDOG_ERROR,
+    WATCHDOG_WARNING,
+    WATCHDOG_NOTICE,
+    WATCHDOG_INFO,
+    // WATCHDOG_DEBUG,
+    // WATCHDOG_DEPRECATED,
+  ));
   $config->save();
 }
 


### PR DESCRIPTION
Disabled values are commented out for a better comprehension of the list. Please tell me if it should be removed.