### PR TITLE
Update common.inc

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -2391,7 +2391,12 @@ function format_date($timestamp, $date_format_name = 'medium', $pattern = '', $t
   }
 
   // Create a DateTime object from the timestamp.
-  $date_time = date_create('@' . $timestamp);
+  if ($timestamp != NULL && !empty($timestamp)) {
+    $date_time = date_create('@' . intval($timestamp));
+  }
+  else {
+    $date_time = date_create('@' . time());
+  }
   // Set the time zone for the DateTime object.
   date_timezone_set($date_time, $timezones[$timezone]);
 


### PR DESCRIPTION
I am inclined that this PR is not accepted, because the same error that is discussed for Drupal on https://www.drupal.org/node/1874768 is always caused by some contributed module which feeds incorrect parameter to `format_date()` function and that in turn breaks the core. The error (backdrop-contrib/demo#1) caused by the demo module is an example of this. So ideally this error should always be addressed in the responsible contrib module.

However, reading https://www.drupal.org/node/1874768 and seeing that all kinds of bad coding in conrib modules can cause this, I thought maybe safeguarding the core files and make them foolproof is a good idea. 