### PR TITLE
Issue #4194: Allow any fieldset to avoide collapse if default values …

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -3814,8 +3814,22 @@ function form_process_fieldset(&$element, &$form_state) {
   if (!empty($element['#collapsible'])) {
     $element['#attached']['library'][] = array('system', 'backdrop.collapse');
     $element['#attributes']['class'][] = 'collapsible';
+    $add_class = TRUE;
+
     if (!empty($element['#collapsed'])) {
-      $element['#attributes']['class'][] = 'collapsed';
+      if (!empty($element['#defaults'])) {
+        foreach ($element['#defaults'] as $key => $value) {
+          if (in_array($key, element_children($element))) {
+            if ($element[$key]['#default_value'] != $value) {
+              $add_class = FALSE;
+            }
+          }
+        }
+      }
+
+      if ($add_class) {
+        $element['#attributes']['class'][] = 'collapsed';
+      }
     }
   }
 

--- a/core/modules/views/handlers/views_handler_field.inc
+++ b/core/modules/views/handlers/views_handler_field.inc
@@ -652,12 +652,20 @@ class views_handler_field extends views_handler {
       '#fieldset' => 'style_settings',
     );
 
+    $options = $this->option_definition();
     $form['alter'] = array(
       '#title' => t('Rewrite results'),
       '#type' => 'fieldset',
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
       '#weight' => 100,
+      '#defaults' => array(
+        'alter_text' => $options['alter']['contains']['alter_text']['default'],
+        'make_link' => $options['alter']['contains']['make_link']['default'],
+        'trim' => $options['alter']['contains']['trim']['default'],
+        'strip_tags' => $options['alter']['contains']['strip_tags']['default'],
+        'nl2br' => $options['alter']['contains']['nl2br']['default'],
+      ),
     );
 
     if ($this->allow_advanced_render()) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4194#issuecomment-549588451

# API CHANGE:

Adds an additional `#defaults` form API property for fieldsets. When provided, a collapsed fieldset will not be collapsed if any of these defaults have been overridden. 
