### PR TITLE
Issue #74 add entity cache to core

### DIFF
--- a/core/modules/comment/comment.entity.inc
+++ b/core/modules/comment/comment.entity.inc
@@ -335,7 +335,7 @@ class CommentStorageController extends EntityDatabaseStorageController {
     // If entity caching is enabled on nodes, clear the cache for the node.
     $node_info = entity_get_info('node');
     if (isset($node_info['entity cache']) && $node_info['entity cache']) {
-      cache_clear_all($comment->nid, 'cache_entity_node');
+      cache('entity_node')->delete($comment->nid);
     }
   }
 
@@ -359,7 +359,9 @@ class CommentStorageController extends EntityDatabaseStorageController {
     // the deleted comments were on.
     $node_info = entity_get_info('node');
     if (isset($node_info['entity cache']) && $node_info['entity cache']) {
-      cache_clear_all(array_unique($nodes), 'cache_entity_node');
+      foreach (array_unique($nodes) as $nid) {
+        cache('entity_node')->delete($nid);
+      }
     }
 
   }

--- a/core/modules/comment/comment.entity.inc
+++ b/core/modules/comment/comment.entity.inc
@@ -202,6 +202,18 @@ class Comment extends Entity {
 class CommentStorageController extends EntityDatabaseStorageController {
 
   /**
+   * Overrides DefaultEntityController::load().
+   */
+  public function load($ids = array(), $conditions = array()) {
+    $comments = parent::load($ids, $conditions);
+
+    foreach ($comments as $key => $comment) {
+      $comment->new = node_mark($comment->nid, $comment->changed);
+    }
+    return $comments;
+  }
+
+  /**
    * Overrides EntityDatabaseStorageController::buildQuery().
    */
   protected function buildQuery($ids, $conditions = array(), $revision_id = FALSE) {
@@ -222,7 +234,6 @@ class CommentStorageController extends EntityDatabaseStorageController {
     // Set up standard comment properties.
     foreach ($comments as $key => $comment) {
       $comment->name = $comment->uid ? $comment->registered_name : $comment->name;
-      $comment->new = node_mark($comment->nid, $comment->changed);
       $comment->node_type = 'comment_node_' . $comment->node_type;
       $comments[$key] = $comment;
     }
@@ -320,6 +331,12 @@ class CommentStorageController extends EntityDatabaseStorageController {
     if ($comment->status == COMMENT_PUBLISHED) {
       module_invoke_all('comment_publish', $comment);
     }
+
+    // If entity caching is enabled on nodes, clear the cache for the node.
+    $node_info = entity_get_info('node');
+    if (isset($node_info['entity cache']) && $node_info['entity cache']) {
+      cache_clear_all($comment->nid, 'cache_entity_node');
+    }
   }
 
   /**
@@ -335,7 +352,16 @@ class CommentStorageController extends EntityDatabaseStorageController {
 
     foreach ($comments as $comment) {
       $this->updateNodeStatistics($comment->nid);
+      $nodes[] = $comment->nid;
     }
+
+    // If entity caching is enabled on nodes, clear the cache for the nodes that
+    // the deleted comments were on.
+    $node_info = entity_get_info('node');
+    if (isset($node_info['entity cache']) && $node_info['entity cache']) {
+      cache_clear_all(array_unique($nodes), 'cache_entity_node');
+    }
+
   }
 
   /**

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -302,6 +302,10 @@ function comment_schema() {
     ),
   );
 
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_comment'] = $cache_schema;
+  $schema['cache_entity_comment']['description'] = "Cache table used to store Comment entity records.";
+
   return $schema;
 }
 
@@ -431,6 +435,15 @@ function comment_update_1005() {
     $config->set('module', 'comment');
     $config->save();
   }
+}
+
+/**
+ * Creates the table to enable caching of Comment entities.
+ */
+function comment_update_1006() {
+  $table = backdrop_get_schema_unprocessed('system', 'cache');
+  $table['description'] = "Cache table used to store Comment entity records.";
+  db_create_table('cache_entity_comment', $table);
 }
 
 /**

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -71,7 +71,7 @@ define('COMMENT_NODE_OPEN', 2);
  * Implements hook_entity_info().
  */
 function comment_entity_info() {
-  $return = array(
+  $entity_info = array(
     'comment' => array(
       'label' => t('Comment'),
       'bundle label' => t('Node type'),
@@ -96,12 +96,12 @@ function comment_entity_info() {
 
   // If the cache table has been created, then enable entity caching.
   if (db_table_exists('cache_entity_comment')) {
-    $return['comment']['entity cache'] = TRUE;
-    $return['comment']['field cache'] = FALSE;
+    $entity_info['comment']['entity cache'] = TRUE;
+    $entity_info['comment']['field cache'] = FALSE;
   }
 
   foreach (node_type_get_names() as $type => $name) {
-    $return['comment']['bundles']['comment_node_' . $type] = array(
+    $entity_info['comment']['bundles']['comment_node_' . $type] = array(
       'label' => t('@node_type comment', array('@node_type' => $name)),
       // Provide the node type/bundle name for other modules, so it does not
       // have to be extracted manually from the bundle name.
@@ -121,7 +121,7 @@ function comment_entity_info() {
     );
   }
 
-  return $return;
+  return $entity_info;
 }
 
 /**

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -94,6 +94,12 @@ function comment_entity_info() {
     ),
   );
 
+  // If the cache table has been created, then enable entity caching.
+  if (db_table_exists('cache_entity_comment')) {
+    $return['comment']['entity cache'] = TRUE;
+    $return['comment']['field cache'] = FALSE;
+  }
+
   foreach (node_type_get_names() as $type => $name) {
     $return['comment']['bundles']['comment_node_' . $type] = array(
       'label' => t('@node_type comment', array('@node_type' => $name)),

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -1135,7 +1135,7 @@ class CommentPreviewTest extends CommentHelperCase {
  * Tests anonymous commenting.
  */
 class CommentAnonymous extends CommentHelperCase {
-  function setUp() {
+  function setUp($modules = array()) {
     parent::setUp();
     config_set('system.core', 'user_register', USER_REGISTER_VISITORS);
   }
@@ -1540,7 +1540,7 @@ class CommentPagerTest extends CommentHelperCase {
  * Tests comments with node access.
  */
 class CommentNodeAccessTest extends CommentHelperCase {
-  function setUp() {
+  function setUp($modules = array()) {
     parent::setUp('search', 'node_access_test');
 
     $web_user_role = $this->web_user->roles[count($this->web_user->roles) - 1];
@@ -1712,7 +1712,7 @@ class CommentApprovalTest extends CommentHelperCase {
  * Tests the Comment module blocks.
  */
 class CommentBlockFunctionalTest extends CommentHelperCase {
-  function setUp() {
+  function setUp($modules = array()) {
     parent::setUp(array('block'));
 
     $admin_user_role = $this->admin_user->roles[count($this->admin_user->roles) - 1];
@@ -2001,7 +2001,7 @@ class CommentActionsTestCase extends CommentHelperCase {
  * Tests fields on comments.
  */
 class CommentFieldsTest extends CommentHelperCase {
-  function setUp() {
+  function setUp($modules = array()) {
     parent::setUp(array('field_ui'));
   }
 

--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -29,10 +29,13 @@
  *     entity type's base table.
  *   - static cache: (used by DefaultEntityController) FALSE to disable
  *     static caching of entities during a page request. Defaults to TRUE.
+ *   - entity cache: (used by DefaultEntityController) Set to TRUE to enable
+ *     persistent caching of fully loaded entities. This will be considered to
+ *     be FALSE if there is not a cache table for the entity. Defaults to FALSE.
  *   - field cache: (used by Field API loading and saving of field data) FALSE
- *     to disable Field API's persistent cache of field data. Only recommended
- *     if a higher level persistent cache is available for the entity type.
- *     Defaults to TRUE.
+ *     to disable Field API's persistent cache of field data. Setting this to
+ *     FALSE is recommended if a higher level persistent cache is available for
+ *     the entity type. Defaults to TRUE.
  *   - load hook: The name of the hook which should be invoked by
  *     DefaultEntityController:attachLoad(), for example 'node_load'.
  *   - fieldable: Set to TRUE if you want your entity type to be fieldable.

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -159,12 +159,14 @@ class DefaultEntityController implements EntityControllerInterface {
    */
   public function resetCache(array $ids = NULL) {
     // Reset the persistent cache.
-    if (!empty($ids)) {
-      cache_clear_all($ids, 'cache_entity_' . $this->entityType);
-    }
-    else {
-      // Force all cached entries to be deleted.
-      cache_clear_all('*', 'cache_entity_' . $this->entityType, TRUE);
+    if (isset($this->entityInfo['entity cache']) && $this->entityInfo['entity cache']) {
+      if (!empty($ids)) {
+        cache_clear_all($ids, 'cache_entity_' . $this->entityType);
+      }
+      else {
+        // Force all cached entries to be deleted.
+        cache_clear_all('*', 'cache_entity_' . $this->entityType, TRUE);
+      }
     }
 
     $this->resetStaticCache($ids);
@@ -251,7 +253,7 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Try to load entities from the persistent cache.
-    if ($this->entityInfo['entity cache'] && !$revision_id && $ids && !$conditions) {
+    if (isset($this->entityInfo['entity cache']) && $this->entityInfo['entity cache'] && !$revision_id && $ids && !$conditions) {
       $cached_entities = array();
       if ($ids && !$conditions) {
         $cached = cache_get_multiple($ids, 'cache_entity_' . $this->entityType);
@@ -301,7 +303,7 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Add entities to the entity cache if we are not loading a revision.
-    if ($this->entityInfo['entity cache'] && !empty($queried_entities) && !$revision_id) {
+    if (isset($this->entityInfo['entity cache']) && $this->entityInfo['entity cache'] && !empty($queried_entities) && !$revision_id) {
       // Only cache the entities which were loaded by ID. Entities that were
       // loaded based on conditions will never be found via cacheGet() and we
       // would keep on caching them.

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -28,6 +28,15 @@ interface EntityControllerInterface {
   public function resetCache(array $ids = NULL);
 
   /**
+   * Resets the internal, static entity cache.
+   *
+   * @param string[] $ids
+   *   (optional) If specified, the cache is reset for the entities with the
+   *   given ids only.
+   */
+  public function resetStaticCache(array $ids = NULL);
+
+  /**
    * Loads one or more entities.
    *
    * @param $ids
@@ -149,6 +158,22 @@ class DefaultEntityController implements EntityControllerInterface {
    * Implements EntityControllerInterface::resetCache().
    */
   public function resetCache(array $ids = NULL) {
+    // Reset the persistent cache.
+    if (!empty($ids)) {
+      cache_clear_all($ids, 'cache_entity_' . $this->entityType);
+    }
+    else {
+      // Force all cached entries to be deleted.
+      cache_clear_all('*', 'cache_entity_' . $this->entityType, TRUE);
+    }
+
+    $this->resetStaticCache($ids);
+  }
+
+  /**
+   * Implements EntityControllerInterface::resetStaticCache().
+   */
+  public function resetStaticCache(array $ids = NULL) {
     if (isset($ids)) {
       foreach ($ids as $id) {
         unset($this->entityCache[$id]);
@@ -181,6 +206,40 @@ class DefaultEntityController implements EntityControllerInterface {
     // and we need to know if it's empty for this reason to avoid querying the
     // database when all requested entities are loaded from cache.
     $passed_ids = !empty($ids) ? array_flip($ids) : FALSE;
+
+    // Use an entity field query to transform the list of conditions into
+    // the set of entity IDs which the conditions admit, then re-enter this
+    // method with that set as the $ids constraint.
+    if ($conditions) {
+      $query = new EntityFieldQuery();
+      $query->entityCondition('entity_type', $this->entityType);
+      foreach ($conditions as $property_name => $condition) {
+        // Note $condition might be multiple values, which are treated as OR
+        // by default.
+        $query->propertyCondition($property_name, $condition);
+      }
+
+      // Limit the result set also by the passed in IDs.
+      if ($passed_ids) {
+        $query->propertyCondition($this->idKey, array_keys($passed_ids));
+      }
+
+      $result = $query->execute();
+      if (isset($result[$this->entityType])) {
+        $entity_ids = array_keys($result[$this->entityType]);
+        if ($revision_id) {
+          return $this->load($entity_ids, array($this->revisionKey => $revision_id));
+        }
+        else {
+          return $this->load($entity_ids);
+        }
+      }
+      else {
+        // No results found.
+        return array();
+      }
+    }
+
     // Try to load entities from the static cache, if the entity type supports
     // static caching.
     if ($this->cache && !$revision_id) {
@@ -188,6 +247,32 @@ class DefaultEntityController implements EntityControllerInterface {
       // If any entities were loaded, remove them from the ids still to load.
       if ($passed_ids) {
         $ids = array_keys(array_diff_key($passed_ids, $entities));
+      }
+    }
+
+    // Try to load entities from the persistent cache.
+    if ($this->entityInfo['entity cache'] && !$revision_id && $ids && !$conditions) {
+      $cached_entities = array();
+      if ($ids && !$conditions) {
+        $cached = cache_get_multiple($ids, 'cache_entity_' . $this->entityType);
+
+        if ($cached) {
+          foreach ($cached as $item) {
+            $cached_entities[$item->cid] = $item->data;
+          }
+        }
+      }
+
+      $entities += $cached_entities;
+
+      // If any entities were loaded, remove them from the ids still to load.
+      $ids = array_diff($ids, array_keys($cached_entities));
+
+      if ($this->cache) {
+        // Add entities to the cache if we are not loading a revision.
+        if (!empty($cached_entities) && !$revision_id) {
+          $this->cacheSet($cached_entities);
+        }
       }
     }
 
@@ -213,6 +298,21 @@ class DefaultEntityController implements EntityControllerInterface {
     if (!empty($queried_entities)) {
       $this->attachLoad($queried_entities, $revision_id);
       $entities += $queried_entities;
+    }
+
+    // Add entities to the entity cache if we are not loading a revision.
+    if ($this->entityInfo['entity cache'] && !empty($queried_entities) && !$revision_id) {
+      // Only cache the entities which were loaded by ID. Entities that were
+      // loaded based on conditions will never be found via cacheGet() and we
+      // would keep on caching them.
+      if ($passed_ids) {
+        $queried_entities_by_id = array_intersect_key($queried_entities, $passed_ids);
+        if (!empty($queried_entities_by_id)) {
+          foreach ($queried_entities_by_id as $id => $item) {
+            cache_set($id, $item, 'cache_entity_' . $this->entityType);
+          }
+        }
+      }
     }
 
     if ($this->cache) {

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -165,7 +165,7 @@ class DefaultEntityController implements EntityControllerInterface {
       }
       else {
         // Force all cached entries to be deleted.
-        cache_clear_all('*', 'cache_entity_' . $this->entityType, TRUE);
+        cache_flush('cache_entity_' . $this->entityType);
       }
     }
 
@@ -176,7 +176,7 @@ class DefaultEntityController implements EntityControllerInterface {
    * Implements EntityControllerInterface::resetStaticCache().
    */
   public function resetStaticCache(array $ids = NULL) {
-    if (isset($ids)) {
+    if (isset($ids) && !empty($ids)) {
       foreach ($ids as $id) {
         unset($this->entityCache[$id]);
       }
@@ -212,7 +212,7 @@ class DefaultEntityController implements EntityControllerInterface {
     // Use an entity field query to transform the list of conditions into
     // the set of entity IDs which the conditions admit, then re-enter this
     // method with that set as the $ids constraint.
-    if ($conditions) {
+    if ($conditions && !$revision_id) {
       $query = new EntityFieldQuery();
       $query->entityCondition('entity_type', $this->entityType);
       foreach ($conditions as $property_name => $condition) {
@@ -229,12 +229,7 @@ class DefaultEntityController implements EntityControllerInterface {
       $result = $query->execute();
       if (isset($result[$this->entityType])) {
         $entity_ids = array_keys($result[$this->entityType]);
-        if ($revision_id) {
-          return $this->load($entity_ids, array($this->revisionKey => $revision_id));
-        }
-        else {
-          return $this->load($entity_ids);
-        }
+        return $this->load($entity_ids);
       }
       else {
         // No results found.

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -169,7 +169,7 @@ class DefaultEntityController implements EntityControllerInterface {
       $this->persistanctCache = TRUE;
     }
     else {
-      $this->entityCache = FALSE;
+      $this->persistanctCache = FALSE;
     }
   }
 

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -118,13 +118,22 @@ class DefaultEntityController implements EntityControllerInterface {
   protected $revisionTable;
 
   /**
+   * Whether this entity type should use the persistent entity cache.
+   *
+   * Set by entity info.
+   *
+   * @var boolean
+   */
+  protected $persistanctCache;
+
+  /**
    * Whether this entity type should use the static cache.
    *
    * Set by entity info.
    *
    * @var boolean
    */
-  protected $cache;
+  protected $staticCache;
 
   /**
    * Implements EntityControllerInterface::__construct().
@@ -151,7 +160,17 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Check if the entity type supports static caching of loaded entities.
-    $this->cache = !empty($this->entityInfo['static cache']);
+    $this->staticCache = !empty($this->entityInfo['static cache']);
+
+    // Check if the entity type supports usage of the persistant entity cache.
+    if (isset($this->entityInfo['entity cache'])
+      && $this->entityInfo['entity cache']
+      && db_table_exists('cache_entity_' . $this->entityType)) {
+      $this->persistanctCache = TRUE;
+    }
+    else {
+      $this->entityCache = FALSE;
+    }
   }
 
   /**
@@ -159,7 +178,7 @@ class DefaultEntityController implements EntityControllerInterface {
    */
   public function resetCache(array $ids = NULL) {
     // Reset the persistent cache.
-    if (isset($this->entityInfo['entity cache']) && $this->entityInfo['entity cache']) {
+    if ($this->persistanctCache) {
       if (!empty($ids)) {
         cache_clear_all($ids, 'cache_entity_' . $this->entityType);
       }
@@ -239,7 +258,7 @@ class DefaultEntityController implements EntityControllerInterface {
 
     // Try to load entities from the static cache, if the entity type supports
     // static caching.
-    if ($this->cache && !$revision_id) {
+    if ($this->staticCache && !$revision_id) {
       $entities += $this->cacheGet($ids, $conditions);
       // If any entities were loaded, remove them from the ids still to load.
       if ($passed_ids) {
@@ -248,7 +267,7 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Try to load entities from the persistent cache.
-    if (isset($this->entityInfo['entity cache']) && $this->entityInfo['entity cache'] && !$revision_id && $ids && !$conditions) {
+    if ($this->persistanctCache && !$revision_id && $ids && !$conditions) {
       $cached_entities = array();
       if ($ids && !$conditions) {
         $cached = cache_get_multiple($ids, 'cache_entity_' . $this->entityType);
@@ -265,7 +284,7 @@ class DefaultEntityController implements EntityControllerInterface {
       // If any entities were loaded, remove them from the ids still to load.
       $ids = array_diff($ids, array_keys($cached_entities));
 
-      if ($this->cache) {
+      if ($this->staticCache) {
         // Add entities to the cache if we are not loading a revision.
         if (!empty($cached_entities) && !$revision_id) {
           $this->cacheSet($cached_entities);
@@ -298,7 +317,7 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Add entities to the entity cache if we are not loading a revision.
-    if (isset($this->entityInfo['entity cache']) && $this->entityInfo['entity cache'] && !empty($queried_entities) && !$revision_id) {
+    if ($this->persistanctCache && !empty($queried_entities) && !$revision_id) {
       // Only cache the entities which were loaded by ID. Entities that were
       // loaded based on conditions will never be found via cacheGet() and we
       // would keep on caching them.
@@ -312,7 +331,7 @@ class DefaultEntityController implements EntityControllerInterface {
       }
     }
 
-    if ($this->cache) {
+    if ($this->staticCache) {
       // Add entities to the cache if we are not loading a revision.
       if (!empty($queried_entities) && !$revision_id) {
         $this->cacheSet($queried_entities);

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -30,9 +30,9 @@ interface EntityControllerInterface {
   /**
    * Resets the internal, static entity cache.
    *
-   * @param string[] $ids
+   * @param array $ids
    *   (optional) If specified, the cache is reset for the entities with the
-   *   given ids only.
+   *   given IDs only.
    */
   public function resetStaticCache(array $ids = NULL);
 
@@ -124,7 +124,7 @@ class DefaultEntityController implements EntityControllerInterface {
    *
    * @var boolean
    */
-  protected $persistanctCache;
+  protected $persistentCache;
 
   /**
    * Whether this entity type should use the static cache.
@@ -162,14 +162,14 @@ class DefaultEntityController implements EntityControllerInterface {
     // Check if the entity type supports static caching of loaded entities.
     $this->staticCache = !empty($this->entityInfo['static cache']);
 
-    // Check if the entity type supports usage of the persistant entity cache.
+    // Check if the entity type supports usage of the persistent entity cache.
     if (isset($this->entityInfo['entity cache'])
       && $this->entityInfo['entity cache']
       && db_table_exists('cache_entity_' . $this->entityType)) {
-      $this->persistanctCache = TRUE;
+      $this->persistentCache = TRUE;
     }
     else {
-      $this->persistanctCache = FALSE;
+      $this->persistentCache = FALSE;
     }
   }
 
@@ -178,7 +178,7 @@ class DefaultEntityController implements EntityControllerInterface {
    */
   public function resetCache(array $ids = NULL) {
     // Reset the persistent cache.
-    if ($this->persistanctCache) {
+    if ($this->persistentCache) {
       if (!empty($ids)) {
         cache_clear_all($ids, 'cache_entity_' . $this->entityType);
       }
@@ -195,7 +195,8 @@ class DefaultEntityController implements EntityControllerInterface {
    * Implements EntityControllerInterface::resetStaticCache().
    */
   public function resetStaticCache(array $ids = NULL) {
-    if (isset($ids) && !empty($ids)) {
+    // An empty array will not clear any cache, but NULL will clear everything.
+    if (isset($ids)) {
       foreach ($ids as $id) {
         unset($this->entityCache[$id]);
       }
@@ -267,7 +268,7 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Try to load entities from the persistent cache.
-    if ($this->persistanctCache && !$revision_id && $ids && !$conditions) {
+    if ($this->persistentCache && !$revision_id && $ids && !$conditions) {
       $cached_entities = array();
       if ($ids && !$conditions) {
         $cached = cache_get_multiple($ids, 'cache_entity_' . $this->entityType);
@@ -317,7 +318,7 @@ class DefaultEntityController implements EntityControllerInterface {
     }
 
     // Add entities to the entity cache if we are not loading a revision.
-    if ($this->persistanctCache && !empty($queried_entities) && !$revision_id) {
+    if ($this->persistentCache && !empty($queried_entities) && !$revision_id) {
       // Only cache the entities which were loaded by ID. Entities that were
       // loaded based on conditions will never be found via cacheGet() and we
       // would keep on caching them.

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -26,7 +26,7 @@ function entity_flush_caches() {
 
   $entities = entity_get_info();
   foreach ($entities as $type => $info) {
-    if ($info['entity cache']) {
+    if (isset($info['entity cache']) && $info['entity cache']) {
       $bins[] = 'cache_entity_' . $type;
     }
   }

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -19,6 +19,22 @@ function entity_modules_disabled() {
 }
 
 /**
+ * Implements hook_flush_caches().
+ */
+function entity_flush_caches() {
+  $bins = array();
+
+  $entities = entity_get_info();
+  foreach ($entities as $type => $info) {
+    if ($info['entity cache']) {
+      $bins[] = 'cache_entity_' . $type;
+    }
+  }
+
+  return $bins;
+}
+
+/**
  * Load a custom entity display mode by entity type and machine name.
  *
  * @param string $entity_type

--- a/core/modules/file/file.install
+++ b/core/modules/file/file.install
@@ -214,6 +214,10 @@ function file_schema() {
     ),
   );
 
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_file'] = $cache_schema;
+  $schema['cache_entity_file']['description'] = "Cache table used to store File entity records.";
+
   return $schema;
 }
 
@@ -1182,4 +1186,13 @@ function file_update_1007() {
     $config->set('permissions', $permissions);
     $config->save();
   }
+}
+
+/**
+ * Creates the table to enable caching of Comment entities.
+ */
+function file_update_1008() {
+  $table = backdrop_get_schema_unprocessed('system', 'cache');
+  $table['description'] = "Cache table used to store File entity records.";
+  db_create_table('cache_entity_file', $table);
 }

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -461,7 +461,7 @@ function file_entity_info() {
     );
   }
 
-  return array(
+  $return = array(
     'file' => array(
       'label' => t('File'),
       'bundle label' => t('Type'),
@@ -493,6 +493,14 @@ function file_entity_info() {
       'static cache' => FALSE,
     ),
   );
+
+  // If the cache table has been created, then enable entity caching.
+  if (db_table_exists('cache_entity_file')) {
+    $return['file']['entity cache'] = TRUE;
+    $return['file']['field cache'] = FALSE;
+  }
+
+  return $return;
 }
 
 /**

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -461,7 +461,7 @@ function file_entity_info() {
     );
   }
 
-  $return = array(
+  $entity_info = array(
     'file' => array(
       'label' => t('File'),
       'bundle label' => t('Type'),
@@ -496,11 +496,11 @@ function file_entity_info() {
 
   // If the cache table has been created, then enable entity caching.
   if (db_table_exists('cache_entity_file')) {
-    $return['file']['entity cache'] = TRUE;
-    $return['file']['field cache'] = FALSE;
+    $entity_info['file']['entity cache'] = TRUE;
+    $entity_info['file']['field cache'] = FALSE;
   }
 
-  return $return;
+  return $entity_info;
 }
 
 /**

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -810,6 +810,10 @@ class FilterSecurityTestCase extends BackdropWebTestCase {
     );
     $this->backdropPost('admin/config/content/formats/' . $format_id, $edit, t('Save configuration'));
 
+    // Remove the entity cache entry for the node so that field_attach_load can
+    // run again and the filters can be re-applied.
+    cache_clear_all($node->nid, 'cache_entity_node');
+
     // Verify that filter_test_replace filter replaced the content.
     $this->backdropGet('node/' . $node->nid);
     $this->assertNoText($body_raw, 'Node body not found.');
@@ -817,6 +821,10 @@ class FilterSecurityTestCase extends BackdropWebTestCase {
 
     // Disable the text format entirely.
     $this->backdropPost('admin/config/content/formats/' . $format_id . '/disable', array(), t('Disable'));
+
+    // Remove the entity cache entry for the node so that field_attach_load can
+    // run again and the filters can be re-applied.
+    cache_clear_all($node->nid, 'cache_entity_node');
 
     // Verify that the content is empty, because the text format does not exist.
     $this->backdropGet('node/' . $node->nid);

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -812,7 +812,7 @@ class FilterSecurityTestCase extends BackdropWebTestCase {
 
     // Remove the entity cache entry for the node so that field_attach_load can
     // run again and the filters can be re-applied.
-    cache_clear_all($node->nid, 'cache_entity_node');
+    cache('entity_node')->delete($node->nid);
 
     // Verify that filter_test_replace filter replaced the content.
     $this->backdropGet('node/' . $node->nid);
@@ -824,7 +824,7 @@ class FilterSecurityTestCase extends BackdropWebTestCase {
 
     // Remove the entity cache entry for the node so that field_attach_load can
     // run again and the filters can be re-applied.
-    cache_clear_all($node->nid, 'cache_entity_node');
+    cache('entity_node')->delete($node->nid);
 
     // Verify that the content is empty, because the text format does not exist.
     $this->backdropGet('node/' . $node->nid);

--- a/core/modules/link/tests/link.validate.test
+++ b/core/modules/link/tests/link.validate.test
@@ -112,7 +112,7 @@ class LinkValidateTest extends LinkBaseTestClass {
     $this->assertNoText(t('The value %value provided for %field is not a valid URL.', array('%field' => $this->field_name, '%value' => trim($url))));
 
     $nid = db_query("SELECT MAX(nid) FROM {node}")->fetchField();
-    $node = node_load($nid, NULL, TRUE);
+    $node = node_load($nid);
     $this->assertEqual($url, $node->{$this->field_name}['und'][0]['url']);
 
     $this->backdropGet('node/' . $node->nid);

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2547,7 +2547,7 @@ class LocaleMultilingualFieldsFunctionalTest extends BackdropWebTestCase {
       'langcode' => 'it',
     );
     $this->backdropPost(NULL, $edit, t('Save'));
-    $node = $this->backdropGetNodeByTitle($edit[$title_key]);
+    $node = $this->backdropGetNodeByTitle($edit[$title_key], TRUE);
     $this->assertTrue($node, 'Node found in database.');
 
     $assert = isset($node->body['it']) && !isset($node->body['en']) && $node->body['it'][0]['value'] == $body_value;

--- a/core/modules/node/node.install
+++ b/core/modules/node/node.install
@@ -306,6 +306,10 @@ function node_schema() {
     ),
   );
 
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_node'] = $cache_schema;
+  $schema['cache_entity_node']['description'] = "Cache table used to store Node entity records.";
+
   return $schema;
 }
 

--- a/core/modules/node/node.install
+++ b/core/modules/node/node.install
@@ -1980,6 +1980,15 @@ function node_update_1020() {
 }
 
 /**
+ * Creates the table to enable caching of Nodes entities.
+ */
+function node_update_1021() {
+  $table = backdrop_get_schema_unprocessed('system', 'cache');
+  $table['description'] = "Cache table used to store Node entity records.";
+  db_create_table('cache_entity_node', $table);
+}
+
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -151,8 +151,6 @@ function node_entity_info() {
       'revision table' => 'node_revision',
       'fieldable' => TRUE,
       'redirect support' => TRUE,
-      'entity cache' => TRUE,
-      'field cache' => FALSE,
       'entity keys' => array(
         'id' => 'nid',
         'revision' => 'vid',
@@ -178,6 +176,12 @@ function node_entity_info() {
       ),
     ),
   );
+
+  // If the cache table has been created, then enable entity caching on nodes.
+  if (db_table_exists('cache_entity_node')) {
+    $return['node']['entity cache'] = TRUE;
+    $return['node']['field cache'] = FALSE;
+  }
 
   // Search integration is provided by node.module, so search-related
   // display modes for nodes are defined here and not in search.module.

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -141,7 +141,7 @@ function node_cron() {
  * Implements hook_entity_info().
  */
 function node_entity_info() {
-  $return = array(
+  $entity_info = array(
     'node' => array(
       'label' => t('Node'),
       'bundle label' => t('Type'),
@@ -179,14 +179,14 @@ function node_entity_info() {
 
   // If the cache table has been created, then enable entity caching on nodes.
   if (db_table_exists('cache_entity_node')) {
-    $return['node']['entity cache'] = TRUE;
-    $return['node']['field cache'] = FALSE;
+    $entity_info['node']['entity cache'] = TRUE;
+    $entity_info['node']['field cache'] = FALSE;
   }
 
   // Search integration is provided by node.module, so search-related
   // display modes for nodes are defined here and not in search.module.
   if (module_exists('search')) {
-    $return['node']['view modes'] += array(
+    $entity_info['node']['view modes'] += array(
       'search_index' => array(
         'label' => t('Search index'),
         'custom settings' => FALSE,
@@ -202,7 +202,7 @@ function node_entity_info() {
   // messages, and the path to attach Field admin pages to.
   node_type_cache_reset();
   foreach (node_type_get_names() as $type => $name) {
-    $return['node']['bundles'][$type] = array(
+    $entity_info['node']['bundles'][$type] = array(
       'label' => $name,
       'admin' => array(
         'path' => 'admin/structure/types/manage/%node_type',
@@ -213,7 +213,7 @@ function node_entity_info() {
     );
   }
 
-  return $return;
+  return $entity_info;
 }
 
 /**

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -151,6 +151,8 @@ function node_entity_info() {
       'revision table' => 'node_revision',
       'fieldable' => TRUE,
       'redirect support' => TRUE,
+      'entity cache' => TRUE,
+      'field cache' => FALSE,
       'entity keys' => array(
         'id' => 'nid',
         'revision' => 'vid',

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -390,7 +390,7 @@ class PageEditTestCase extends BackdropWebTestCase {
     $this->backdropPost(NULL, $edit, t('Save'));
 
     // Ensure that the node revision has been created.
-    $revised_node = $this->backdropGetNodeByTitle($edit['title']);
+    $revised_node = $this->backdropGetNodeByTitle($edit['title'], TRUE);
     $this->assertNotIdentical($node->vid, $revised_node->vid, 'A new revision has been created.');
     // Ensure that the node author is preserved when it was not changed in the
     // edit form.
@@ -681,7 +681,7 @@ class PagePreviewTestCase extends BackdropWebTestCase {
     $edit['scheduled[time]'] = format_date(REQUEST_TIME + 360, 'custom', 'H:i:s', $web_user->timezone);
     $this->backdropPost(NULL, $edit, t('Preview'));
     $this->backdropPost(NULL, array(), t('Save'));
-    $node = $this->backdropGetNodeByTitle($name);
+    $node = $this->backdropGetNodeByTitle($name, TRUE);
     $this->assertEqual($node->status, '0', 'The node is in the state Draft.');
 
     $this->assertNotEqual($node->scheduled, 0, 'The node has a non zero published date.');

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -139,7 +139,7 @@ class NodeLoadHooksTestCase extends BackdropWebTestCase {
     // node_test_node_load() are correctly updated.
     $nodes = node_load_multiple(array(), array('status' => NODE_NOT_PUBLISHED));
     $loaded_node = end($nodes);
-    $this->assertEqual($loaded_node->node_test_loaded_nids, array($node4->nid, $node3->nid), 'hook_node_load() received the correct list of node IDs the second time it was called.');
+    $this->assertEqual($loaded_node->node_test_loaded_nids, array($node3->nid, $node4->nid), 'hook_node_load() received the correct list of node IDs the second time it was called.');
     $this->assertEqual($loaded_node->node_test_loaded_types, array('page', 'post'), 'hook_node_load() received the correct list of node types the second time it was called.');
   }
 }

--- a/core/modules/simpletest/tests/file.test
+++ b/core/modules/simpletest/tests/file.test
@@ -1597,7 +1597,7 @@ class FileDeleteTest extends FileHookTestCase {
       ->execute();
     // Remove the entity cache entry for this file so that hook_file_load will
     // be called again.
-    cache_clear_all($file->fid, 'cache_entity_file');
+    cache('entity_file')->delete($file->fid);
 
     backdrop_cron_run();
 
@@ -1966,7 +1966,7 @@ class FileLoadTest extends FileHookTestCase {
 
     // Remove the entity cache entry for this file so that hook_file_load will
     // be called again.
-    cache_clear_all($file->fid, 'cache_entity_file');
+    cache('entity_file')->delete($file->fid);
 
     // Load by fid.
     file_test_reset();

--- a/core/modules/simpletest/tests/file.test
+++ b/core/modules/simpletest/tests/file.test
@@ -1595,6 +1595,10 @@ class FileDeleteTest extends FileHookTestCase {
       ))
       ->condition('fid', $file->fid)
       ->execute();
+    // Remove the entity cache entry for this file so that hook_file_load will
+    // be called again.
+    cache_clear_all($file->fid, 'cache_entity_file');
+
     backdrop_cron_run();
 
     // system_cron() loads
@@ -1959,6 +1963,10 @@ class FileLoadTest extends FileHookTestCase {
     $by_path_file = reset($by_path_files);
     $this->assertTrue($by_path_file->file_test['loaded'], 'file_test_file_load() was able to modify the file during load.');
     $this->assertEqual($by_path_file->fid, $file->fid, "Loading by filepath got the correct fid.", 'File');
+
+    // Remove the entity cache entry for this file so that hook_file_load will
+    // be called again.
+    cache_clear_all($file->fid, 'cache_entity_file');
 
     // Load by fid.
     file_test_reset();

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -2079,8 +2079,8 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
     $user1 = user_load(1);
     $user1->pass_raw = user_password();
     require_once BACKDROP_ROOT . '/' . settings_get('password_inc', 'core/includes/password.inc');
-    $user1->pass = user_hash_password(trim($user1->pass_raw));
-    db_query("UPDATE {users} SET pass = :pass WHERE uid = :uid", array(':pass' => $user1->pass, ':uid' => $user1->uid));
+    $user1->pass = $user1->pass_raw;
+    user_save($user1);
     $this->backdropLogin($user1);
     $this->backdropGet($this->update_url, array('external' => TRUE));
     $this->assertResponse(200);

--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -163,6 +163,10 @@ function taxonomy_schema() {
     ),
   );
 
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_taxonomy_term'] = $cache_schema;
+  $schema['cache_entity_taxonomy_term']['description'] = "Cache table used to store Taxonomy Term entity records.";
+
   return $schema;
 }
 
@@ -353,6 +357,15 @@ function taxonomy_update_1007() {
     $config->set('module', 'taxonomy');
     $config->save();
   }
+}
+
+/**
+ * Creates the table to enable caching of Comment entities.
+ */
+function taxonomy_update_1008() {
+  $table = backdrop_get_schema_unprocessed('system', 'cache');
+  $table['description'] = "Cache table used to store Taxonomy Term entity records.";
+  db_create_table('cache_entity_taxonomy_term', $table);
 }
 
 /**

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -107,6 +107,13 @@ function taxonomy_entity_info() {
       ),
     ),
   );
+
+  // If the cache table has been created, then enable entity caching.
+  if (db_table_exists('cache_entity_taxonomy_term')) {
+    $return['taxonomy_term']['entity cache'] = TRUE;
+    $return['taxonomy_term']['field cache'] = FALSE;
+  }
+
   foreach (taxonomy_vocabulary_load_multiple(FALSE) as $machine_name => $vocabulary) {
     $return['taxonomy_term']['bundles'][$machine_name] = array(
       'label' => $vocabulary->name,

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -80,7 +80,7 @@ function taxonomy_vocabulary_list_permissions($vocabulary) {
  * Implements hook_entity_info().
  */
 function taxonomy_entity_info() {
-  $return = array(
+  $entity_info = array(
     'taxonomy_term' => array(
       'label' => t('Taxonomy term'),
       'bundle label' => t('Vocabulary'),
@@ -110,12 +110,12 @@ function taxonomy_entity_info() {
 
   // If the cache table has been created, then enable entity caching.
   if (db_table_exists('cache_entity_taxonomy_term')) {
-    $return['taxonomy_term']['entity cache'] = TRUE;
-    $return['taxonomy_term']['field cache'] = FALSE;
+    $entity_info['taxonomy_term']['entity cache'] = TRUE;
+    $entity_info['taxonomy_term']['field cache'] = FALSE;
   }
 
   foreach (taxonomy_vocabulary_load_multiple(FALSE) as $machine_name => $vocabulary) {
-    $return['taxonomy_term']['bundles'][$machine_name] = array(
+    $entity_info['taxonomy_term']['bundles'][$machine_name] = array(
       'label' => $vocabulary->name,
       'admin' => array(
         'path' => 'admin/structure/taxonomy/%taxonomy_vocabulary',
@@ -126,7 +126,7 @@ function taxonomy_entity_info() {
     );
   }
 
-  return $return;
+  return $entity_info;
 }
 
 /**

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -155,6 +155,10 @@ function user_schema() {
     ),
   );
 
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_user'] = $cache_schema;
+  $schema['cache_entity_user']['description'] = "Cache table used to store Users entity records.";
+
   return $schema;
 }
 
@@ -1190,6 +1194,15 @@ function user_update_1015() {
     $config->set('display.default.display_options.filters.name.expose.identifier', 'username');
   }
   $config->save();
+}
+
+/**
+ * Creates the table to enable caching of User entities.
+ */
+function user_update_1016() {
+  $table = backdrop_get_schema_unprocessed('system', 'cache');
+  $table['description'] = "Cache table used to store User entity records.";
+  db_create_table('cache_entity_user', $table);
 }
 
 /**

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1811,7 +1811,7 @@ function user_login_finalize(&$edit = array()) {
   // If entity caching is enabled, clear the cache entry for the user.
   $entity_info = entity_get_info('user');
   if (isset($entity_info['entity cache']) && $entity_info['entity cache']) {
-    cache_clear_all($user->uid, 'cache_entity_user');
+    cache('entity_user')->delete($user->uid);
   }
 
   user_module_invoke('login', $edit, $user);

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -113,6 +113,7 @@ function user_entity_info() {
       'base table' => 'users',
       'fieldable' => TRUE,
       'redirect support' => TRUE,
+      'entity cache' => TRUE,
       'entity class' => 'User',
       'entity keys' => array(
         'id' => 'uid',

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -105,7 +105,7 @@ function user_theme() {
  * Implements hook_entity_info().
  */
 function user_entity_info() {
-  $return = array(
+  $entity_info = array(
     'user' => array(
       'label' => t('User account'),
       'bundle label' => t('Type'),
@@ -137,11 +137,11 @@ function user_entity_info() {
 
   // If the cache table has been created, then enable entity caching on nodes.
   if (db_table_exists('cache_entity_user')) {
-    $return['user']['entity cache'] = TRUE;
-    $return['user']['field cache'] = FALSE;
+    $entity_info['user']['entity cache'] = TRUE;
+    $entity_info['user']['field cache'] = FALSE;
   }
 
-  return $return;
+  return $entity_info;
 }
 
 /**

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -105,7 +105,7 @@ function user_theme() {
  * Implements hook_entity_info().
  */
 function user_entity_info() {
-  return array(
+  $return = array(
     'user' => array(
       'label' => t('User account'),
       'bundle label' => t('Type'),
@@ -113,7 +113,6 @@ function user_entity_info() {
       'base table' => 'users',
       'fieldable' => TRUE,
       'redirect support' => TRUE,
-      'entity cache' => TRUE,
       'entity class' => 'User',
       'entity keys' => array(
         'id' => 'uid',
@@ -135,6 +134,14 @@ function user_entity_info() {
       ),
     ),
   );
+
+  // If the cache table has been created, then enable entity caching on nodes.
+  if (db_table_exists('cache_entity_user')) {
+    $return['user']['entity cache'] = TRUE;
+    $return['user']['field cache'] = FALSE;
+  }
+
+  return $return;
 }
 
 /**

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1808,6 +1808,12 @@ function user_login_finalize(&$edit = array()) {
   // or incorrectly does a redirect which would leave the old session in place.
   backdrop_session_regenerate();
 
+  // If entity caching is enabled, clear the cache entry for the user.
+  $entity_info = entity_get_info('user');
+  if (isset($entity_info['entity cache']) && $entity_info['entity cache']) {
+    cache_clear_all($user->uid, 'cache_entity_user');
+  }
+
   user_module_invoke('login', $edit, $user);
 }
 

--- a/core/modules/user/user.pages.inc
+++ b/core/modules/user/user.pages.inc
@@ -225,7 +225,7 @@ function user_logout() {
 
   $entity_info = entity_get_info('user');
   if (isset($entity_info['entity cache']) && $entity_info['entity cache']) {
-    cache_clear_all($user->uid, 'cache_entity_user');
+    cache('entity_user')->delete($user->uid);
   }
 
   // Destroy the current session, and reset $user to the anonymous user.

--- a/core/modules/user/user.pages.inc
+++ b/core/modules/user/user.pages.inc
@@ -223,6 +223,11 @@ function user_logout() {
 
   module_invoke_all('user_logout', $user);
 
+  $entity_info = entity_get_info('user');
+  if (isset($entity_info['entity cache']) && $entity_info['entity cache']) {
+    cache_clear_all($user->uid, 'cache_entity_user');
+  }
+
   // Destroy the current session, and reset $user to the anonymous user.
   session_destroy();
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/74

This PR implements the core functionality of the Entity Cache module from D7 by integrating it directly into `DefaultEntityController`. I have tried to make the new functionality as transparent as possible to the rest of Backdrop or any contributed modules.

I did not port any of the tests because they just extended core tests from modules that added entities with the entitycache module enabled. By integrating the functionality into `DefaultEntityController` we have effectively the same result.