### PR TITLE
Issue #3516: Make the 'Formatting options' link less distracting.

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -837,9 +837,11 @@ td.checkbox .form-item input {
 
 /* Filter */
 .filter-wrapper {
-  border-top: 0;
   padding: 10px 2px;
   background-color: #f8f8f8;
+  border: 1px #d1d1d1;
+  border-style: none solid solid solid;
+  border-radius: 0;
 }
 .js fieldset.filter-wrapper.collapsed {
   padding: 1.2em 0;

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -694,6 +694,9 @@ fieldset .fieldset-wrapper {
   background-image: none;
   padding: .3em 1.8em .3em .3em;
 }
+.js fieldset.collapsible .fieldset-legend {
+  font-size: 16px;
+}
 .js fieldset.collapsible .fieldset-legend a:before {
   content: "";
   position: absolute;
@@ -836,10 +839,18 @@ td.checkbox .form-item input {
 .filter-wrapper {
   border-top: 0;
   padding: 10px 2px;
+  background-color: #f8f8f8;
+}
+.js fieldset.filter-wrapper.collapsed {
+  padding: 1.2em 0;
+}
+.js fieldset.filter-wrapper.collapsible .fieldset-legend {
+  font-size: 16px;
+  text-transform: none;
 }
 .filter-wrapper .fieldset-wrapper {
-  padding: 0 6px;
-  margin-top: 45px;
+  padding: 0 34px;
+  margin-top: 30px;
 }
 .filter-wrapper .form-item,
 .filter-wrapper .filter-guidelines,

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -646,12 +646,12 @@ fieldset .fieldset-legend {
   top: 0;
   width: 100%;
   margin-top: .25em;
-  padding-left: 15px; /* LTR */
+  padding-left: 1em; /* LTR */
   text-transform: uppercase;
 }
 [dir="rtl"] fieldset .fieldset-legend {
   right: 0;
-  padding-right: 15px;
+  padding-right: 1em;
   padding-left: 0;
 }
 legend {
@@ -695,7 +695,7 @@ fieldset .fieldset-wrapper {
   padding: .3em 1.8em .3em .3em;
 }
 .js fieldset.collapsible .fieldset-legend {
-  font-size: 16px;
+  font-size: 1em;
 }
 .js fieldset.collapsible .fieldset-legend a:before {
   content: "";
@@ -847,11 +847,11 @@ td.checkbox .form-item input {
   padding: 1.2em 0;
 }
 .js fieldset.filter-wrapper.collapsible .fieldset-legend {
-  font-size: 16px;
+  font-size: .8333em;
   text-transform: none;
 }
 .filter-wrapper .fieldset-wrapper {
-  padding: 0 34px;
+  padding: .6em 2.3em;
   margin-top: 30px;
 }
 .filter-wrapper .form-item,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3516

Before: 
<img width="770" alt="screen shot 2019-02-03 at 1 08 06 am" src="https://user-images.githubusercontent.com/397895/52174947-44ffea00-2750-11e9-9bfa-56e0ebab2d4b.png">

After:
<img width="632" alt="screen shot 2019-02-03 at 1 07 08 am" src="https://user-images.githubusercontent.com/397895/52174949-492c0780-2750-11e9-845f-4a90e4dacca9.png">

