### PR TITLE
Ref #4147 - Rename system.performance config key to system.core

### DIFF
--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -1,5 +1,5 @@
 {
-    "_config_name": "system.performance",
+    "_config_name": "system.core",
     "_config_static": true,
     "_config_translatables": [
         "anonymous",


### PR DESCRIPTION
I feel like there must be something more I should do with this, but I renamed the core config key as mentioned in #4147.  I spun up a fresh Backdrop off this, and everything went well.