### PR TITLE
Issue #3453: Enable manual core updates by default on all new sites.

### DIFF
--- a/core/modules/installer/config/installer.settings.json
+++ b/core/modules/installer/config/installer.settings.json
@@ -4,5 +4,5 @@
         "url": "https://projects.backdropcms.org",
         "name": "Backdrop"
     },
-    "core_update": false
+    "core_update": true
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3453
Replaces https://github.com/backdrop/backdrop/pull/2441