### PR TITLE
Issue #3557: Ignore node_module folder in core to use Backdrop with npm/grunt/nodejs

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -2246,7 +2246,7 @@ function file_scan_directory($dir, $mask, $options = array(), $depth = 0) {
     }
 
     if (!empty($ignore_directories)) {
-      $nomask = '/^(\.\.?)|CVS|' . implode('|', $ignore_directories) . '$/';
+      $nomask = '/^((\.\.?)|CVS|' . implode('|', $ignore_directories) . ')$/';
     }
   }
 

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -2227,12 +2227,28 @@ function file_download_access($uri) {
  *   'filename', and 'name' members corresponding to the matching files.
  */
 function file_scan_directory($dir, $mask, $options = array(), $depth = 0) {
-  // By default, do not check for files in common special-purpose directories.
-  $ignore_directories = array(
-    'node_modules',
-    'bower_components',
-  );
-  $no_mask = '/^((\..*)|' . implode('|', $ignore_directories) .  ')$/';
+  // Default nomask option.
+  $nomask = '/(\.\.?|CVS)$/';
+
+  // Overrides the $nomask variable accordingly if $options['nomask'] is set.
+  //
+  // Allow directories specified in settings.php to be ignored. You can use this
+  // to not check for files in common special-purpose directories. For example,
+  // node_modules and bower_components. Ignoring irrelevant directories is a
+  // performance boost.
+  if (!isset($options['nomask'])) {
+    $ignore_directories = config_get('system.core', 'file_scan_ignore_directories');
+
+    if (!empty($ignore_directories)) {
+      foreach ($ignore_directories as $index => $ignore_directory) {
+        $ignore_directories[$index] = preg_quote($ignore_directory, '/');
+      }
+    }
+
+    if (!empty($ignore_directories)) {
+      $nomask = '/^(\.\.?)|CVS|' . implode('|', $ignore_directories) . '$/';
+    }
+  }
 
   // Merge in defaults.
   $options += array(

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -20,6 +20,10 @@
     "file_default_scheme": "public",
     "file_private_path": "",
     "file_public_path": "files",
+    "file_scan_ignore_directories": [
+        "node_modules",
+        "bower_components"
+    ],
     "file_temporary_path": "",
     "file_transliterate_lowercase": 0,
     "file_transliterate_uploads": 1,

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3039,6 +3039,17 @@ function system_update_1067() {
 }
 
 /**
+ * Convert the file_scan_ignore_directories variable to use configuration.
+ */
+function system_update_1068() {
+  $config = config('system.core');
+  $config->set('file_scan_ignore_directories', update_variable_get('file_scan_ignore_directories', array()));
+  $config->save();
+
+  update_variable_del('file_scan_ignore_directories');
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3043,7 +3043,7 @@ function system_update_1067() {
  */
 function system_update_1068() {
   $config = config('system.core');
-  $config->set('file_scan_ignore_directories', update_variable_get('file_scan_ignore_directories', array()));
+  $config->set('file_scan_ignore_directories', update_variable_get('file_scan_ignore_directories', array('node_modules', 'bower_components')));
   $config->save();
 
   update_variable_del('file_scan_ignore_directories');


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3557

http://drupal.org/node/2482549

**Problem/Motivation**
Drupal crashes with a segfault when doing a file scan and the the source contains a npm/grunt/nodejs source folder (node_modules). This is probably due to the many folder nesting of npm:
https://drupal.stackexchange.com/questions/126880/how-do-i-prevent-drupal-raising-a-segmentation-fault-when-using-a-node-js-themin

**Proposed resolution**
Ignore the node_modules folder in `includes/file.inc`, it has no use for Drupal.
Backport [Ignore front end vendor folders to improve directory search performance](https://www.drupal.org/node/2329453)