### PR TITLE
Issue #4254: Dashboard News block follow-ups. Add cache, customizable URL.

### DIFF
--- a/core/modules/dashboard/config/dashboard.settings.json
+++ b/core/modules/dashboard/config/dashboard.settings.json
@@ -1,5 +1,5 @@
 {
     "_config_name": "dashboard.settings",
     "dashboard_login_redirect": true,
-    "news_feed_url": "https://backdropcms.org/api/notifications2"
+    "news_feed_url": "https://backdropcms.org/api/notifications"
 }

--- a/core/modules/dashboard/config/dashboard.settings.json
+++ b/core/modules/dashboard/config/dashboard.settings.json
@@ -1,4 +1,5 @@
 {
     "_config_name": "dashboard.settings",
-    "dashboard_login_redirect": true
+    "dashboard_login_redirect": true,
+    "news_feed_url": "https://backdropcms.org/api/notifications2"
 }

--- a/core/modules/dashboard/dashboard.install
+++ b/core/modules/dashboard/dashboard.install
@@ -38,7 +38,7 @@ function dashboard_uninstall() {
 function dashboard_update_1000() {
   $config = config('dashboard.settings');
   if ($config->get('news_feed_url') === NULL) {
-    $config->set('news_feed_url', 'https://backdropcms.org/api/notifications2');
+    $config->set('news_feed_url', 'https://backdropcms.org/api/notifications');
     $config->save();
   }
 }

--- a/core/modules/dashboard/dashboard.install
+++ b/core/modules/dashboard/dashboard.install
@@ -31,3 +31,14 @@ function dashboard_uninstall() {
   $config->delete();
   layout_reset_caches();
 }
+
+/**
+ * Set the URL for the Dashboard news feed.
+ */
+function dashboard_update_1000() {
+  $config = config('dashboard.settings');
+  if ($config->get('news_feed_url') === NULL) {
+    $config->set('news_feed_url', 'https://backdropcms.org/api/notifications2');
+    $config->save();
+  }
+}

--- a/core/modules/dashboard/dashboard.module
+++ b/core/modules/dashboard/dashboard.module
@@ -253,6 +253,18 @@ function dashboard_theme() {
 }
 
 /**
+ * Implements hook_cron().
+ */
+function dashboard_cron() {
+  $last_news_fetch = state_get('dashboard_news_timestamp');
+  $fetch_interval = 21600; // 6 hours.
+  if (REQUEST_TIME - $last_news_fetch > $fetch_interval) {
+    DashboardNewsBlock::refreshNewsFeed();
+    state_set('dashboard_news_timestamp', REQUEST_TIME);
+  }
+}
+
+/**
  * Menu callback; Dashboard settings form.
  */
 function dashboard_admin_settings() {

--- a/core/modules/dashboard/includes/block.news.inc
+++ b/core/modules/dashboard/includes/block.news.inc
@@ -31,15 +31,14 @@ class DashboardNewsBlock extends Block {
    * {@inheritdoc}
    */
   public function getContent() {
-    $feed = backdrop_http_request('https://backdropcms.org/api/notifications');
+    $news = $this->getNews();
     $links = array();
-    if ($feed->code === '200') {
-      $news = json_decode($feed->data);
-      foreach ($news->notifications as $key => $notifications) {
+    if ($news) {
+      foreach ($news as $key => $notifications) {
         $links[] = '<p>' . l(
-            $notifications->notification->title,
-            $notifications->notification->url
-          ) . ' - ' . filter_xss($notifications->notification->summary) . '</p>';
+            $notifications['title'],
+            $notifications['url']
+          ) . ' - ' . filter_xss($notifications['summary']) . '</p>';
       }
     }
 
@@ -72,5 +71,54 @@ class DashboardNewsBlock extends Block {
         'This block provides a news feed from BackdropCMS.org. Its contents can not be edited.'
       ),
     );
+  }
+
+  /**
+   * Return the current list of news items.
+   *
+   * This response is cached. If there is no recent cache, a new one will be
+   * generated on-the-fly. If the first request fails, the cache will persist
+   * with FALSE as the saved value until the next time the cache is cleared or
+   * cron updates the news list.
+   *
+   * @return FALSE|array
+   */
+  public static function getNews() {
+    $cache = cache()->get('dashboard_news_feed');
+    // If no cache is set at all, fetch results immediately.
+    if ($cache === FALSE) {
+      $news = DashboardNewsBlock::refreshNewsFeed();
+    }
+    else {
+      $news = $cache->data;
+    }
+    return $news;
+  }
+
+  /**
+   * Fetch news from the news source and set the cache for future responses.
+   *
+   * @return FALSE|array
+   */
+  public static function refreshNewsFeed() {
+    $news = FALSE;
+    $feed_url = config_get('dashboard.settings', 'news_feed_url');
+
+    // A short timeout means that we won't delay loading the dashboard if the
+    // cache is cleared and no network is available.
+    if ($feed_url) {
+      $feed = backdrop_http_request($feed_url, array(
+        'timeout' => 2,
+      ));
+      if ($feed->code === '200') {
+        $news = json_decode($feed->data, TRUE);
+      }
+    }
+
+    // Cache for one week, though the feed will be updated more frequently by
+    // dashboard_cron().
+    cache()->set('dashboard_news_feed', $news, REQUEST_TIME + 604800);
+
+    return $news;
   }
 }

--- a/core/modules/dashboard/tests/dashboard.test
+++ b/core/modules/dashboard/tests/dashboard.test
@@ -113,6 +113,7 @@ class DashboardTest extends BackdropWebTestCase {
 
     // The backdrop-news block was found.
     $this->assertText('Backdrop News', 'Backdrop News block found.');
+    $this->assertText('No news at this time.');
 
     // The menu admin block was found.
     $menu_admin_block = $this->xpath('//*[contains(@class,:block)]//tbody/tr/td[contains(text(),:menu)]', array(

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1737,10 +1737,6 @@ class BackdropWebTestCase extends BackdropTestCase {
     // Reset/rebuild all data structures after enabling the modules.
     $this->resetAll();
 
-    // Run cron once in that environment, as install.php does at the end of
-    // the installation process.
-    backdrop_cron_run();
-
     // Ensure that the session is not written to the new environment and replace
     // the global $user session with uid 1 from the new test site.
     backdrop_save_session(FALSE);
@@ -1767,6 +1763,10 @@ class BackdropWebTestCase extends BackdropTestCase {
       $dashboard_config->set('news_feed_url', FALSE);
       $dashboard_config->save();
     }
+
+    // Run cron once in that environment, as install.php does at the end of
+    // the installation process.
+    backdrop_cron_run();
 
     backdrop_set_time_limit($this->timeLimit);
     $this->setup = TRUE;

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1761,6 +1761,13 @@ class BackdropWebTestCase extends BackdropTestCase {
     // Use the test mail class instead of the default mail handler class.
     config_set('system.mail', 'default-system', 'TestingMailSystem');
 
+    // Disable news checking against BackdropCMS.org.
+    $dashboard_config = config('dashboard.settings');
+    if (!$dashboard_config->isNew()) {
+      $dashboard_config->set('news_feed_url', FALSE);
+      $dashboard_config->save();
+    }
+
     backdrop_set_time_limit($this->timeLimit);
     $this->setup = TRUE;
     return TRUE;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4254.

~Not 100% ready. We should update tests to set the value to FALSE to suppress hitting BackdropCMS.org on cron runs.~ Tests fixed and now checking the feed is disabled during test runs.