### PR TITLE
Issue #4022: [UX] Missing translation calls tested

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -569,7 +569,7 @@ function node_add_body_field($type, $label = 'Body') {
       'field_name' => 'body',
       'entity_type' => 'node',
       'bundle' => $type->type,
-      'label' => $label,
+      'label' => st($label),
       'widget' => array('type' => 'text_textarea_with_summary'),
       'settings' => array('display_summary' => TRUE),
       'display' => array(
@@ -771,7 +771,7 @@ function node_type_set_defaults($info = array()) {
     'modified' => FALSE,
     'disabled' => FALSE,
     'has_title' => TRUE,
-    'title_label' => 'Title',
+    'title_label' => st('Title'),
     'settings' => array(),
   );
   $new_type = (object) $new_type;


### PR DESCRIPTION
Missing translation function calls in `node.module`
Issue: https://github.com/backdrop/backdrop-issues/issues/4022
I used the `st()` function, because `t()` doesn't work during installation process, and `standard.install` calls functions of `node.module`: `node_add_body_field()` and `node_type_set_defaults()`