### PR TITLE
Issue #4270: Fix regression when adding blocks with file fields

### DIFF
--- a/core/modules/file/js/file.js
+++ b/core/modules/file/js/file.js
@@ -203,7 +203,7 @@ Backdrop.file = Backdrop.file || {
    */
   dialogCloseEvent: function(e, dialog, $element) {
     var $browserContainer = $element.find(".file-browser");
-    if ($browserContainer) {
+    if ($browserContainer.length > 0) {
       // These two variables are set server-side when submitting the dialog, in
       // file_managed_file_browser_submit().
       var selectedFid = Backdrop.settings.file.browser.selectedFid;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4270

`$browserContainer` is set but has zero length.