### PR TITLE
Issue #3794: DateThemeTestCase fails depending on current time

### DIFF
--- a/core/modules/date/tests/date_themes.test
+++ b/core/modules/date/tests/date_themes.test
@@ -104,15 +104,20 @@ class DateThemeTestCase extends BackdropWebTestCase {
       $this->verbose('<br />Expected:<pre>' . check_plain($expected) . '</pre>Got:<pre>' . check_plain($output) . '</pre>');
     }
 
-    // Start and end date on same day, one week in future,
+    // Start and end date on same day, 7 days in future,
     // with timezone identifier, with remaining days.
-    $start = time() + 604800;
-    $end = $start + 3600;
-    $tz = 'Europe/Moscow';
-    $dateTimeStart = new DateTime("@$start");
-    $dateTimeStart->setTimeZone(new DateTimeZone($tz));
-    $dateTimeEnd = new DateTime("@$end");
-    $dateTimeEnd->setTimeZone(new DateTimeZone($tz));
+    $tz = 'Asia/Srednekolymsk';
+    $dateTimeStart = new DateTime('now', new DateTimeZone($tz));
+    $currentHour = $dateTimeStart->format('H');
+    if ($currentHour > 22) {
+      // Make sure start and end are the same day.
+      $dateTimeStart->modify('- 1 hour');
+    }
+    // Make sure we have 7 days remaining.
+    $offsetHours = (7 * 24) + $currentHour;
+    $dateTimeStart->modify("+ $offsetHours hours");
+    $dateTimeEnd = clone $dateTimeStart;
+    $dateTimeEnd->modify('+ 1 hour');
 
     $variables['dates']['value']['formatted'] = $dateTimeStart->format('d.m.Y - H:i e');
     $variables['dates']['value']['formatted_date'] = $dateTimeStart->format('d.m.Y');


### PR DESCRIPTION
Rewriting testDateDisplayCombination so it doesn't fail anymore depending on testing time.

See https://github.com/backdrop/backdrop-issues/issues/3794 for details.