### PR TITLE
Issue #3459: file_unmanaged_move() should issue rename() where possible instead of copy() & unlink()

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1158,11 +1158,8 @@ function file_unmanaged_move($source, $destination = NULL, $replace = FILE_EXIST
   if (!file_unmanaged_prepare($source, $destination, $replace)) {
     return FALSE;
   }
-  // Ensure compatibility with Windows.
-  // @see backdrop_unlink()
-  if ((substr(PHP_OS, 0, 3) == 'WIN') && (!file_stream_wrapper_valid_scheme(file_uri_scheme($source)))) {
-    chmod($source, 0600);
-  }
+  // The file must be writable in the old location before moving.
+  backdrop_chmod($source);
   // Attempt to resolve the URIs. This is necessary in certain configurations
   // (see above) and can also permit fast moves across local schemes.
   $real_source = ($real_source = backdrop_realpath($source)) ? $real_source : $source;

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1140,7 +1140,7 @@ function file_move(File $source, $destination = NULL, $replace = FILE_EXISTS_REN
  * @param $destination
  *   A URI containing the destination that $source should be moved to. The
  *   URI may be a bare filepath (without a scheme) and in that case the default
- *   scheme (file://) will be used. If this value is omitted, Drupal's default
+ *   scheme (file://) will be used. If this value is omitted, Backdrop's default
  *   files scheme will be used, usually "public://".
  * @param $replace
  *   Replace behavior when the destination file already exists:

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1168,8 +1168,7 @@ function file_unmanaged_move($source, $destination = NULL, $replace = FILE_EXIST
   if (!@rename($real_source, $real_destination)) {
     // Fall back to slow copy and unlink procedure. This is necessary for
     // renames across schemes that are not local, or where rename() has not been
-    // implemented. It's not necessary to use drupal_unlink() as the Windows
-    // issue has already been resolved above.
+    // implemented.
     if (!@copy($real_source, $real_destination) || !@unlink($real_source)) {
       watchdog('file', 'The specified file %file could not be moved to %destination.', array('%file' => $source, '%destination' => $destination), WATCHDOG_ERROR);
       return FALSE;

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -860,7 +860,7 @@ function file_valid_uri($uri) {
 }
 
 /**
- * Copies a file to a new location without invoking the file API.
+ * Copies a file to a new location without database changes or hook invocation.
  *
  * This is a powerful function that in many ways performs like an advanced
  * version of copy().
@@ -870,10 +870,9 @@ function file_valid_uri($uri) {
  * - If the $source and $destination are equal, the behavior depends on the
  *   $replace parameter. FILE_EXISTS_REPLACE will error out. FILE_EXISTS_RENAME
  *   will rename the file until the $destination is unique.
- * - Provides a fallback using realpaths if the move fails using stream
- *   wrappers. This can occur because PHP's copy() function does not properly
- *   support streams if safe_mode or open_basedir are enabled. See
- *   https://bugs.php.net/bug.php?id=60456
+ * - Works around a PHP 5.3 bug where copy() does not properly support streams
+ *   if safe_mode or open_basedir are enabled.
+ *   @see https://bugs.php.net/bug.php?id=60456
  *
  * @param $source
  *   A string specifying the filepath or URI of the source file.
@@ -894,6 +893,54 @@ function file_valid_uri($uri) {
  * @see file_copy()
  */
 function file_unmanaged_copy($source, $destination = NULL, $replace = FILE_EXISTS_RENAME) {
+  if (!file_unmanaged_prepare($source, $destination, $replace)) {
+    return FALSE;
+  }
+  // Attempt to resolve the URIs. This is necessary in certain configurations
+  // (see above).
+  $real_source = ($real_source = backdrop_realpath($source)) ? $real_source : $source;
+  $real_destination = ($real_destination = backdrop_realpath($destination)) ? $real_destination : $destination;
+  // Perform the copy operation.
+  if (!@copy($real_source, $real_destination)) {
+    watchdog('file', 'The specified file %file could not be copied to %destination.', array('%file' => $source, '%destination' => $destination), WATCHDOG_ERROR);
+    return FALSE;
+  }
+  // Set the permissions on the new file.
+  backdrop_chmod($destination);
+  return $destination;
+}
+
+/**
+ * Internal function that prepares the destination for a file_unmanaged_copy or
+ * file_unmanaged_move operation.
+ *
+ * - Checks if $source and $destination are valid and readable/writable.
+ * - Checks that $source is not equal to $destination; if they are an error
+ *   is reported.
+ * - If file already exists in $destination either the call will error out,
+ *   replace the file or rename the file based on the $replace parameter.
+ *
+ * @param $source
+ *   A string specifying the filepath or URI of the source file.
+ * @param $destination
+ *   A URI containing the destination that $source should be moved/copied to.
+ *   The URI may be a bare filepath (without a scheme) and in that case the
+ *   default scheme (file://) will be used. If this value is omitted, Drupal's
+ *   default files scheme will be used, usually "public://".
+ * @param $replace
+ *   Replace behavior when the destination file already exists:
+ *   - FILE_EXISTS_REPLACE - Replace the existing file.
+ *   - FILE_EXISTS_RENAME - Append _{incrementing number} until the filename is
+ *       unique.
+ *   - FILE_EXISTS_ERROR - Do nothing and return FALSE.
+ *
+ * @return
+ *   TRUE, or FALSE in the event of an error.
+ *
+ * @see file_unmanaged_copy()
+ * @see file_unmanaged_move()
+ */
+function file_unmanaged_prepare($source, &$destination = NULL, $replace = FILE_EXISTS_RENAME) {
   $original_source = $source;
 
   // Assert that the source file actually exists.
@@ -913,7 +960,6 @@ function file_unmanaged_copy($source, $destination = NULL, $replace = FILE_EXIST
   if (!isset($destination)) {
     $destination = file_build_uri(backdrop_basename($source));
   }
-
 
   // Prepare the destination directory.
   if (file_prepare_directory($destination)) {
@@ -949,20 +995,8 @@ function file_unmanaged_copy($source, $destination = NULL, $replace = FILE_EXIST
   }
   // Make sure the .htaccess files are present.
   file_ensure_htaccess();
-  // Perform the copy operation.
-  if (!@copy($source, $destination)) {
-    // If the copy failed and realpaths exist, retry the operation using them
-    // instead.
-    if ($real_source === FALSE || $real_destination === FALSE || !@copy($real_source, $real_destination)) {
-      watchdog('file', 'The specified file %file could not be copied to %destination.', array('%file' => $source, '%destination' => $destination), WATCHDOG_ERROR);
-      return FALSE;
-    }
-  }
 
-  // Set the permissions on the new file.
-  backdrop_chmod($destination);
-
-  return $destination;
+  return TRUE;
 }
 
 /**
@@ -1013,8 +1047,6 @@ function file_destination($destination, $replace) {
 /**
  * Moves a file to a new location and update the file's database entry.
  *
- * Moving a file is performed by copying the file to the new location and then
- * deleting the original.
  * - Checks if $source and $destination are valid and readable/writable.
  * - Performs a file move if $source is not equal to $destination.
  * - If file already exists in $destination either the call will error out,
@@ -1092,13 +1124,24 @@ function file_move(File $source, $destination = NULL, $replace = FILE_EXISTS_REN
 
 /**
  * Moves a file to a new location without database changes or hook invocation.
+ * This is a powerful function that in many ways performs like an advanced
+ * version of rename().
+ * - Checks if $source and $destination are valid and readable/writable.
+ * - Checks that $source is not equal to $destination; if they are an error
+ *   is reported.
+ * - If file already exists in $destination either the call will error out,
+ *   replace the file or rename the file based on the $replace parameter.
+ * - Works around a PHP 5.3 bug where rename() does not properly support streams
+ *   if safe_mode or open_basedir are enabled.
+ *   @see https://bugs.php.net/bug.php?id=60456
  *
  * @param $source
- *   A string specifying the filepath or URI of the original file.
+ *   A string specifying the filepath or URI of the source file.
  * @param $destination
- *   A string containing the destination that $source should be moved to.
- *   This must be a stream wrapper URI. If this value is omitted, Backdrop's
- *   default files scheme will be used, usually "public://".
+ *   A URI containing the destination that $source should be moved to. The
+ *   URI may be a bare filepath (without a scheme) and in that case the default
+ *   scheme (file://) will be used. If this value is omitted, Drupal's default
+ *   files scheme will be used, usually "public://".
  * @param $replace
  *   Replace behavior when the destination file already exists:
  *   - FILE_EXISTS_REPLACE - Replace the existing file.
@@ -1107,16 +1150,37 @@ function file_move(File $source, $destination = NULL, $replace = FILE_EXISTS_REN
  *   - FILE_EXISTS_ERROR - Do nothing and return FALSE.
  *
  * @return
- *   The URI of the moved file, or FALSE in the event of an error.
+ *   The path to the new file, or FALSE in the event of an error.
  *
  * @see file_move()
  */
 function file_unmanaged_move($source, $destination = NULL, $replace = FILE_EXISTS_RENAME) {
-  $filepath = file_unmanaged_copy($source, $destination, $replace);
-  if ($filepath == FALSE || file_unmanaged_delete($source) == FALSE) {
+  if (!file_unmanaged_prepare($source, $destination, $replace)) {
     return FALSE;
   }
-  return $filepath;
+  // Ensure compatibility with Windows.
+  // @see backdrop_unlink()
+  if ((substr(PHP_OS, 0, 3) == 'WIN') && (!file_stream_wrapper_valid_scheme(file_uri_scheme($source)))) {
+    chmod($source, 0600);
+  }
+  // Attempt to resolve the URIs. This is necessary in certain configurations
+  // (see above) and can also permit fast moves across local schemes.
+  $real_source = ($real_source = backdrop_realpath($source)) ? $real_source : $source;
+  $real_destination = ($real_destination = backdrop_realpath($destination)) ? $real_destination : $destination;
+  // Perform the move operation.
+  if (!@rename($real_source, $real_destination)) {
+    // Fall back to slow copy and unlink procedure. This is necessary for
+    // renames across schemes that are not local, or where rename() has not been
+    // implemented. It's not necessary to use drupal_unlink() as the Windows
+    // issue has already been resolved above.
+    if (!@copy($real_source, $real_destination) || !@unlink($real_source)) {
+      watchdog('file', 'The specified file %file could not be moved to %destination.', array('%file' => $source, '%destination' => $destination), WATCHDOG_ERROR);
+      return FALSE;
+    }
+  }
+  // Set the permissions on the new file.
+  backdrop_chmod($destination);
+  return $destination;
 }
 
 /**

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -946,12 +946,12 @@ function file_unmanaged_prepare($source, &$destination = NULL, $replace = FILE_E
   // Assert that the source file actually exists.
   if (!file_exists($source)) {
     // @todo Replace backdrop_set_message() calls with exceptions instead.
-    backdrop_set_message(t('The specified file %file could not be copied because no file by that name exists. Please check that you supplied the correct filename.', array('%file' => $original_source)), 'error');
+    backdrop_set_message(t('The specified file %file could not be moved/copied because no file by that name exists. Please check that you supplied the correct filename.', array('%file' => $original_source)), 'error');
     if (($realpath = backdrop_realpath($original_source)) !== FALSE) {
       watchdog('file', 'File %file (%realpath) could not be copied because it does not exist.', array('%file' => $original_source, '%realpath' => $realpath));
     }
     else {
-      watchdog('file', 'File %file could not be copied because it does not exist.', array('%file' => $original_source));
+      watchdog('file', 'File %file could not be moved/copied because it does not exist.', array('%file' => $original_source));
     }
     return FALSE;
   }
@@ -971,8 +971,8 @@ function file_unmanaged_prepare($source, &$destination = NULL, $replace = FILE_E
     $dirname = backdrop_dirname($destination);
     if (!file_prepare_directory($dirname)) {
       // The destination is not valid.
-      watchdog('file', 'File %file could not be copied because the destination directory %destination is not configured correctly.', array('%file' => $original_source, '%destination' => $dirname));
-      backdrop_set_message(t('The specified file %file could not be copied because the destination directory is not properly configured. This may be caused by a problem with file or directory permissions. More information is available in the system log.', array('%file' => $original_source)), 'error');
+      watchdog('file', 'File %file could not be moved/copied because the destination directory %destination is not configured correctly.', array('%file' => $original_source, '%destination' => $dirname));
+      backdrop_set_message(t('The specified file %file could not be moved/copied because the destination directory is not properly configured. This may be caused by a problem with file or directory permissions. More information is available in the system log.', array('%file' => $original_source)), 'error');
       return FALSE;
     }
   }
@@ -980,8 +980,8 @@ function file_unmanaged_prepare($source, &$destination = NULL, $replace = FILE_E
   // Determine whether we can perform this operation based on overwrite rules.
   $destination = file_destination($destination, $replace);
   if ($destination === FALSE) {
-    backdrop_set_message(t('The file %file could not be copied because a file by that name already exists in the destination directory.', array('%file' => $original_source)), 'error');
-    watchdog('file', 'File %file could not be copied because a file by that name already exists in the destination directory (%directory)', array('%file' => $original_source, '%directory' => $destination));
+    backdrop_set_message(t('The file %file could not be moved/copied because a file by that name already exists in the destination directory.', array('%file' => $original_source)), 'error');
+    watchdog('file', 'File %file could not be moved/copied because a file by that name already exists in the destination directory (%directory)', array('%file' => $original_source, '%directory' => $destination));
     return FALSE;
   }
 
@@ -989,8 +989,8 @@ function file_unmanaged_prepare($source, &$destination = NULL, $replace = FILE_E
   $real_source = backdrop_realpath($source);
   $real_destination = backdrop_realpath($destination);
   if ($source == $destination || ($real_source !== FALSE) && ($real_source == $real_destination)) {
-    backdrop_set_message(t('The specified file %file was not copied because it would overwrite itself.', array('%file' => $source)), 'error');
-    watchdog('file', 'File %file could not be copied because it would overwrite itself.', array('%file' => $source));
+    backdrop_set_message(t('The specified file %file was not moved/copied because it would overwrite itself.', array('%file' => $source)), 'error');
+    watchdog('file', 'File %file could not be moved/copied because it would overwrite itself.', array('%file' => $source));
     return FALSE;
   }
   // Make sure the .htaccess files are present.

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -925,7 +925,7 @@ function file_unmanaged_copy($source, $destination = NULL, $replace = FILE_EXIST
  * @param $destination
  *   A URI containing the destination that $source should be moved/copied to.
  *   The URI may be a bare filepath (without a scheme) and in that case the
- *   default scheme (file://) will be used. If this value is omitted, Drupal's
+ *   default scheme (file://) will be used. If this value is omitted, Backdrop's
  *   default files scheme will be used, usually "public://".
  * @param $replace
  *   Replace behavior when the destination file already exists:


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3459