### PR TITLE
Issue #4289: Add cache clear buttons to the theme overview page.

### DIFF
--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -270,8 +270,14 @@ table.screenshot {
   text-align: right;
   border-bottom: 1px solid #cdcdcd;
 }
-.system-themes-cache-buttons p{
+[dir="rtl"] .system-themes-cache-buttons {
   text-align: left;
+}
+.system-themes-cache-buttons p {
+  text-align: left;
+}
+[dir="rtl"] .system-themes-cache-buttons p {
+  text-align: right;
 }
 .system-themes-list {
   margin-bottom: 20px;

--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -266,6 +266,13 @@ table.screenshot {
 .theme-info p {
   margin-top: 0;
 }
+.system-themes-cache-buttons {
+  text-align: right;
+  border-bottom: 1px solid #cdcdcd;
+}
+.system-themes-cache-buttons p{
+  text-align: left;
+}
 .system-themes-list {
   margin-bottom: 20px;
 }
@@ -375,8 +382,8 @@ table.screenshot {
   padding: 0;
 }
 .theme-selector .operations li {
-  float: left; /* LTR */
-  margin: 0;
+  display: inline-block;
+  margin: .5em 0 1em 0;
   padding: 0 0.7em;
   list-style-type: none;
   border-right: 1px solid #cdcdcd;  /* LTR */
@@ -384,7 +391,6 @@ table.screenshot {
 [dir="rtl"] .theme-selector .operations li {
   border-right: none;
   border-left: 1px solid #cdcdcd;
-  float: right;
 }
 .theme-selector .operations li.last {
   padding: 0 0 0 0.7em; /* LTR */

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -88,7 +88,7 @@ function theme_system_themes_page($variables) {
 
   $output = '<div id="system-themes-page">';
 
-  // @todo make these not dependant on admin_bar?
+  // @todo Remove check for on admin_bar. https://github.com/backdrop/backdrop-issues/issues/5664
   if (module_exists('admin_bar')) {
     // If we have a cached menu for the current user, only output the hash
     // for the client-side HTTP cache callback URL.
@@ -100,7 +100,7 @@ function theme_system_themes_page($variables) {
         'query' => array('token' => $hash, backdrop_get_destination()),
       );
       $output .= '<div class="system-themes-cache-buttons message-info">';
-      $output .= '<p>' . t('Not seeing theme changes? Clear the CSS/JS cache if you\'ve changed existing files. Rebuild the theme registry if you\'ve added new files to your theme.') . '</p>';
+      $output .= '<p>' . t('Not seeing theme changes? Clear the CSS/JS cache if existing files have changed. Rebuild the theme registry if new files or functions have been added to your theme.') . '</p>';
       $output .= l(t('Flush CSS/JS cache'), 'admin_bar/flush-cache/assets', $options);
       $output .= l(t('Rebuild theme registry'), 'admin_bar/flush-cache/theme', $options);
       $output .= '</div>';

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -88,11 +88,31 @@ function theme_system_themes_page($variables) {
 
   $output = '<div id="system-themes-page">';
 
+  // @todo make these not dependant on admin_bar?
+  if (module_exists('admin_bar')) {
+    // If we have a cached menu for the current user, only output the hash
+    // for the client-side HTTP cache callback URL.
+    global $user, $language;
+    $cid = 'admin_bar:' . $user->uid . ':' . session_id() . ':' . $language->langcode;
+    if ($hash = admin_bar_cache_get($cid)) {
+      $options = array(
+        'attributes' => array('class' => array('button')),
+        'query' => array('token' => $hash, backdrop_get_destination()),
+      );
+      $output .= '<div class="system-themes-cache-buttons message-info">';
+      $output .= '<p>' . t('Not seeing theme changes? Clear the CSS/JS cache if you\'ve changed existing files. Rebuild the theme registry if you\'ve added new files to your theme.') . '</p>';
+      $output .= l(t('Flush CSS/JS cache'), 'admin_bar/flush-cache/assets', $options);
+      $output .= l(t('Rebuild theme registry'), 'admin_bar/flush-cache/theme', $options);
+      $output .= '</div>';
+    }
+  }
+
   foreach ($variables['theme_group_titles'] as $state => $title) {
     if (!count($theme_groups[$state])) {
       // Skip this group of themes if no theme is there.
       continue;
     }
+
     // Start new theme group.
     $output .= '<div class="system-themes-list system-themes-list-'. $state .' clearfix"><h2>'. $title .'</h2>';
 
@@ -121,8 +141,9 @@ function theme_system_themes_page($variables) {
         $output .= '<div class="incompatible">' . t('This theme requires PHP version @php_required and is incompatible with PHP version !php_version.', array('@php_required' => $theme->info['php'], '!php_version' => phpversion())) . '</div>';
       }
       else {
-        $output .= theme('links', array('links' => $theme->operations, 'attributes' => array('class' => array('operations', 'clearfix'))));
+        $output .= theme('links', array('links' => $theme->operations, 'attributes' => array('class' => array('operations'))));
       }
+
       $output .= '</div></div>';
     }
     $output .= '</div>';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4289