### PR TITLE
Views locale edit link field uses the old D6 path.

### DIFF
--- a/core/modules/locale/views/views_handler_field_locale_link_edit.inc
+++ b/core/modules/locale/views/views_handler_field_locale_link_edit.inc
@@ -52,7 +52,7 @@ class views_handler_field_locale_link_edit extends views_handler_field {
     $text = !empty($this->options['text']) ? $this->options['text'] : t('edit');
 
     $this->options['alter']['make_link'] = TRUE;
-    $this->options['alter']['path'] = 'admin/build/translate/edit/' . $data;
+    $this->options['alter']['path'] = 'admin/config/regional/translate/edit/' . $data;
     $this->options['alter']['query'] = backdrop_get_destination();
 
     return $text;

--- a/core/modules/views/includes/ajax.inc
+++ b/core/modules/views/includes/ajax.inc
@@ -53,7 +53,7 @@ function views_ajax() {
       // Overwrite the destination.
       // @see backdrop_get_destination()
       $origin_destination = $path;
-      $query = backdrop_http_build_query($_REQUEST);
+      $query = backdrop_http_build_query(backdrop_get_query_parameters());
       if ($query != '') {
         $origin_destination .= '?' . $query;
       }


### PR DESCRIPTION
https://www.drupal.org/node/1976836

https://git.drupalcode.org/project/views/commit/d08465de955b88e5f262c06d99b79ceb167dca88

https://github.com/backdrop/backdrop-issues/issues/3720