### PR TITLE
Issue #3617: [UX] Better messages and clear caches when changing the default theme

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2534,6 +2534,15 @@ function node_form_system_themes_admin_form_alter(&$form, &$form_state, $form_id
     '#type' => 'checkbox',
     '#title' => t('Use the administration theme when editing or creating content'),
     '#default_value' => config_get('system.core', 'node_admin_theme'),
+    '#states' => array(
+      'visible' => array(
+        array(
+          // Hide this checkbox if "Default theme" has been selected from the
+          // "Administration theme" dropdown menu.
+          ':input[name="admin_theme"]' => array('!value' => 0),
+        ),
+      ),
+    ),
   );
   $form['#submit'][] = 'node_form_system_themes_admin_form_submit';
 }

--- a/core/modules/system/js/themes.js
+++ b/core/modules/system/js/themes.js
@@ -11,16 +11,17 @@ Backdrop.behaviors.systemFieldsetSummaries = {
     $(context).find('fieldset.admin-theme-form').backdropSetSummary(function (element) {
       var $element = $(element);
       var admin_theme  = $element.find('[name="admin_theme"]').val();
+      var admin_theme_name  = $element.find('[name="admin_theme"] :selected').text();
       var node_admin_theme = $element.find('[name="node_admin_theme"]').prop('checked');
 
-      if (node_admin_theme) {
-        return Backdrop.t('@admin_theme - also used when editing or creating content', { '@admin_theme': admin_theme });
+      if (node_admin_theme && admin_theme != 0) {
+        return Backdrop.t('@theme_name - also used when editing or creating content', { '@theme_name': admin_theme_name });
       }
       if (admin_theme == 0) {
         return Backdrop.t('Same theme as the rest of the site');
       }
       else {
-        return admin_theme;
+        return admin_theme_name;
       }
     });
   }

--- a/core/modules/system/js/themes.js
+++ b/core/modules/system/js/themes.js
@@ -11,12 +11,12 @@ Backdrop.behaviors.systemFieldsetSummaries = {
     $(context).find('fieldset.admin-theme-form').backdropSetSummary(function (element) {
       var $element = $(element);
       var admin_theme  = $element.find('[name="admin_theme"]').val();
-      var node_admin_theme = $element.find('node_admin_theme').prop('checked');
+      var node_admin_theme = $element.find('[name="node_admin_theme"]').prop('checked');
 
       if (node_admin_theme) {
         return Backdrop.t('@admin_theme - also used when editing or creating content', { '@admin_theme': admin_theme });
       }
-      if (admin_theme == 'Default theme') {
+      if (admin_theme == 0) {
         return Backdrop.t('Same theme as the rest of the site');
       }
       else {

--- a/core/modules/system/js/themes.js
+++ b/core/modules/system/js/themes.js
@@ -10,8 +10,8 @@ Backdrop.behaviors.systemFieldsetSummaries = {
   attach: function (context) {
     $(context).find('fieldset.admin-theme-form').backdropSetSummary(function (element) {
       var $element = $(element);
-      var admin_theme  = $element.find('[name="admin_theme"]').val();
-      var admin_theme_name  = $element.find('[name="admin_theme"] :selected').text();
+      var admin_theme = $element.find('[name="admin_theme"]').val();
+      var admin_theme_name = $element.find('[name="admin_theme"] :selected').text();
       var node_admin_theme = $element.find('[name="node_admin_theme"]').prop('checked');
 
       if (node_admin_theme && admin_theme != 0) {

--- a/core/modules/system/js/themes.js
+++ b/core/modules/system/js/themes.js
@@ -1,0 +1,29 @@
+/**
+ * Provides summary text for the "Administration theme" fieldset, in the "List
+ * themes" page (/admin/appearance).
+ */
+ (function ($) {
+
+"use strict";
+
+Backdrop.behaviors.systemFieldsetSummaries = {
+  attach: function (context) {
+    $(context).find('fieldset.admin-theme-form').backdropSetSummary(function (element) {
+      var $element = $(element);
+      var admin_theme  = $element.find('[name="admin_theme"]').val();
+      var node_admin_theme = $element.find('node_admin_theme').prop('checked');
+
+      if (node_admin_theme) {
+        return Backdrop.t('@admin_theme - also used when editing or creating content', { '@admin_theme': admin_theme });
+      }
+      if (admin_theme == 'Default theme') {
+        return Backdrop.t('Same theme as the rest of the site');
+      }
+      else {
+        return admin_theme;
+      }
+    });
+  }
+};
+
+})(jQuery);

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -235,6 +235,14 @@ function system_themes_admin_form($form, &$form_state, $theme_options) {
   $form['admin_theme'] = array(
     '#type' => 'fieldset',
     '#title' => t('Administration theme'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#attributes' => array(
+      'class' => array('admin-theme-form'),
+    ),
+    '#attached' => array(
+      'js' => array(backdrop_get_path('module', 'system') . '/js/themes.js'),
+    ),
   );
   $form['admin_theme']['admin_theme'] = array(
     '#type' => 'select',

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -264,7 +264,23 @@ function system_themes_admin_form($form, &$form_state, $theme_options) {
  */
 function system_themes_admin_form_submit($form, &$form_state) {
   backdrop_set_message(t('The configuration options have been saved.'));
-  config_set('system.core', 'admin_theme', $form_state['values']['admin_theme']);
+
+  // The human names of the themes are already available to us via the
+  // $form['admin_theme']['admin_theme']['#options'] array.
+  $current_admin_theme = config_get('system.core', 'admin_theme');
+  $current_default_theme = config_get('system.core', 'theme_default');
+  $current_default_theme_name = $form['admin_theme']['admin_theme']['#options'][$current_default_theme];
+  $new_admin_theme = $form_state['values']['admin_theme'];
+  $new_admin_theme_name = $form['admin_theme']['admin_theme']['#options'][$new_admin_theme];
+
+  if (!$new_admin_theme) {
+    backdrop_set_message(t('The administration theme will be the same as the rest of the site (currently %default_theme).', array('%default_theme' => $current_default_theme_name)));
+  }
+  elseif ($current_admin_theme != $new_admin_theme) {
+    backdrop_set_message(t('The administration theme has been changed to %admin_theme.', array('%admin_theme' => $new_admin_theme_name)));
+  }
+
+  config_set('system.core', 'admin_theme', $new_admin_theme);
 }
 
 /**

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -265,18 +265,17 @@ function system_themes_admin_form($form, &$form_state, $theme_options) {
 function system_themes_admin_form_submit($form, &$form_state) {
   backdrop_set_message(t('The configuration options have been saved.'));
 
-  // The human names of the themes are already available to us via the
-  // $form['admin_theme']['admin_theme']['#options'] array.
-  $current_admin_theme = config_get('system.core', 'admin_theme');
+  $themes = list_themes();
   $current_default_theme = config_get('system.core', 'theme_default');
-  $current_default_theme_name = $form['admin_theme']['admin_theme']['#options'][$current_default_theme];
+  $current_admin_theme = config_get('system.core', 'admin_theme');
   $new_admin_theme = $form_state['values']['admin_theme'];
-  $new_admin_theme_name = $form['admin_theme']['admin_theme']['#options'][$new_admin_theme];
 
   if (!$new_admin_theme) {
+    $current_default_theme_name = $themes[$current_default_theme]->info['name'];
     backdrop_set_message(t('The administration theme will be the same as the rest of the site (currently %default_theme).', array('%default_theme' => $current_default_theme_name)));
   }
   elseif ($current_admin_theme != $new_admin_theme) {
+    $new_admin_theme_name = $themes[$new_admin_theme]->info['name'];
     backdrop_set_message(t('The administration theme has been changed to %admin_theme.', array('%admin_theme' => $new_admin_theme_name)));
   }
 

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -221,7 +221,7 @@ function system_themes_page() {
 
   $admin_form = backdrop_get_form('system_themes_admin_form', $admin_theme_options);
 
-  return theme('system_themes_page', array('theme_groups' => $theme_groups, 'theme_group_titles' => $theme_group_titles)) . backdrop_render($admin_form);
+  return backdrop_render($admin_form) . theme('system_themes_page', array('theme_groups' => $theme_groups, 'theme_group_titles' => $theme_group_titles));
 }
 
 /**

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -330,7 +330,7 @@ function system_theme_default() {
     if (!empty($themes[$theme])) {
       // Enable the theme if it is currently disabled.
       if (empty($themes[$theme]->status)) {
-       theme_enable(array($theme));
+        theme_enable(array($theme));
       }
       // Set the default theme.
       config_set('system.core', 'theme_default', $theme);
@@ -338,22 +338,30 @@ function system_theme_default() {
       // Rebuild the menu. This duplicates the menu_rebuild() in theme_enable().
       // However, modules must know the current default theme in order to use
       // this information in hook_menu() or hook_menu_alter() implementations,
-      // and doing the config_set() before the theme_enable() could result
-      // in a race condition where the theme is default but not enabled.
+      // and doing the config_set() before the theme_enable() could result in a
+      // race condition where the theme is default but not enabled.
       menu_rebuild();
 
-      // The status message depends on whether an admin theme is currently in use:
-      // a value of 0 means the admin theme is set to be the default theme.
+      // The status message depends on whether an admin theme is currently in
+      // use: a value of 0 means the admin theme is set to be the default theme.
       $admin_theme = config_get('system.core', 'admin_theme');
+
+      // If the admin theme is set to a different theme than the one the user
+      // has just switched to, show an info message to explain why.
       if ($admin_theme && $admin_theme != $theme) {
-        backdrop_set_message(t('Please note that the administration theme is still set to the %admin_theme theme; consequently, the theme on this page remains unchanged. All non-administrative sections of the site, however, will show the selected %selected_theme theme by default.', array(
+        backdrop_set_message(t('%theme is now the default theme for all non-administrative pages.', array('%theme' => $themes[$theme]->info['name'])));
+        backdrop_set_message(t('The administration theme is still set to the %admin_theme theme.', array(
           '%admin_theme' => $themes[$admin_theme]->info['name'],
-          '%selected_theme' => $themes[$theme]->info['name'],
-        )));
+        )), 'info');
       }
       else {
         backdrop_set_message(t('%theme is now the default theme.', array('%theme' => $themes[$theme]->info['name'])));
       }
+
+      // Clear caches after changing the theme.
+      cache_clear_all();
+      backdrop_set_message(t('All caches have been cleared.'));
+
     }
     else {
       backdrop_set_message(t('The %theme theme was not found.', array('%theme' => $theme)), 'error');


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3617

Alternative to https://github.com/backdrop/backdrop/pull/2546

Moves the "Administration theme" fieldset/form at the top of the page, and makes the fieldset collapsible and collapsed by default.