### PR TITLE
Issue #3936: Fix group operators in views "rearrange filter criteria" dialog

### DIFF
--- a/core/modules/views_ui/js/views-admin.js
+++ b/core/modules/views_ui/js/views-admin.js
@@ -724,7 +724,7 @@ $.extend(Backdrop.viewsUi.RearrangeFilterHandler.prototype, {
         // first operator dropdown we encounter, going backwards from the current
         // row. This dropdown is the one associated with the current row's filter
         // group.
-        var operatorValue = $draggableRow.prevAll('.views-group-title').find('option:selected').html();
+        var operatorValue = $draggableRow.prevAll('.views-group-title').find('option:selected').last().html();
         var operatorLabel = '<span class="views-operator-label">' + operatorValue + '</span>';
         // If the next visible row after this one is a draggable filter row,
         // display the operator label next to the current row. (Checking for


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#3936

It seemed like the reason both operators were showing up as the value of the first operator was because in views-admin.js, when getting the operator value, `find()` returns the elements in the order they are on the page, so the value found was always the value of the first operator, not the one relating to the current group. I added `.last()` after `find(‘option:selected’)` to access the operator value that is associated with the current row’s group. 