### PR TITLE
Issue #3247: [UX] Removing 'main content' block causes some page elements not to display

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -98,7 +98,7 @@ function system_theme() {
     'page_components' => array(
       'variables' => array('settings' => NULL, 'child_delta' => NULL),
       'template' => 'templates/page-components',
-    ),
+    ) + $base,
     'system_admin_index' => array(
       'variables' => array('menu_items' => NULL),
     ) + $base,


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3247