### PR TITLE
Issue #3412: [UX] Permissions page: Use darker gray background for module-grouping rows.

### DIFF
--- a/core/modules/user/css/user.css
+++ b/core/modules/user/css/user.css
@@ -1,6 +1,7 @@
 
 #permissions td.module {
   font-weight: bold;
+  background: #dddddd;
 }
 #permissions td.permission {
   padding-left: 1.5em; /* LTR */


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3412