### PR TITLE
Issue #3581: Adds a reset button to admin/modules filter

### DIFF
--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -70,6 +70,14 @@ small .admin-link:after {
 /**
  * Modules page.
  */
+#system-modules .form-item-search {
+  display: inline-block;
+}
+#system-modules .search-reset {
+  line-height: 42px;
+  position: relative;
+  top: 1px;
+}
 #system-modules .table-filter {
   margin: 1em 0;
   padding: 7px 13px;

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -520,6 +520,16 @@ function system_modules($form, $form_state = array()) {
     ),
     '#default_value' => (isset($_GET['search'])) ? $_GET['search'] : '',
   );
+  $form['filter']['reset'] = array(
+    '#theme' => 'link',
+    '#text' => t('Reset'),
+    '#path' => 'admin/modules',
+    '#options' => array(
+      'attributes' => array(
+        'class' => array('button', 'button-secondary', 'search-reset'),
+      ),
+    ),
+  );
 
   // Get current list of modules.
   $files = system_rebuild_module_data();

--- a/core/modules/system/system.tests.info
+++ b/core/modules/system/system.tests.info
@@ -1,3 +1,9 @@
+[FilterResetTestCase]
+name = Filter modules and reset filter
+description = Filter the modules list, then reset the filter.
+group = Module
+file = tests/system.test
+
 [EnableDisableTestCase]
 name = Enable/disable modules
 description = Enable/disable core module and confirm table creation/deletion.

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -96,6 +96,30 @@ class ModuleTestCase extends WatchdogTestCase {
 }
 
 /**
+ * Test module filter.
+ */
+class FilterResetTestCase extends ModuleTestCase {
+  protected $profile = 'testing';
+
+  /**
+   * Test that the search and reset functionality on the modules page works.
+   */
+  function testFilterReset() {
+    $edit = array();
+    $edit['search'] = 'image';
+    $this->backdropPost('admin/modules', $edit, t('Save configuration'));
+    $this->assertUrl('admin/modules', array(
+      'query' => array(
+        'search' => 'image',
+      ),
+    ));
+
+    $this->clickLink(t('Reset'));
+    $this->assertUrl('admin/modules');
+  }
+}
+
+/**
  * Test module enabling/disabling functionality.
  */
 class EnableDisableTestCase extends ModuleTestCase {


### PR DESCRIPTION
This PR attempts to provide the new feature requested in this issue: https://github.com/backdrop/backdrop-issues/issues/3581 

It adds a "Reset" button by way of a link back to the `/admin/modules` page that is styled like a button.

Screenshot:
![Screen Shot 2019-04-20 at 2 11 10 PM](https://user-images.githubusercontent.com/1205329/56460769-2afc9d80-6376-11e9-840e-73901ec2d299.png)
