### PR TITLE
Allow the CKEditor Styles dropdown to use tag names (for easy use of the <small> tag)

### DIFF
--- a/core/modules/ckeditor/ckeditor.admin.inc
+++ b/core/modules/ckeditor/ckeditor.admin.inc
@@ -73,7 +73,7 @@ function ckeditor_settings_form(&$form, $form_state, $format) {
   }
   $elements['plugins']['style']['style_list'] = array(
     '#type' => 'textarea',
-    '#rows' => 4,
+    '#rows' => max(4, count(explode("\n", $style_list))),
     '#default_value' => $style_list,
     '#description' => t('A list of tags that will be provided in the "Styles" dropdown. Enter one tag on each line in the format: "element[.class]|Label" (where the class is optional).') . '<br />' . t('Example: "code|Code" or "h1.title|Title".') . '<br />' . t('All tags entered here will be automatically added to the "Allowed HTML tags" list below (if the "Limit allowed HTML tags" filter is enabled). Each tag should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
   );

--- a/core/modules/ckeditor/ckeditor.admin.inc
+++ b/core/modules/ckeditor/ckeditor.admin.inc
@@ -75,7 +75,7 @@ function ckeditor_settings_form(&$form, $form_state, $format) {
     '#type' => 'textarea',
     '#rows' => 4,
     '#default_value' => $style_list,
-    '#description' => t('A list of tags that will be provided in the "Styles" dropdown. Enter one tag on each line in the format: "element[.class]|Label" (where the class is optional).') . '<br />' . t('Example: "code|Code" or "h1.title|Title".') . '<br />' . t('If the "Limit allowed HTML tags" filter is enabled, make sure to add these tags to the "Allowed HTML tags" list below. Each tag should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
+    '#description' => t('A list of tags that will be provided in the "Styles" dropdown. Enter one tag on each line in the format: "element[.class]|Label" (where the class is optional).') . '<br />' . t('Example: "code|Code" or "h1.title|Title".') . '<br />' . t('All tags entered here will be automatically added to the "Allowed HTML tags" list below (if the "Limit allowed HTML tags" filter is enabled). Each tag should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
   );
 
   array_unshift($form['#validate'], 'ckeditor_settings_form_validate');

--- a/core/modules/ckeditor/ckeditor.admin.inc
+++ b/core/modules/ckeditor/ckeditor.admin.inc
@@ -7,8 +7,17 @@
  * Editor settings callback; Provide options for CKEditor module.
  */
 function ckeditor_settings_form(&$form, $form_state, $format) {
+  // Build the toolbar based on the current values from $form_state. This
+  // maintains the toolbar button changes when a form validation error occurs.
+  $format_copy = clone $format;
+  if (isset($form_state['input']['editor_settings']['toolbar'])) {
+    if ($toolbar = @json_decode($form_state['input']['editor_settings']['toolbar'], TRUE)) {
+      $format_copy->editor_settings['toolbar'] = $toolbar;
+    }
+  }
+
   $plugins = ckeditor_plugins();
-  $toolbar_element = theme('ckeditor_settings_toolbar', array('format' => $format, 'plugins' => $plugins));
+  $toolbar_element = theme('ckeditor_settings_toolbar', array('format' => $format_copy, 'plugins' => $plugins));
   $elements = array(
     '#attached' => array(
       'library' => array(
@@ -66,7 +75,7 @@ function ckeditor_settings_form(&$form, $form_state, $format) {
     '#type' => 'textarea',
     '#rows' => 4,
     '#default_value' => $style_list,
-    '#description' => t('A list of classes that will be provided in the "Styles" dropdown. Enter one class on each line in the format: element.class|Label. Example: h1.title|Title.') . '<br />' . t('Each style should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
+    '#description' => t('A list of tags that will be provided in the "Styles" dropdown. Enter one tag on each line in the format: "element[.class]|Label" (where the class is optional).') . '<br />' . t('Example: "code|Code" or "h1.title|Title".') . '<br />' . t('Each style should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
   );
 
   array_unshift($form['#validate'], 'ckeditor_settings_form_validate');
@@ -87,8 +96,8 @@ function ckeditor_settings_form_validate($form, &$form_state) {
 
   $styles = _ckeditor_settings_parse_style_list($settings['plugins']['style']['style_list']);
   foreach ($styles as $style) {
-    if (empty($style['name']) || empty($style['element']) || empty($style['attributes']['class'])) {
-      form_error($form['editor_settings']['plugins']['style']['style_list'], t('The CKEditor list of styles is not formatted properly. Be sure to include one style per line, with the format "element.class|Label".'));
+    if (empty($style['name']) || empty($style['element'])) {
+      form_error($form['editor_settings']['plugins']['style']['style_list'], t('The CKEditor list of styles is not formatted properly. Be sure to include one style per line, with the format "element[.class]|Label" (where the class is optional). Example: "code|Code" or "h1.title|Title".'));
     }
   }
 }
@@ -125,11 +134,14 @@ function _ckeditor_settings_parse_style_list($style_list_string) {
     if ($style) {
       @list($element, $label) = explode('|', $style, 2);
       @list($element, $class) = explode('.', $element, 2);
-      $styles[] = array(
+      $style = array(
         'name' => $label,
         'element' => $element,
-        'attributes' => array('class' => $class),
       );
+      if ($class) {
+        $style['attributes']['class'] = $class;
+      }
+      $styles[] = $style;
     }
   }
   return $styles;
@@ -148,7 +160,8 @@ function _ckeditor_settings_stringify_style_list(array $style_list = NULL) {
   $string = '';
   if ($style_list) {
     foreach ($style_list as $style) {
-      $string .= $style['element'] . '.' . $style['attributes']['class'] . '|' . $style['name'] . "\n";
+      $class = !empty($style['attributes']['class']) ? '.' . $style['attributes']['class'] : '';
+      $string .= $style['element'] . $class . '|' . $style['name'] . "\n";
     }
   }
   return $string;

--- a/core/modules/ckeditor/ckeditor.admin.inc
+++ b/core/modules/ckeditor/ckeditor.admin.inc
@@ -75,7 +75,7 @@ function ckeditor_settings_form(&$form, $form_state, $format) {
     '#type' => 'textarea',
     '#rows' => 4,
     '#default_value' => $style_list,
-    '#description' => t('A list of tags that will be provided in the "Styles" dropdown. Enter one tag on each line in the format: "element[.class]|Label" (where the class is optional).') . '<br />' . t('Example: "code|Code" or "h1.title|Title".') . '<br />' . t('Each style should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
+    '#description' => t('A list of tags that will be provided in the "Styles" dropdown. Enter one tag on each line in the format: "element[.class]|Label" (where the class is optional).') . '<br />' . t('Example: "code|Code" or "h1.title|Title".') . '<br />' . t('If the "Limit allowed HTML tags" filter is enabled, make sure to add these tags to the "Allowed HTML tags" list below. Each tag should be in your theme\'s main CSS as well as in your theme\'s ckeditor-iframe.css file.'),
   );
 
   array_unshift($form['#validate'], 'ckeditor_settings_form_validate');

--- a/core/modules/ckeditor/js/ckeditor.admin.js
+++ b/core/modules/ckeditor/js/ckeditor.admin.js
@@ -5,6 +5,8 @@
 Backdrop.behaviors.ckeditorAdmin = {
   attach: function (context, settings) {
     var $context = $(context);
+
+    // Attach behavior for the drag-and-drop toolbar configuration.
     $context.find('.ckeditor-toolbar-configuration').once('ckeditor-toolbar', function() {
       var $wrapper = $(this);
       var $textareaWrapper = $(this).find('.form-item-editor-settings-toolbar').hide();
@@ -344,6 +346,33 @@ Backdrop.behaviors.ckeditorAdmin = {
           adminToolbarInitButton($button, feature, false);
         });
       }
+    });
+
+    // Attach behavior for the adding/remove of tags to the style list.
+    $context.find('.ckeditor-plugin-style textarea').once('ckeditor-style-list').each(function() {
+      var $textarea = $(this);
+
+      $textarea.on('change.ckeditorStyleChange', function() {
+        // Name matches that of the button when addedFeature() was called.
+        var stylesFeature = new Backdrop.EditorFeature('Styles');
+        var userInput = $(this).val().split("\n");
+        for (var n = 0; n < userInput.length; n++) {
+          // Each row is formatted as "tag.class|Label".
+          var row = userInput[n].split("|");
+          // Remove any white space.
+          var tagAndClass = row[0].replace(/\s/, '').split(".");
+          var tagName = tagAndClass[0];
+          var className = tagAndClass[1];
+          if (tagName) {
+            var featureRule = new Backdrop.EditorFeatureHTMLRule({
+              tags: [tagName],
+              classes: (typeof className !== 'undefined') ? [className] : []
+            });
+            stylesFeature.addHTMLRule(featureRule);
+          }
+        }
+        Backdrop.editorConfiguration.modifiedFeature(stylesFeature);
+      }).triggerHandler('change.ckeditorStyleChange');
     });
   }
 };

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -153,6 +153,9 @@ function filter_admin_format_page($format = NULL) {
  * @ingroup forms
  */
 function filter_admin_format_form($form, &$form_state, $format) {
+  // Make this form rebuild on every validation.
+  $form['#rebuild'] = TRUE;
+
   $is_fallback = ($format->format == filter_fallback_format());
   $editors = filter_get_editors();
   if (isset($form_state['editor_info'])) {

--- a/core/modules/filter/js/filter.admin.js
+++ b/core/modules/filter/js/filter.admin.js
@@ -266,7 +266,7 @@ Backdrop.EditorFeature.prototype.addHTMLRule = function (rule) {
  *
  * Examples:
  *  - required: true,
- *  - tags: ['<a>']
+ *  - tags: ['a']
  *  - attributes: ['href', 'alt']
  *  - styles: ['color', 'text-decoration']
  *  - classes: ['external', 'internal']


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2980

Replaces https://github.com/backdrop/backdrop/pull/2102 and https://github.com/backdrop/backdrop/pull/2777