### PR TITLE
Issue #1579: Use saveXML() instead of saveHTML() when saving image captions

### DIFF
--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -2458,7 +2458,7 @@ function _filter_image_caption($text) {
     $attributes['class'][] = 'caption-' . $node->tagName;
 
     $theme_parameters = array(
-      'item' => $node->ownerDocument->saveHTML($node),
+      'item' => $node->ownerDocument->saveXML($node),
       'tag' => $tag,
       'caption' => $caption,
       'attributes' => $attributes,


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/1579