### PR TITLE
Issue #3557: [PHP 7.3] strpos explicit string needle warnings

### DIFF
--- a/core/modules/field/modules/number/tests/number.test
+++ b/core/modules/field/modules/number/tests/number.test
@@ -62,7 +62,7 @@ class NumberFieldTestCase extends BackdropWebTestCase {
     preg_match('|test-entity/manage/(\d+)/edit|', $this->url, $match);
     $id = $match[1];
     $this->assertRaw(t('test_entity @id has been created.', array('@id' => $id)), 'Entity was created');
-    $this->assertRaw(round($value, 2), 'Value is displayed.');
+    $this->assertRaw($value, 'Value is displayed.');
 
     // Try to create entries with more than one decimal separator; assert fail.
     $wrong_entries = array(

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -3174,7 +3174,7 @@ class BackdropWebTestCase extends BackdropTestCase {
     if (!$message) {
       $message = t('Raw "@raw" found', array('@raw' => $raw));
     }
-    return $this->assert(strpos($this->backdropGetContent(), $raw) !== FALSE, $message, $group);
+    return $this->assert(strpos($this->backdropGetContent(), (string) $raw) !== FALSE, $message, $group);
   }
 
   /**
@@ -3194,7 +3194,7 @@ class BackdropWebTestCase extends BackdropTestCase {
     if (!$message) {
       $message = t('Raw "@raw" not found', array('@raw' => $raw));
     }
-    return $this->assert(strpos($this->backdropGetContent(), $raw) === FALSE, $message, $group);
+    return $this->assert(strpos($this->backdropGetContent(), (string) $raw) === FALSE, $message, $group);
   }
 
   /**


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3557

https://www.drupal.org/node/3020771

When the test suite is run on PHP 7.3, there is a warning due to changes in PHP 7.3:

```
exception: [Deprecated] Line 3015 of modules/simpletest/drupal_web_test_case.php:
strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior
```

If the second parameter (needle) of the `strpos` call is an integer, PHP uses the `chr()` value of that integer, which is likely not the intended behavior. Because of this, PHP now warnings when it sees an integer. The caller is now responsible to call `chr()` if intended.