### PR TITLE
Add conditional translation to the node block

### DIFF
--- a/core/modules/node/node.block.inc
+++ b/core/modules/node/node.block.inc
@@ -23,7 +23,14 @@ class NodeBlock extends Block {
    */
   function getTitle() {
     $title = NULL;
-    $node = node_load($this->settings['nid']);
+
+    // Look for and load translated node if translations are available.
+    if (module_exists('translation')) {
+      $node = $this->loadTranslatedNode();
+    } else {
+      $node = node_load($this->settings['nid']);
+    }
+
     if ($this->settings['title_display'] === LAYOUT_TITLE_CUSTOM && $this->settings['title']) {
       $title = check_plain($this->settings['title']);
     }
@@ -45,7 +52,12 @@ class NodeBlock extends Block {
    *  Sets block content on block view.
    */
   function getContent() {
-    $node = node_load($this->settings['nid']);
+    // Look for and load translated node if translations are available.
+    if (module_exists('translation')) {
+      $node = $this->loadTranslatedNode();
+    } else {
+      $node = node_load($this->settings['nid']);
+    }
 
     // Prevent display of no access to the node.
     if (!node_access('view', $node)) {
@@ -76,6 +88,24 @@ class NodeBlock extends Block {
     $content['#theme'] = 'node__block-' . $this->settings['nid'];
 
     return $content;
+  }
+
+  function loadTranslatedNode() {
+    global $language;
+
+    $node = node_load($this->settings['nid']);
+
+    if (!empty($node->tnid) && !empty($node->langcode)) {
+      $translations = translation_node_get_translations($node->tnid);
+
+      foreach ($translations as $code => $translation) {
+        if ($code == $language->langcode) {
+          return node_load($translation->nid);
+        }
+      }
+    }
+
+    return $node;
   }
 
   /**

--- a/core/modules/node/node.block.inc
+++ b/core/modules/node/node.block.inc
@@ -25,7 +25,7 @@ class NodeBlock extends Block {
     $title = NULL;
 
     // Look for and load translated node if translations are available.
-    if (module_exists('translation')) {
+    if (module_exists('translation') && !empty($this->settings['translate'])) {
       $node = $this->loadTranslatedNode();
     } else {
       $node = node_load($this->settings['nid']);
@@ -53,7 +53,7 @@ class NodeBlock extends Block {
    */
   function getContent() {
     // Look for and load translated node if translations are available.
-    if (module_exists('translation')) {
+    if (module_exists('translation') && !empty($this->settings['translate'])) {
       $node = $this->loadTranslatedNode();
     } else {
       $node = node_load($this->settings['nid']);
@@ -181,6 +181,14 @@ class NodeBlock extends Block {
       '#default_value' => !empty($settings['links']),
       '#title' => t('Include the links "add comment", "read more" etc.'),
     );
+
+    if (module_exists('translation')) {
+      $form['translate'] = array(
+        '#type' => 'checkbox',
+        '#default_value' => !empty($settings['translate']),
+        '#title' => t('Automatically load translated version of the content'),
+      );
+    }
   }
 
   /**
@@ -218,5 +226,6 @@ class NodeBlock extends Block {
     $this->settings['link_node_title'] = (bool) $form_state['values']['link_node_title'];
     $this->settings['display_submitted'] = (bool) $form_state['values']['display_submitted'];
     $this->settings['view_mode'] = (string) $form_state['values']['view_mode'];
+    $this->settings['translate'] = (bool) $form_state['values']['translate'];
   }
 }

--- a/core/modules/node/node.block.inc
+++ b/core/modules/node/node.block.inc
@@ -186,7 +186,7 @@ class NodeBlock extends Block {
       $form['translate'] = array(
         '#type' => 'checkbox',
         '#default_value' => !empty($settings['translate']),
-        '#title' => t('Automatically load translated version of the content'),
+        '#title' => t('Load translated version of the content if available'),
       );
     }
   }

--- a/core/modules/node/node.block.inc
+++ b/core/modules/node/node.block.inc
@@ -226,6 +226,8 @@ class NodeBlock extends Block {
     $this->settings['link_node_title'] = (bool) $form_state['values']['link_node_title'];
     $this->settings['display_submitted'] = (bool) $form_state['values']['display_submitted'];
     $this->settings['view_mode'] = (string) $form_state['values']['view_mode'];
-    $this->settings['translate'] = (bool) $form_state['values']['translate'];
+    if (module_exists('translation')) {
+      $this->settings['translate'] = (bool) $form_state['values']['translate'];
+    }
   }
 }

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -2445,6 +2445,106 @@ class NodeBlockFunctionalTest extends BackdropWebTestCase {
 }
 
 /**
+ * Test translation settings on existing content block.
+ */
+class NodeTranslateBlockFunctionalTest extends BackdropWebTestCase {
+
+  function setUp() {
+    parent::setUp('node', 'block', 'locale', 'language', 'translation');
+
+    // Create users and test node.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'administer content types',
+      'administer nodes',
+      'administer blocks',
+      'administer layouts',
+      'translate content',
+      'administer languages',
+      'access content',
+      'create page content',
+    ));
+
+    // Delete the two default nodes.
+    node_delete_multiple(array(1, 2));
+  }
+
+  /**
+   * Tests the Existing content block.
+   */
+  function testNodeTranslateBlock() {
+    $this->backdropLogin($this->admin_user);
+
+    $langcode = 'es';
+    // Add languages.
+    $edit['predefined_langcode'] = $langcode;
+    $this->backdropPost('admin/config/regional/language/add', $edit, t('Add language'));
+
+    // Set "Page" content type to use multilingual support with
+    // translation.
+    $this->backdropGet('admin/structure/types/manage/page');
+    $edit = array();
+    $edit['language'] = TRANSLATION_ENABLED;
+    $this->backdropPost('admin/structure/types/manage/page', $edit, t('Save content type'));
+    $this->assertRaw(t('The content type %type has been updated.', array('%type' => 'Page')), 'Page content type has been updated.');
+
+    // Add some test nodes.
+    $node1_settings = array('uid' => $this->admin_user->uid, 'type' => 'page');
+    $node1 = $this->backdropCreateNode($node1_settings);
+
+    // Add node in default language.
+    $field_langcode = LANGUAGE_NONE;
+    $title_en = 'English title';
+    $node2_settings["title"] = $title_en;
+    $node2_settings["body[$field_langcode][0][value]"] = 'English. Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+    $node2_settings['langcode'] = 'en';
+
+    $this->backdropPost('node/add/page', $node2_settings, t('Save'));
+    $node2 = $this->backdropGetNodeByTitle($title_en);
+
+    // Add translated node.
+    $this->backdropGet('node/add/page', array('query' => array('translation' => $node2->nid, 'target' => $langcode)));
+
+    $title_es = 'Título en español';
+    $node3_settings["title"] = $title_es;
+    $node3_settings["body[$field_langcode][0][value]"] = 'Spanish. Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+    $node2_settings['langcode'] = $langcode;
+    $this->backdropPost(NULL, $node3_settings, t('Save'));
+    $node3 = $this->backdropGetNodeByTitle($title_es);
+
+    $this->assertRaw(t('Page %title has been created.', array('%title' => $node3->title)), 'Translation created.');
+
+    // Check that $node2 does not appear on $node1 path.
+    $this->backdropGet('node/' . $node1->nid);
+    $this->assertNoText($node2->title, t('Node 2 title not found on Node 1.'));
+
+    // Add an Existing content block with default settings.
+    $this->backdropGet('admin/structure/layouts/manage/default');
+    $this->clickLink(t('Add block'), 3);
+    $this->clickLink(t('Existing content'));
+    $edit = array(
+      'nid' => $node2->nid,
+      'leave_node_title' => TRUE,
+      'link_node_title' => TRUE,
+      'links' => TRUE,
+      'translate' => TRUE,
+    );
+    $this->backdropPost(NULL, $edit, t('Add block'));
+    $this->backdropPost(NULL, array(), t('Save layout'));
+
+    $this->backdropGet('node/' . $node1->nid);
+
+    // Check the title is in English.
+    $this->assertText('English title', 'The English node appears on the page.');
+
+    // Switch language
+    $this->backdropGet('es/node/' . $node1->nid);
+
+    // Check that translated node appears.
+    $this->assertText('Título en español', 'The translated node appears on the page.');
+  }
+}
+
+/**
  * Test to ensure that a node's content is always rebuilt.
  */
 class NodeBuildContent extends BackdropWebTestCase {


### PR DESCRIPTION
This PR contains two commits, the first one is to automatically load translations of nodes in the existing content block if the translation module and a translation of the node is available, the second adds an option for site builders to disable the feature on a per-block basis.

As discussed in backdrop/backdrop-issues#3464