### PR TITLE
Issue #3242: [UX] Clear entity info caches when loading the layouts list and layout edit form.

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -1555,6 +1555,10 @@ function layout_block_remove_page(Layout $layout, Block $block, $renderer_name) 
  * @ingroup forms
  */
 function layout_condition_add_form($form, &$form_state, Layout $layout = NULL, Block $block = NULL, LayoutMenuItem $menu_item = NULL, $condition_id = NULL) {
+  // Ensure entity info such as entity labels are up to date.
+  // See https://github.com/backdrop/backdrop-issues/issues/3242
+  entity_info_cache_clear();
+
   form_load_include($form_state, 'inc', 'layout', 'layout.admin');
   $form_state['layout'] = $layout;
   $form_state['block'] = $block;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -10,6 +10,10 @@
  * Output a list of pages that are managed.
  */
 function layout_list_page() {
+  // Ensure entity info such as entity labels are up to date.
+  // See https://github.com/backdrop/backdrop-issues/issues/3242
+  entity_info_cache_clear();
+
   $layouts = layout_load_all();
 
   // Group layouts by path.
@@ -199,6 +203,10 @@ function layout_add_page() {
  * @ingroup forms
  */
 function layout_settings_form($form, &$form_state, Layout $layout) {
+  // Ensure entity info such as entity labels are up to date.
+  // See https://github.com/backdrop/backdrop-issues/issues/3242
+  entity_info_cache_clear();
+
   form_load_include($form_state, 'inc', 'layout', 'layout.admin');
 
   $form_state['layout'] = &$layout;


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3242