### PR TITLE
Issue #3456: Don't break on whitespace the more/less links.

### DIFF
--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -91,6 +91,9 @@ small .admin-link:after {
 #system-modules td.operations {
   width: 120px;
 }
+.requirements-toggle {
+  white-space: nowrap;
+}
 .requirements-toggle .arrow {
   border-bottom-color: transparent;
   border-left-color: transparent;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3456