### PR TITLE
Update Front page link on update complete page

### DIFF
--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -2195,7 +2195,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
     $this->backdropPost($this->update_url, array(), t('Continue'), array('external' => TRUE));
     $this->assertText(t('No pending updates.'));
     $this->assertNoLink('Administration pages');
-    $this->clickLink('Front page');
+    $this->clickLink('Home page');
     $this->assertResponse(200);
 
     // Click through update.php with 'access administration pages' permission.
@@ -2220,7 +2220,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
     $this->assertLink('site');
     $this->assertNoLink('Administration pages');
     $this->assertNoLink('logged');
-    $this->clickLink('Front page');
+    $this->clickLink('Home page');
     $this->assertResponse(200);
 
     backdrop_set_installed_schema_version('update_script_test', backdrop_get_installed_schema_version('update_script_test') - 1);

--- a/core/update.php
+++ b/core/update.php
@@ -175,7 +175,7 @@ function update_script_selection_form($form, &$form_state) {
  */
 function update_helpful_links() {
   $links['front'] = array(
-    'title' => t('Front page'),
+    'title' => t('Home page'),
     'href' => '<front>',
   );
   if (user_access('access administration pages')) {


### PR DESCRIPTION
Changes the title from `Front page` --> `Home page`
Closes [#3678](https://github.com/backdrop/backdrop-issues/issues/3678)