### PR TITLE
Issue #3700: php 7.3: session_id() cannot be changed after session is started

### DIFF
--- a/core/includes/session.inc
+++ b/core/includes/session.inc
@@ -370,10 +370,20 @@ function backdrop_session_regenerate() {
 
   if (backdrop_session_started()) {
     $old_session_id = session_id();
+    // PHP 7.3 requires closing the session before setting a new session ID.
+    $original_session_saving = backdrop_save_session();
+    backdrop_save_session(FALSE);
+    session_write_close();
+    backdrop_session_started(FALSE);
   }
   session_id(backdrop_random_key());
 
   if (isset($old_session_id)) {
+    // Preserve and restore user object, as starting session will reset it.
+    $original_user = $user;
+    backdrop_session_start();
+    $user = $original_user;
+    backdrop_save_session($original_session_saving);
     $params = session_get_cookie_params();
     $expire = $params['lifetime'] ? REQUEST_TIME + $params['lifetime'] : 0;
     setcookie(session_name(), session_id(), $expire, $params['path'], $params['domain'], $params['secure'], $params['httponly']);


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3700