### PR TITLE
Issue #3408: remove top padding from custom blocks when styled as messages.

### DIFF
--- a/core/modules/system/css/messages.theme.css
+++ b/core/modules/system/css/messages.theme.css
@@ -55,6 +55,10 @@
   margin-bottom: 0;
   margin-left: 0;
 }
+.block.messages .block-content * {
+  margin-block-start: 0;
+  padding-top: 0;
+}
 
 .messages.status {
   color: #234600;


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3408