### PR TITLE
Issue #4072: Use labels instead of UUIDs for region names in the blocks listing.

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2967,7 +2967,7 @@ function layout_block_list() {
 
   $page['description'] = array(
     '#type' => 'help',
-    '#markup' => t('A summary of all available blocks. The <em>Usage</em> column shows the layouts and regions to which blocks are currently assigned, in the format <em>Layout name (region)</em>.'),
+    '#markup' => t('A summary of all available blocks. The <em>Usage</em> column shows the layouts and regions to which each block is currently placed, in the format <em>Layout name (region)</em>.'),
   );
 
   $page['table'] = array(

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -3018,10 +3018,13 @@ function layout_get_block_usage($module = NULL, $delta = NULL) {
           $flexi_regions[$flexi_region_name] = $layout->positions[$uuid];
         }
 
-        $layout->positions = $flexi_regions;
+        $layout_positions = $flexi_regions;
+      }
+      else {
+        $layout_positions = $layout->positions;
       }
 
-      foreach ($layout->positions as $position => $uuids) {
+      foreach ($layout_positions as $position => $uuids) {
         foreach ($uuids as $uuid) {
           $block = $layout->content[$uuid];
           $block->layout_title = $layout->title;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2941,7 +2941,7 @@ function layout_block_list() {
                 $instances[$position][] = $instance;
               }
             }
-            $positions = implode(', ', array_map('ucfirst', array_keys($instances)));
+            $positions = implode(', ', array_keys($instances));
             $usages[] = l($instance->layout_title . ' (' . $positions . ')', 'admin/structure/layouts/manage/' . $layout);
           }
         }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -763,12 +763,12 @@ function layout_settings_form_save_submit($form, &$form_state) {
 }
 
 /**
- * Form callback; Main form for editing a layout's content.
+ * Form callback; Main form for editing a layout's content ("Manage blocks").
  *
- * No validation function is necessary, as all 'validation' is handled
- * either in the lead-up to form rendering (through the selection of
- * specified content types) or by the validation functions specific to
- * the ajax modals & content types.
+ * No validation function is necessary, as all 'validation' is handled either in
+ * the lead-up to form rendering (through the selection of specified content
+ * types) or by the validation functions specific to the AJAX modals & content
+ * types.
  *
  * @ingroup forms
  */
@@ -893,9 +893,8 @@ function layout_content_form_validate($form, &$form_state) {
 /**
  * Handle form submission of the display content editor.
  *
- * This reads the location of the various blocks from the form, which will
- * have been modified via JavaScript, rearranges them and then saves
- * the display.
+ * This reads the location of the various blocks from the form, which will have
+ * been modified via JavaScript, rearranges them and then saves the display.
  */
 function layout_content_form_submit($form, &$form_state) {
   /* @var Layout $layout */
@@ -2924,6 +2923,7 @@ function layout_configure_region_page_submit($form, &$form_state) {
 function layout_block_list() {
   $rows = array();
 
+  $module_info = system_get_info('module');
   $module_blocks = layout_get_block_info();
   $usage = layout_get_block_usage();
 
@@ -2947,7 +2947,7 @@ function layout_block_list() {
         }
         $usage_list = $usages ? theme('item_list', array('items' => $usages)) : t('Not in use');
         $block_name = check_plain($block['info']) . ' (' . $delta . ')';
-        $rows[] = array('name' => $block_name, 'usage' => $usage_list, 'module' => $module, 'contexts' => $contexts);
+        $rows[] = array('name' => $block_name, 'usage' => $usage_list, 'module' => $module_info[$module]['name'], 'contexts' => $contexts);
       }
     }
   }
@@ -2963,14 +2963,14 @@ function layout_block_list() {
   $sort = tablesort_get_sort($header);
 
   backdrop_sort($rows, array($order['sql'] => SORT_STRING));
-  $rows = ($sort == 'asc') ? $rows : array_reverse($rows);
+  $rows = ($sort == 'asc') ? array_reverse($rows) : $rows;
 
   $page['description_container'] = array(
     '#type' => 'container',
   );
 
   $page['description_container']['description'] = array(
-    '#markup' => '<p>' . t("Provides a summary of all available blocks. The 'Usage' column shows which layout and region to which blocks are currently assigned in the format 'Layout name (region)'.") . '<p>',
+    '#markup' => '<p>' . t("Provides a summary of all available blocks. The 'Usage' column shows the layouts and respective regions to which each block is currently placed, in the format 'Layout name (region)'.") . '<p>',
   );
 
   $page['table'] = array(
@@ -2999,9 +2999,28 @@ function layout_block_list() {
  */
 function layout_get_block_usage($module = NULL, $delta = NULL) {
   $blocks = &backdrop_static(__FUNCTION__, array());
+
+  $all_template_info = layout_get_layout_template_info(NULL, TRUE);
+
   if (empty($blocks)) {
     $layout_info = layout_load_all();
     foreach ($layout_info as $layout) {
+
+      $layout_template = $layout->layout_template;
+      $layout_has_flexible_template = !empty($all_template_info[$layout_template]['flexible']);
+
+      // Layouts that use flexible templates return cryptic UUIDs as region
+      // names. Replace these UUIDs with the respective user-friendly labels.
+      if ($layout_has_flexible_template) {
+        $flexi_regions = array_flip($all_template_info[$layout_template]['regions']);
+
+        foreach ($flexi_regions as $flexi_region_name => $uuid) {
+          $flexi_regions[$flexi_region_name] = $layout->positions[$uuid];
+        }
+
+        $layout->positions = $flexi_regions;
+      }
+
       foreach ($layout->positions as $position => $uuids) {
         foreach ($uuids as $uuid) {
           $block = $layout->content[$uuid];

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2986,8 +2986,8 @@ function layout_block_list() {
  * @param string $module
  *   The module providing the required blocks.
  * @param string $delta
- *   The block delta. If $delta is provided, $module is also required since
- *   block deltas are not required to be unique.
+ *   The block delta. If $delta is provided, then $module is also required
+ *   (since block deltas are not required to be unique).
  *
  * @return array
  *   An array of block usage instances keyed by block module, delta, layout
@@ -2996,36 +2996,16 @@ function layout_block_list() {
  */
 function layout_get_block_usage($module = NULL, $delta = NULL) {
   $blocks = &backdrop_static(__FUNCTION__, array());
-
-  $all_template_info = layout_get_layout_template_info(NULL, TRUE);
-
   if (empty($blocks)) {
     $layout_info = layout_load_all();
     foreach ($layout_info as $layout) {
-
-      $layout_template = $layout->layout_template;
-      $layout_has_flexible_template = !empty($all_template_info[$layout_template]['flexible']);
-
-      // Layouts that use flexible templates return cryptic UUIDs as region
-      // names. Replace these UUIDs with the respective user-friendly labels.
-      if ($layout_has_flexible_template) {
-        $flexi_regions = array_flip($all_template_info[$layout_template]['regions']);
-
-        foreach ($flexi_regions as $flexi_region_name => $uuid) {
-          $flexi_regions[$flexi_region_name] = $layout->positions[$uuid];
-        }
-
-        $layout_positions = $flexi_regions;
-      }
-      else {
-        $layout_positions = $layout->positions;
-      }
-
-      foreach ($layout_positions as $position => $uuids) {
+      $layout_template = layout_get_layout_template_info($layout->layout_template);
+      $regions = $layout_template['regions'];
+      foreach ($layout->positions as $position => $uuids) {
         foreach ($uuids as $uuid) {
           $block = $layout->content[$uuid];
           $block->layout_title = $layout->title;
-          $blocks[$block->module][$block->delta][$layout->name][$position][] = $block;
+          $blocks[$block->module][$block->delta][$layout->name][$regions[$position]][] = $block;
         }
       }
     }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2965,12 +2965,9 @@ function layout_block_list() {
   backdrop_sort($rows, array($order['sql'] => SORT_STRING));
   $rows = ($sort == 'asc') ? array_reverse($rows) : $rows;
 
-  $page['description_container'] = array(
-    '#type' => 'container',
-  );
-
-  $page['description_container']['description'] = array(
-    '#markup' => '<p>' . t("Provides a summary of all available blocks. The 'Usage' column shows the layouts and respective regions to which each block is currently placed, in the format 'Layout name (region)'.") . '<p>',
+  $page['description'] = array(
+    '#type' => 'help',
+    '#markup' => t('A summary of all available blocks. The <em>Usage</em> column shows the layouts and regions to which blocks are currently assigned, in the format <em>Layout name (region)</em>.'),
   );
 
   $page['table'] = array(

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2425,14 +2425,17 @@ class LayoutBlockUsageTestCase extends BackdropWebTestCase {
   /**
    * Checks block usage.
    */
-  protected function checkBlockUsage($delta, $layout, $position) {
+  protected function checkBlockUsage($delta, $layout_name, $position) {
     backdrop_static_reset('layout_get_block_usage');
     layout_reset_caches();
     module_load_include('inc', 'layout', 'layout.admin');
+    $layout = layout_load($layout_name);
+    $layout_template = layout_get_layout_template_info($layout->layout_template);
+    $position = $layout_template['regions'][$position];
     $usage = layout_get_block_usage();
-    $this->assertTrue(isset($usage['system'][$delta][$layout][$position]), 'Block usage returned correctly. Block found in array.');
-    if (isset($usage['system'][$delta][$layout][$position])) {
-      return count($usage['system'][$delta][$layout][$position]);
+    $this->assertTrue(isset($usage['system'][$delta][$layout->name][$position]), 'Block usage returned correctly. Block found in array.');
+    if (isset($usage['system'][$delta][$layout->name][$position])) {
+      return count($usage['system'][$delta][$layout->name][$position]);
     }
     return FALSE;
   }
@@ -2440,14 +2443,15 @@ class LayoutBlockUsageTestCase extends BackdropWebTestCase {
   /**
    * Checks block not in usage.
    */
-  protected function checkBlockNoUsage($delta, $layout, $position) {
+  protected function checkBlockNoUsage($delta, $layout_name, $position) {
     backdrop_static_reset('layout_get_block_usage');
     layout_reset_caches();
     module_load_include('inc', 'layout', 'layout.admin');
+    $layout = layout_load($layout_name);
     $layout_template = layout_get_layout_template_info($layout->layout_template);
     $position = $layout_template['regions'][$position];
     $usage = layout_get_block_usage();
-    $this->assertFalse(isset($usage[$delta][$layout][$position]), 'Block usage returned correctly. Block not found in array.');
+    $this->assertFalse(isset($usage[$delta][$layout->name][$position]), 'Block usage returned correctly. Block not found in array.');
     return TRUE;
   }
 }

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2444,6 +2444,8 @@ class LayoutBlockUsageTestCase extends BackdropWebTestCase {
     backdrop_static_reset('layout_get_block_usage');
     layout_reset_caches();
     module_load_include('inc', 'layout', 'layout.admin');
+    $layout_template = layout_get_layout_template_info($layout->layout_template);
+    $position = $layout_template['regions'][$position];
     $usage = layout_get_block_usage();
     $this->assertFalse(isset($usage[$delta][$layout][$position]), 'Block usage returned correctly. Block not found in array.');
     return TRUE;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4072