### PR TITLE
Issue #3609 - removing duplicate content on field date description

### DIFF
--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -492,7 +492,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
   }
   $tz_handling = $settings['tz_handling'];
 
-  $description = t('Select the date attributes to collect and store.');
+  $description = t('');
   if ($has_data) {
     $description .= ' ' . t('Changes to date attributes only effects new or updated content.');
   }

--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -492,7 +492,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
   }
   $tz_handling = $settings['tz_handling'];
 
-  $description = t('');
+  $description = t();
   if ($has_data) {
     $description .= ' ' . t('Changes to date attributes only effects new or updated content.');
   }

--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -492,9 +492,9 @@ function _date_field_settings_form($field, $instance, $has_data) {
   }
   $tz_handling = $settings['tz_handling'];
 
-  $description = t();
+  $description = '';
   if ($has_data) {
-    $description .= ' ' . t('Changes to date attributes only effects new or updated content.');
+    $description = t('Changes to date attributes only effects new or updated content.');
   }
   $options = date_granularity_names();
   $checkbox_year = array(


### PR DESCRIPTION
Simpl UI change, just removing the desription which duplicates the label above the date select elements.  This change just sets the label to '', which keeps the remaining description logic intact.  

I've attached an image of the field description in action after the change.  

![Screenshot_2019-04-20_14-19-38](https://user-images.githubusercontent.com/238274/56461385-b9255380-6377-11e9-8820-be0610258134.png)
