### PR TITLE
Fixes #4261 - Removed extraneous characters on comment line (typo)

### DIFF
--- a/core/includes/database/select.inc
+++ b/core/includes/database/select.inc
@@ -1446,7 +1446,7 @@ class SelectQuery extends Query implements SelectQueryInterface {
   }
 
   /**
-   * Implements SelectQueryInterface::addField().di
+   * Implements SelectQueryInterface::addField().
    */
   public function addField($table_alias, $field, $alias = NULL) {
     // If no alias is specified, first try the field name itself.


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#4261

I removed the extraneous couple of letters (aka the typo).. No other changes were made.