### PR TITLE
Use CSS grid instead of tables for grid and provide fallback

### DIFF
--- a/core/modules/views/css/views.css
+++ b/core/modules/views/css/views.css
@@ -48,7 +48,67 @@
   text-align: center;
 }
 
+/* Views grid styles */
+
+.views-view-grid {
+  display: -ms-grid;
+  display: grid;
+}
+.views-view-grid-cols-1 {
+  -ms-grid-columns: (1fr)[1];
+  grid-template-columns: repeat(1, 1fr);
+}
+.views-view-grid-cols-2 {
+  -ms-grid-columns: (1fr)[2];
+  grid-template-columns: repeat(2, 1fr);
+}
+.views-view-grid-cols-3 {
+  -ms-grid-columns: (1fr)[3];
+  grid-template-columns: repeat(3, 1fr);
+}
+.views-view-grid-cols-4 {
+  -ms-grid-columns: (1fr)[4];
+  grid-template-columns: repeat(4, 1fr);
+}
+.views-view-grid-cols-5 {
+  -ms-grid-columns: (1fr)[5];
+  grid-template-columns: repeat(5, 1fr);
+}
+.views-view-grid-cols-6 {
+  -ms-grid-columns: (1fr)[6];
+  grid-template-columns: repeat(6, 1fr);
+}
+.views-view-grid-cols-7 {
+  -ms-grid-columns: (1fr)[7];
+  grid-template-columns: repeat(7, 1fr);
+}
+.views-view-grid-cols-8 {
+  -ms-grid-columns: (1fr)[8];
+  grid-template-columns: repeat(8, 1fr);
+}
+.views-view-grid-cols-9 {
+  -ms-grid-columns: (1fr)[9];
+  grid-template-columns: repeat(9, 1fr);
+}
+.views-view-grid-cols-10 {
+  -ms-grid-columns: (1fr)[10];
+  grid-template-columns: repeat(10, 1fr);
+}
+.views-view-grid-cols-11 {
+  -ms-grid-columns: (1fr)[11];
+  grid-template-columns: repeat(11, 1fr);
+}
+.views-view-grid-cols-12 {
+  -ms-grid-columns: (1fr)[12];
+  grid-template-columns: repeat(12, 1fr);
+}
+.views-view-grid .views-row {
+  padding: 1rem;
+  border: 1px solid #cccccc;
+}
+
 /* Remove the border on tbody that system puts in */
+/* Deprecated */
 .views-view-grid tbody {
   border-top: none;
 }

--- a/core/modules/views/plugins/views_plugin_style_grid.inc
+++ b/core/modules/views/plugins/views_plugin_style_grid.inc
@@ -38,13 +38,22 @@ class views_plugin_style_grid extends views_plugin_style {
       '#required' => TRUE,
       '#min' => 1,
       '#step' => 1,
+      '#weight' => -2,
     );
     $form['alignment'] = array(
       '#type' => 'radios',
       '#title' => t('Alignment'),
       '#options' => array('horizontal' => t('Horizontal'), 'vertical' => t('Vertical')),
       '#default_value' => $this->options['alignment'],
-      '#description' => t('Horizontal alignment will place items starting in the upper left and moving right. Vertical alignment will place items starting in the upper left and moving down.'),
+    );
+    $form['alignment']['horizontal']['#description'] = t('Places items starting in the upper left and moving right.');
+    $form['alignment']['vertical']['#description'] = t('Places items starting in the upper left and moving down.');
+
+    $form['deprecated_table'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Use table (deprecated)'),
+      '#description' => t('Some sites might have made style changes based on the deprecated grid based on table. Only select this if absolutely needed.'),
+      '#default_value' => !empty($this->options['deprecated_table']),
     );
 
     $form['fill_single_line'] = array(
@@ -52,6 +61,11 @@ class views_plugin_style_grid extends views_plugin_style {
       '#title' => t('Fill up single line'),
       '#description' => t('If you disable this option, a grid with only one row will have the same number of table cells (<TD>) as items. Disabling it can cause problems with your CSS.'),
       '#default_value' => !empty($this->options['fill_single_line']),
+      '#states' => array(
+        'invisible' => array(
+          ':input[name="style_options[deprecated_table]"]' => array('checked' => FALSE),
+        ),
+      ),
     );
 
     $form['caption'] = array(
@@ -59,6 +73,11 @@ class views_plugin_style_grid extends views_plugin_style {
       '#title' => t('Short description of table'),
       '#description' => t('Include a caption for better accessibility of your table.'),
       '#default_value' => $this->options['caption'],
+      '#states' => array(
+        'invisible' => array(
+          ':input[name="style_options[deprecated_table]"]' => array('checked' => FALSE),
+        ),
+      ),
     );
 
     $form['summary'] = array(
@@ -66,6 +85,11 @@ class views_plugin_style_grid extends views_plugin_style {
       '#title' => t('Table summary'),
       '#description' => t('This value will be displayed as table-summary attribute in the html. Use this to give a summary of complex tables.'),
       '#default_value' => $this->options['summary'],
+      '#states' => array(
+        'invisible' => array(
+          ':input[name="style_options[deprecated_table]"]' => array('checked' => FALSE),
+        ),
+      ),
     );
   }
 }

--- a/core/modules/views/templates/views-view-grid.tpl.php
+++ b/core/modules/views/templates/views-view-grid.tpl.php
@@ -19,6 +19,18 @@
 <?php if (!empty($title)) : ?>
   <h3><?php print $title; ?></h3>
 <?php endif; ?>
+
+<?php if (empty($deprecated_table)) : ?>
+<div class="<?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
+  <?php foreach ($rows as $row_count => $row): ?>
+    <div <?php if (!empty($row_classes[$row_count])) { print 'class="' . implode(' ', $row_classes[$row_count]) . '"';  } ?>>
+      <?php print $row; ?>
+    </div>
+  <?php endforeach; ?>
+</div>
+<?php endif; ?>
+
+<?php if (!empty($deprecated_table)) : ?>
 <table class="<?php print implode(' ', $classes); ?>"<?php print backdrop_attributes($attributes); ?>>
   <?php if (!empty($caption)) : ?>
     <caption><?php print $caption; ?></caption>
@@ -36,3 +48,4 @@
     <?php endforeach; ?>
   </tbody>
 </table>
+<?php endif; ?>

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -691,111 +691,187 @@ function template_preprocess_views_view_grid(&$variables) {
   $rows = array();
   $row_indexes = array();
 
-  if ($options['alignment'] == 'horizontal') {
-    $row = array();
-    $col_count = 0;
-    $row_count = 0;
+  if (empty($options['deprecated_table'])) {
+    $rows = $variables['rows'];
+
+    // Set up striping values.
     $count = 0;
-    foreach ($variables['rows'] as $row_index => $item) {
-      $count++;
-      $row[] = $item;
-      $row_indexes[$row_count][$col_count] = $row_index;
-      $col_count++;
-      if ($count % $columns == 0) {
-        $rows[] = $row;
-        $row = array();
-        $col_count = 0;
-        $row_count++;
-      }
-    }
-    if ($row) {
-      // Fill up the last line only if it's configured, but this is default.
-      if (!empty($handler->options['fill_single_line']) && count($rows)) {
-        for ($i = 0; $i < ($columns - $col_count); $i++) {
-          $row[] = '';
+    $max = count($rows);
+
+    // Reorder based on vertical alignment.
+    if ($options['alignment'] == 'vertical') {
+      $rows = array();
+      $rows_reorder = array();
+      $num_rows = floor(count($variables['rows']) / $columns);
+      // The remainders are the 'odd' columns that are slightly longer.
+      $remainders = count($variables['rows']) % $columns;
+      $row = 0;
+      $col = 0;
+
+      foreach ($variables['rows'] as $count => $item) {
+        $rows_reorder[$row][$col] = $item;
+
+        $row_indexes[$row][$col] = $count;
+
+        $row++;
+
+        if (!$remainders && $row == $num_rows) {
+          $row = 0;
+          $col++;
+        }
+        elseif ($remainders && $row == $num_rows + 1) {
+          $row = 0;
+          $col++;
+          $remainders--;
         }
       }
-      $rows[] = $row;
-    }
-  }
-  else {
-    $num_rows = floor(count($variables['rows']) / $columns);
-    // The remainders are the 'odd' columns that are slightly longer.
-    $remainders = count($variables['rows']) % $columns;
-    $row = 0;
-    $col = 0;
-    foreach ($variables['rows'] as $count => $item) {
-      $rows[$row][$col] = $item;
-      $row_indexes[$row][$col] = $count;
-      $row++;
 
-      if (!$remainders && $row == $num_rows) {
-        $row = 0;
-        $col++;
+      // Flatten now that items are reordered.
+      $col = 0;
+      foreach ($rows_reorder as $row) {
+        foreach ($row as $column) {
+          $rows[$col] = $column;
+          $col++;
+        }
       }
-      elseif ($remainders && $row == $num_rows + 1) {
-        $row = 0;
-        $col++;
-        $remainders--;
-      }
-    }
-    for ($i = 0; $i < count($rows[0]); $i++) {
-      // This should be string so that's okay :)
-      if (!isset($rows[count($rows) - 1][$i])) {
-        $rows[count($rows) - 1][$i] = '';
-      }
-    }
-  }
 
-  // Apply the row classes
-  foreach ($rows as $row_number => $row) {
-    $row_classes = array();
-    if ($default_row_class) {
-      $row_classes[] =  'row-' . ($row_number + 1);
     }
-    if ($row_class_special) {
-      if ($row_number == 0) {
-        $row_classes[] =  'row-first';
-      }
-      if (count($rows) == ($row_number + 1)) {
-        $row_classes[] =  'row-last';
-      }
-    }
-    $variables['row_classes'][$row_number] = $row_classes;
-    foreach ($rows[$row_number] as $column_number => $item) {
-      $column_classes = array();
+
+    $count = 0;
+    foreach ($rows as $id => $row) {
+      $count++;
+      $variables['row_classes'][$id] = array();
       if ($default_row_class) {
-        $column_classes[] = 'col-'. ($column_number + 1);
+        $variables['row_classes'][$id][] = 'views-row';
+        $variables['row_classes'][$id][] = 'views-row-' . $count;
       }
       if ($row_class_special) {
-        if ($column_number == 0) {
-          $column_classes[] = 'col-first';
+        $variables['row_classes'][$id][] = ($count % 2 ? 'odd' : 'even');
+        if ($count == 1) {
+          $variables['row_classes'][$id][] = 'first';
         }
-        elseif (count($rows[$row_number]) == ($column_number + 1)) {
-          $column_classes[] = 'col-last';
+        if ($count == $max) {
+          $variables['row_classes'][$id][] = 'last';
         }
       }
-      if (isset($row_indexes[$row_number][$column_number]) && $column_class = $view->style_plugin->get_row_class($row_indexes[$row_number][$column_number])) {
-        $column_classes[] = $column_class;
+      if ($row_class = $view->style_plugin->get_row_class($id)) {
+        $variables['row_classes'][$id][] = $row_class;
       }
-      $variables['column_classes'][$row_number][$column_number] = $column_classes;
     }
-  }
-  $variables['rows'] = $rows;
-  $variables['classes'] = array('views-view-grid', 'cols-' . $columns);
-
-  // Add the summary to the list if set.
-  if (!empty($handler->options['summary'])) {
-    $variables['attributes'] = array('summary' => filter_xss_admin($handler->options['summary']));
-  }
-
-  // Add the caption to the list if set.
-  if (!empty($handler->options['caption'])) {
-    $variables['caption'] = filter_xss_admin($handler->options['caption']);
+    $variables['classes'] = array('views-view-grid', 'views-view-grid-cols-' . $columns);
   }
   else {
-    $variables['caption'] = '';
+    if ($options['alignment'] == 'horizontal') {
+      $row = array();
+      $col_count = 0;
+      $row_count = 0;
+      $count = 0;
+      foreach ($variables['rows'] as $row_index => $item) {
+        $count++;
+        $row[] = $item;
+        $row_indexes[$row_count][$col_count] = $row_index;
+        $col_count++;
+        if ($count % $columns == 0) {
+          $rows[] = $row;
+          $row = array();
+          $col_count = 0;
+          $row_count++;
+        }
+      }
+      if ($row) {
+        // Fill up the last line only if it's configured, but this is default.
+        if (!empty($handler->options['fill_single_line']) && count($rows)) {
+          for ($i = 0; $i < ($columns - $col_count); $i++) {
+            $row[] = '';
+          }
+        }
+        $rows[] = $row;
+      }
+    }
+    else {
+      $num_rows = floor(count($variables['rows']) / $columns);
+      // The remainders are the 'odd' columns that are slightly longer.
+      $remainders = count($variables['rows']) % $columns;
+      $row = 0;
+      $col = 0;
+      foreach ($variables['rows'] as $count => $item) {
+        $rows[$row][$col] = $item;
+        $row_indexes[$row][$col] = $count;
+        $row++;
+
+        if (!$remainders && $row == $num_rows) {
+          $row = 0;
+          $col++;
+        }
+        elseif ($remainders && $row == $num_rows + 1) {
+          $row = 0;
+          $col++;
+          $remainders--;
+        }
+      }
+      for ($i = 0; $i < count($rows[0]); $i++) {
+        // This should be string so that's okay :)
+        if (!isset($rows[count($rows) - 1][$i])) {
+          $rows[count($rows) - 1][$i] = '';
+        }
+      }
+    }
+
+    // Apply the row classes
+    foreach ($rows as $row_number => $row) {
+      $row_classes = array();
+      if ($default_row_class) {
+        $row_classes[] =  'row-' . ($row_number + 1);
+      }
+      if ($row_class_special) {
+        if ($row_number == 0) {
+          $row_classes[] =  'row-first';
+        }
+        if (count($rows) == ($row_number + 1)) {
+          $row_classes[] =  'row-last';
+        }
+      }
+      $variables['row_classes'][$row_number] = $row_classes;
+      foreach ($rows[$row_number] as $column_number => $item) {
+        $column_classes = array();
+        if ($default_row_class) {
+          $column_classes[] = 'col-'. ($column_number + 1);
+        }
+        if ($row_class_special) {
+          if ($column_number == 0) {
+            $column_classes[] = 'col-first';
+          }
+          elseif (count($rows[$row_number]) == ($column_number + 1)) {
+            $column_classes[] = 'col-last';
+          }
+        }
+        if (isset($row_indexes[$row_number][$column_number]) && $column_class = $view->style_plugin->get_row_class($row_indexes[$row_number][$column_number])) {
+          $column_classes[] = $column_class;
+        }
+        $variables['column_classes'][$row_number][$column_number] = $column_classes;
+      }
+    }
+
+    $variables['classes'] = array('views-view-grid', 'cols-' . $columns);
+
+    // Add the summary to the list if set.
+    if (!empty($handler->options['summary'])) {
+      $variables['attributes'] = array('summary' => filter_xss_admin($handler->options['summary']));
+    }
+
+    // Add the caption to the list if set.
+    if (!empty($handler->options['caption'])) {
+      $variables['caption'] = filter_xss_admin($handler->options['caption']);
+    }
+    else {
+      $variables['caption'] = '';
+    }
   }
+
+  $variables['rows'] = $rows;
+
+  // Add the deprecated table to the list if set.
+  $variables['deprecated_table'] = !empty($options['deprecated_table']) ? TRUE : FALSE;
 }
 
 /**

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -691,7 +691,10 @@ function template_preprocess_views_view_grid(&$variables) {
   $rows = array();
   $row_indexes = array();
 
-  if (empty($options['deprecated_table'])) {
+  // For old view default to table if view settings haven't been updated.
+  $variables['deprecated_table'] = (!isset($options['deprecated_table']) || $options['deprecated_table']) ? TRUE : FALSE;
+
+  if (!$variables['deprecated_table']) {
     $rows = $variables['rows'];
 
     // Set up striping values.
@@ -869,9 +872,6 @@ function template_preprocess_views_view_grid(&$variables) {
   }
 
   $variables['rows'] = $rows;
-
-  // Add the deprecated table to the list if set.
-  $variables['deprecated_table'] = !empty($options['deprecated_table']) ? TRUE : FALSE;
 }
 
 /**


### PR DESCRIPTION
Addresses https://github.com/backdrop/backdrop-issues/issues/2811. This is inspired by https://github.com/backdrop/backdrop/pull/1988.

Includes:

* support IE 11 with CSS prefixes
* new views will default to CSS grid, old views will still use tables
* toggle on UI for grid to choose the old table