### PR TITLE
Issue #3375: PHP7 warning when uploading a user picture

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -361,7 +361,7 @@ function user_validate_picture(&$form, &$form_state) {
     'file_validate_is_image' => array(),
     'file_validate_image_orientation' => array(TRUE),
     'file_validate_image_resolution' => array(config_get('system.core', 'user_picture_dimensions')),
-    'file_validate_size' => array(config_get('system.core', 'user_picture_file_size') * 1024),
+    'file_validate_size' => array((int) config_get('system.core', 'user_picture_file_size') * 1024),
   );
 
   // Save the file as a temporary file.


### PR DESCRIPTION
https://www.drupal.org/node/2899679

>Tested with PHP 7.1.6, when uploading a picture against a user the following warning appears:
>`Warning: A non-numeric value encountered in user_validate_picture() (line 692 of modules/user/user.module).`
>
>A typecast should resolve this