### PR TITLE
Issue #2052: Let File entity handle deletion of non-existent files.

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3578,12 +3578,7 @@ function system_cron() {
     if ($file = file_load($row->fid)) {
       $references = file_usage_list($file);
       if (empty($references)) {
-        if (file_exists($file->uri)) {
-          $file->delete();
-        }
-        else {
-          watchdog('file system', 'Could not delete temporary file "%path" during garbage collection', array('%path' => $file->uri), WATCHDOG_ERROR);
-        }
+        $file->delete();
       }
       else {
         watchdog('file system', 'Did not delete temporary file "%path" during garbage collection because it is in use by the following modules: %modules.', array('%path' => $file->uri, '%modules' => implode(', ', array_keys($references))), WATCHDOG_INFO);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2052

Removed the file_exists() test from system_cron() file garbage collection. The File entity will clean up the file entries whether the file exists or not.