### PR TITLE
Issue #3375: Make cache_form expiration configurable, to mitigate runaway cache_form tables

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -556,12 +556,16 @@ function form_get_cache($form_build_id, &$form_state) {
 
 /**
  * Stores a form in the cache.
+ *
+ * The default cache_form expiration is 6 hours. On busy sites, the cache_form
+ * table can become very large. A shorter cache lifetime can help to keep the
+ * table's size under control.
  */
 function form_set_cache($form_build_id, $form, $form_state) {
-  // The default cache_form expiration is 6 hours. On busy sites, the cache_form
-  // table can become very large. A shorter cache lifetime can help to keep the
-  // table's size under control.
-  $expire = config_get('system.core', 'form_cache_expiration');
+  // Try to read the 'form_cache_expiration' setting from settings.php. If not
+  // set in settings.php, then default to the value set in 'system.core' config
+  // (via system_update_1067 - setting not exposed in the admin UI currently).
+  $expire = settings_get('form_cache_expiration', config_get('system.core', 'form_cache_expiration'));
 
   // Ensure that the form build_id embedded in the form structure is the same as
   // the one passed in as a parameter. This is an additional safety measure to

--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -558,8 +558,10 @@ function form_get_cache($form_build_id, &$form_state) {
  * Stores a form in the cache.
  */
 function form_set_cache($form_build_id, $form, $form_state) {
-  // 6 hours cache life time for forms should be plenty.
-  $expire = 21600;
+  // The default cache_form expiration is 6 hours. On busy sites, the cache_form
+  // table can become very large. A shorter cache lifetime can help to keep the
+  // table's size under control.
+  $expire = config_get('system.core', 'form_cache_expiration');
 
   // Ensure that the form build_id embedded in the form structure is the same as
   // the one passed in as a parameter. This is an additional safety measure to

--- a/core/modules/simpletest/tests/form.test
+++ b/core/modules/simpletest/tests/form.test
@@ -1443,6 +1443,59 @@ class FormsFormStoragePageCacheTestCase extends BackdropWebTestCase {
 }
 
 /**
+ * Test cache_form.
+ */
+class FormsFormCacheTestCase extends DrupalWebTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Form caching',
+      'description' => 'Tests storage and retrieval of forms from cache.',
+      'group' => 'Form API',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('form_test');
+  }
+
+  /**
+   * Tests storing and retrieving the form from cache.
+   */
+  function testCacheForm() {
+    $form = backdrop_get_form('form_test_cache_form');
+    $form_state = array('foo' => 'bar', 'build_info' => array('baz'));
+    form_set_cache($form['#build_id'], $form, $form_state);
+
+    $cached_form_state = array();
+    $cached_form = form_get_cache($form['#build_id'], $cached_form_state);
+
+    $this->assertEqual($cached_form['#build_id'], $form['#build_id'], 'Form retrieved from cache_form successfully.');
+    $this->assertEqual($cached_form_state['foo'], 'bar', 'Data retrieved from cache_form successfully.');
+  }
+
+  /**
+   * Tests changing form_cache_expiration.
+   */
+  function testCacheFormCustomExpiration() {
+    config_set('system.core', 'form_cache_expiration', -1 * (24 * 60 * 60));
+
+    $form = backdrop_get_form('form_test_cache_form');
+    $form_state = array('foo' => 'bar', 'build_info' => array('baz'));
+    form_set_cache($form['#build_id'], $form, $form_state);
+
+    // Clear expired entries from cache_form, which should include the entry we
+    // just stored. Without this, the form will still be retrieved from cache.
+    cache_clear_all(NULL, 'cache_form');
+
+    $cached_form_state = array();
+    $cached_form = form_get_cache($form['#build_id'], $cached_form_state);
+
+    $this->assertNull($cached_form, 'Expired form was not returned from cache.');
+    $this->assertTrue(empty($cached_form_state), 'No data retrieved from cache for expired form.');
+  }
+}
+
+/**
  * Test wrapper form callbacks.
  */
 class FormsFormWrapperTestCase extends BackdropWebTestCase {

--- a/core/modules/simpletest/tests/form_test.module
+++ b/core/modules/simpletest/tests/form_test.module
@@ -959,6 +959,24 @@ function form_test_storage_page_cache_rebuild($form, &$form_state) {
 }
 
 /**
+ * A simple form for testing form caching.
+ */
+function form_test_cache_form($form, &$form_state) {
+  $form['title'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Title',
+    '#required' => TRUE,
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Save',
+  );
+
+  return $form;
+}
+
+/**
  * A form for testing form labels and required marks.
  */
 function form_label_test_form() {

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -25,6 +25,7 @@
     "file_transliterate_uploads": 1,
     "file_transliterate_uploads_display_name": 0,
     "filter_fallback_format": "plain_text",
+    "form_cache_expiration": 21600,
     "image_toolkit": "gd",
     "image_jpeg_quality": "75",
     "image_style_flood_limit": 5,

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3019,7 +3019,6 @@ function system_update_1066() {
   }
 }
 
-
 /**
  * Add default value for form_cache_expiration.
  */

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3019,6 +3019,16 @@ function system_update_1066() {
   }
 }
 
+
+/**
+ * Add default value for form_cache_expiration.
+ */
+function system_update_1067() {
+  $config = config('system.core');
+  $config->set('form_cache_expiration', 21600);
+  $config->save();
+}
+
 /**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.

--- a/settings.php
+++ b/settings.php
@@ -221,6 +221,23 @@ ini_set('session.cookie_lifetime', 2000000);
 // $settings['omit_vary_cookie'] = TRUE;
 
 /**
+ * Expiration of cache_form entries:
+ *
+ * Backdrop's Form API stores details of forms in cache_form and these entries
+ * are kept for at least 6 hours by default. Expired entries are cleared by
+ * cron. Busy sites can encounter problems with the cache_form table becoming
+ * very large. It's possible to mitigate this by setting a shorter expiration
+ * for cached forms. In some cases it may be desirable to set a longer cache
+ * expiration. For example to prolong cache_form entries for Ajax forms in
+ * cached HTML.
+ *
+ * @see form_set_cache()
+ * @see system_cron()
+ * @see ajax_get_form()
+ */
+// $settings['form_cache_expiration'] = 21600;
+
+/**
  * String overrides:
  *
  * To override specific strings on your site with or without enabling locale


### PR DESCRIPTION
https://www.drupal.org/node/2091511

>## Problem/Motivation
>Busy sites that use a lot of forms can make a lot of entries in the cache_form table. This is particuarly true of sites using Ubercart, Commerce, or other modules like Fivestar, Ideal Comments, or Hierarchical Select.
>
>This is a very common problem which I have seen cause problems for my clients, especially when database replication is involved. A search shows how widespread the issue is: https://www.google.com/search?q=cache_form%20big
>
>The cache_form table is truncated via cron, in `system_cron`. The default expiry for `cache_form` entries is 6 hours, hardcoded in `form_set_cache`.
>
>## Proposed resolution
>By changing `$expiry = 21600;` from a hardcoded variable to `variable_get('cache_form_expiry', 21600);`, users can choose how often entries are pruned from cache. With shorter lifetimes, the form_cache table will be truncated more often, and will not grow as large.
>
>I would suggest making the default expiry one hour, rather than 6, also.
>
>*Remaining tasks*: None, subject to community review (especially of the comment).
>
>*User interface changes*: None.
>
>*API changes*: None.