### PR TITLE
Issue #3257: Allowing color elements to be put in multiple fieldsets.

### DIFF
--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Allows users to change the color scheme of themes.

--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Allows users to change the color scheme of themes.
@@ -101,17 +102,11 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
     );
 
     // Add palette fields.
-    $palette = color_get_palette($theme_name);
-    $names = $theme_info['fields'];
-    foreach ($palette as $name => $value) {
-      if (isset($names[$name])) {
-        $form['color']['palette'][$name] = array(
-          '#type' => 'color',
-          '#title' => check_plain($names[$name]),
-          '#value_callback' => 'color_palette_color_value',
-          '#default_value' => $value,
-          '#size' => 8,
-        );
+    $placed = backdrop_static('_color_get_color_element', array());
+    foreach ($theme_info['fields'] as $name => $label) {
+      // Avoid placing them if they have already been placed by the theme.
+      if (!isset($placed[$theme_name]) || !isset($placed[$theme_name][$name])) {
+        $form['color']['palette'][$name] = _color_get_color_element($theme_name, $name);
       }
     }
 
@@ -128,6 +123,41 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
       bartik_form_system_theme_settings_alter($form, $form_state);
     }
   }
+}
+
+/**
+ * Creates the render array for a color element.
+ *
+ * The function also stores which color elements have already been generated, so
+ * that the color module does not attempt to print out color settings twice.
+ *
+ * @param string $theme_name
+ *   The theme to get color settings from.
+ * @param string $color_name
+ *   The name of the color element to return.
+ *
+ * @return array
+ *   The render array for the color element.
+ */
+function _color_get_color_element($theme_name, $color_name) {
+  $placed = &backdrop_static(__FUNCTION__, array());
+
+  $theme_info = color_get_info($theme_name);
+  $palette = color_get_palette($theme_name);
+
+  $placed[$theme_name][$color_name] = TRUE;
+
+  return array(
+    '#type' => 'color',
+    '#title' => check_plain($theme_info['fields'][$color_name]),
+    '#value_callback' => 'color_palette_color_value',
+    '#default_value' => $palette[$color_name],
+    '#size' => 8,
+    '#parents' => array('palette', $color_name),
+    '#attributes' => array(
+      'data-color-name' => $color_name,
+    ),
+  );
 }
 
 /**

--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -102,11 +102,11 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
     );
 
     // Add palette fields.
-    $placed = backdrop_static('_color_get_color_element', array());
+    $placed = backdrop_static('color_get_color_element', array());
     foreach ($theme_info['fields'] as $name => $label) {
       // Avoid placing them if they have already been placed by the theme.
       if (!isset($placed[$theme_name]) || !isset($placed[$theme_name][$name])) {
-        $form['color']['palette'][$name] = _color_get_color_element($theme_name, $name);
+        $form['color']['palette'][$name] = color_get_color_element($theme_name, $name);
       }
     }
 
@@ -128,8 +128,9 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
 /**
  * Creates the render array for a color element.
  *
- * The function also stores which color elements have already been generated, so
- * that the color module does not attempt to print out color settings twice.
+ * The function also stores a list of which color elements have already been
+ * generated, so that the color module does not attempt to print out color
+ * settings twice.
  *
  * @param string $theme_name
  *   The theme to get color settings from.
@@ -139,14 +140,19 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
  * @return array
  *   The render array for the color element.
  */
-function _color_get_color_element($theme_name, $color_name) {
+function color_get_color_element($theme_name, $color_name) {
+  // Store a list of which elemets are already placed using backdrop_static()
+  // so that other parts of the color module can access the list.
   $placed = &backdrop_static(__FUNCTION__, array());
 
+  // Get the color settings from the theme.
   $theme_info = color_get_info($theme_name);
   $palette = color_get_palette($theme_name);
 
+  // Remember that the element has already been placed.
   $placed[$theme_name][$color_name] = TRUE;
 
+  // Return the render array for the color element.
   return array(
     '#type' => 'color',
     '#title' => check_plain($theme_info['fields'][$color_name]),

--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -102,11 +102,10 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
     );
 
     // Add palette fields.
-    $placed = backdrop_static('color_get_color_element', array());
     foreach ($theme_info['fields'] as $name => $label) {
       // Avoid placing them if they have already been placed by the theme.
-      if (!isset($placed[$theme_name]) || !isset($placed[$theme_name][$name])) {
-        $form['color']['palette'][$name] = color_get_color_element($theme_name, $name);
+      if (!in_array($name, $form['#color_elements'])) {
+        $form['color']['palette'][$name] = color_get_color_element($theme_name, $name, $form);
       }
     }
 
@@ -136,21 +135,19 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
  *   The theme to get color settings from.
  * @param string $color_name
  *   The name of the color element to return.
+ * @param array $form
+ *   The form array for the theme settings form.
  *
  * @return array
  *   The render array for the color element.
  */
-function color_get_color_element($theme_name, $color_name) {
-  // Store a list of which elemets are already placed using backdrop_static()
-  // so that other parts of the color module can access the list.
-  $placed = &backdrop_static(__FUNCTION__, array());
-
+function color_get_color_element($theme_name, $color_name, &$form) {
   // Get the color settings from the theme.
   $theme_info = color_get_info($theme_name);
   $palette = color_get_palette($theme_name);
 
   // Remember that the element has already been placed.
-  $placed[$theme_name][$color_name] = TRUE;
+  $form['#color_elements'][] = $color_name;
 
   // Return the render array for the color element.
   return array(

--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -104,7 +104,7 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
     // Add palette fields.
     foreach ($theme_info['fields'] as $name => $label) {
       // Avoid placing them if they have already been placed by the theme.
-      if (!in_array($name, $form['#color_elements'])) {
+      if (!isset($form['#color_elements']) || !in_array($name, $form['#color_elements'])) {
         $form['color']['palette'][$name] = color_get_color_element($theme_name, $name, $form);
       }
     }

--- a/core/modules/color/css/color.admin.css
+++ b/core/modules/color/css/color.admin.css
@@ -3,41 +3,26 @@
  * Stylesheet for the administration pages of the Color module.
  */
 
-.color-form .form-item label {
+.form-item-scheme label,
+.form-type-color label {
   display: inline-block;
   vertical-align: middle;
   margin: 0;
   padding: 0;
 }
 
-#palette,
-.form-type-select {
-  float: left; /* LTR */
-  clear: both;
-  width: 100%;
-  max-width: 20em;
-  padding-right: 2em;
-}
-
-[dir="rtl"] #palette,
-[dir="rtl"] .form-type-select {
-  float: right;
-}
-
 .color-form select,
-.color-form input,
-.color-form .sp-replacer {
-  float: right;
+input[type=color] {
+  float: right; /* LTR */
   max-width: 9em;
 }
 
 [dir="rtl"] .color-form select,
-[dir="rtl"] .color-form input,
-[dir="rtl"] .color-form .sp-replacer {
+[dir="rtl"] input[type=color] {
   float: left;
 }
 
-.color-form .form-item {
+.form-type-color {
   height: 35px;
   width: 100%;
   margin-top: .5em;
@@ -47,7 +32,7 @@
 }
 
 /* Color inputs */
-#color_scheme_form input[type=color] {
+#system-theme-settings input[type=color] {
   border-radius: 100%;
   height: 35px;
   width: 35px;
@@ -56,18 +41,18 @@
 }
 
 /* Styles to control the color inputs in Firefox. */
-#color_scheme_form input[type=color]::-moz-color-swatch {
+#system-theme-settings input[type=color]::-moz-color-swatch {
   border: none;
   border-radius: 100%;
 }
 
 /* Styles to control the color inputs in Chrome. */
-#color_scheme_form input[type=color]::-webkit-color-swatch {
+#system-theme-settings input[type=color]::-webkit-color-swatch {
   border: none;
   border-radius: 100%;
 }
 
-#color_scheme_form input[type=color]::-webkit-color-swatch-wrapper {
+#system-theme-settings input[type=color]::-webkit-color-swatch-wrapper {
   padding: 0;
 }
 

--- a/core/modules/color/js/color.js
+++ b/core/modules/color/js/color.js
@@ -57,7 +57,7 @@ Backdrop.behaviors.color = {
         var colors = schemes[schemeName];
         for (var fieldName in colors) {
           if (colors.hasOwnProperty(fieldName)) {
-            var input = $('#edit-palette-' + fieldName);
+            var input = $("input[data-color-name='" + fieldName + "']");
             if (input.val() && input.val() != colors[fieldName]) {
               input.val(colors[fieldName]);
             }
@@ -67,10 +67,9 @@ Backdrop.behaviors.color = {
       }
     });
 
-    $('#palette input').change(function () {
+    $('input[data-color-name]').change(function () {
       var schemeName =  document.getElementById('edit-scheme').value;
-      var key = this.id.substring(13);
-
+      var key = this.dataset.colorName;
       if (schemeName !== '' && this.value !== schemes[schemeName][key]) {
         resetScheme();
       }
@@ -79,7 +78,11 @@ Backdrop.behaviors.color = {
 
     // Setup the preview.
     $('#system-theme-settings').addClass('has-preview').after(settings.colorPreviewMarkup);
-    updatePreview();
+    // Wait for the iframe to be loaded before attempting to apply the preview
+    // settings for the first time.
+    $('#preview').load(function () {
+      updatePreview();
+    });
 
     /**
      * Saves the current form values and refreshes the preview.
@@ -91,8 +94,8 @@ Backdrop.behaviors.color = {
         palette: {}
       };
       values['scheme'] = $('#edit-scheme').val();
-      $('#color_scheme_form input').each(function () {
-        values['palette'][this.id.substring(13)] = this.value;
+      $('input[data-color-name]').each(function () {
+        values['palette'][this.dataset.colorName] = this.value;
       });
 
       $.ajax({
@@ -100,9 +103,9 @@ Backdrop.behaviors.color = {
         dataType: 'json',
         url : Backdrop.settings.basePath + 'color/save_preview_settings/' + settings.colorThemeName + '/?token=' + settings.colorPreviewToken,
         data: values,
-        success : function(response) {
+        complete : function(response) {
           // Refresh the preview.
-          document.getElementById('preview').contentDocument.location.reload(true);
+          var preview = document.getElementById('preview').contentDocument.location.reload(true);
         }
       });
     }

--- a/core/modules/color/js/color.js
+++ b/core/modules/color/js/color.js
@@ -78,11 +78,7 @@ Backdrop.behaviors.color = {
 
     // Setup the preview.
     $('#system-theme-settings').addClass('has-preview').after(settings.colorPreviewMarkup);
-    // Wait for the iframe to be loaded before attempting to apply the preview
-    // settings for the first time.
-    $('#preview').load(function () {
-      updatePreview();
-    });
+    updatePreview();
 
     /**
      * Saves the current form values and refreshes the preview.

--- a/core/themes/basis/theme-settings.php
+++ b/core/themes/basis/theme-settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Theme settings file for Basis.
@@ -7,6 +8,51 @@
  * inform the user that the module supports color schemes if the Color module
  * is enabled.
  */
-$form['color'] = array(
-  '#markup' => '<p>' . t('This theme supports custom color palettes if the Color module is enabled on the <a href="!url">modules page</a>. Enable the Color module to customize this theme.', array('!url' => url('admin/modules'))) . '</p>',
-);
+
+if (module_exists('color')) {
+  $form['header'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Header Settings'),
+    '#collapsible' => TRUE,
+  );
+  $fields = array(
+    'header',
+    'base',
+    'slogan',
+    'titleslogan',
+    'hovermenu',
+  );
+  foreach ($fields as $field) {
+    $form['header'][$field] = _color_get_color_element('basis', $field);
+  }
+
+  $form['general'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('General Settings'),
+    '#collapsible' => TRUE,
+  );
+  $fields = array(
+    'bg',
+    'text',
+    'link',
+    'primarytabs',
+    'borders',
+    'formfocusborder',
+    'buttons',
+  );
+  foreach ($fields as $field) {
+    $form['general'][$field] = _color_get_color_element('basis', $field);
+  }
+
+  $form['footer'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Footer Settings'),
+    '#collapsible' => TRUE,
+    'color_footer' => _color_get_color_element('basis', 'footer'),
+  );
+}
+else {
+  $form['color'] = array(
+    '#markup' => '<p>' . t('This theme supports custom color palettes if the Color module is enabled on the <a href="!url">modules page</a>. Enable the Color module to customize this theme.', array('!url' => url('admin/modules'))) . '</p>',
+  );
+}

--- a/core/themes/basis/theme-settings.php
+++ b/core/themes/basis/theme-settings.php
@@ -23,7 +23,7 @@ if (module_exists('color')) {
     'hovermenu',
   );
   foreach ($fields as $field) {
-    $form['header'][$field] = color_get_color_element('basis', $field);
+    $form['header'][$field] = color_get_color_element('basis', $field, $form);
   }
 
   $form['general'] = array(
@@ -41,14 +41,14 @@ if (module_exists('color')) {
     'buttons',
   );
   foreach ($fields as $field) {
-    $form['general'][$field] = color_get_color_element('basis', $field);
+    $form['general'][$field] = color_get_color_element('basis', $field, $form);
   }
 
   $form['footer'] = array(
     '#type' => 'fieldset',
     '#title' => t('Footer Settings'),
     '#collapsible' => TRUE,
-    'color_footer' => color_get_color_element('basis', 'footer'),
+    'color_footer' => color_get_color_element('basis', 'footer', $form),
   );
 }
 else {

--- a/core/themes/basis/theme-settings.php
+++ b/core/themes/basis/theme-settings.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Theme settings file for Basis.
@@ -8,7 +7,6 @@
  * inform the user that the module supports color schemes if the Color module
  * is enabled.
  */
-
 if (module_exists('color')) {
   $form['header'] = array(
     '#type' => 'fieldset',

--- a/core/themes/basis/theme-settings.php
+++ b/core/themes/basis/theme-settings.php
@@ -23,7 +23,7 @@ if (module_exists('color')) {
     'hovermenu',
   );
   foreach ($fields as $field) {
-    $form['header'][$field] = _color_get_color_element('basis', $field);
+    $form['header'][$field] = color_get_color_element('basis', $field);
   }
 
   $form['general'] = array(
@@ -41,14 +41,14 @@ if (module_exists('color')) {
     'buttons',
   );
   foreach ($fields as $field) {
-    $form['general'][$field] = _color_get_color_element('basis', $field);
+    $form['general'][$field] = color_get_color_element('basis', $field);
   }
 
   $form['footer'] = array(
     '#type' => 'fieldset',
     '#title' => t('Footer Settings'),
     '#collapsible' => TRUE,
-    'color_footer' => _color_get_color_element('basis', 'footer'),
+    'color_footer' => color_get_color_element('basis', 'footer'),
   );
 }
 else {


### PR DESCRIPTION
Moved the code to create the render arrays for color elements into a function that can be called from the theme settings page and changed the code in the color module to use the function as well, converted the JS code to use data attributes for finding the color elements, and fixed some bugs and coding standards problems.