### PR TITLE
Issue #4096: [UX] Content type settings: move the "Show option for scheduling" checkbox before the "Default status" select

### DIFF
--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -179,6 +179,11 @@ function node_type_form($form, &$form_state, $type = NULL) {
     '#group' => 'additional_settings',
     '#weight' => -10,
   );
+  $form['workflow']['scheduling_enabled'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show option for scheduling'),
+    '#default_value' => $type->settings['scheduling_enabled'],
+  );
   $form['workflow']['status_default'] = array(
     '#type' => 'radios',
     '#title' => t('Default status'),
@@ -195,11 +200,6 @@ function node_type_form($form, &$form_state, $type = NULL) {
     'visible' => array(
       'input[name="scheduling_enabled"]' => array('checked' => TRUE),
     ),
-  );
-  $form['workflow']['scheduling_enabled'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Show option for scheduling'),
-    '#default_value' => $type->settings['scheduling_enabled'],
   );
   $form['workflow']['sticky'] = array(
     '#type' => 'checkboxes',


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/4096

Moves the "Show option for scheduling" checkbox before the "Default status" select:

![Screen Shot 2019-09-27 at 9 52 12 am](https://user-images.githubusercontent.com/2423362/65732294-90ff0500-e10c-11e9-847a-164ff5e772cb.png)
