### PR TITLE
Issue 1294: exclude .tests.info when using updater

### DIFF
--- a/core/includes/updater.inc
+++ b/core/includes/updater.inc
@@ -144,6 +144,11 @@ abstract class Updater implements BackdropUpdaterInterface {
       return FALSE;
     }
     foreach ($info_files as $info_file) {
+      // Exclude info files for tests.
+      if (backdrop_substr($info_file->filename, -10) == 'tests.info') {
+        unset($info_files[$info_file->uri]);
+        continue;
+      }
       if (backdrop_substr($info_file->filename, 0, -5) == backdrop_basename($directory)) {
         // Info file Has the same name as the directory, return it.
         return $info_file->uri;

--- a/core/includes/updater.inc
+++ b/core/includes/updater.inc
@@ -145,7 +145,7 @@ abstract class Updater implements BackdropUpdaterInterface {
     }
     foreach ($info_files as $info_file) {
       // Exclude info files for tests.
-      if (backdrop_substr($info_file->filename, -10) == 'tests.info') {
+      if (backdrop_substr($info_file->filename, -11) == '.tests.info') {
         unset($info_files[$info_file->uri]);
         continue;
       }


### PR DESCRIPTION
Addresses https://github.com/backdrop/backdrop-issues/issues/1294