### PR TITLE
Issue #3913: added test for empty/null tid to taxonomy_build_node_index function

### DIFF
--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -2003,12 +2003,14 @@ function taxonomy_build_node_index(Node $node) {
     if (!empty($tid_all)) {
       $query = db_insert('taxonomy_index')->fields(array('nid', 'tid', 'sticky', 'created'));
       foreach ($tid_all as $tid) {
-        $query->values(array(
-          'nid' => $node->nid,
-          'tid' => $tid,
-          'sticky' => $sticky,
-          'created' => $node->created,
-        ));
+        if (!empty($tid)) {
+          $query->values(array(
+            'nid' => $node->nid,
+            'tid' => $tid,
+            'sticky' => $sticky,
+            'created' => $node->created,
+          ));
+        }
       }
       $query->execute();
     }


### PR DESCRIPTION
By @jackaponte, @laryn, @bradbulger, @ksthomas (Crediting everyone who helped on the issue!)

As discussed in https://github.com/backdrop/backdrop-issues/issues/3913, there's a bug in core that prevents saving new nodes with term reference fields that aren't required and have no terms selected. This pull request fixes that bug by adding in a test for null `tid` values before trying to populate the taxonomy index.

Steps to reproduce the bug and fix it with the change in this pull request:

1. Installed fresh copy of Backdrop 1.13.2
2. Added test term to Tags vocabulary
3. Attempted to save a new Post node without entering a tag; saved with no problems.
4. Changed widget for Tags field on Post content type to "Select list"
5. Attempted to save a new Post node without selecting a tag; saved with no problems.
6. Added a new "Test Vocab" vocabulary to the site.
7. Added a term reference field to the Post content type for the Test Vocab vocabulary using the "Select list" widget
8. Attempted to save a new Post node without selecting any taxonomy terms; got the errors we've been reporting.
9. Added a test for empty/null tid to taxonomy_build_node_index function
10. Attempted to save a new Post node without selecting a tag; saved with no problems.