### PR TITLE
issue #3941 install dbtasks now checks for utf8mb4 support

### DIFF
--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -305,6 +305,10 @@ abstract class DatabaseTasks {
       'arguments'   => array(),
     ),
     array(
+      'function'    => 'checkUtf8mb4',
+      'arguments'   => array(),
+    ),
+    array(
       'arguments'   => array(
         'CREATE TABLE {backdrop_install_test} (id int NULL)',
         'Backdrop can use CREATE TABLE database commands.',


### PR DESCRIPTION
This solves https://github.com/backdrop/backdrop-issues/issues/3941
I haven't tested with other databases other than mariadb but I can't see why it wouldn't work.  I wonder why it has been left out in the first place.

