### PR TITLE
Issue 3622: fix non-numeric warning

### DIFF
--- a/core/modules/field/modules/options/options.element.inc
+++ b/core/modules/field/modules/options/options.element.inc
@@ -331,7 +331,10 @@ function _form_options_from_text($text, $key_type, $flat = FALSE, &$duplicates =
   $options = array();
   $new_key = 1;
   foreach ($items as $item) {
-    $int_key = $item['key'] * 1;
+    if (!is_numeric($item['key'])) {
+      continue;
+    }
+    $int_key = (int) $item['key'];
     if (is_int($int_key)) {
       $new_key = max($int_key, $new_key);
     }


### PR DESCRIPTION
Addresses https://github.com/backdrop/backdrop-issues/issues/3622

Adapts this patch https://www.drupal.org/project/options_element/issues/2920613 but added check for is_numeric since we want to avoid strings like "9ABC" to be converted to 9 which is how casting to integer works.