### PR TITLE
Issue #4022: [UX] Missing translation calls fixed

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -569,7 +569,7 @@ function node_add_body_field($type, $label = 'Body') {
       'field_name' => 'body',
       'entity_type' => 'node',
       'bundle' => $type->type,
-      'label' => $label,
+      'label' => t($label),
       'widget' => array('type' => 'text_textarea_with_summary'),
       'settings' => array('display_summary' => TRUE),
       'display' => array(


### PR DESCRIPTION
Missing translation function calls in `node.module`
Issue: https://github.com/backdrop/backdrop-issues/issues/4022