### PR TITLE
Issue #3365: BackdropCMS v. 1.11.1 is changing underscores in classes to hyphens

### DIFF
--- a/core/modules/layout/layout.theme.inc
+++ b/core/modules/layout/layout.theme.inc
@@ -300,7 +300,7 @@ function template_preprocess_block(&$variables) {
   if (!empty($style->settings['classes'])) {
     $new_classes = explode(' ', $style->settings['classes']);
     foreach ($new_classes as $class) {
-      $variables['classes'][] = backdrop_clean_css_identifier($class);
+      $variables['classes'][] = backdrop_clean_css_identifier($class, array());
     }
     $variables['classes'] = array_filter($variables['classes']);
   }
@@ -369,7 +369,7 @@ function template_preprocess_block_dynamic(&$variables) {
   // Add title tag and classes.
   $title_classes = explode(' ', $style->settings['title_classes']);
   foreach ($title_classes as $n => $class) {
-    $title_classes[$n] = backdrop_clean_css_identifier($class);
+    $title_classes[$n] = backdrop_clean_css_identifier($class, array());
   }
   $title_classes = array_filter($title_classes);
   $variables['title_tag'] = $style->settings['title_tag'];
@@ -380,7 +380,7 @@ function template_preprocess_block_dynamic(&$variables) {
   // Add content tag and classes.
   $content_classes = explode(' ', $style->settings['content_classes']);
   foreach ($content_classes as $n => $class) {
-    $content_classes[$n] = backdrop_clean_css_identifier($class);
+    $content_classes[$n] = backdrop_clean_css_identifier($class, array());
   }
   $content_classes = array_filter($content_classes);
   $variables['content_tag'] = $style->settings['content_tag'];

--- a/core/modules/layout/plugins/renderers/layout_renderer_standard.inc
+++ b/core/modules/layout/plugins/renderers/layout_renderer_standard.inc
@@ -597,7 +597,7 @@ class LayoutRendererStandard {
     if (isset($style_settings['classes'])) {
       $classes = explode(' ', $style_settings['classes']);
       foreach ($classes as $n => $class) {
-        $classes[$n] = backdrop_clean_css_identifier($class);
+        $classes[$n] = backdrop_clean_css_identifier($class, array());
       }
       $classes = array_filter($classes);
     }


### PR DESCRIPTION
Don't replace underscores with hyphens in custom class names.