### PR TITLE
Issue #3375: Fix documentation of taxonomy term title callback code to match nodes and to not imply that it sets the title of the term page

### DIFF
--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -288,6 +288,8 @@ function taxonomy_menu() {
     'title' => 'Taxonomy term',
     'title callback' => 'taxonomy_term_title',
     'title arguments' => array(2),
+    // The page callback also invokes drupal_set_title() in case the menu
+    // router's title is overridden by a menu link.
     'page callback' => 'taxonomy_term_page',
     'page arguments' => array(2),
     'access arguments' => array('access content'),
@@ -1560,13 +1562,15 @@ function taxonomy_field_formatter_prepare_view($entity_type, $entities, $field, 
 }
 
 /**
- * Title callback for term pages.
+ * Title callback: Returns the title of the taxonomy term.
  *
  * @param TaxonomyTerm $term
  *   A taxonomy term entity.
  *
  * @return
- *   The term name to be used as the page title.
+ *   An unsanitized string that is the title of the taxonomy term.
+ *
+ * @see taxonomy_menu()
  */
 function taxonomy_term_title(TaxonomyTerm $term) {
   return $term->name;


### PR DESCRIPTION
https://www.drupal.org/node/2889279

>This is a followup to [#1041906: Taxonomy term menu link title overrides term page title](https://www.drupal.org/project/drupal/issues/1041906) that fixes a couple things in the documentation to match the corresponding documentation for nodes, as well as to make the documentation not imply that the title callback in `hook_menu()` is used to set the term page title when it isn't.