### PR TITLE
Issue #3223: Use a string when rewriting database prefix.

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1084,6 +1084,7 @@ function install_settings_form_submit($form, &$form_state) {
 
   // Check if UTF-8 MB4 support exists in the database and add to settings.php.
   if (install_verify_database_utf8mb4()) {
+    $settings = array();
     $settings['database_charset'] = array(
       'value' => 'utf8mb4',
       'required' => TRUE,

--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -473,7 +473,7 @@ abstract class DatabaseTasks {
             'required' => TRUE,
           );
           $settings['database_prefix'] = array(
-            'value' => $db_settings['prefix'],
+            'value' => $db_settings['prefix']['default'],
           );
           backdrop_rewrite_settings($settings);
         }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3223.