### PR TITLE
Issue #3361: Use 1 instead of '1' in settings.node_preview

### DIFF
--- a/core/modules/node/node.install
+++ b/core/modules/node/node.install
@@ -1957,7 +1957,7 @@ function node_update_1019() {
     $config = config($config_name);
     $settings = $config->get('settings');
     if (!isset($settings['node_preview'])) {
-      $config->set('settings.node_preview', '1');
+      $config->set('settings.node_preview', 1);
       $config->save();
     }
   }


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3361