### PR TITLE
Issue #3739: [DX] Watchdog deprecated messages for `element_validate_integer()`, `element_validate_integer()` and `element_validate_number()`

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -2490,6 +2490,36 @@ function drupal_var_export($var, $prefix = '') {
 }
 
 /**
+ * This function has been removed with the inclusion of support for HTML5 number
+ * elements. See https://api.backdropcms.org/node/43955
+ *
+ * @deprecated since 1.0.0
+ */
+function element_validate_integer() {
+  watchdog_deprecated_function('element_validate', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
+}
+
+/**
+ * This function has been removed with the inclusion of support for HTML5 number
+ * elements. See https://api.backdropcms.org/node/43955
+ *
+ * @deprecated since 1.0.0
+ */
+function element_validate_integer_positive() {
+  watchdog_deprecated_function('element_validate', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
+}
+
+/**
+ * This function has been removed with the inclusion of support for HTML5 number
+ * elements. See https://api.backdropcms.org/node/43955
+ *
+ * @deprecated since 1.0.0
+ */
+function element_validate_number() {
+  watchdog_deprecated_function('element_validate', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
+}
+
+/**
  * Drupal-compatible wrapper for clearing caches.
  *
  * Backdrop no longer needs to "rebuild" its node types, which previously

--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -2496,7 +2496,7 @@ function drupal_var_export($var, $prefix = '') {
  * @deprecated since 1.0.0
  */
 function element_validate_integer() {
-  watchdog_deprecated_function('element_validate', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
+  watchdog_deprecated_function('drupal', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
 }
 
 /**
@@ -2506,7 +2506,7 @@ function element_validate_integer() {
  * @deprecated since 1.0.0
  */
 function element_validate_integer_positive() {
-  watchdog_deprecated_function('element_validate', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
+  watchdog_deprecated_function('drupal', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
 }
 
 /**
@@ -2516,7 +2516,7 @@ function element_validate_integer_positive() {
  * @deprecated since 1.0.0
  */
 function element_validate_number() {
-  watchdog_deprecated_function('element_validate', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
+  watchdog_deprecated_function('drupal', __FUNCTION__, l(t('Change record'), 'https://api.backdropcms.org/node/43955', array('attributes' => array('target' => '_blank'))));
 }
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/3739