### PR TITLE
Added a bottom border to Admin tables in seven

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -501,7 +501,7 @@ table {
   border: 0;
 }
 tbody {
-  border-bottom: 1px solid #eeeeee;
+  border-bottom: 1px solid #f7f7f7;
 }
 tr.even,
 tr.odd {

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -500,6 +500,9 @@ table {
   border-spacing: 0;
   border: 0;
 }
+tbody {
+  border-bottom: 1px solid #eeeeee;
+}
 tr.even,
 tr.odd {
   border: 1px solid #f7f7f7;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3741

This was requested: 
<img width="658" alt="Screen Shot 2019-05-31 at 5 34 26 PM" src="https://user-images.githubusercontent.com/397895/58741200-3b6b5380-83cb-11e9-9801-5c5aff067c62.png">


This was rejected: 
<img width="673" alt="Screen Shot 2019-05-31 at 5 27 47 PM" src="https://user-images.githubusercontent.com/397895/58740994-6a80c580-83c9-11e9-8016-0a6de4d38fe7.png">
