### PR TITLE
Views: Parameter 3 to views_ui_build_form_state() expected to be a reference...

### DIFF
--- a/core/modules/views_ui/views_ui.admin.inc
+++ b/core/modules/views_ui/views_ui.admin.inc
@@ -2880,6 +2880,11 @@ function views_ui_ajax_form($js, $key, $view, $display_id = '') {
       $stack = $view->stack;
       $top = array_shift($stack);
       $top[0] = $js;
+
+      // Change view into a reference.
+      $stepview = $top[2];
+      $top[2] = &$stepview;
+
       $form_state = call_user_func_array('views_ui_build_form_state', $top);
       $form_state['input'] = array();
       $form_state['path'] = views_ui_build_form_path($form_state);


### PR DESCRIPTION
...value given in views_ui_ajax_form()

https://www.drupal.org/project/views/issues/2810431

https://git.drupalcode.org/project/views/commit/8b6ccb08b1fdddca26c2ac6d3b0c6c3929ca41ae

https://github.com/backdrop/backdrop-issues/issues/3853