### PR TITLE
Issue #2398: Use Layout context info to load a complete User entity

### DIFF
--- a/core/modules/field/field.block.inc
+++ b/core/modules/field/field.block.inc
@@ -76,8 +76,8 @@ class FieldBlock extends Block {
     list($entity_type, $field_name) = explode('-', $this->childDelta);
     $entity = $this->contexts[$entity_type]->data;
 
-    // Do not render if the entity is not found on this layout.
-    if (empty($entity)) {
+    // Do not proceed if the entity is not an EntityInterface object
+    if (!is_a($entity, 'EntityInterface')) {
       return NULL;
     }
 

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -799,12 +799,7 @@ class Layout {
 
     // Add on the current user context, which is always available.
     if (!isset($this->contexts['current_user'])) {
-      $this->contexts['current_user'] = layout_create_context('user', array(
-        'name' => 'current_user',
-        'label' => t('Current user'),
-        'locked' => TRUE,
-      ));
-      $this->contexts['current_user']->setData($GLOBALS['user']);
+      $this->contexts['current_user'] = layout_current_user_context();
     }
 
     // Add on the overrides path context, which is always available.

--- a/core/modules/layout/includes/layout_menu_item.class.inc
+++ b/core/modules/layout/includes/layout_menu_item.class.inc
@@ -253,12 +253,7 @@ class LayoutMenuItem {
     }
 
     // Add on the current user context, which is always available.
-    $contexts['current_user'] = layout_create_context('user', array(
-      'name' => 'current_user',
-      'label' => t('Current user'),
-      'locked' => TRUE,
-    ));
-    $contexts['current_user']->setData($GLOBALS['user']);
+    $contexts['current_user'] = layout_current_user_context();
 
     $this->contexts += $contexts;
 

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1813,6 +1813,35 @@ function layout_context_required_by_path($path) {
 }
 
 /**
+ * Return the current user context, which is always available.
+ */
+function layout_current_user_context() {
+  global $user;
+
+  $current_user_context = layout_create_context('user', array(
+    'name' => 'current_user',
+    'label' => t('Current user'),
+    'locked' => TRUE,
+  ));
+
+  // Get a complete user entity
+  $context_info = layout_get_context_info('user');
+  if (isset($context_info['load callback']) && function_exists($context_info['load callback'])) {
+    // in case this has been set by other modules
+    $load_function = $context_info['load callback'];
+  }
+  else {
+    // fall back to default
+    $load_function = 'user_load';
+  }
+  $current_user = $load_function($user->uid);
+
+  $current_user_context->setData($current_user);
+
+  return $current_user_context;
+}
+
+/**
  * Determine if a block has the necessary contexts.
  *
  * @param Layout $layout


### PR DESCRIPTION
Because the "current_user" context is created in both the Layout and LayoutMenuItem classes, I created a function in the main layout module, layout_current_user_context(), to centralize the code for creating and loading a context for the current user.

https://github.com/backdrop/backdrop-issues/issues/2398