### PR TITLE
Issue #2693: Fix reporting of requirement errors on update.php.

### DIFF
--- a/core/update.php
+++ b/core/update.php
@@ -464,6 +464,7 @@ if (empty($op) && update_access_allowed()) {
 
   // Load module basics.
   include_once BACKDROP_ROOT . '/core/includes/module.inc';
+  include_once BACKDROP_ROOT . '/core/includes/tablesort.inc';
   $module_list['system']['filename'] = 'core/modules/system/system.module';
   module_list(TRUE, FALSE, FALSE, $module_list);
   backdrop_load('module', 'system');


### PR DESCRIPTION
Fixes update.php error display when requirements are not met in https://github.com/backdrop/backdrop-issues/issues/2693