### PR TITLE
Attachments on Views Content Panes don't always inherit exposed filters

### DIFF
--- a/core/modules/views/plugins/views_plugin_display_attachment.inc
+++ b/core/modules/views/plugins/views_plugin_display_attachment.inc
@@ -227,6 +227,8 @@ class views_plugin_display_attachment extends views_plugin_display {
 
     $args = $this->get_option('inherit_arguments') ? $this->view->args : array();
     $view->set_arguments($args);
+    $exposed_input = $this->get_option('inherit_exposed_filters') ? $this->view->exposed_input : array();
+    $view->set_exposed_input($exposed_input);
     $view->set_display($this->display->id);
     if ($this->get_option('inherit_pager')) {
       $view->display_handler->use_pager = $this->view->display[$display_id]->handler->use_pager();


### PR DESCRIPTION
https://www.drupal.org/node/2171389

https://git.drupalcode.org/project/views/commit/0352f384439734bc1e6f173d65c5461e969a7398

https://github.com/backdrop/backdrop-issues/issues/3719