### PR TITLE
Issue #4318: Theme settings: Fix color input label alignment

### DIFF
--- a/core/modules/color/css/color.admin.css
+++ b/core/modules/color/css/color.admin.css
@@ -32,6 +32,10 @@ input[type=color] {
 }
 
 /* Color inputs */
+#system-theme-settings .form-type-color label {
+  max-width: 80%;
+}
+
 #system-theme-settings input[type=color] {
   border-radius: 100%;
   height: 35px;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4318