### PR TITLE
Added the missing @see lines to config_ function doc blocks

### DIFF
--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -63,6 +63,11 @@ function config($config_file, $type = 'active') {
  * @param string $option
  *   The name of the config option within the file to delete. The config option
  *   may contain periods to indicate levels within the config file.
+ * 
+ * @see config_set()
+ * @see config_get()
+ * @see config_diff()
+ * @see config_menu()
  *
  * @since 1.7.0
  */
@@ -87,6 +92,12 @@ function config_clear($config_file, $option) {
  * @return mixed
  *   The contents of the requested config option. Returns NULL if the specified
  *   option was not found in the file at all.
+ *
+ * @see config_set()
+ * @see config_diff()
+ * @see config_clear()
+ * @see config_menu()
+ *
  */
 function config_get($config_file, $option = NULL) {
   $config = config($config_file);
@@ -145,6 +156,12 @@ function config_get_translated($config_file, $option = NULL, $args = array(), $o
  *   may contain periods to indicate levels within the config file.
  * @param mixed $value
  *   The value to save into the config file.
+ *
+ * @see config_get()
+ * @see config_diff()
+ * @see config_clear()
+ * @see config_menu()
+ *
  */
 function config_set($config_file, $option, $value) {
   $config = config($config_file);

--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -97,7 +97,6 @@ function config_clear($config_file, $option) {
  * @see config_diff()
  * @see config_clear()
  * @see config_menu()
- *
  */
 function config_get($config_file, $option = NULL) {
   $config = config($config_file);
@@ -161,7 +160,6 @@ function config_get_translated($config_file, $option = NULL, $args = array(), $o
  * @see config_diff()
  * @see config_clear()
  * @see config_menu()
- *
  */
 function config_set($config_file, $option, $value) {
   $config = config($config_file);

--- a/core/modules/config/config.admin.inc
+++ b/core/modules/config/config.admin.inc
@@ -131,12 +131,6 @@ function config_sync_form_submit(array &$form, array &$form_state) {
  *
  * @return string
  *   Table showing a two-way diff between the active and staged configuration.
- * 
- * @see config_set()
- * @see config_get()
- * @see config_clear()
- * @see config_menu()
- *
  */
 function config_diff_page($config_file) {
   $diff = config_diff($config_file);
@@ -548,6 +542,12 @@ function config_get_modified_times() {
  *
  * @return array
  *   An array of formatted strings showing the diffs between the two storages.
+ * 
+ * @see config_set()
+ * @see config_get()
+ * @see config_clear()
+ * @see config_menu()
+ *
  */
 function config_diff($name) {
   $active_storage = config_get_config_storage('active');

--- a/core/modules/config/config.admin.inc
+++ b/core/modules/config/config.admin.inc
@@ -131,6 +131,12 @@ function config_sync_form_submit(array &$form, array &$form_state) {
  *
  * @return string
  *   Table showing a two-way diff between the active and staged configuration.
+ * 
+ * @see config_set()
+ * @see config_get()
+ * @see config_clear()
+ * @see config_menu()
+ *
  */
 function config_diff_page($config_file) {
   $diff = config_diff($config_file);

--- a/core/modules/config/config.module
+++ b/core/modules/config/config.module
@@ -6,6 +6,12 @@
 
 /**
  * Implements hook_menu().
+ * 
+ * @see config_set()
+ * @see config_get()
+ * @see config_clear()
+ * @see config_diff()
+ *
  */
 function config_menu() {
   $items['admin/config/development/configuration'] = array(


### PR DESCRIPTION
The PR adds the missing @see lines to `config_` functions' doc blocks to address the issue reported on https://github.com/backdrop-ops/api.backdropcms.org/issues/71.