### PR TITLE
Revert unnecessary error suppression

### DIFF
--- a/core/modules/simpletest/tests/file.test
+++ b/core/modules/simpletest/tests/file.test
@@ -1066,7 +1066,7 @@ class FileDirectoryTest extends FileTestCase {
     $this->assertEqual($path, FALSE, 'An error is returned when filepath destination already exists with FILE_EXISTS_ERROR.', 'File');
 
     try {
-      @file_destination("core/misc/a\xFFtest\x80€.txt", FILE_EXISTS_REPLACE);
+      file_destination("core/misc/a\xFFtest\x80€.txt", FILE_EXISTS_REPLACE);
       $this->fail('Expected exception not thrown');
     }
     catch (RuntimeException $e) {


### PR DESCRIPTION
This change was made while troubleshooting test failures for the recent security release. [It is not required](https://gitter.im/backdrop/security?at=5c929c358126720abc163127):

>@quicksketch Mar 21 07:01
> Oh, I meant to remove that `@`...

https://github.com/backdrop/backdrop/pull/2538/files#diff-9f03a6320e6628a6c62d2c4a6b2773b3R1069