### PR TITLE
Issue #2999: Date format labels should read Configure not Edit.

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -2279,7 +2279,7 @@ function system_date_time_formats() {
         // Prepare Operational links.
         $links = array();
         $links['edit'] = array(
-          'title' => t('Edit'),
+          'title' => t('Configure'),
           'href' => 'admin/config/regional/date-time/formats/' . $date_format_name . '/edit',
         );
         if (module_exists('locale')) {

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1330,7 +1330,7 @@ class DateTimeFunctionalTest extends BackdropWebTestCase {
 
     // Edit custom date format.
     $this->backdropGet('admin/config/regional/date-time/formats');
-    $this->clickLink(t('Edit'));
+    $this->clickLink(t('Configure'));
     $edit = array(
       'pattern' => 'Y m',
     );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2999