### PR TITLE
Issue #3834: Use human name for vocabularies on URL alias bulk actions page

### DIFF
--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -175,7 +175,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     // Remember this is editing, not inserting. In the event the image is
     // removed and re-uploaded.
     $form_state['storage']['editing_image'] = TRUE;
-    backdrop_set_title(t('Edit image details'));
+    backdrop_set_title(t('Edit image'));
     $submit_button_label = t('Update');
   }
   else {

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -175,7 +175,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     // Remember this is editing, not inserting. In the event the image is
     // removed and re-uploaded.
     $form_state['storage']['editing_image'] = TRUE;
-    backdrop_set_title(t('Edit image'));
+    backdrop_set_title(t('Edit image details'));
     $submit_button_label = t('Update');
   }
   else {

--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -644,9 +644,10 @@ function path_bulk_update_form($form, &$form_state) {
       if (isset($path_info['pattern items'])) {
         foreach ($path_info['pattern items'] as $item => $item_label) {
           $human_name = $item;
-          // Use the human name in the row title for vocabularies, not the machine name they are keyed by.
-          if ($type == taxonomy_term) {
-            $human_name = substr(strip_tags($item_label), 26, -5);
+          if ($type == 'taxonomy_term') {
+            //For vocabularies, use their human name in the checkbox label instead of their 
+            //machine name.
+            $human_name = $path_info[$item . '-human'];
           }
           $form['update'][$type][$item] = array(
             '#type' => 'checkbox',

--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -643,9 +643,14 @@ function path_bulk_update_form($form, &$form_state) {
       // vocabularies.
       if (isset($path_info['pattern items'])) {
         foreach ($path_info['pattern items'] as $item => $item_label) {
+          $human_name = $item;
+          // Use the human name in the row title for vocabularies, not the machine name they are keyed by.
+          if ($type == taxonomy_term) {
+            $human_name = substr(strip_tags($item_label), 26, -5);
+          }
           $form['update'][$type][$item] = array(
             '#type' => 'checkbox',
-            '#title' => t('All !label URL aliases', array('!label' => $item)),
+            '#title' => t('All !label URL aliases', array('!label' => $human_name)),
             '#attributes' => array(
               'class' => array('path-type', 'path-' . $type),
               'data-path-type' => array($type),

--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -645,7 +645,7 @@ function path_bulk_update_form($form, &$form_state) {
         foreach ($path_info['pattern items'] as $item => $item_label) {
           $human_name = $item;
           // Use the human name in the row title for vocabularies, not the machine name they are keyed by.
-          if ($type == taxonomy_term) {
+          if ($type == 'taxonomy_term') {
             $human_name = substr(strip_tags($item_label), 26, -5);
           }
           $form['update'][$type][$item] = array(

--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -643,12 +643,9 @@ function path_bulk_update_form($form, &$form_state) {
       // vocabularies.
       if (isset($path_info['pattern items'])) {
         foreach ($path_info['pattern items'] as $item => $item_label) {
-          $human_name = $item;
-          if ($type == 'taxonomy_term') {
-            //For vocabularies, use their human name in the checkbox label instead of their 
-            //machine name.
-            $human_name = $path_info[$item . '-human'];
-          }
+          // For vocabularies, use their human name in the checkbox label instead of their 
+          // machine name.
+          $human_name = $type == 'taxonomy_term' ? $path_info[$item . '-human'] : $item;
           $form['update'][$type][$item] = array(
             '#type' => 'checkbox',
             '#title' => t('All !label URL aliases', array('!label' => $human_name)),

--- a/core/modules/path/path.admin.inc
+++ b/core/modules/path/path.admin.inc
@@ -644,16 +644,10 @@ function path_bulk_update_form($form, &$form_state) {
       if (isset($path_info['pattern items'])) {
         foreach ($path_info['pattern items'] as $item => $item_label) {
           $human_name = $item;
-<<<<<<< HEAD
           if ($type == 'taxonomy_term') {
             //For vocabularies, use their human name in the checkbox label instead of their 
             //machine name.
             $human_name = $path_info[$item . '-human'];
-=======
-          // Use the human name in the row title for vocabularies, not the machine name they are keyed by.
-          if ($type == 'taxonomy_term') {
-            $human_name = substr(strip_tags($item_label), 26, -5);
->>>>>>> cef03a45637f8217ed72f291496ec095fd3d6747
           }
           $form['update'][$type][$item] = array(
             '#type' => 'checkbox',

--- a/core/modules/taxonomy/taxonomy.path.inc
+++ b/core/modules/taxonomy/taxonomy.path.inc
@@ -35,9 +35,11 @@ function taxonomy_path_info() {
         foreach ($languages as $langcode => $language) {
           $info['taxonomy_term']['pattern items'][$vocabulary_name . '_' . $langcode] = t('URL alias pattern for all %vocab-name URLs in %language', array('%vocab-name' => $vocabulary->name, '%language' => $language->name));
         }
+        $info['taxonomy_term'][$vocabulary_name . '-human'] = $vocabulary->name;
       }
       else {
         $info['taxonomy_term']['pattern items'][$vocabulary_name] = t('URL alias pattern for all %vocab-name URLs', array('%vocab-name' => $vocabulary->name));
+        $info['taxonomy_term'][$vocabulary_name . '-human'] = $vocabulary->name;
       }
     }
   }


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#3834

The URL bulk actions page appears to be using the machine name instead of the human name because the pattern items descriptions are keyed by machine name. This PR takes a substring of the pattern items description string, “URL alias pattern for all [human name] URLs”, to get the human name, but I’m wondering if there’s a better way to do this. I didn’t see another way to access the human name from within the path_bulk_update_form() function that makes this page, because the info it receives from path_get_info() does not appear to include the human name outside of that string, but I’m wondering if there is another way to get the human name.