### PR TITLE
Issue #4218: Replaced double hyphens with middots in menu parent select list.

### DIFF
--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -394,8 +394,8 @@ function _menu_get_options($menus, $available_menus, $item) {
   foreach ($menus as $menu_name => $title) {
     if (isset($available_menus[$menu_name])) {
       $tree = menu_tree_all_data($menu_name, NULL);
-      $options[$menu_name . ':0'] = '<' . $title . '>';
-      _menu_parents_recurse($tree, $menu_name, '--', $options, $item['mlid'], $limit);
+      $options[$menu_name . ':0'] = $title;
+      _menu_parents_recurse($tree, $menu_name, '· ', $options, $item['mlid'], $limit);
     }
   }
   return $options;
@@ -417,7 +417,7 @@ function _menu_parents_recurse($tree, $menu_name, $indent, &$options, $exclude, 
       }
       $options[$menu_name . ':' . $data['link']['mlid']] = $title;
       if ($data['below']) {
-        _menu_parents_recurse($data['below'], $menu_name, $indent . '--', $options, $exclude, $depth_limit);
+        _menu_parents_recurse($data['below'], $menu_name, $indent . '· ', $options, $exclude, $depth_limit);
       }
     }
   }


### PR DESCRIPTION
https://github.com/backdrop/backdrop-issues/issues/4218