### PR TITLE
Issue #3821: add missing `type = module` in the .info files of modules of the "Testing" core profile

### DIFF
--- a/core/profiles/testing/modules/backdrop_system_listing_compatible_test/backdrop_system_listing_compatible_test.info
+++ b/core/profiles/testing/modules/backdrop_system_listing_compatible_test/backdrop_system_listing_compatible_test.info
@@ -3,4 +3,5 @@ description = "Support module for testing the backdrop_system_listing function."
 package = Testing
 version = BACKDROP_VERSION
 backdrop = 1.x
+type = module
 hidden = TRUE

--- a/core/profiles/testing/modules/backdrop_system_listing_incompatible_test/backdrop_system_listing_incompatible_test.info
+++ b/core/profiles/testing/modules/backdrop_system_listing_incompatible_test/backdrop_system_listing_incompatible_test.info
@@ -6,4 +6,5 @@ version = BACKDROP_VERSION
 ; precedence over the version of the same module that is in the
 ; modules/simpletest/tests directory.
 backdrop = 0.x
+type = module
 hidden = TRUE


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3821