### PR TITLE
Wrong example in documentation for `hook_views_pre_view()`

### DIFF
--- a/core/modules/views/views.api.php
+++ b/core/modules/views/views.api.php
@@ -712,7 +712,7 @@ function hook_views_pre_view(&$view, &$display_id, &$args) {
     user_access('administer site configuration') &&
     $display_id == 'public_display'
   ) {
-    $display_id = 'private_display';
+    $view->set_display('private_display');
   }
 }
 


### PR DESCRIPTION
https://www.drupal.org/node/2308885

https://git.drupalcode.org/project/views/commit/dbc703c73f486875874947d5a047f68e45f4c7ff

https://github.com/backdrop/backdrop-issues/issues/3719