### PR TITLE
Issue #3728: Replace deprecated `format_username()` in `comment.test` with `user_format_name()`

### DIFF
--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -1909,9 +1909,9 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
     $tests['[comment:parent:title]'] = check_plain($parent_comment->subject);
     $tests['[comment:node:nid]'] = $comment->nid;
     $tests['[comment:node:title]'] = check_plain($node->title);
-    $tests['[comment:author]'] = check_plain(format_username($this->admin_user));
+    $tests['[comment:author]'] = check_plain(user_format_name($this->admin_user));
     $tests['[comment:author:uid]'] = $comment->uid;
-    $tests['[comment:author:name]'] = check_plain(format_username($this->admin_user));
+    $tests['[comment:author:name]'] = check_plain(user_format_name($this->admin_user));
 
     // Test to make sure that we generated something for each token.
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated.');
@@ -1930,8 +1930,8 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
     $tests['[comment:body]'] = $comment->comment_body[LANGUAGE_NONE][0]['value'];
     $tests['[comment:parent:title]'] = $parent_comment->subject;
     $tests['[comment:node:title]'] = $node->title;
-    $tests['[comment:author]'] = format_username($this->admin_user);
-    $tests['[comment:author:name]'] = format_username($this->admin_user);
+    $tests['[comment:author]'] = user_format_name($this->admin_user);
+    $tests['[comment:author:name]'] = user_format_name($this->admin_user);
 
     foreach ($tests as $input => $expected) {
       $output = token_replace($input, array('comment' => $comment), array('language' => $language, 'sanitize' => FALSE));


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3728