### PR TITLE
Issue #3874: Fix description in deprecated function `taxonomy_vocabulary_machine_name_load()`

### DIFF
--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -1206,8 +1206,7 @@ function taxonomy_vocabulary_load($machine_name) {
 }
 
 /**
- * Legacy wrapper to return the vocabulary object matching a vocabulary machine
- * name.
+ * Legacy wrapper to return the vocabulary object matching a machine name.
  *
  * This function is no longer necessary, as all vocabularies are always loaded
  * by machine name. Simply call taxonomy_vocabulary_load() directly.

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -1206,7 +1206,8 @@ function taxonomy_vocabulary_load($machine_name) {
 }
 
 /**
- * Legacy wrapper to return the parents of a term by TID.
+ * Legacy wrapper to return the vocabulary object matching a vocabulary machine
+ * name.
  *
  * This function is no longer necessary, as all vocabularies are always loaded
  * by machine name. Simply call taxonomy_vocabulary_load() directly.


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/3874