### PR TITLE
Issue #4193: The `file_temporary_path` is not set on `system.core.json` file

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -2675,6 +2675,10 @@ function file_directory_temp() {
       // everything to use slash which is supported on all platforms.
       $temporary_directory = str_replace('\\', '/', $temporary_directory);
     }
+    
+    // Now when the temporary directory is found, we need to save it to
+    // the configuration file.
+    config_set('system.core', 'file_temporary_path', $temporary_directory);
   }
 
   return $temporary_directory;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4193