### PR TITLE
Issue #4126: Fields with multiple values get two values by default

### DIFF
--- a/core/modules/field/field.form.inc
+++ b/core/modules/field/field.form.inc
@@ -185,7 +185,7 @@ function field_multiple_value_form($field, $instance, $langcode, $items, &$form,
   switch ($field['cardinality']) {
     case FIELD_CARDINALITY_UNLIMITED:
       $field_state = field_form_get_state($parents, $field_name, $langcode, $form_state);
-      $max = $field_state['items_count'];
+      $max = $field_state['items_count'] -1;
       break;
 
     default:


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/4126