### PR TITLE
Issue #4199: Optimize core calls to `file_directory_temp()`

### DIFF
--- a/core/includes/stream_wrappers.inc
+++ b/core/includes/stream_wrappers.inc
@@ -967,11 +967,7 @@ class BackdropTemporaryStreamWrapper extends BackdropLocalStreamWrapper {
    * Implements abstract public function getDirectoryPath()
    */
   public function getDirectoryPath() {
-    $temp = config_get('system.core', 'file_temporary_path');
-    if (empty($temp)) {
-      $temp = file_directory_temp();
-    }
-    return $temp;
+    return config_get('system.core', 'file_temporary_path');
   }
 
   /**

--- a/core/modules/config/config.admin.inc
+++ b/core/modules/config/config.admin.inc
@@ -197,10 +197,11 @@ function config_export_full_form_submit(array $form, array &$form_state) {
  * Downloads a tarball of the site configuration.
  */
 function config_download_full_export() {
-  $file_path = file_create_filename('config.tar.gz', file_directory_temp());
+  $temp = config_get('system.core', 'file_temporary_path');
+  $file_path = file_create_filename('config.tar.gz', $temp);
   $config_storage = config_get_config_storage();
   $config_storage->exportArchive($file_path);
-  $filename = str_replace(file_directory_temp() . '/', '', $file_path);
+  $filename = str_replace($temp . '/', '', $file_path);
   $headers = array(
     'Content-Disposition' => 'attachment; filename=config.tar.gz',
     'Content-type' => 'application/x-gzip',

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -304,7 +304,8 @@ class ConfigurationUITest extends BackdropWebTestCase {
     file_put_contents($uri, $archive_data);
 
     // Extract the archive and verify it's not empty.
-    $file_path = file_directory_temp() . '/' . file_uri_target($uri);
+    $temp = config_get('system.core', 'file_temporary_path');
+    $file_path = $temp . '/' . file_uri_target($uri);
     $archiver = new Archive_Tar($file_path);
     $archive_contents = $archiver->listContent();
     $archive_files = array();

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1780,7 +1780,7 @@ function system_file_system_settings() {
   $form['file_temporary_path'] = array(
     '#type' => 'textfield',
     '#title' => t('Temporary directory'),
-    '#default_value' => file_directory_temp(),
+    '#default_value' => config_get('system.core', 'file_temporary_path'),
     '#maxlength' => 255,
     '#description' => t('A local file system path where temporary files will be stored. This directory should not be accessible over the web.'),
     '#after_build' => array('system_check_directory'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4199