### PR TITLE
Ensure when checking for overrides Objects are not used as arrays

### DIFF
--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -454,7 +454,9 @@ class Config {
 
     $this->name = $name;
     $this->storage = $storage;
-    $this->overrides = isset($config[$name]) ? $config[$name] : NULL;
+    // If $config is not an array, then some library or module may have
+    // interacted with the $config in a preboot situation.
+    $this->overrides = (is_array($config) && isset($config[$name])) ? $config[$name] : NULL;
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4334

@herbdool @quicksketch I work with the [CiviCRM library](https://civicrm.org/) and within our daily automatic tests we have been running into an issue with out backdrop integration namely an error 

```
<font size='1'><table class='xdebug-error xe-uncaught-exception' dir='ltr' border='1' cellspacing='0' cellpadding='1'>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Fatal error: Uncaught Error: Cannot use object of type CRM_Core_Config as array in /home/jenkins/bknix-max/build/build-1/web/core/includes/config.inc on line <i>457</i></th></tr>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Error: Cannot use object of type CRM_Core_Config as array in /home/jenkins/bknix-max/build/build-1/web/core/includes/config.inc on line <i>457</i></th></tr>
```

This aims to fix it so that your overrides checking code works for Arrays and Objects