### PR TITLE
Issue 4180: fix broken test at midnight in testing timezone

### DIFF
--- a/core/modules/date/tests/date_themes.test
+++ b/core/modules/date/tests/date_themes.test
@@ -113,6 +113,10 @@ class DateThemeTestCase extends BackdropWebTestCase {
       // Make sure start and end are the same day.
       $dateTimeStart->modify('- 1 hour');
     }
+    elseif ($currentHour < 1) {
+      // Make sure it's really 7 days.
+      $dateTimeStart->modify('- 2 hours');
+    }
     // We need 168 hours (7 days) remaining.
     $offsetHours = 7 * 24;
     $dateTimeStart->modify("+ $offsetHours hours");


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4180. Because of the nature of this test, it's really hard to reproduce (both, that it fails now and that the change fixes it).