### PR TITLE
Issue #3588: Make EnableDisableTestCase ignore modules outside of core.

### DIFF
--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -109,7 +109,7 @@ class EnableDisableTestCase extends ModuleTestCase {
     // hidden or required, or testing-only modules.
     $modules = system_rebuild_module_data();
     foreach ($modules as $name => $module) {
-      if ($module->info['package'] == 'Testing' || !empty($module->info['hidden']) || !empty($module->info['required'])) {
+      if ($module->info['package'] == 'Testing' || !empty($module->info['hidden']) || !empty($module->info['required']) || (strpos($module->filename, 'core/') !== 0)) {
         unset($modules[$name]);
       }
     }


### PR DESCRIPTION
Addresses backdrop/backdrop-issues#3588.