### PR TITLE
Issue #3326: [DX] Allow defining watchdog severity levels via the admin UI.

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1559,7 +1559,7 @@ function system_logging_settings($form, &$form_state) {
   );
   $form['watchdog_enabled_severity_levels'] = array(
     '#type' => 'checkboxes',
-    '#title' => t("Enabled severity levels"),
+    '#title' => t('Types of messages to log'),
     '#options' => array(
       WATCHDOG_EMERGENCY => t('Emergency'),
       WATCHDOG_ALERT => t('Alert'),
@@ -1572,7 +1572,6 @@ function system_logging_settings($form, &$form_state) {
       WATCHDOG_DEPRECATED => t('Deprecated'),
     ),
     '#default_value' => config_get('system.core', 'watchdog_enabled_severity_levels'),
-    '#description' => t('Which type of messages to log in watchdog.'),
   );
 
   return system_settings_form($form);

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1559,7 +1559,7 @@ function system_logging_settings($form, &$form_state) {
   );
   $form['watchdog_enabled_severity_levels'] = array(
     '#type' => 'checkboxes',
-    '#title' => t('Types of messages to log'),
+    '#title' => t('Severity of messages to log'),
     '#options' => array(
       WATCHDOG_EMERGENCY => t('Emergency'),
       WATCHDOG_ALERT => t('Alert'),

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1572,6 +1572,7 @@ function system_logging_settings($form, &$form_state) {
       WATCHDOG_DEPRECATED => t('Deprecated'),
     ),
     '#default_value' => config_get('system.core', 'watchdog_enabled_severity_levels'),
+    '#description' => t('The <em>debug</em> and <em>deprecated</em> severity levels are recommended for developer environments, but not on production sites.'),
   );
 
   return system_settings_form($form);

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1542,7 +1542,7 @@ function system_run_cron_submit($form, &$form_state) {
  * Form builder; Configure error reporting settings.
  *
  * @ingroup forms
- * @see system_logging_settings_submit()
+ * @see system_logging_settings_validate()
  */
 function system_logging_settings($form, &$form_state) {
   $form['#config'] = 'system.core';
@@ -1557,8 +1557,34 @@ function system_logging_settings($form, &$form_state) {
     ),
     '#description' => t('It is recommended that sites running on production environments do not display any errors.'),
   );
+  $form['watchdog_enabled_severity_levels'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t("Enabled severity levels"),
+    '#options' => array(
+      WATCHDOG_EMERGENCY => t('Emergency'),
+      WATCHDOG_ALERT => t('Alert'),
+      WATCHDOG_CRITICAL => t('Critial'),
+      WATCHDOG_ERROR => t('Error'),
+      WATCHDOG_WARNING => t('Warning'),
+      WATCHDOG_NOTICE => t('Notice'),
+      WATCHDOG_INFO => t('Info'),
+      WATCHDOG_DEBUG => t('Debug'),
+      WATCHDOG_DEPRECATED => t('Deprecated'),
+    ),
+    '#default_value' => config_get('system.core', 'watchdog_enabled_severity_levels'),
+    '#description' => t('Which type of messages to log in watchdog.'),
+  );
 
   return system_settings_form($form);
+}
+
+/**
+ * Validates the submitted logging form.
+ */
+function system_logging_settings_validate($form, &$form_state) {
+  // Cleanup enabled severity levels. Form API sets the value of unselected
+  // checkboxes to 0.
+  $form_state['values']['watchdog_enabled_severity_levels'] = array_keys(array_filter($form_state['values']['watchdog_enabled_severity_levels'], function($v){return $v !== 0;}));
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3326

Replaces https://github.com/backdrop/backdrop/pull/2328