### PR TITLE
Views: 3.21 Regression, malformed SQL: 'Is none of' within grouped exposed filter.

### DIFF
--- a/core/modules/views/includes/handlers.inc
+++ b/core/modules/views/includes/handlers.inc
@@ -1083,15 +1083,18 @@ class views_join {
           }
 
           if (is_array($info['value'])) {
+            $value_placeholders = array();
+
             // With an array of values, we need multiple placeholders and the
             // 'IN' operator is implicit.
             foreach ($info['value'] as $value) {
               $placeholder_i = ':views_join_condition_' . $select_query->nextPlaceholder();
+              $value_placeholders[] = $placeholder_i;
               $arguments[$placeholder_i] = $value;
             }
 
             $operator = !empty($info['operator']) ? $info['operator'] : 'IN';
-            $placeholder = '( ' . implode(', ', array_keys($arguments)) . ' )';
+            $placeholder = '( ' . implode(', ', $value_placeholders) . ' )';
           }
           else {
             // With a single value, the '=' operator is implicit.

--- a/core/modules/views/tests/handlers/views_handler_manytoone.test
+++ b/core/modules/views/tests/handlers/views_handler_manytoone.test
@@ -182,7 +182,7 @@ class ViewsHandlerManyToOneTest extends ViewsSqlTest {
     $node[$this->fields[0]['field_name']][LANGUAGE_NONE][]['value'] = '1';
     $node[$this->fields[1]['field_name']][LANGUAGE_NONE][]['value'] = '1';
     $node['field_tags'][LANGUAGE_NONE][]['tid'] = $this->terms[1]->tid;
-    $this->nodes[0] = $this->drupalCreateNode($node);
+    $this->nodes[0] = $this->backdropCreateNode($node);
 
     // Create a node where the field_bool is not checked, field_list is empty
     // and tag is term 1.
@@ -191,12 +191,12 @@ class ViewsHandlerManyToOneTest extends ViewsSqlTest {
     $node[$this->fields[0]['field_name']] = array();
     $node[$this->fields[1]['field_name']] = array();
     $node['field_tags'][LANGUAGE_NONE][]['tid'] = $this->terms[0]->tid;
-    $this->nodes[1] = $this->drupalCreateNode($node);
+    $this->nodes[1] = $this->backdropCreateNode($node);
 
     // Create a user where field_bool is checked, field_list is '1' and tag is
     // term 1.
     $permissions = array('access content');
-    $account = $this->drupalCreateUser($permissions);
+    $account = $this->backdropCreateUser($permissions);
     $account->{$this->fields[0]['field_name']}[LANGUAGE_NONE][]['value'] = '1';
     $account->{$this->fields[1]['field_name']}[LANGUAGE_NONE][]['value'] = '1';
     $account->field_tags[LANGUAGE_NONE][]['tid'] = $this->terms[0]->tid;

--- a/core/modules/views/tests/handlers/views_handler_manytoone.test
+++ b/core/modules/views/tests/handlers/views_handler_manytoone.test
@@ -22,21 +22,21 @@ class ViewsHandlerManyToOneTest extends ViewsSqlTest {
   /**
    * Nodes used by this test.
    *
-   * @var stdClass[]
+   * @var Node[]
    */
   protected $nodes;
 
   /**
    * Accounts used by this test.
    *
-   * @var stdClass[]
+   * @var User[]
    */
   protected $accounts;
 
   /**
    * Terms used by this test.
    *
-   * @var stdClass[]
+   * @var TaxonomyTerm[]
    */
   protected $terms;
 

--- a/core/modules/views/tests/handlers/views_handler_manytoone.test
+++ b/core/modules/views/tests/handlers/views_handler_manytoone.test
@@ -1,0 +1,614 @@
+<?php
+
+/**
+ * Tests the many to one helper handler class.
+ */
+class ViewsHandlerManyToOneTest extends ViewsSqlTest {
+
+  /**
+   * Field definitions used by this test.
+   *
+   * @var array
+   */
+  protected $fields;
+
+  /**
+   * Instances of fields used by this test.
+   *
+   * @var array
+   */
+  protected $instances;
+
+  /**
+   * Nodes used by this test.
+   *
+   * @var stdClass[]
+   */
+  protected $nodes;
+
+  /**
+   * Accounts used by this test.
+   *
+   * @var stdClass[]
+   */
+  protected $accounts;
+
+  /**
+   * Terms used by this test.
+   *
+   * @var stdClass[]
+   */
+  protected $terms;
+
+  /**
+   * Provide the test's meta information.
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Handler: Many To One Helper',
+      'description' => 'Tests the many to one helper handler',
+      'group' => 'Views Handlers',
+    );
+  }
+
+  /**
+   * Clears views data cache.
+   */
+  protected function clearViewsDataCache() {
+    backdrop_static_reset('_views_fetch_data_cache');
+    backdrop_static_reset('_views_fetch_data_recursion_protected');
+    backdrop_static_reset('_views_fetch_data_fully_loaded');
+  }
+
+  /**
+   * Returns a new term with random properties.
+   *
+   * @param string $vocabulary
+   *   Vocabulary ID to create term in.
+   *
+   * @return stdClass
+   *   Term with random properties.
+   */
+  protected function createTerm($vocabulary) {
+    $term = new stdClass();
+    $term->name = $this->randomName();
+    $term->description = $this->randomName();
+    // Use the first available text format.
+    $term->format = db_query_range('SELECT format FROM {filter_format}', 0, 1)->fetchField();
+    $term->vid = $vocabulary->vid;
+    taxonomy_term_save($term);
+    return $term;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create boolean field.
+    $this->fields[0] = array(
+      'field_name' => 'field_bool',
+      'type' => 'list_boolean',
+      'cardinality' => 1,
+      'settings' => array(
+        'allowed_values' => array(
+          0 => '',
+          1 => '',
+        ),
+      ),
+    );
+    $this->fields[0] = field_create_field($this->fields[0]);
+
+    // Create text list field.
+    $this->fields[1] = array(
+      'field_name' => 'field_list',
+      'type' => 'list_text',
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+      'settings' => array(
+        'allowed_values' => array(
+          1 => '1',
+          2 => '2',
+          3 => '3',
+        ),
+      ),
+    );
+    $this->fields[1] = field_create_field($this->fields[1]);
+
+    // Create boolean field instance for Post nodes.
+    $instance = array(
+      'field_name' => $this->fields[0]['field_name'],
+      'entity_type' => 'node',
+      'bundle' => 'post',
+      'widget' => array(
+        'type' => 'options_onoff',
+      ),
+    );
+    $this->instances[0][] = field_create_instance($instance);
+
+    // Create text list field instance for Post nodes.
+    $instance = array(
+      'field_name' => $this->fields[1]['field_name'],
+      'entity_type' => 'node',
+      'bundle' => 'post',
+      'widget' => array(
+        'type' => 'options_buttons',
+      ),
+    );
+    $this->instances[1][] = field_create_instance($instance);
+
+    // Create boolean field instance for users.
+    $instance = array(
+      'field_name' => $this->fields[0]['field_name'],
+      'entity_type' => 'user',
+      'bundle' => 'user',
+      'widget' => array(
+        'type' => 'options_onoff',
+      ),
+    );
+    $this->instances[0][] = field_create_instance($instance);
+
+    // Create text list field instance for users.
+    $instance = array(
+      'field_name' => $this->fields[1]['field_name'],
+      'entity_type' => 'user',
+      'bundle' => 'user',
+      'widget' => array(
+        'type' => 'options_buttons',
+      ),
+    );
+    $this->instances[1][] = field_create_instance($instance);
+
+    // Create tags field instance for users.
+    $instance = array(
+      'field_name' => 'field_tags',
+      'entity_type' => 'user',
+      'bundle' => 'user',
+    );
+    $this->instances[2][] = field_create_instance($instance);
+
+    // Clear views data cache.
+    $this->clearViewsDataCache();
+
+    // Create two tags.
+    $vocabulary = taxonomy_vocabulary_load('tags');
+    $this->terms[] = $this->createTerm($vocabulary);
+    $this->terms[] = $this->createTerm($vocabulary);
+
+    // Create a node where the field_bool is checked, field_list is '1' and
+    // tag is term 2.
+    $node = array();
+    $node['type'] = 'post';
+    $node[$this->fields[0]['field_name']][LANGUAGE_NONE][]['value'] = '1';
+    $node[$this->fields[1]['field_name']][LANGUAGE_NONE][]['value'] = '1';
+    $node['field_tags'][LANGUAGE_NONE][]['tid'] = $this->terms[1]->tid;
+    $this->nodes[0] = $this->drupalCreateNode($node);
+
+    // Create a node where the field_bool is not checked, field_list is empty
+    // and tag is term 1.
+    $node = array();
+    $node['type'] = 'post';
+    $node[$this->fields[0]['field_name']] = array();
+    $node[$this->fields[1]['field_name']] = array();
+    $node['field_tags'][LANGUAGE_NONE][]['tid'] = $this->terms[0]->tid;
+    $this->nodes[1] = $this->drupalCreateNode($node);
+
+    // Create a user where field_bool is checked, field_list is '1' and tag is
+    // term 1.
+    $permissions = array('access content');
+    $account = $this->drupalCreateUser($permissions);
+    $account->{$this->fields[0]['field_name']}[LANGUAGE_NONE][]['value'] = '1';
+    $account->{$this->fields[1]['field_name']}[LANGUAGE_NONE][]['value'] = '1';
+    $account->field_tags[LANGUAGE_NONE][]['tid'] = $this->terms[0]->tid;
+    $this->accounts[0] = user_save($account);
+  }
+
+  /**
+   * Tests duplicate grouped "none of" filters on boolean field.
+   */
+  public function testGropedNoneOf() {
+    $view = $this->getGroupedNoneOfTestView();
+    $this->executeView($view);
+
+    // Assert that nodes have been created and have expected field values.
+    $value = field_get_items('node', $this->nodes[0], $this->fields[0]['field_name'], LANGUAGE_NONE);
+    $value = isset($value[0]['value']) ? (int) $value[0]['value'] : 0;
+    $this->assertIdentical($value, 1, 'First node has been created and boolean field is checked.');
+
+    $value = field_get_items('node', $this->nodes[1], $this->fields[0]['field_name'], LANGUAGE_NONE);
+    $this->assertFalse($value, 'Second node has been created and boolean field is not checked.');
+
+    // Assert that user has been created and has expected field values.
+    $value = field_get_items('user', $this->accounts[0], $this->fields[0]['field_name'], LANGUAGE_NONE);
+    $value = isset($value[0]['value']) ? (int) $value[0]['value'] : 0;
+    $this->assertIdentical($value, 1, 'User has been created and boolean field is checked.');
+
+    // Assert that node id with empty field value matches user id so that the
+    // node would be excluded from the result, if the joins are missing extras.
+    $this->assertIdentical((int) $this->accounts[0]->uid, (int) $this->nodes[1]->nid, 'Node ID of second node matches UID of first user.');
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 1, 'View has one result.');
+    $nid = isset($view->result[0]->nid) ? (int) $view->result[0]->nid : 0;
+    $this->assertIdentical($nid, (int) $this->nodes[1]->nid, 'View result has correct node ID.');
+  }
+
+  /**
+   * Tests duplicate grouped "one of" filters on taxonomy term field.
+   */
+  public function testGroupedOneOf() {
+    $view = $this->getGroupedOneOfTestView();
+    $this->executeView($view);
+
+    // Assert that nodes have been created and have expected field values.
+    $value = field_get_items('node', $this->nodes[0], 'field_tags', LANGUAGE_NONE);
+    $value = isset($value[0]['tid']) ? (int) $value[0]['tid'] : 0;
+    $this->assertIdentical($value, 2, 'First node has been created and tags field references term 2.');
+
+    $value = field_get_items('node', $this->nodes[1], 'field_tags', LANGUAGE_NONE);
+    $value = isset($value[0]['tid']) ? (int) $value[0]['tid'] : 0;
+    $this->assertIdentical($value, 1, 'Second node has been created and tags field references term 1.');
+
+    // Assert that user has been created and has expected field values.
+    $value = field_get_items('user', $this->accounts[0], 'field_tags', LANGUAGE_NONE);
+    $value = isset($value[0]['tid']) ? (int) $value[0]['tid'] : 0;
+    $this->assertIdentical($value, 1, 'User has been created and tags field references term 1.');
+
+    // Assert that node id with empty field value matches user id so that the
+    // node would be excluded from the result, if the joins are missing extras.
+    $this->assertIdentical((int) $this->accounts[0]->uid, (int) $this->nodes[1]->nid, 'Node ID of second node matches UID of first user.');
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 1, 'View has one result.');
+    $nid = isset($view->result[0]->nid) ? (int) $view->result[0]->nid : 0;
+    $this->assertIdentical($nid, (int) $this->nodes[1]->nid, 'View result has correct node ID.');
+  }
+
+  /**
+   * Tests exposed filter with "Reduce duplicates." and grouped options.
+   */
+  public function testReducedExposedGroupedOptions() {
+    // Assert that nodes have been created and have expected field values.
+    $value = field_get_items('node', $this->nodes[0], 'field_list', LANGUAGE_NONE);
+    $value = isset($value[0]['value']) ? (int) $value[0]['value'] : 0;
+    $this->assertIdentical($value, 1, 'First node has been created and list field has value 1.');
+
+    $value = field_get_items('node', $this->nodes[1], 'field_list', LANGUAGE_NONE);
+    $value = isset($value[0]['tid']) ? (int) $value[0]['tid'] : 0;
+    $this->assertFalse($value, 'Second node has been created and list is empty.');
+
+    // Assert that user has been created and has expected field values.
+    $value = field_get_items('user', $this->accounts[0], 'field_list', LANGUAGE_NONE);
+    $value = isset($value[0]['value']) ? (int) $value[0]['value'] : 0;
+    $this->assertIdentical($value, 1, 'User has been created and list field has value 1.');
+
+    // Assert that node id with empty field value matches user id so that the
+    // node would be excluded from the result option 1, if the joins are missing
+    // extras.
+    $this->assertIdentical((int) $this->accounts[0]->uid, (int) $this->nodes[1]->nid, 'Node ID of second node matches UID of first user.');
+
+    /* Default option: Any. */
+    $view = $this->getReducedExposedGroupedOptionsTestView();
+    $this->executeView($view);
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 2, 'Default option: View has two results.');
+
+    /* Option 1: Is none of 1 or 2. */
+    $view = $this->getReducedExposedGroupedOptionsTestView();
+    $view->set_exposed_input(array(
+      'field_list_value' => '1',
+    ));
+    $this->executeView($view);
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 1, 'Option 1: View has one result.');
+    $nid = isset($view->result[0]->nid) ? (int) $view->result[0]->nid : 0;
+    $this->assertIdentical($nid, (int) $this->nodes[1]->nid, 'Option 1: View result has correct node ID.');
+
+    /* Option 2: Is one of 1. */
+    $view = $this->getReducedExposedGroupedOptionsTestView();
+    $view->set_exposed_input(array(
+      'field_list_value' => '2',
+    ));
+    $this->executeView($view);
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 1, 'Option 2: View has one result.');
+    $nid = isset($view->result[0]->nid) ? (int) $view->result[0]->nid : 0;
+    $this->assertIdentical($nid, (int) $this->nodes[0]->nid, 'Option 2: View result has correct node ID.');
+
+    // @todo: Add test for Option 3: Is one of 1 or 2.
+    // @todo: Add test for Option 4: Is all of 1 and 2.
+
+    /* Option 5: Is empty. */
+    $view = $this->getReducedExposedGroupedOptionsTestView();
+    $view->set_exposed_input(array(
+      'field_list_value' => '5',
+    ));
+    $this->executeView($view);
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 1, 'Option 5: View has one result.');
+    $nid = isset($view->result[0]->nid) ? (int) $view->result[0]->nid : 0;
+    $this->assertIdentical($nid, (int) $this->nodes[1]->nid, 'Option 5: View result has correct node ID.');
+
+    /* Option 6: Is not empty. */
+    $view = $this->getReducedExposedGroupedOptionsTestView();
+    $view->set_exposed_input(array(
+      'field_list_value' => '6',
+    ));
+    $this->executeView($view);
+
+    // Assert correct result set.
+    $result_count = isset($view->result) && is_array($view->result) ? count($view->result) : 0;
+    $this->assertEqual($result_count, 1, 'Option 6: View has one result.');
+    $nid = isset($view->result[0]->nid) ? (int) $view->result[0]->nid : 0;
+    $this->assertIdentical($nid, (int) $this->nodes[0]->nid, 'Option 6: View result has correct node ID.');
+  }
+
+  /**
+   * Generates test_not view.
+   */
+  protected function getGroupedNoneOfTestView() {
+    $view = new view();
+    $view->name = 'test_not';
+    $view->description = '';
+    $view->tag = 'default';
+    $view->base_table = 'node';
+    $view->human_name = 'test_not';
+    $view->core = 7;
+    $view->api_version = '3.0';
+    $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+    /* Display: Master */
+    $handler = $view->new_display('default', 'Master', 'default');
+    $handler->display->display_options['use_more_always'] = FALSE;
+    $handler->display->display_options['access']['type'] = 'perm';
+    $handler->display->display_options['cache']['type'] = 'none';
+    $handler->display->display_options['query']['type'] = 'views_query';
+    $handler->display->display_options['exposed_form']['type'] = 'basic';
+    $handler->display->display_options['pager']['type'] = 'full';
+    $handler->display->display_options['style_plugin'] = 'default';
+    $handler->display->display_options['row_plugin'] = 'fields';
+    /* Field: Content: Title */
+    $handler->display->display_options['fields']['title']['id'] = 'title';
+    $handler->display->display_options['fields']['title']['table'] = 'node';
+    $handler->display->display_options['fields']['title']['field'] = 'title';
+    $handler->display->display_options['fields']['title']['label'] = '';
+    $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+    $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+    /* Sort criterion: Content: Post date */
+    $handler->display->display_options['sorts']['created']['id'] = 'created';
+    $handler->display->display_options['sorts']['created']['table'] = 'node';
+    $handler->display->display_options['sorts']['created']['field'] = 'created';
+    $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+    $handler->display->display_options['filter_groups']['operator'] = 'OR';
+    $handler->display->display_options['filter_groups']['groups'] = array(
+      1 => 'AND',
+      2 => 'AND',
+    );
+    /* Filter criterion: Content: Published */
+    $handler->display->display_options['filters']['status']['id'] = 'status';
+    $handler->display->display_options['filters']['status']['table'] = 'node';
+    $handler->display->display_options['filters']['status']['field'] = 'status';
+    $handler->display->display_options['filters']['status']['value'] = 1;
+    $handler->display->display_options['filters']['status']['group'] = 1;
+    $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+    /* Filter criterion: Content: Type */
+    $handler->display->display_options['filters']['type']['id'] = 'type';
+    $handler->display->display_options['filters']['type']['table'] = 'node';
+    $handler->display->display_options['filters']['type']['field'] = 'type';
+    $handler->display->display_options['filters']['type']['value'] = array(
+      'article' => 'article',
+    );
+    $handler->display->display_options['filters']['type']['group'] = 1;
+    /* Filter criterion: Field: field_bool (field_bool) */
+    $handler->display->display_options['filters']['field_bool_value']['id'] = 'field_bool_value';
+    $handler->display->display_options['filters']['field_bool_value']['table'] = 'field_data_field_bool';
+    $handler->display->display_options['filters']['field_bool_value']['field'] = 'field_bool_value';
+    $handler->display->display_options['filters']['field_bool_value']['operator'] = 'not';
+    $handler->display->display_options['filters']['field_bool_value']['value'] = array(
+      1 => '1',
+    );
+    $handler->display->display_options['filters']['field_bool_value']['group'] = 1;
+    /* Filter criterion: Field: field_bool (field_bool) */
+    $handler->display->display_options['filters']['field_bool_value_1']['id'] = 'field_bool_value_1';
+    $handler->display->display_options['filters']['field_bool_value_1']['table'] = 'field_data_field_bool';
+    $handler->display->display_options['filters']['field_bool_value_1']['field'] = 'field_bool_value';
+    $handler->display->display_options['filters']['field_bool_value_1']['operator'] = 'not';
+    $handler->display->display_options['filters']['field_bool_value_1']['value'] = array(
+      1 => '1',
+    );
+    $handler->display->display_options['filters']['field_bool_value_1']['group'] = 2;
+    /* Filter criterion: Content: Type */
+    $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
+    $handler->display->display_options['filters']['type_1']['table'] = 'node';
+    $handler->display->display_options['filters']['type_1']['field'] = 'type';
+    $handler->display->display_options['filters']['type_1']['value'] = array(
+      'article' => 'article',
+    );
+    $handler->display->display_options['filters']['type_1']['group'] = 2;
+    /* Filter criterion: Content: Published */
+    $handler->display->display_options['filters']['status_1']['id'] = 'status_1';
+    $handler->display->display_options['filters']['status_1']['table'] = 'node';
+    $handler->display->display_options['filters']['status_1']['field'] = 'status';
+    $handler->display->display_options['filters']['status_1']['value'] = '1';
+    $handler->display->display_options['filters']['status_1']['group'] = 2;
+
+    return $view;
+  }
+
+  /**
+   * Generates test_not view.
+   */
+  protected function getGroupedOneOfTestView() {
+    $view = new view();
+    $view->name = 'test_oneof';
+    $view->description = '';
+    $view->tag = 'default';
+    $view->base_table = 'node';
+    $view->human_name = 'test_oneof';
+    $view->core = 7;
+    $view->api_version = '3.0';
+    $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+    /* Display: Master */
+    $handler = $view->new_display('default', 'Master', 'default');
+    $handler->display->display_options['use_more_always'] = FALSE;
+    $handler->display->display_options['access']['type'] = 'perm';
+    $handler->display->display_options['cache']['type'] = 'none';
+    $handler->display->display_options['query']['type'] = 'views_query';
+    $handler->display->display_options['exposed_form']['type'] = 'basic';
+    $handler->display->display_options['pager']['type'] = 'full';
+    $handler->display->display_options['style_plugin'] = 'default';
+    $handler->display->display_options['row_plugin'] = 'fields';
+    /* Field: Content: Title */
+    $handler->display->display_options['fields']['title']['id'] = 'title';
+    $handler->display->display_options['fields']['title']['table'] = 'node';
+    $handler->display->display_options['fields']['title']['field'] = 'title';
+    $handler->display->display_options['fields']['title']['label'] = '';
+    $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+    $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+    /* Sort criterion: Content: Post date */
+    $handler->display->display_options['sorts']['created']['id'] = 'created';
+    $handler->display->display_options['sorts']['created']['table'] = 'node';
+    $handler->display->display_options['sorts']['created']['field'] = 'created';
+    $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+    $handler->display->display_options['filter_groups']['operator'] = 'OR';
+    $handler->display->display_options['filter_groups']['groups'] = array(
+      1 => 'AND',
+      2 => 'AND',
+    );
+    /* Filter criterion: Content: Tags (field_tags) */
+    $handler->display->display_options['filters']['field_tags_tid']['id'] = 'field_tags_tid';
+    $handler->display->display_options['filters']['field_tags_tid']['table'] = 'field_data_field_tags';
+    $handler->display->display_options['filters']['field_tags_tid']['field'] = 'field_tags_tid';
+    $handler->display->display_options['filters']['field_tags_tid']['value'] = array(
+      1 => '1',
+    );
+    $handler->display->display_options['filters']['field_tags_tid']['group'] = 2;
+    $handler->display->display_options['filters']['field_tags_tid']['reduce_duplicates'] = TRUE;
+    $handler->display->display_options['filters']['field_tags_tid']['type'] = 'select';
+    $handler->display->display_options['filters']['field_tags_tid']['vocabulary'] = 'tags';
+    /* Filter criterion: Content: Tags (field_tags) */
+    $handler->display->display_options['filters']['field_tags_tid_1']['id'] = 'field_tags_tid_1';
+    $handler->display->display_options['filters']['field_tags_tid_1']['table'] = 'field_data_field_tags';
+    $handler->display->display_options['filters']['field_tags_tid_1']['field'] = 'field_tags_tid';
+    $handler->display->display_options['filters']['field_tags_tid_1']['value'] = array(
+      1 => '1',
+    );
+    $handler->display->display_options['filters']['field_tags_tid_1']['reduce_duplicates'] = TRUE;
+    $handler->display->display_options['filters']['field_tags_tid_1']['type'] = 'select';
+    $handler->display->display_options['filters']['field_tags_tid_1']['vocabulary'] = 'tags';
+    return $view;
+  }
+
+  /**
+   * Generates test_not view.
+   */
+  protected function getReducedExposedGroupedOptionsTestView() {
+    $view = new view();
+    $view->name = 'test_reduced_exposed_grouped_options';
+    $view->description = '';
+    $view->tag = 'default';
+    $view->base_table = 'node';
+    $view->human_name = 'test_reduced_exposed_grouped_options';
+    $view->core = 7;
+    $view->api_version = '3.0';
+    $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+    /* Display: Master */
+    $handler = $view->new_display('default', 'Master', 'default');
+    $handler->display->display_options['use_more_always'] = FALSE;
+    $handler->display->display_options['access']['type'] = 'perm';
+    $handler->display->display_options['cache']['type'] = 'none';
+    $handler->display->display_options['query']['type'] = 'views_query';
+    $handler->display->display_options['exposed_form']['type'] = 'basic';
+    $handler->display->display_options['pager']['type'] = 'full';
+    $handler->display->display_options['style_plugin'] = 'default';
+    $handler->display->display_options['row_plugin'] = 'fields';
+    /* Field: Content: Title */
+    $handler->display->display_options['fields']['title']['id'] = 'title';
+    $handler->display->display_options['fields']['title']['table'] = 'node';
+    $handler->display->display_options['fields']['title']['field'] = 'title';
+    $handler->display->display_options['fields']['title']['label'] = '';
+    $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+    $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+    /* Sort criterion: Content: Post date */
+    $handler->display->display_options['sorts']['created']['id'] = 'created';
+    $handler->display->display_options['sorts']['created']['table'] = 'node';
+    $handler->display->display_options['sorts']['created']['field'] = 'created';
+    $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+    /* Filter criterion: Content: Published */
+    $handler->display->display_options['filters']['status']['id'] = 'status';
+    $handler->display->display_options['filters']['status']['table'] = 'node';
+    $handler->display->display_options['filters']['status']['field'] = 'status';
+    $handler->display->display_options['filters']['status']['value'] = 1;
+    $handler->display->display_options['filters']['status']['group'] = 1;
+    $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+    /* Filter criterion: Content: list (field_list) */
+    $handler->display->display_options['filters']['field_list_value']['id'] = 'field_list_value';
+    $handler->display->display_options['filters']['field_list_value']['table'] = 'field_data_field_list';
+    $handler->display->display_options['filters']['field_list_value']['field'] = 'field_list_value';
+    $handler->display->display_options['filters']['field_list_value']['exposed'] = TRUE;
+    $handler->display->display_options['filters']['field_list_value']['expose']['operator_id'] = 'field_list_value_op';
+    $handler->display->display_options['filters']['field_list_value']['expose']['label'] = 'list (field_list)';
+    $handler->display->display_options['filters']['field_list_value']['expose']['operator'] = 'field_list_value_op';
+    $handler->display->display_options['filters']['field_list_value']['expose']['identifier'] = 'field_list_value';
+    $handler->display->display_options['filters']['field_list_value']['is_grouped'] = TRUE;
+    $handler->display->display_options['filters']['field_list_value']['group_info']['label'] = 'list (field_list)';
+    $handler->display->display_options['filters']['field_list_value']['group_info']['identifier'] = 'field_list_value';
+    $handler->display->display_options['filters']['field_list_value']['group_info']['group_items'] = array(
+      1 => array(
+        'title' => 'Not 1 or 2',
+        'operator' => 'not',
+        'value' => array(
+          1 => '1',
+          2 => '2',
+        ),
+      ),
+      2 => array(
+        'title' => '1',
+        'operator' => 'or',
+        'value' => array(
+          1 => '1',
+        ),
+      ),
+      3 => array(
+        'title' => '1 or 2',
+        'operator' => 'or',
+        'value' => array(
+          1 => '1',
+          2 => '2',
+        ),
+      ),
+      4 => array(
+        'title' => '1 and 2',
+        'operator' => 'and',
+        'value' => array(
+          1 => '1',
+          2 => '2',
+        ),
+      ),
+      5 => array(
+        'title' => 'empty',
+        'operator' => 'empty',
+        'value' => array(),
+      ),
+      6 => array(
+        'title' => 'not empty',
+        'operator' => 'not empty',
+        'value' => array(),
+      ),
+    );
+    return $view;
+  }
+
+}

--- a/core/modules/views/tests/handlers/views_handler_manytoone.test
+++ b/core/modules/views/tests/handlers/views_handler_manytoone.test
@@ -406,7 +406,7 @@ class ViewsHandlerManyToOneTest extends ViewsSqlTest {
     $handler->display->display_options['filters']['type']['table'] = 'node';
     $handler->display->display_options['filters']['type']['field'] = 'type';
     $handler->display->display_options['filters']['type']['value'] = array(
-      'article' => 'article',
+      'post' => 'post',
     );
     $handler->display->display_options['filters']['type']['group'] = 1;
     /* Filter criterion: Field: field_bool (field_bool) */
@@ -432,7 +432,7 @@ class ViewsHandlerManyToOneTest extends ViewsSqlTest {
     $handler->display->display_options['filters']['type_1']['table'] = 'node';
     $handler->display->display_options['filters']['type_1']['field'] = 'type';
     $handler->display->display_options['filters']['type_1']['value'] = array(
-      'article' => 'article',
+      'post' => 'post',
     );
     $handler->display->display_options['filters']['type_1']['group'] = 2;
     /* Filter criterion: Content: Published */

--- a/core/modules/views/tests/views.tests.info
+++ b/core/modules/views/tests/views.tests.info
@@ -191,7 +191,7 @@ group = Views Handlers
 file = handlers/views_handler_filter_string.test
 
 [ViewsHandlerManyToOneTest]
-name = Many To One
+name = Handler: Many To One Helper
 description = Tests the many to one helper handler class.
 group = Views Handlers
 file = handlers/views_handler_manytoone.test.test

--- a/core/modules/views/tests/views.tests.info
+++ b/core/modules/views/tests/views.tests.info
@@ -192,7 +192,7 @@ file = handlers/views_handler_filter_string.test
 
 [ViewsHandlerManyToOneTest]
 name = Handler: Many To One Helper
-description = Tests the many to one helper handler class.
+description = Tests the many to one helper handler.
 group = Views Handlers
 file = handlers/views_handler_manytoone.test.test
 

--- a/core/modules/views/tests/views.tests.info
+++ b/core/modules/views/tests/views.tests.info
@@ -190,6 +190,12 @@ description = Tests the core views_handler_filter_string handler.
 group = Views Handlers
 file = handlers/views_handler_filter_string.test
 
+[ViewsHandlerManyToOneTest]
+name = Many To One
+description = Tests the many to one helper handler class.
+group = Views Handlers
+file = handlers/views_handler_manytoone.test.test
+
 [ViewsHandlerSortDateTest]
 name = Sort: date
 description = Test the core views_handler_sort_date handler.


### PR DESCRIPTION
https://www.drupal.org/node/3040391

https://git.drupalcode.org/project/views/commit/9aaf2f8d1557438023ecdadad0f9f41d43d6f641

https://github.com/backdrop/backdrop-issues/issues/3853

**NOTE**: the changes in the conditionals in `includes/handlers.inc` from the original commit have not been included in this PR intentionally, since that was handled in https://github.com/backdrop/backdrop-issues/issues/3614