### PR TITLE
Issue #1849: [UX] Admin bar: remove empty `class=""` attribute when removing the `active-search-item` class

### DIFF
--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -431,13 +431,13 @@ Backdrop.adminBar.behaviors.search = function (context, settings, $adminBar) {
     $this.trigger(show ? 'showPath' : 'hidePath', [this]);
   }
 
-  /**	
-   * Closes the search results and clears the search input.	
-   */	
-  function resultsClickHandler(e, link) {	
-    var $original = $(this).data('original-link');	
-    $original.trigger('mouseleave');	
-    $input.val('').trigger('keyup');	
+  /**
+   * Closes the search results and clears the search input.
+   */
+  function resultsClickHandler(e, link) {
+    var $original = $(this).data('original-link');
+    $original.trigger('mouseleave');
+    $input.val('').trigger('keyup');
   }
 
   /**

--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -412,22 +412,23 @@ Backdrop.adminBar.behaviors.search = function (context, settings, $adminBar) {
       e.preventDefault();
     }
     if (show) {
-      $adminBar.find('.active-search-item').removeClass('active-search-item');
+      if ($adminBar.find('.active-search-item').classList.length === 1) {
+        $adminBar.find('.active-search-item').removeAttr('class');
+      }
+      else {
+        $adminBar.find('.active-search-item').removeClass('active-search-item');
+      }
       $(this).addClass('active-search-item');
     }
     else {
-      $(this).removeClass('active-search-item');
+      if ($(this).classList.length === 1) {
+        $(this).removeAttr('class');
+      }
+      else {
+        $(this).removeClass('active-search-item');
+      }
     }
     $this.trigger(show ? 'showPath' : 'hidePath', [this]);
-  }
-
-  /**
-   * Closes the search results and clears the search input.
-   */
-  function resultsClickHandler(e, link) {
-    var $original = $(this).data('original-link');
-    $original.trigger('mouseleave');
-    $input.val('').trigger('keyup');
   }
 
   /**

--- a/core/modules/admin_bar/js/admin_bar.js
+++ b/core/modules/admin_bar/js/admin_bar.js
@@ -431,6 +431,15 @@ Backdrop.adminBar.behaviors.search = function (context, settings, $adminBar) {
     $this.trigger(show ? 'showPath' : 'hidePath', [this]);
   }
 
+  /**	
+   * Closes the search results and clears the search input.	
+   */	
+  function resultsClickHandler(e, link) {	
+    var $original = $(this).data('original-link');	
+    $original.trigger('mouseleave');	
+    $input.val('').trigger('keyup');	
+  }
+
   /**
    * Shows the link in the menu that corresponds to a search result.
    */


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/1849