### PR TITLE
Issue #1478: Avoid race-condition in comment-new test checking.

### DIFF
--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -69,6 +69,10 @@ class CommentHelperCase extends BackdropWebTestCase {
     $this->admin_user = $this->backdropCreateUser(array('administer site configuration', 'administer content types', 'create post content', 'edit any post content', 'delete any post content', 'administer comments', 'administer layouts', 'administer fields'));
     $this->web_user = $this->backdropCreateUser(array('create post content', 'edit own comments'));
     $this->node = $this->backdropCreateNode(array('type' => 'post', 'promote' => 1, 'uid' => $this->web_user->uid));
+
+    // Disable safety cron run that can affect the updating of comment "new"
+    // status during shutdown functions when cron takes a long time.
+    config_get('system.core', 'cron_safe_threshold', 0);
   }
 
   /**
@@ -621,6 +625,10 @@ class CommentInterfaceTest extends CommentHelperCase {
         $comments = $this->xpath('//*[contains(@class, "comment-new")]');
         if ($case['user'] != 'anonymous') {
           $this->assertTrue(count($comments) == 1, 'comment-new class found.');
+
+          // node_tag_new() writes to the database after delivering the page,
+          // wait to ensure the record is written before reloading the page.
+          sleep(2);
 
           // Request the node again. The comment-new class should disappear.
           $this->backdropGet('node/' . $node->nid);


### PR DESCRIPTION
This should fix one of our random test failures:

```
---- Comment: Comment interface (CommentInterfaceTest) ----

Status    Group      Filename          Line Function                            
--------------------------------------------------------------------------------
Fail      Other      comment.test       628 CommentInterfaceTest->testCommentCl
    comment-new class not found.
```

This test failure may occur because the comment "new" status is done by checking a timestamp in the database. Backdrop writes this timestamp _after_ returning the HTML of the page, so it's possible if background operations (such as cron run) take more than than a second then the "new" flag won't disappear immediately. It's also possible to get the "new" flag if you load the same page twice within the same second. This adds a sleep() to ensure at least a second has passed so the timestamp changes.