### PR TITLE
Issue #3873: find a better way for empty field handling

### DIFF
--- a/core/modules/field/field.default.inc
+++ b/core/modules/field/field.default.inc
@@ -92,13 +92,8 @@ function field_default_validate($entity_type, $entity, $field, $instance, $langc
  * below.
  */
 function field_default_submit($entity_type, $entity, $field, $instance, $langcode, &$items, $form, &$form_state) {
-  // Empty values are okay for setting default values, so we want to avoid
-  // calling _field_filter_items(). Example: set the default value for a text
-  // format. See https://github.com/backdrop/backdrop-issues/issues/3378
-  if (!empty($entity)){
-    // Filter out empty values.
-    $items = _field_filter_items($field, $items);
-  }
+  // Filter out empty values.
+  $items = _field_filter_items($field, $items);
   // Reorder items to account for drag-n-drop reordering.
   $items = _field_sort_items($field, $items);
 }

--- a/core/modules/field/modules/number/tests/number.test
+++ b/core/modules/field/modules/number/tests/number.test
@@ -183,4 +183,41 @@ class NumberFieldTestCase extends BackdropWebTestCase {
     }
   }
 
+  /**
+   * Test empty value submission.
+   */
+  function testNumberFieldEmpty() {
+    // Add a content type.
+    $this->backdropGet('admin/structure/types/add');
+    $name = $this->randomName();
+    $bundle = backdrop_strtolower($name);
+    $edit = array('name' => $name, 'type' => $bundle);
+    $this->backdropPost(NULL, $edit, t('Save and add fields'));
+
+    // Add a decimal field to the newly created type.
+    $label = $this->randomName();
+    $field_name = backdrop_strtolower($label);
+    $edit = array(
+      'fields[_add_new_field][label]' => $label,
+      'fields[_add_new_field][field_name]' => $field_name,
+      'fields[_add_new_field][type]' => 'number_decimal',
+      'fields[_add_new_field][widget_type]' => 'number',
+    );
+    $this->backdropPost(NULL, $edit, t('Save'));
+
+    // Set an empty default value for that type via UI.
+    $path = "admin/structure/types/manage/$bundle/fields/field_{$field_name}";
+    $this->backdropGet($path);
+    $langcode = LANGUAGE_NONE;
+    $edit = array(
+      "field_{$field_name}[$langcode][0][value]" => '',
+    );
+    $this->backdropPost(NULL, $edit, t('Save settings'));
+    // Default value should still be NULL.
+    $config = config("field.instance.node.{$bundle}.field_{$field_name}");
+    $this->assertEqual($config->get('default_value'), NULL, 'Default value of number field is NULL');
+    // @see https://github.com/backdrop/backdrop-issues/issues/3873
+    // Unfortunately it seems impossible to get the Exception in a test case.
+  }
+
 }

--- a/core/modules/field/modules/number/tests/number.test
+++ b/core/modules/field/modules/number/tests/number.test
@@ -216,8 +216,13 @@ class NumberFieldTestCase extends BackdropWebTestCase {
     // Default value should still be NULL.
     $config = config("field.instance.node.{$bundle}.field_{$field_name}");
     $this->assertEqual($config->get('default_value'), NULL, 'Default value of number field is NULL');
-    // @see https://github.com/backdrop/backdrop-issues/issues/3873
-    // Unfortunately it seems impossible to get the Exception in a test case.
+    $node_user = $this->backdropCreateUser(array('bypass node access'));
+    $this->backdropLogin($node_user);
+    // Save the same empty value in a node entity (node needs a title).
+    $edit['title'] = $this->randomName();
+    $this->backdropGet("node/add/{$bundle}");
+    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->assertResponse(200, 'Post to create new node with empty number value returned 200 OK');
   }
 
 }

--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -158,7 +158,16 @@ function text_field_load($entity_type, $entities, $field, $instances, $langcode,
  */
 function text_field_is_empty($item, $field) {
   if (!isset($item['value']) || $item['value'] === '') {
-    return !isset($item['summary']) || $item['summary'] === '';
+    if (isset($item['format']) && $item['format'] !== '') {
+      // If this text field has a text format setting,
+      // save it regardless of empty value to keep the format.
+      return FALSE;
+    }
+    elseif (!isset($item['summary']) || $item['summary'] === '') {
+      // Neither value nor summary nor format are set,
+      // no need to save to database.
+      return TRUE;
+    }
   }
   return FALSE;
 }

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -412,7 +412,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
     $this->assertText("Saved $field_name configuration", 'The form was successfully submitted.');
     field_info_cache_clear();
     $instance = field_info_instance('node', $field_name, $this->type);
-    $this->assertEqual($instance['default_value'], array(array('value' => '')), 'The default value was correctly saved.');
+    $this->assertEqual($instance['default_value'], NULL, 'The default value was correctly saved.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3873

Reverts https://github.com/backdrop/backdrop/commit/c0cd5a3852ce39bd1fafa9e9463e4687e395faf9 and provides a different way to keep text format settings.