### PR TITLE
Issue #3375: file_save_upload() should not alter the file URI string before validation

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1510,7 +1510,7 @@ function file_save_upload($form_field_name, $validators = array(), $destination 
   // evaluates to TRUE.
   if (!settings_get('allow_insecure_uploads', 0) && preg_match('/\.(php|pl|py|cgi|asp|js)(\.|$)/i', $file->filename) && (substr($file->filename, -4) != '.txt')) {
     $file->filemime = 'text/plain';
-    $file->uri .= '.txt';
+    // The destination filename will also later be used to create the URI.
     $file->filename .= '.txt';
     // The .txt extension may not be in the allowed list of extensions. We have
     // to add it here or else the file upload will fail.


### PR DESCRIPTION
https://www.drupal.org/node/1815504

>I'm attempting to validate a file using `hook_file_validate()` but the check for insecure uploads alters the file's URI by appending ".txt". The problem is that in `hook_file_validate`, I cannot use that altered URI to locate the file. Also, there is nothing to tell me that the file's URI has been altered due to security concerns.
>
>There is no need to alter the `$file->uri` before validation, since it's reconstructed later based on the munged filename.