### PR TITLE
1610 menu defaults

### DIFF
--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -676,7 +676,7 @@ function menu_form_node_form_alter(&$form, $form_state) {
   $form['menu']['enabled'] = array(
     '#type' => 'checkbox',
     '#title' => t('Provide a menu link'),
-    '#default_value' => (int) (bool) $link['mlid'],
+    '#default_value' => empty($form['#node']->nid) ? $node_type->settings['menu_default'] : (int) (bool) $link['mlid'],
   );
   $form['menu']['link'] = array(
     '#type' => 'container',
@@ -696,8 +696,9 @@ function menu_form_node_form_alter(&$form, $form_state) {
   $form['menu']['link']['link_title'] = array(
     '#type' => 'textfield',
     '#title' => t('Menu link title'),
+    '#description' => theme('token_tree_link', array('token_types' => array('node'))),
     '#maxlength' => 255,
-    '#default_value' => $link['link_title'],
+    '#default_value' => $link['mlid'] ? $link['link_title'] : $node_type->settings['menu_title'],
   );
 
   $form['menu']['link']['description'] = array(
@@ -744,6 +745,11 @@ function menu_node_submit(Node $node, $form, $form_state) {
   if (!empty($form_state['values']['menu']['parent'])) {
     list($node->menu['menu_name'], $node->menu['plid']) = explode(':', $form_state['values']['menu']['parent']);
   }
+
+  // Replace tokens in the menu link title.
+  if (!empty($form_state['values']['menu']['link_title'])) {
+    $node->menu['link_title'] = token_replace($form_state['values']['menu']['link_title'], array('node' => $node));
+  }
 }
 
 /**
@@ -764,6 +770,21 @@ function menu_form_node_type_form_alter(&$form, $form_state) {
     ),
     '#group' => 'additional_settings',
     '#weight' => 15,
+  );
+  $form['menu']['menu_default'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Provide a default menu link'),
+    '#description' => t("Set the default value of the 'Provide a menu link' checkbox on the content authoring form."),
+    '#default_value' => $node_type->settings['menu_default'],
+  );
+  $token_link = ' ' . theme('token_tree_link', array('token_types' => array('node')));
+  $form['menu']['menu_title'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Default menu link title'),
+    '#description' => t("Set the default value of the 'Menu link title' field on the content authoring form.") . $token_link,
+    '#default_value' => $node_type->settings['menu_title'],
+    '#element_validate' => array('token_element_validate'),
+    '#token_types' => array('node'),
   );
   $form['menu']['menu_options'] = array(
     '#type' => 'checkboxes',
@@ -800,6 +821,9 @@ function menu_form_node_type_form_alter(&$form, $form_state) {
 function menu_node_type_load(&$types) {
   foreach ($types as $type_name => $type) {
     $types[$type_name]->settings += array(
+      // Pages have a menu item by default.
+      'menu_default' => ($type_name == 'page') ? TRUE : FALSE,
+      'menu_title' => '[node:title]',
       'menu_options' => array(),
       'menu_parent' => 'main-menu:0',
     );

--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -696,9 +696,8 @@ function menu_form_node_form_alter(&$form, $form_state) {
   $form['menu']['link']['link_title'] = array(
     '#type' => 'textfield',
     '#title' => t('Menu link title'),
-    '#description' => theme('token_tree_link', array('token_types' => array('node'))),
     '#maxlength' => 255,
-    '#default_value' => $link['mlid'] ? $link['link_title'] : $node_type->settings['menu_title'],
+    '#default_value' => $link['mlid'] ? $link['link_title'] : '',
   );
 
   $form['menu']['link']['description'] = array(
@@ -745,11 +744,6 @@ function menu_node_submit(Node $node, $form, $form_state) {
   if (!empty($form_state['values']['menu']['parent'])) {
     list($node->menu['menu_name'], $node->menu['plid']) = explode(':', $form_state['values']['menu']['parent']);
   }
-
-  // Replace tokens in the menu link title.
-  if (!empty($form_state['values']['menu']['link_title'])) {
-    $node->menu['link_title'] = token_replace($form_state['values']['menu']['link_title'], array('node' => $node));
-  }
 }
 
 /**
@@ -776,15 +770,6 @@ function menu_form_node_type_form_alter(&$form, $form_state) {
     '#title' => t('Provide a default menu link'),
     '#description' => t("Set the default value of the 'Provide a menu link' checkbox on the content authoring form."),
     '#default_value' => $node_type->settings['menu_default'],
-  );
-  $token_link = ' ' . theme('token_tree_link', array('token_types' => array('node')));
-  $form['menu']['menu_title'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Default menu link title'),
-    '#description' => t("Set the default value of the 'Menu link title' field on the content authoring form.") . $token_link,
-    '#default_value' => $node_type->settings['menu_title'],
-    '#element_validate' => array('token_element_validate'),
-    '#token_types' => array('node'),
   );
   $form['menu']['menu_options'] = array(
     '#type' => 'checkboxes',
@@ -822,7 +807,6 @@ function menu_node_type_load(&$types) {
   foreach ($types as $type_name => $type) {
     $types[$type_name]->settings += array(
       'menu_default' => FALSE,
-      'menu_title' => '[node:title]',
       'menu_options' => array(),
       'menu_parent' => 'main-menu:0',
     );

--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -822,7 +822,7 @@ function menu_node_type_load(&$types) {
   foreach ($types as $type_name => $type) {
     $types[$type_name]->settings += array(
       // Pages have a menu item by default.
-      'menu_default' => ($type_name == 'page') ? TRUE : FALSE,
+      'menu_default' => FALSE,
       'menu_title' => '[node:title]',
       'menu_options' => array(),
       'menu_parent' => 'main-menu:0',

--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -821,7 +821,6 @@ function menu_form_node_type_form_alter(&$form, $form_state) {
 function menu_node_type_load(&$types) {
   foreach ($types as $type_name => $type) {
     $types[$type_name]->settings += array(
-      // Pages have a menu item by default.
       'menu_default' => FALSE,
       'menu_title' => '[node:title]',
       'menu_options' => array(),

--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -701,11 +701,12 @@ function menu_form_node_form_alter(&$form, $form_state) {
   );
 
   $form['menu']['link']['description'] = array(
-    '#type' => 'textarea',
-    '#title' => t('Description'),
+    '#type' => 'textfield',
+    '#size' => 120,
+    '#title' => t('Description or clarification'),
     '#default_value' => isset($link['options']['attributes']['title']) ? $link['options']['attributes']['title'] : '',
     '#rows' => 1,
-    '#description' => t('Shown when hovering over the menu link.'),
+    '#description' => t('Shown when hovering over the menu link.') . ' ' . t('Often read by screen readers.'),
   );
 
   $default = ($link['mlid'] ? $link['menu_name'] . ':' . $link['plid'] : $node_type->settings['menu_parent']);
@@ -767,16 +768,14 @@ function menu_form_node_type_form_alter(&$form, $form_state) {
   );
   $form['menu']['menu_default'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Provide a default menu link'),
-    '#description' => t("Set the default value of the 'Provide a menu link' checkbox on the content authoring form."),
+    '#title' => t('Add a link into the menu for new content of this type'),
     '#default_value' => $node_type->settings['menu_default'],
   );
   $form['menu']['menu_options'] = array(
     '#type' => 'checkboxes',
-    '#title' => t('Available menus'),
+    '#title' => t('Menus where this content may be placed'),
     '#default_value' => $node_type->settings['menu_options'],
     '#options' => $menu_options,
-    '#description' => t('The menus available to place links in for this content type.'),
   );
   // To avoid an 'illegal option' error after saving the form we have to load
   // all available menu items.
@@ -788,7 +787,7 @@ function menu_form_node_type_form_alter(&$form, $form_state) {
     '#title' => t('Default parent item'),
     '#default_value' => $node_type->settings['menu_parent'],
     '#options' => $options,
-    '#description' => t('Choose the menu item to be the default parent for a new link in the content authoring form.'),
+    '#description' => t('Links to content will be placed below this item in the menu.'),
     '#attributes' => array('class' => array('menu-title-select')),
   );
 

--- a/core/modules/menu/tests/menu.test
+++ b/core/modules/menu/tests/menu.test
@@ -681,6 +681,7 @@ class MenuNodeTestCase extends BackdropWebTestCase {
     $edit = array(
       "title" => $node_title,
       "body[$language][0][value]" => $this->randomString(),
+      "menu[enabled]" => 0,
     );
     $this->backdropPost('node/add/page', $edit, t('Save'));
     $node = $this->backdropGetNodeByTitle($node_title);

--- a/core/modules/views/plugins/views_plugin_display_page.inc
+++ b/core/modules/views/plugins/views_plugin_display_page.inc
@@ -264,7 +264,7 @@ class views_plugin_display_page extends views_plugin_display {
     $options['path'] = array(
       'category' => 'page',
       'title' => t('Path'),
-      'value' => views_ui_truncate($path, 24),
+      'value' => $path,
     );
 
     $menu = $this->get_option('menu');

--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -130,6 +130,7 @@ function standard_install() {
         'node_submitted' => FALSE,
         'node_user_picture' => FALSE,
         'comment_default' => COMMENT_NODE_CLOSED,
+        'menu_default' => TRUE,
         'menu_options' => array('main-menu'),
       ),
       'is_new' => TRUE,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1610
Replaces https://github.com/backdrop/backdrop/pull/2951

First commit: Feature removal.
* Removes the option to set a Default `Menu link title`

Second commit: UX Updates.
* Changes checkbox label `Provide a default menu link` to `Add a link into the menu for new content`
* Removes description text from `Add a link into the menu by default` checkbox
* Changes checkboxes label `Available menus` to `Menus where this content may be placed`
* Removes description text for `Menus available for placing links`
* Updated description text for `Default parent item` to `Links to content will be placed below this item in the menu.`
* Changes the link `Description` field from textarea to textfield.
* adds `Often read by screen readers.` to link description `#description`.