### PR TITLE
Issue #4193: The `file_temporary_path` is not initially set on `system.core.json` file

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -724,6 +724,9 @@ function system_install() {
 
   // Set the public files path to the directory with the settings.php file.
   config_set('system.core', 'file_public_path', str_replace('./', '', conf_path() . '/files'));
+  
+  // Sets the path of system-appropriate temporary directory.
+  config_set('system.core', 'file_temporary_path', file_directory_temp());
 
   // Clear out module list and hook implementation statics before calling
   // system_rebuild_theme_data().

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3091,7 +3091,7 @@ function system_update_1069() {
 }
 
 /**
- * Removes an unused state value.
+ * Set file_temporary_path on existing sites, if not already set.
  */
 function system_update_1070() {
   $config = config('system.core');

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3095,9 +3095,13 @@ function system_update_1069() {
  */
 function system_update_1070() {
   $config = config('system.core');
-  $file_temporary_path = $config->get('file_temporary_path') ? $config->get('file_temporary_path') : file_directory_temp();
-  $config->set('file_temporary_path', $file_temporary_path);
-  $config->save();
+  if ($config->get('file_temporary_path')) {
+    $file_temporary_path = $config->get('file_temporary_path');
+  }
+  else {
+    $config->set('file_temporary_path', file_directory_temp());
+    $config->save();
+  }  
 }
 
 /**

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3095,13 +3095,10 @@ function system_update_1069() {
  */
 function system_update_1070() {
   $config = config('system.core');
-  if ($config->get('file_temporary_path')) {
-    $file_temporary_path = $config->get('file_temporary_path');
-  }
-  else {
+  if ($config->get('file_temporary_path') == NULL) {
     $config->set('file_temporary_path', file_directory_temp());
     $config->save();
-  }  
+  }
 }
 
 /**

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3091,6 +3091,16 @@ function system_update_1069() {
 }
 
 /**
+ * Removes an unused state value.
+ */
+function system_update_1070() {
+  $config = config('system.core');
+  $file_temporary_path = $config->get('file_temporary_path') ? $config->get('file_temporary_path') : file_directory_temp();
+  $config->set('file_temporary_path', $file_temporary_path);
+  $config->save();
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Resolves https://github.com/backdrop/backdrop-issues/issues/4193