### PR TITLE
 Issue #3364: Backdrop Install.php shows "Backdrop already installed" when database credentials are incorrect.

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -283,7 +283,8 @@ function install_begin_request(&$install_state) {
   backdrop_maintenance_theme();
 
   // Check existing settings.php.
-  $install_state['settings_verified'] = install_verify_settings();
+  $settings_errors = array();
+  $install_state['settings_verified'] = install_verify_settings($settings_errors);
 
   if ($install_state['settings_verified']) {
     // Initialize the database system. Note that the connection
@@ -292,6 +293,10 @@ function install_begin_request(&$install_state) {
 
     // Verify the last completed task in the database, if there is one.
     $task = install_verify_completed_task();
+  }
+  elseif ($settings_errors) {
+    $task = NULL;
+    throw new Exception(install_database_connection_error($settings_errors));
   }
   else {
     $task = NULL;
@@ -893,21 +898,26 @@ function install_verify_database_utf8mb4() {
 
 /**
  * Verifies the existing settings in settings.php.
+ *
+ * @return array
+ *   An array of errors that will be populated with any problems.
  */
-function install_verify_settings() {
+function install_verify_settings(&$errors) {
   global $databases;
+  $errors = array();
 
   // Verify existing settings (if any).
-  if (!empty($databases) && install_verify_pdo()) {
+  if (!install_verify_pdo()) {
+    $errors['pdo_missing'] = st('The required extension "PDO" is either not installed on this system or is not compatible with Backdrop.');
+  }
+  elseif (!empty($databases)) {
     $database = $databases['default']['default'];
     backdrop_static_reset('conf_path');
     $settings_file = conf_path(FALSE) . '/settings.php';
     $errors = install_database_errors($database, $settings_file);
-    if (empty($errors)) {
-      return TRUE;
-    }
   }
-  return FALSE;
+
+  return empty($errors);
 }
 
 /**
@@ -1457,6 +1467,17 @@ function install_select_language_form($form, &$form_state, $files) {
 function install_no_profile_error() {
   backdrop_set_title(st('No profiles available'));
   return st('We were unable to find any installation profiles. Installation profiles tell us what modules to enable and what schema to install in the database. A profile is necessary to continue with the installation process.');
+}
+
+/**
+ * Indicates a database connection error.
+ */
+function install_database_connection_error($errors = array()) {
+  backdrop_set_title(st('Database connection error'));
+
+  $output = '<p>' . st('It looks like your settings.php database connection may be incorrect.') . '</p>';
+  $output .= implode("\n", $errors);
+  return $output;
 }
 
 /**


### PR DESCRIPTION
Replacing https://github.com/backdrop/backdrop/pull/2478 after it was reverted.

Note the main problem with this previously was that it broke the preview sandboxes. So we need to ensure that a sandbox is generated correctly by the `backdrop-ci` user in the comments below.