### PR TITLE
Issue #3804: [UX] Search result list is hidden

### DIFF
--- a/core/modules/admin_bar/css/admin_bar.css
+++ b/core/modules/admin_bar/css/admin_bar.css
@@ -304,7 +304,6 @@
 }
 [dir="rtl"] #admin-bar .dropdown li ul {
   left: auto;
-  right: -999em;
 }
 
 /* Third-and-above-level lists */


### PR DESCRIPTION
Fix: https://github.com/backdrop/backdrop-issues/issues/3804
Bug in 'Administration bar' core module: If an RTL language is default, the search result list is hidden under search bar. We need to remove a line (307) from admin_bar.css, and the result list appears.