### PR TITLE
Typo in the description text on date fields

### DIFF
--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -494,7 +494,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
 
   $description = '';
   if ($has_data) {
-    $description = t('Changes to collected date attributes affect only new or updated content.');
+    $description = t('Changes to date granularity affect only new or updated content.');
   }
   $options = date_granularity_names();
   $checkbox_year = array(

--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -494,7 +494,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
 
   $description = '';
   if ($has_data) {
-    $description = t('Changes to date attributes only effects new or updated content.');
+    $description = t('Changes to collected date attributes affect only new or updated content.');
   }
   $options = date_granularity_names();
   $checkbox_year = array(

--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -507,7 +507,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
   unset($options['year']);
   $form['granularity'] = array(
     '#type' => 'checkboxes',
-    '#title' => t('Date attributes to collect'),
+    '#title' => t('Date granularity'),
     '#default_value' => $granularity,
     '#options' => $options,
     '#attributes' => array(


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3609

Follow-up to https://github.com/backdrop/backdrop/pull/2593, to fix the typo.