### PR TITLE
Issue #4021: Property langcode of non-object

### DIFF
--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -422,6 +422,7 @@ function locale_language_url_rewrite_url(&$path, &$options) {
   if (!isset($languages)) {
     // Get the enabled languages only.
     $languages = language_list(TRUE);
+    $languages = array_keys($languages);
   }
 
   // Array key doesn't even exist in the options.

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -431,7 +431,7 @@ function locale_language_url_rewrite_url(&$path, &$options) {
     $options['language'] = $language_url;
   }
   // We allow only enabled languages here.
-  elseif (!isset($languages[$options['language']])) {
+  elseif (is_object($options['language']) && !array_key_exists($options['language']->langcode, $languages)) {
     unset($options['language']);
     return;
   }

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -425,24 +425,24 @@ function locale_language_url_rewrite_url(&$path, &$options) {
     $languages = array_keys($languages);
   }
 
-  // Array key doesn't even exist in the options.
+  // Prevent "undefined index" if array key doesn't even exist.
   if (!isset($options['language'])) {
-    $options['language'] = FALSE;
+    $options['language'] = NULL;
   }
+
   // If language isn't provided as an option, we go for current URL language.
   if (!is_object($options['language'])) {
     global $language_url;
     $options['language'] = $language_url;
   }
-  else {
+
+  if (is_object($options['language'])) {
     // Sort out disabled languages.
     if (!in_array($options['language']->langcode, $languages)) {
       unset($options['language']);
       return;
     }
-  }
 
-  if (is_object($options['language'])) {
     switch (config_get('locale.settings', 'language_negotiation_url_part')) {
       case LANGUAGE_NEGOTIATION_URL_DOMAIN:
         $domains = locale_language_negotiation_url_domains();

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -424,9 +424,8 @@ function locale_language_url_rewrite_url(&$path, &$options) {
     $languages = language_list(TRUE);
     $languages = array_flip(array_keys($languages));
   }
-
   // Language can be passed as an option, or we go for current URL language.
-  if (!isset($options['language'])) {
+  if (!isset($options['language']) || $options['language'] === FALSE) {
     global $language_url;
     $options['language'] = $language_url;
   }

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -431,7 +431,7 @@ function locale_language_url_rewrite_url(&$path, &$options) {
     $options['language'] = $language_url;
   }
   // We allow only enabled languages here.
-  elseif (!isset($languages[$options['language']->langcode])) {
+  elseif (!isset($languages[$options['language']])) {
     unset($options['language']);
     return;
   }

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -422,20 +422,26 @@ function locale_language_url_rewrite_url(&$path, &$options) {
   if (!isset($languages)) {
     // Get the enabled languages only.
     $languages = language_list(TRUE);
-    $languages = array_flip(array_keys($languages));
   }
-  // Language can be passed as an option, or we go for current URL language.
-  if (!isset($options['language']) || $options['language'] === FALSE) {
+
+  // Array key doesn't even exist in the options.
+  if (!isset($options['language'])) {
+    $options['language'] = FALSE;
+  }
+  // If language isn't provided as an option, we go for current URL language.
+  if (!is_object($options['language'])) {
     global $language_url;
     $options['language'] = $language_url;
   }
-  // We allow only enabled languages here.
-  elseif (is_object($options['language']) && !array_key_exists($options['language']->langcode, $languages)) {
-    unset($options['language']);
-    return;
+  else {
+    // Sort out disabled languages.
+    if (!in_array($options['language']->langcode, $languages)) {
+      unset($options['language']);
+      return;
+    }
   }
 
-  if (isset($options['language'])) {
+  if (is_object($options['language'])) {
     switch (config_get('locale.settings', 'language_negotiation_url_part')) {
       case LANGUAGE_NEGOTIATION_URL_DOMAIN:
         $domains = locale_language_negotiation_url_domains();


### PR DESCRIPTION
See details in https://github.com/backdrop/backdrop-issues/issues/4021

If language isn't set, $languages[$options['language']] is no object.