### PR TITLE
Issue #4193: The `file_temporary_path` is not set on `system.core.json` file

### DIFF
--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -26,7 +26,7 @@
     "file_default_scheme": "public",
     "file_private_path": "",
     "file_public_path": "files",
-    "file_temporary_path": "",
+    "file_temporary_path": "/tmp",
     "file_transliterate_lowercase": 0,
     "file_transliterate_uploads": 1,
     "file_transliterate_uploads_display_name": 0,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4193