### PR TITLE
Issue #2805: Allow override of any config value.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -821,7 +821,7 @@ function backdrop_settings_initialize() {
   global $base_url, $base_path, $base_root;
 
   // Export these settings.php variables to the global namespace.
-  global $databases, $cookie_domain, $conf, $settings, $installed_profile, $is_https, $base_secure_url, $base_insecure_url, $config_directories;
+  global $databases, $cookie_domain, $conf, $settings, $installed_profile, $is_https, $base_secure_url, $base_insecure_url, $config_directories, $config;
   $conf = array();
   $settings = array();
 

--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -73,6 +73,26 @@ function config_clear($config_file, $option) {
 }
 
 /**
+ * A shortcut function to check if a value is overridden within a config file.
+ *
+ * @param string $config_file
+ *   The name of the configuration object to check. The name corresponds to
+ *   an JSON configuration file. For @code config(book.admin) @endcode, the
+ *   config object returned will contain the contents of book.admin.json.
+ * @param string $option
+ *   The name of the config option within the file to check. The config option
+ *   may contain periods to indicate levels within the config file.
+ *
+ * @return bool
+ *   TRUE if the config option is overridden. FALSE otherwise.
+ *
+ * @see Config::isOverridden()
+ */
+function config_is_overridden($config_file, $option) {
+  return config($config_file)->isOverridden($option);
+}
+
+/**
  * A shortcut function to load and retrieve a single value from a config file.
  *
  * @param string $config_file
@@ -376,6 +396,13 @@ class Config {
   protected $data;
 
   /**
+   * Any overrides specified for this configuration object.
+   *
+   * @var array
+   */
+  protected $overrides;
+
+  /**
    * The state of validation on this object.
    *
    * This value is set to TRUE by Config::validate() and is reset to FALSE after
@@ -414,8 +441,11 @@ class Config {
    *   configuration data.
    */
   public function __construct($name, ConfigStorageInterface $storage) {
+    global $config;
+
     $this->name = $name;
     $this->storage = $storage;
+    $this->overrides = isset($config[$name]) ? $config[$name] : NULL;
   }
 
   /**
@@ -535,6 +565,19 @@ class Config {
   }
 
   /**
+   * Check if a particular config key is overridden.
+   *
+   * @param $key
+   *   A string that maps to a key within the configuration data.
+   *
+   * @return bool
+   *   TRUE if the $key is overridden. FALSE otherwise.
+   */
+  public function isOverridden($key) {
+    return $this->getOverride($key) !== NULL;
+  }
+
+  /**
    * Gets data from this configuration object.
    *
    * @param string $key
@@ -555,6 +598,32 @@ class Config {
    *   The data that was requested.
    */
   public function get($key = '') {
+    $value = $this->getOverride($key);
+    if (!isset($value)) {
+      $value = $this->getOriginal($key);
+    }
+    return $value;
+  }
+
+  /**
+   * Gets the current config value as specified in the written config storage.
+   *
+   * In most cases, Config::get() should be used to pull the config value and
+   * also include any overrides to apply. This method should be used only when
+   * explicitly wanting the currently saved value (as stored in a config file)
+   * rather than what may be specified in an override (as provided in
+   * settings.php).
+   *
+   * @param string $key
+   *   The string that maps to a key with the configuration data. See
+   *   Config::get() for full examples.
+   *
+   * @return mixed
+   *   The data that was requested.
+   *
+   * @see Config::get()
+   */
+  public function getOriginal($key = '') {
     if (!$this->isLoaded) {
       $this->load();
     }
@@ -582,6 +651,67 @@ class Config {
         return $key_exists ? $value : NULL;
       }
     }
+  }
+
+  /**
+   * Checks if a config value has an override specified.
+   *
+   * @param string $key
+   *   The string that maps to a key with the configuration data.
+   *
+   *   A key may be overridden at any level, for example if
+   *   $key === 'foo.bar.key1', the matched value could be provided by an override
+   *   from 'foo.bar.key1', 'foo.bar', or 'foo'. In settings.php any of the
+   *   following would provide an overridden value for 'foo.bar.key1'.
+   *
+   *   @code
+   *   // Exact match.
+   *   $config['example.settings']['foo.bar.key1'] = 'value1';
+   *
+   *   // One level up.
+   *   $config['example.settings']['foo.bar'] = array(
+   *     'key1' => 'value1',
+   *   );
+   *
+   *   // A root level override.
+   *   $config['example.settings']['foo'] = array(
+   *     'bar' => array(
+   *       'key1' => 'value1',
+   *       'key2' => 'value2',
+   *     ),
+   *     'baz' => 'other value',
+   *   );
+   *   @endcode
+   *
+   * @see Config::get()
+   * @see settings.php
+   */
+  public function getOverride($key) {
+    $value = NULL;
+    $parts = explode('.', $key);
+    $popped_parts = array();
+    while ($parts) {
+      $assembled_key = implode('.', $parts);
+      if (isset($this->overrides[$assembled_key])) {
+        // An override is matched at some level.
+        $value = $this->overrides[$assembled_key];
+        // Drill down back into the override value to get the requested key.
+        foreach ($popped_parts as $popped_part) {
+          if (isset($value[$popped_part])) {
+            $value = $value[$popped_part];
+          }
+          else {
+            $value = NULL;
+            $popped_parts = array();
+          }
+        }
+      }
+      // If an override was not found at this key, go up a level in the key
+      // and continue until there are no more $parts left.
+      array_unshift($popped_parts, array_pop($parts));
+    }
+
+    return $value;
   }
 
   /**
@@ -688,11 +818,24 @@ class Config {
    *   Identifier to store value in configuration.
    * @param mixed $value
    *   Value to associate with identifier.
+   * @param bool $include_overridden_value
+   *   Set to TRUE to write the config value even if this key has been
+   *   overridden (usually through settings.php). Overridden keys are ignored
+   *   by default to prevent accidentally writing values that may be
+   *   environment-specific or contain sensitive information that should not
+   *   be written to config.
    *
    * @return Config
    *   The configuration object.
    */
-  public function set($key, $value) {
+  public function set($key, $value, $include_overridden_value = FALSE) {
+    // If setting a value that matches an override-provided one, don't actually
+    // write it to config.
+    $override_value = $this->getOverride($key);
+    if (isset($override_value) && ($override_value === $value) && !$include_overridden_value) {
+      return $this;
+    }
+
     if (!$this->isLoaded) {
       $this->load();
     }
@@ -733,6 +876,18 @@ class Config {
       $this->set($key, $value);
     }
     return $this;
+  }
+
+  /**
+   * Sets overrides for this configuration object.
+   *
+   * @param array $overrides
+   *   A list of overrides keyed by strings.
+   *
+   * @see Config::getOverride()
+   */
+  public function setOverrides($overrides) {
+    $this->overrides = $overrides;
   }
 
   /**

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -94,19 +94,69 @@ class ConfigurationTest extends BackdropWebTestCase {
    * Tests that a config setting can be overidden.
    */
   public function testOverrideConfig() {
+    $original_data = array(
+      'foo' => array(
+        'key1' => 'value1',
+        'key2' => 'value2',
+        'key3' => 'value3',
+      ),
+      'bar' => array(
+        'keyA' => 'valueA',
+        'keyB' => 'valueB',
+      ),
+    );
+
     // Set variable the regular method.
-    $config_data = config('foo.bar');
-    $config_data->set('foo', 'bar');
+    $config_data = config('config.test');
+    $config_data->setData($original_data);
     $config_data->save();
-    $this->assertEqual('bar', config('foo.bar')->get('foo'), 'Content retrieved from written config data using Config classes.');
+
+    $this->assertEqual('value1', config('config.test')->get('foo.key1'), 'Sample config retrieved from written config data using Config classes.');
+    $this->assertEqual('valueB', config('config.test')->get('bar.keyB'), 'Sample config retrieved from written config data using Config classes.');
+
     // Simulate overriding in settings file.
-    global $config;
-    $config['foo.bar']['foo'] = 'chocolate';
-    $this->assertEqual('chocolate', config('foo.bar')->get('foo'), 'Config variable overridden in global configuration override.');
-    $this->assertTrue(config_is_overridden('foo.bar', 'foo'), 'Foo variable is overidden.');
-    $config_data->set('foo', 'bar');
+    $GLOBALS['config']['config.test']['foo.key1'] = 'chocolate';
+    $config_data = config('config.test');
+    $this->assertEqual('chocolate', $config_data->get('foo.key1'), 'Config variable overridden in global configuration override.');
+    $this->assertTrue(config_is_overridden('config.test', 'foo.key1'), 'Nested config variable is overridden.');
+    $this->assertFalse(config_is_overridden('config.test', 'foo'), 'Root config variable not considered overridden.');
+    $this->assertEqual($original_data['foo']['key2'], $config_data->get('foo.key2'), 'Sibling key not affected by override.');
+    $this->assertEqual($original_data['bar'], $config_data->get('bar'), 'Uncle key not affected by override.');
+
+    // Simulate overriding a collection of values.
+    $override_data = array(
+      'key1' => 'chocolate',
+      'key2' => 'vanilla',
+    );
+    unset($GLOBALS['config']['config.test']['foo.key1']);
+    $GLOBALS['config']['config.test']['foo'] = $override_data;
+
+    $config_data = config('config.test');
+    $this->assertEqual('chocolate', $config_data->get('foo.key1'), 'Config variable overridden in global configuration override.');
+    $this->assertEqual('vanilla', $config_data->get('foo.key2'), 'Config variable overridden in global configuration override.');
+    $this->assertEqual($override_data, $config_data->get('foo'), 'Entire set of nested data overridden. Discarding 3rd undefined key.');
+    $this->assertTrue(config_is_overridden('config.test', 'foo.key1'), 'Nested config variable is overridden when overriding parent.');
+    $this->assertTrue(config_is_overridden('config.test', 'foo'), 'Root config variable is considered overridden when overriding parent.');
+
+    // Try overwriting the overridden config, which won't actually write.
+    $config_data->set('foo.key1', 'chocolate');
     $config_data->save();
-    $this->assertEqual('chocolate', config('foo.bar')->get('foo'), 'Config variable still overidden and cannot be set regular way.');
+
+    $config_data = config('config.test');
+    $this->assertEqual('chocolate', config('config.test')->get('foo.key1'), 'Config variable still overridden and cannot be set regular way.');
+    $this->assertEqual($config_data->getOriginal('foo.key1'), 'value1', 'Config original value still in place.');
+    $this->assertEqual($config_data->getOverride('foo.key1'), 'chocolate', 'Overridden value retrieved correctly.');
+
+    // Actually overwrite the config with the overridden value.
+    $config_data->set('foo.key1', 'chocolate', TRUE);
+    $config_data->save();
+
+    // Reload the config to read from disk again, the overridden value should
+    // now be on disk.
+    unset($GLOBALS['config']['config.test']['foo']);
+    $config_data = config('config.test');
+    $this->assertEqual(FALSE, $config_data->isOverridden('foo.key1'), 'Original value no longer overridden.');
+    $this->assertEqual($config_data->get('foo.key1'), 'chocolate', 'Original value has been updated to include overridden value.');
   }
 }
 

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -89,6 +89,25 @@ class ConfigurationTest extends BackdropWebTestCase {
     );
     $this->assertEqual($config->get(), $expected_config, 'The configuration file contained the expected configuration.');
   }
+
+  /**
+   * Tests that a config setting can be overidden.
+   */
+  public function testOverrideConfig() {
+    // Set variable the regular method.
+    $config_data = config('foo.bar');
+    $config_data->set('foo', 'bar');
+    $config_data->save();
+    $this->assertEqual('bar', config('foo.bar')->get('foo'), 'Content retrieved from written config data using Config classes.');
+    // Simulate overriding in settings file.
+    global $config;
+    $config['foo.bar']['foo'] = 'chocolate';
+    $this->assertEqual('chocolate', config('foo.bar')->get('foo'), 'Config variable overridden in global configuration override.');
+    $this->assertTrue(config_is_overridden('foo.bar', 'foo'), 'Foo variable is overidden.');
+    $config_data->set('foo', 'bar');
+    $config_data->save();
+    $this->assertEqual('chocolate', config('foo.bar')->get('foo'), 'Config variable still overidden and cannot be set regular way.');
+  }
 }
 
 /**

--- a/settings.php
+++ b/settings.php
@@ -399,6 +399,23 @@ $settings['404_fast_html'] = '<!DOCTYPE html><html><head><title>404 Not Found</t
 $settings['backdrop_drupal_compatibility'] = TRUE;
 
 /**
+ * Configuration overrides.
+ *
+ * These settings allow you to specify values for anything stored in config
+ * within the files stored in the $config_directories variable above.
+ * This can be useful to store per-environment values or sensitive data that
+ * is undesirable to store in the config storage.
+ *
+ * There are particular configuration values that are risky to override. For
+ * example overriding field storage will create errors because associated
+ * database changes are necessary. Modifying values within complicated objects
+ * such as views, content types, vocabularies, etc. may not work as expected.
+ * Use any available API functions for complex systems instead.
+ */
+//$config['system.core']['site_name'] = 'My Backdrop site';
+//$config['system.core']['file_temporary_path'] = '/tmp';
+
+/**
  * Include a local settings file, if available.
  *
  * To make local development easier, you can add a settings.local.php file that


### PR DESCRIPTION
Work in progress to fix https://github.com/backdrop/backdrop-issues/issues/2805.

See the settings.php examples within to test out the functionality. Not ready as there are no tests, and we don't have any visual indication of overridden values.

I'm also not crazy about introducing a new global variable. But with limited usage and the ability to set per-instance overrides, it's controlled in a way that we can safely specify overrides in testing without a lot of effort.