### PR TITLE
Issue #3755: Fixing delete row token checking.

### DIFF
--- a/core/modules/layout/layout.flexible.inc
+++ b/core/modules/layout/layout.flexible.inc
@@ -737,7 +737,7 @@ function layout_flexible_template_edit_row_ajax($form, $form_state) {
  * @ingroup forms
  */
 function layout_flexible_template_delete_row(LayoutFlexibleTemplate $flexible_template, $original_row) {
-  if (!isset($_GET['token']) || backdrop_valid_token($_GET['token'], 'backdrop-region-' . $original_row)) {
+  if (!isset($_GET['token']) || !backdrop_valid_token($_GET['token'], 'layout-region-' . $original_row)) {
     return MENU_ACCESS_DENIED;
   }
 


### PR DESCRIPTION
Fixes an issue discovered in https://github.com/backdrop/backdrop-issues/issues/3755 where the token isn't correctly checked.