### PR TITLE
Issue #4237: Fix type mismatch for file status comparison

### DIFF
--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -418,8 +418,9 @@ function block_custom_block_save(array $edit, $delta = NULL, $langcode = NULL) {
   // See https://github.com/backdrop/backdrop-issues/issues/2137.
   $fids = filter_parse_file_fids($edit['body']['value']);
   $files = file_load_multiple($fids);
+  $status_permanent = FILE_STATUS_PERMANENT;
   foreach ($files as $fid => $file) {
-    if ($file && $file->status != FILE_STATUS_PERMANENT) {
+    if ($file && $file->status !== "$status_permanent") {
       // This makes the file "self-referencing", so it will never be deleted.
       file_usage_add($file, 'file', 'file', $file->fid);
     }

--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -418,9 +418,8 @@ function block_custom_block_save(array $edit, $delta = NULL, $langcode = NULL) {
   // See https://github.com/backdrop/backdrop-issues/issues/2137.
   $fids = filter_parse_file_fids($edit['body']['value']);
   $files = file_load_multiple($fids);
-  $status_permanent = FILE_STATUS_PERMANENT;
   foreach ($files as $fid => $file) {
-    if ($file && $file->status !== "$status_permanent") {
+    if ((int) ($file && $file->status) !== FILE_STATUS_PERMANENT) {
       // This makes the file "self-referencing", so it will never be deleted.
       file_usage_add($file, 'file', 'file', $file->fid);
     }

--- a/core/modules/block/block.module
+++ b/core/modules/block/block.module
@@ -419,7 +419,7 @@ function block_custom_block_save(array $edit, $delta = NULL, $langcode = NULL) {
   $fids = filter_parse_file_fids($edit['body']['value']);
   $files = file_load_multiple($fids);
   foreach ($files as $fid => $file) {
-    if ($file && $file->status !== FILE_STATUS_PERMANENT) {
+    if ($file && $file->status != FILE_STATUS_PERMANENT) {
       // This makes the file "self-referencing", so it will never be deleted.
       file_usage_add($file, 'file', 'file', $file->fid);
     }

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -305,7 +305,7 @@ class Layout {
     }
     $files = file_load_multiple($fids);
     foreach ($files as $fid => $file) {
-      if ($file && $file->status !== FILE_STATUS_PERMANENT) {
+      if ($file && $file->status != FILE_STATUS_PERMANENT) {
         // This makes the file "self-referencing", so it will never be deleted.
         // File usages are not removed for text blocks currently.
         // See https://github.com/backdrop/backdrop-issues/issues/2137.

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -304,8 +304,9 @@ class Layout {
       }
     }
     $files = file_load_multiple($fids);
+    $status_permanent = FILE_STATUS_PERMANENT;
     foreach ($files as $fid => $file) {
-      if ($file && $file->status != FILE_STATUS_PERMANENT) {
+      if ($file && $file->status !== "$status_permanent") {
         // This makes the file "self-referencing", so it will never be deleted.
         // File usages are not removed for text blocks currently.
         // See https://github.com/backdrop/backdrop-issues/issues/2137.

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -304,9 +304,8 @@ class Layout {
       }
     }
     $files = file_load_multiple($fids);
-    $status_permanent = FILE_STATUS_PERMANENT;
     foreach ($files as $fid => $file) {
-      if ($file && $file->status !== "$status_permanent") {
+      if ((int) ($file && $file->status) !== FILE_STATUS_PERMANENT) {
         // This makes the file "self-referencing", so it will never be deleted.
         // File usages are not removed for text blocks currently.
         // See https://github.com/backdrop/backdrop-issues/issues/2137.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4237

The strict comparison of `$file->status !== FILE_STATUS_PERMANENT` can never succeed, as `$file->status` is a string, but `FILE_STATUS_PERMANENT` is defined as integer.