### PR TITLE
Issue #4297 Content display modes: Remove angle brackets from the label options

### DIFF
--- a/core/modules/field_ui/field_ui.admin.inc
+++ b/core/modules/field_ui/field_ui.admin.inc
@@ -997,7 +997,7 @@ function field_ui_display_form($form, &$form_state, $entity_type, $bundle, $view
   $field_label_options = array(
     'above' => t('Above'),
     'inline' => t('Inline'),
-    'hidden' => '<' . t('Hidden') . '>',
+    'hidden' => t('Hidden'),
   );
   $extra_visibility_options = array(
     'visible' => t('Visible'),
@@ -1053,7 +1053,7 @@ function field_ui_display_form($form, &$form_state, $entity_type, $bundle, $view
     );
 
     $formatter_options = field_ui_formatter_options($field['type']);
-    $formatter_options['hidden'] = '<' . t('Hidden') . '>';
+    $formatter_options['hidden'] = t('Hidden');
     $table[$name]['format'] = array(
       'type' => array(
         '#type' => 'select',


### PR DESCRIPTION
In short: Removed strings `'<'` and `'>'`. These where concatenated with `'Hidden'` string.
More info on this issue: [#4297](https://github.com/backdrop/backdrop-issues/issues/4297)