### PR TITLE
3634-Changes Taxonomy term TID is to Taxonomy term ID is

### DIFF
--- a/core/modules/layout/plugins/access/entity_id_layout_access.inc
+++ b/core/modules/layout/plugins/access/entity_id_layout_access.inc
@@ -26,7 +26,7 @@ class EntityIDLayoutAccess extends LayoutAccessNegatable {
     parent::form($form, $form_state);
 
     $form['entity_id'] = array(
-      '#title' => t('@entity @entity_id_key is', array('@entity' => $this->entity_info['label'], '@entity_id_key' => strtoupper($this->entity_info['entity keys']['id']))),
+      '#title' => t('@entity ID is', array('@entity' => $this->entity_info['label'])),
       '#type' => 'textfield',
       '#default_value' => is_null($this->settings['entity_id']) ? NULL : (int) $this->settings['entity_id'],
       '#weight' => 100,


### PR DESCRIPTION
Changing the line "Taxonomy term TID is" to "Taxonomy term ID is" when adding taxonomy visibility conditions to blocks.