### PR TITLE
Translated config for site_name, site_slogan, maintenance message, user mail messages

### DIFF
--- a/core/includes/ajax.inc
+++ b/core/includes/ajax.inc
@@ -589,7 +589,7 @@ function ajax_prepare_response($page_callback_result) {
         break;
 
       case MENU_SITE_OFFLINE:
-        $commands[] = ajax_command_alert(filter_xss_admin(token_replace(t(config_get('system.core', 'maintenance_mode_message')))));
+        $commands[] = ajax_command_alert(filter_xss_admin(token_replace(config_get_translated('system.core', 'maintenance_mode_message'))));
         break;
     }
   }

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -2997,7 +2997,7 @@ function backdrop_deliver_html_page($page_callback_result) {
         // Print a 503 page.
         backdrop_add_http_header('Status', '503 Service unavailable');
         backdrop_set_title(t('Site under maintenance'));
-        print theme('maintenance_page', array('content' => filter_xss_admin(token_replace(t(config_get('system.core', 'maintenance_mode_message'))))));
+        print theme('maintenance_page', array('content' => filter_xss_admin(token_replace(config_get_translated('system.core', 'maintenance_mode_message')))));
         break;
     }
   }

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2692,12 +2692,12 @@ function template_preprocess_page(&$variables) {
   if (backdrop_get_title()) {
     $head_title = array(
       'title' => strip_tags(backdrop_get_title()),
-      'name' => check_plain($site_config->get('site_name')),
+      'name' => check_plain($site_config->getTranslated('site_name')),
     );
   }
   else {
-    $head_title = array('name' => check_plain($site_config->get('site_name')));
-    if ($slogan = $site_config->get('site_slogan')) {
+    $head_title = array('name' => check_plain($site_config->getTranslated('site_name')));
+    if ($slogan = $site_config->getTranslated('site_slogan')) {
       $head_title['slogan'] = check_plain($slogan);
     }
   }
@@ -2792,8 +2792,8 @@ function template_preprocess_maintenance_page(&$variables) {
   // Load site config if available, fallback to the default.
   try {
     $site_config = config('system.core');
-    $site_name = filter_xss_admin($site_config->get('site_name'));
-    $site_slogan = filter_xss_admin($site_config->get('site_slogan'));
+    $site_name = filter_xss_admin($site_config->getTranslated('site_name'));
+    $site_slogan = filter_xss_admin($site_config->getTranslated('site_slogan'));
   }
   catch (ConfigException $e) {
     $site_name = 'Backdrop CMS';

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1828,7 +1828,7 @@ function comment_form($form, &$form_state, $comment) {
       '#default_value' => $author,
       '#maxlength' => 60,
       '#size' => 30,
-      '#description' => t('Leave blank for %anonymous.', array('%anonymous' => config_get('system.core', 'anonymous'))),
+      '#description' => t('Leave blank for %anonymous.', array('%anonymous' => config_get_translated('system.core', 'anonymous'))),
       '#autocomplete_path' => 'user/autocomplete',
     );
   }
@@ -2018,7 +2018,7 @@ function comment_preview($comment) {
       $comment->picture = $account->picture;
     }
     elseif (empty($comment->name)) {
-      $comment->name = config_get('system.core', 'anonymous');
+      $comment->name = config_get_translated('system.core', 'anonymous');
     }
 
     $comment->created = !empty($comment->created) ? $comment->created : REQUEST_TIME;
@@ -2106,7 +2106,7 @@ function comment_submit($comment) {
   // If the comment was posted by an anonymous user and no author name was
   // required, use "Anonymous" by default.
   if ($comment->is_anonymous && (!isset($comment->name) || $comment->name === '')) {
-    $comment->name = config_get('system.core', 'anonymous');
+    $comment->name = config_get_translated('system.core', 'anonymous');
   }
 
   // Validate the comment's subject. If not specified, extract from comment body.

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -2018,7 +2018,7 @@ function comment_preview($comment) {
       $comment->picture = $account->picture;
     }
     elseif (empty($comment->name)) {
-      $comment->name = config_get_translated('system.core', 'anonymous');
+      $comment->name = config_get('system.core', 'anonymous');
     }
 
     $comment->created = !empty($comment->created) ? $comment->created : REQUEST_TIME;
@@ -2106,7 +2106,7 @@ function comment_submit($comment) {
   // If the comment was posted by an anonymous user and no author name was
   // required, use "Anonymous" by default.
   if ($comment->is_anonymous && (!isset($comment->name) || $comment->name === '')) {
-    $comment->name = config_get_translated('system.core', 'anonymous');
+    $comment->name = config_get('system.core', 'anonymous');
   }
 
   // Validate the comment's subject. If not specified, extract from comment body.

--- a/core/modules/comment/comment.tokens.inc
+++ b/core/modules/comment/comment.tokens.inc
@@ -134,7 +134,7 @@ function comment_tokens($type, $tokens, array $data = array(), array $options = 
           break;
 
         case 'name':
-          $name = ($comment->uid == 0) ? config_get_translated('system.core', 'anonymous') : $comment->name;
+          $name = ($comment->uid == 0) ? config_get_translated('system.core', 'anonymous', array(), array('langcode' => $langcode)) : $comment->name;
           $replacements[$original] = $sanitize ? filter_xss($name) : $name;
           break;
 

--- a/core/modules/comment/comment.tokens.inc
+++ b/core/modules/comment/comment.tokens.inc
@@ -134,7 +134,7 @@ function comment_tokens($type, $tokens, array $data = array(), array $options = 
           break;
 
         case 'name':
-          $name = ($comment->uid == 0) ? config_get('system.core', 'anonymous') : $comment->name;
+          $name = ($comment->uid == 0) ? config_get_translated('system.core', 'anonymous') : $comment->name;
           $replacements[$original] = $sanitize ? filter_xss($name) : $name;
           break;
 

--- a/core/modules/comment/views/views_handler_argument_comment_user_uid.inc
+++ b/core/modules/comment/views/views_handler_argument_comment_user_uid.inc
@@ -14,7 +14,7 @@
 class views_handler_argument_comment_user_uid extends views_handler_argument {
   function title() {
     if (!$this->argument) {
-      $title = config_get('system.core', 'anonymous');
+      $title = config_get_translated('system.core', 'anonymous');
     }
     else {
       $title = db_query('SELECT u.name FROM {users} u WHERE u.uid = :uid', array(':uid' => $this->argument))->fetchField();

--- a/core/modules/contact/contact.module
+++ b/core/modules/contact/contact.module
@@ -250,7 +250,7 @@ function contact_show_personal_copy_checkbox() {
 function contact_mail($key, &$message, $params) {
   $language = $message['language'];
   $variables = array(
-    '!site-name' => config_get_translated('system.core', 'site_name', array(), array('langcode' => $language)),
+    '!site-name' => config_get_translated('system.core', 'site_name', array(), array('langcode' => $language->langcode)),
     '!subject' => $params['subject'],
     '!category' => isset($params['category']['category']) ? $params['category']['category'] : '',
     '!form-url' => url($_GET['q'], array('absolute' => TRUE, 'language' => $language)),

--- a/core/modules/contact/contact.module
+++ b/core/modules/contact/contact.module
@@ -250,7 +250,7 @@ function contact_show_personal_copy_checkbox() {
 function contact_mail($key, &$message, $params) {
   $language = $message['language'];
   $variables = array(
-    '!site-name' => config_get('system.core', 'site_name'),
+    '!site-name' => config_get_translated('system.core', 'site_name', array(), array('langcode' => $language)),
     '!subject' => $params['subject'],
     '!category' => isset($params['category']['category']) ? $params['category']['category'] : '',
     '!form-url' => url($_GET['q'], array('absolute' => TRUE, 'language' => $language)),

--- a/core/modules/file/file.pages.inc
+++ b/core/modules/file/file.pages.inc
@@ -89,7 +89,7 @@ function file_manage_form($form, &$form_state, File $file) {
   );
 
   // File user information for administrators.
-  $anonymous = config_get('system.core', 'anonymous');
+  $anonymous = config_get_translated('system.core', 'anonymous');
   $form['user'] = array(
     '#type' => 'fieldset',
     '#access' => user_access('administer files'),
@@ -105,7 +105,7 @@ function file_manage_form($form, &$form_state, File $file) {
         backdrop_get_path('module', 'file') . '/js/file.js',
         array(
           'type' => 'setting',
-          'data' => array('anonymous' => t($anonymous)),
+          'data' => array('anonymous' => $anonymous),
         ),
       ),
     ),

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2206,7 +2206,7 @@ function node_feed($nids = FALSE, $channel = array()) {
 
   $channel_defaults = array(
     'version'     => '2.0',
-    'title'       => config_get('system.core', 'site_name'),
+    'title'       => config_get_translated('system.core', 'site_name'),
     'link'        => $base_url,
     'description' => $rss_config->get('rss_description'),
     'language'    => $language_content->langcode
@@ -2296,7 +2296,7 @@ function node_page_default() {
       $build = node_view_multiple($nodes);
 
       // 'rss.xml' is a path, not a file, registered in node_menu().
-      backdrop_add_feed('rss.xml', $site_config->get('site_name') . ' ' . t('RSS'));
+      backdrop_add_feed('rss.xml', $site_config->getTranslated('site_name') . ' ' . t('RSS'));
       $build['pager'] = array(
         '#theme' => 'pager',
         '#weight' => 5,
@@ -2304,7 +2304,7 @@ function node_page_default() {
       backdrop_set_title('');
     }
     else {
-      backdrop_set_title(t('Welcome to @site-name', array('@site-name' => $site_config->get('site_name'))), PASS_THROUGH);
+      backdrop_set_title(t('Welcome to @site-name', array('@site-name' => $site_config->getTranslated('site_name'))), PASS_THROUGH);
 
       $default_message = '<p>' . t('No content has been promoted yet.') . '</p>';
       $default_links = array();

--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -279,7 +279,7 @@ function node_form($form, &$form_state, Node $node) {
     '#autocomplete_path' => 'user/autocomplete',
     '#default_value' => !empty($node->name) ? $node->name : '',
     '#weight' => -1,
-    '#description' => t('Leave blank for %anonymous.', array('%anonymous' => $config->get('anonymous'))),
+    '#description' => t('Leave blank for %anonymous.', array('%anonymous' => $config->getTranslated('anonymous'))),
   );
   $form['author']['date'] = array(
     '#type' => module_exists('date') ? 'date_popup' : 'textfield',

--- a/core/modules/simpletest/tests/bootstrap.test
+++ b/core/modules/simpletest/tests/bootstrap.test
@@ -346,7 +346,7 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
     $this->backdropGet($test_path);
     $this->assertEqual($this->backdropGetHeader('X-Backdrop-Cache'), 'HIT', 'Page was cached.');
     $this->assertFalse($this->backdropGetHeader('Content-Encoding'), 'A Content-Encoding header was not sent.');
-    $this->assertTitle(t('Hello world! | @site-name', array('@site-name' => config_get('system.core', 'site_name'))), 'Site title matches.');
+    $this->assertTitle(t('Hello world! | @site-name', array('@site-name' => config_get_translated('system.core', 'site_name'))), 'Site title matches.');
     $this->assertRaw('</html>', 'Page was not compressed.');
 
     // Disable compression mode.

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1012,7 +1012,7 @@ class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
     $result = backdrop_http_request(url('node', array('absolute' => TRUE)));
     $this->assertEqual($result->code, 200, 'Fetched page successfully.');
     $this->backdropSetContent($result->data);
-    $this->assertTitle(t('Home | @site-name', array('@site-name' => config_get('system.core', 'site_name'))), 'Site title matches.');
+    $this->assertTitle(t('Home | @site-name', array('@site-name' => config_get_translated('system.core', 'site_name'))), 'Site title matches.');
 
     // Test that code and status message is returned.
     $result = backdrop_http_request(url('pagedoesnotexist', array('absolute' => TRUE)));

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -189,7 +189,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
     $this->backdropLogout();
 
     // Make sure the maintenance mode can be bypassed using hook_menu_site_status_alter().
-    $offline_message = t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => config_get('system.core', 'site_name')));
+    $offline_message = t('@site is currently under maintenance. We should be back shortly. Thank you for your patience.', array('@site' => config_get_translated('system.core', 'site_name')));
     $this->backdropGet('node');
     $this->assertText($offline_message);
     $this->backdropGet('menu_login_callback');

--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -106,8 +106,8 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
 
     // Generate and test sanitized tokens.
     $tests = array();
-    $tests['[site:name]'] = check_plain(config_get('system.core', 'site_name'));
-    $tests['[site:slogan]'] = check_plain(config_get('system.core', 'site_slogan'));
+    $tests['[site:name]'] = check_plain(config_get_translated('system.core', 'site_name'));
+    $tests['[site:slogan]'] = check_plain(config_get_translated('system.core', 'site_slogan'));
     $tests['[site:mail]'] = 'simpletest@example.com';
     $tests['[site:url]'] = url('<front>', $url_options);
     $tests['[site:url-brief]'] = preg_replace(array('!^https?://!', '!/$!'), '', url('<front>', $url_options));
@@ -123,8 +123,8 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
     }
 
     // Generate and test unsanitized tokens.
-    $tests['[site:name]'] = config_get('system.core', 'site_name');
-    $tests['[site:slogan]'] = config_get('system.core', 'site_slogan');
+    $tests['[site:name]'] = config_get_translated('system.core', 'site_name');
+    $tests['[site:slogan]'] = config_get_translated('system.core', 'site_slogan');
 
     foreach ($tests as $input => $expected) {
       $output = token_replace($input, array(), array('language' => $language, 'sanitize' => FALSE));

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -1,6 +1,12 @@
 {
     "_config_name": "system.performance",
     "_config_static": true,
+    "_config_translatables": [
+        "anonymous",
+        "site_name",
+        "site_slogan",
+        "maintenance_mode_message"
+    ],
     "action_recursion_limit": 35,
     "active_menus_default": [],
     "admin_theme": "",

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -3618,7 +3618,7 @@ function hook_tokens($type, $tokens, array $data = array(), array $options = arr
 
         // Default values for the chained tokens handled below.
         case 'author':
-          $name = ($node->uid == 0) ? config_get('system.core', 'anonymous') : $node->name;
+          $name = ($node->uid == 0) ? config_get_translated('system.core', 'anonymous') : $node->name;
           $replacements[$original] = $sanitize ? filter_xss($name) : $name;
           break;
 

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3181,8 +3181,8 @@ function system_header_block($settings) {
   $site_config = config('system.core');
   $variables['logo']        = $settings['logo'] ? backdrop_get_logo() : NULL;
   $variables['logo_attributes'] = $settings['logo'] ? array_diff_key(backdrop_get_logo_info(), array('path' => '')) : array();
-  $variables['site_name']   = $settings['site_name'] ? check_plain($site_config->get('site_name')) : '';
-  $variables['site_slogan'] = $settings['site_slogan'] ? filter_xss_admin($site_config->get('site_slogan')) : '';
+  $variables['site_name']   = $settings['site_name'] ? check_plain($site_config->getTranslated('site_name')) : '';
+  $variables['site_slogan'] = $settings['site_slogan'] ? filter_xss_admin($site_config->getTranslated('site_slogan')) : '';
   $variables['menu']        = $menu ? theme('links__header_menu', array('links' => $menu)) : NULL;
 
   return theme('header', $variables);

--- a/core/modules/system/system.tokens.inc
+++ b/core/modules/system/system.tokens.inc
@@ -290,12 +290,12 @@ function system_tokens($type, $tokens, array $data = array(), array $options = a
     foreach ($tokens as $name => $original) {
       switch ($name) {
         case 'name':
-          $site_name = config_get('system.core', 'site_name');
+          $site_name = config_get_translated('system.core', 'site_name');
           $replacements[$original] = $sanitize ? check_plain($site_name) : $site_name;
           break;
 
         case 'slogan':
-          $slogan = config_get('system.core', 'site_slogan');
+          $slogan = config_get_translated('system.core', 'site_slogan');
           $replacements[$original] = $sanitize ? check_plain($slogan) : $slogan;
           break;
 

--- a/core/modules/taxonomy/taxonomy.pages.inc
+++ b/core/modules/taxonomy/taxonomy.pages.inc
@@ -79,7 +79,7 @@ function taxonomy_term_page(TaxonomyTerm $term) {
  */
 function taxonomy_term_feed(TaxonomyTerm $term) {
   $channel['link'] = url('taxonomy/term/' . $term->tid, array('absolute' => TRUE));
-  $channel['title'] = config_get('system.core', 'site_name') . ' - ' . $term->name;
+  $channel['title'] = config_get_translated('system.core', 'site_name') . ' - ' . $term->name;
   // Only display the description if we have a single term, to avoid clutter and confusion.
   // HTML will be removed from feed description.
   $channel['description'] = check_markup($term->description, $term->format, '', TRUE);

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -445,7 +445,7 @@ function _update_get_cached_available_releases() {
 function update_mail($key, &$message, $params) {
   $language = $message['language'];
   $langcode = $language->langcode;
-  $message['subject'] .= t('New release(s) available for !site_name', array('!site_name' => config_get('system.core', 'site_name')), array('langcode' => $langcode));
+  $message['subject'] .= t('New release(s) available for !site_name', array('!site_name' => config_get_translated('system.core', 'site_name'), array(), array('langcode' => $langcode)), array('langcode' => $langcode));
   foreach ($params as $msg_type => $msg_reason) {
     $message['body'][] = _update_message_text($msg_type, $msg_reason, FALSE, $language);
   }

--- a/core/modules/user/config/user.mail.json
+++ b/core/modules/user/config/user.mail.json
@@ -1,5 +1,23 @@
 {
     "_config_name": "user.mail",
+    "_config_translatables": [
+        "cancel_confirm_body",
+        "cancel_confirm_subject",
+        "password_reset_body",
+        "password_reset_subject",
+        "register_admin_created_body",
+        "register_admin_created_subject",
+        "register_no_approval_required_body",
+        "register_no_approval_required_subject",
+        "register_pending_approval_body",
+        "register_pending_approval_subject",
+        "status_activated_body",
+        "status_activated_subject",
+        "status_blocked_body",
+        "status_blocked_subject",
+        "status_canceled_body",
+        "status_canceled_subject"
+    ],
     "cancel_confirm_body": "[user:name],\n\nA request to cancel your account has been made at [site:name].\n\nYou may now cancel your account on [site:url:brief] by clicking this link or copying and pasting it into your browser:\n\n[user:cancel-url]\n\nNOTE: The cancellation of your account is not reversible.\n\nThis link expires in one day and nothing will happen if it is not used.\n\n--  [site:name] team",
     "cancel_confirm_subject": "Account cancellation request for [user:name] at [site:name]",
     "password_reset_body": "[user:name],\n\nA request to reset the password for your account has been made at [site:name].\n\nYou may now reset your password by clicking this link or copying and pasting it to your browser:\n\n[user:one-time-login-url]\n\nThis link can only be used once and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it is not used.\n\n--  [site:name] team",

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -539,7 +539,7 @@ function user_permission() {
     ),
     'cancel account' => array(
       'title' => t('Cancel own user account'),
-      'description' => t('Note: content may be kept, unpublished, deleted or transferred to the %anonymous-name user depending on the configured <a href="@user-settings-url">user settings</a>.', array('%anonymous-name' => config_get('system.core', 'anonymous'), '@user-settings-url' => url('admin/config/people/settings'))),
+      'description' => t('Note: content may be kept, unpublished, deleted or transferred to the %anonymous-name user depending on the configured <a href="@user-settings-url">user settings</a>.', array('%anonymous-name' => config_get_translated('system.core', 'anonymous'), '@user-settings-url' => url('admin/config/people/settings'))),
     ),
     'select account cancellation method' => array(
       'title' => t('Select method for cancelling own account'),
@@ -2184,7 +2184,7 @@ function _user_mail_text($key, $language = NULL, $variables = array()) {
 
   // We do not sanitize the token replacement, since the output of this
   // replacement is intended for an email message, not a web browser.
-  return token_replace(config('user.mail')->get($key), $variables, array('langcode' => $langcode, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
+  return token_replace(config('user.mail')->getTranslated($key, array(), array('langcode' => $langcode)), $variables, array('langcode' => $langcode, 'callback' => 'user_mail_tokens', 'sanitize' => FALSE, 'clear' => TRUE));
 }
 
 /**

--- a/core/modules/views/includes/ajax.inc
+++ b/core/modules/views/includes/ajax.inc
@@ -164,7 +164,7 @@ function views_ajax_command_replace_title($title) {
   $command = array(
     'command' => 'viewsReplaceTitle',
     'title' => $title,
-    'siteName' => config_get('system.core', 'site_name'),
+    'siteName' => config_get_translated('system.core', 'site_name'),
   );
   return $command;
 }

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -973,7 +973,7 @@ function template_preprocess_views_view_rss(&$variables) {
   if ($view->display_handler->get_option('sitename_title')) {
     $site_config = config('system.core');
     $title = $site_config->get('site_name');
-    if ($slogan = $site_config->get('site_slogan')) {
+    if ($slogan = $site_config->getTranslated('site_slogan')) {
       $title .= ' - ' . $slogan;
     }
   }


### PR DESCRIPTION
Addresses https://github.com/backdrop/backdrop-issues/issues/3455

This is only partial. Would also need to add config variables in update hook. And need to decide if we want the config translatables array by default in the config files.