### PR TITLE
Issue #3848: Add success message when saving view with page display

### DIFF
--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -802,7 +802,7 @@ function views_ui_add_form_save_submit($form, &$form_state) {
     if ($display->handler->has_path()) {
       $one_path = $display->handler->get_option('path');
       if (strpos($one_path, '%') === FALSE) {
-        backdrop_set_message(t('Your view was saved. Click here to <a href="@configure_view_link">configure the view</a> or <a href="@views_listing_page_link">return to the views listing page.</a>', array(
+        backdrop_set_message(t('Your view was saved. You may <a href="@configure_view_link">configure it</a> or <a href="@views_listing_page_link">return to the views listing page.</a>', array(
           '@configure_view_link' => url('admin/structure/views/view/' . $view->name . '/configure'),
           '@views_listing_page_link' => url('admin/structure/views/list'),
         )));

--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -799,14 +799,14 @@ function views_ui_add_form_save_submit($form, &$form_state) {
   $form_state['redirect'] = 'admin/structure/views';
   if (!empty($view->display['page'])) {
     $display = $view->display['page'];
-    backdrop_set_message(t('Your view was saved. Click here to <a href="@configure_view_link">configure the view</a> or <a href="@views_listing_page_link">return to the views listing page.</a>', array(
-      '@configure_view_link' => url('admin/structure/views/view/' . $view->name . '/configure'),
-      '@views_listing_page_link' => url('admin/structure/views/list'),
-    )));
     if ($display->handler->has_path()) {
       $one_path = $display->handler->get_option('path');
       if (strpos($one_path, '%') === FALSE) {
-        $form_state['redirect'] = $one_path;  // PATH TO THE VIEW IF IT HAS ONE
+        backdrop_set_message(t('Your view was saved. Click here to <a href="@configure_view_link">configure the view</a> or <a href="@views_listing_page_link">return to the views listing page.</a>', array(
+          '@configure_view_link' => url('admin/structure/views/view/' . $view->name . '/configure'),
+          '@views_listing_page_link' => url('admin/structure/views/list'),
+        )));
+        $form_state['redirect'] = $one_path;  // Path to the view if it has one.
         return;
       }
     }

--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -802,7 +802,7 @@ function views_ui_add_form_save_submit($form, &$form_state) {
     backdrop_set_message(t('Your view was saved. Click here to <a href="@configure_view_link">configure the view</a> or <a href="@views_listing_page_link">return to the views listing page.</a>', array(
       '@configure_view_link' => url('admin/structure/views/view/' . $view->name . '/configure'),
       '@views_listing_page_link' => url('admin/structure/views/list'),
-      )));  
+    )));
     if ($display->handler->has_path()) {
       $one_path = $display->handler->get_option('path');
       if (strpos($one_path, '%') === FALSE) {

--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -799,6 +799,10 @@ function views_ui_add_form_save_submit($form, &$form_state) {
   $form_state['redirect'] = 'admin/structure/views';
   if (!empty($view->display['page'])) {
     $display = $view->display['page'];
+    backdrop_set_message(t('Your view was saved. Click here to <a href="@configure_view_link">configure the view</a> or <a href="@views_listing_page_link">return to the views listing page.</a>', array(
+      '@configure_view_link' => url('admin/structure/views/view/' . $view->name . '/configure'),
+      '@views_listing_page_link' => url('admin/structure/views/list'),
+      )));  
     if ($display->handler->has_path()) {
       $one_path = $display->handler->get_option('path');
       if (strpos($one_path, '%') === FALSE) {


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#3848. 

I wasn't sure about the best wording for the success message so let me know how to improve it, this is what it looks like as of now:
![Screen Shot 2019-07-17 at 12 23 32 PM](https://user-images.githubusercontent.com/49817604/61405061-bb6f4f00-a88d-11e9-8a2e-b96a077f06be.png)
