### PR TITLE
Issue #3981: Prevent php notice in theme_get_setting().

### DIFF
--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1450,6 +1450,10 @@ function theme_get_setting($setting_name, $theme = NULL) {
     $theme = !empty($GLOBALS['theme_key']) ? $GLOBALS['theme_key'] : '';
   }
 
+  if (empty($theme)) {
+    return;
+  }
+
   if (empty($configs[$theme])) {
     $configs[$theme] = config($theme . '.settings');
     $configs[$theme]->load();


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3981