### PR TITLE
Issue #3323: Typing a "/" in a field label stops the machine name autocomplete

### DIFF
--- a/core/misc/machine-name.js
+++ b/core/misc/machine-name.js
@@ -167,8 +167,9 @@ Backdrop.behaviors.machineName = {
         transliterationOptions[copyOptions[n]] = settings[copyOptions[n]];
       }
     }
+    var urlAppend = encodeURIComponent(source.toLowerCase());
     return $.ajax({
-      url: Backdrop.settings.basePath + "?q=" + Backdrop.encodePath("system/transliterate/" + source.toLowerCase()),
+      url: Backdrop.settings.basePath + "?q=" + Backdrop.encodePath("system/transliterate/" + urlAppend),
       data: transliterationOptions,
       dataType: "text"
     }); 

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -2707,6 +2707,7 @@ function system_transliteration_file_query() {
  */
 function system_transliterate_ajax($string = '') {
   backdrop_add_http_header('Content-Type', 'text/plain');
+  $string = rawurldecode($string);
   $string = system_transliterate_machine_name($string, $_GET);
 
   print $string;


### PR DESCRIPTION
I choose to be as close as possible to the original code (ie lower case in js)