### PR TITLE
Issue #4316: Insert tokens from dialogs into the nearest field automatically.

### DIFF
--- a/core/modules/node/js/node.types.js
+++ b/core/modules/node/js/node.types.js
@@ -111,12 +111,6 @@ Backdrop.behaviors.contentTypes = {
       vals.push(Backdrop.checkPlain($(context).find('input[name="path_pattern"]').val()) || Backdrop.t('No URL alias pattern set'));
       return vals.join(', ');
     });
-
-    // Focus the input#edit-path-pattern field when clicking on the token
-    // browser on the /admin/structure/types/add pages (add a content type).
-    $context.find('#edit-path .token-browser-link').once().on('click', function(){
-      $('input#edit-path-pattern').focus();
-    });
   }
 };
 

--- a/core/modules/path/path.module
+++ b/core/modules/path/path.module
@@ -398,12 +398,11 @@ function path_pattern_settings_form($settings) {
     '#default_value' => $settings['default'],
     '#description' => $settings['description'],
   );
-  $form['path']['path_tokens'] = array(
-    '#theme' => 'token_tree_link',
-    '#token_types' => $settings['token_types'],
-    '#global_types' => FALSE,
-    '#click_insert' => TRUE,
-  );
+  $form['path']['path_pattern']['#description'] .= '<br />' . theme('token_tree_link', array(
+    'token_types' => $settings['token_types'],
+    'global_types' => FALSE,
+    'click_insert' => TRUE,
+  ));
 
   return $form;
 }

--- a/core/modules/system/js/token.js
+++ b/core/modules/system/js/token.js
@@ -19,18 +19,48 @@ Backdrop.behaviors.tokenTree = {
 Backdrop.behaviors.tokenInsert = {
   attach: function (context, settings) {
     // Keep track of which textfield was last selected/focused.
-    $(context).find('textarea, input[type="text"]').focus(function() {
+    $('body').once('token-focus').on('focus', 'textarea, input[type="text"]', function() {
       Backdrop.settings.tokenFocusedField = this;
+      Backdrop.settings.tokenFirstClick = false;
     });
 
+    // Replace all token spans with links.
     $(context).find('.token-click-insert .token-key').once('token-click-insert', function() {
-      var newThis = $('<a href="javascript:void(0);" title="' + Backdrop.t('Insert this token into your form') + '">' + $(this).html() + '</a>').click(function(){
-        if (typeof Backdrop.settings.tokenFocusedField == 'undefined') {
-          alert(Backdrop.t('First click a text field into which the token should be inserted.'));
+      var $span = $(this);
+      // Replace the span contents with a clickable link.
+      $span.html('<a href="javascript:void(0);" title="' + Backdrop.t('Insert this token into your form') + '">' + $span.html() + '</a>');
+    });
+
+    // Bind link clicks to the entire table so we only have a single event.
+    $(context).find('table.token-click-insert').once('token-click-insert')
+      .each(function() {
+        // Reset the first click check when displaying a new table.
+        Backdrop.settings.tokenFirstClick = true;
+      })
+      .on('click', '.token-key a', function() {
+        var $tokenLink = $(this);
+
+        // The first click after showing a table, use the closest field to the
+        // dialog link (if any).
+        if (Backdrop.settings.tokenFirstClick) {
+          Backdrop.settings.tokenFirstClick = false;
+          var dialogOpeningLinkId = $tokenLink.closest('.token-click-insert').attr('data-token-link-id');
+          if (dialogOpeningLinkId) {
+            var fieldToFocus = $('#' + dialogOpeningLinkId).closest('.form-item').find('input').get(0);
+            // If a field is found and it's not the last focused field, set
+            // the cursor to the end of the field value.
+            if (fieldToFocus && fieldToFocus != Backdrop.settings.tokenFocusedField) {
+              fieldToFocus.selectionStart = fieldToFocus.value.length;
+              fieldToFocus.selectionEnd = fieldToFocus.value.length;
+              Backdrop.settings.tokenFocusedField = fieldToFocus;
+            }
+          }
         }
-        else {
+
+        // Add the token value to the focused text field.
+        if (Backdrop.settings.tokenFocusedField) {
           var myField = Backdrop.settings.tokenFocusedField;
-          var myValue = $(this).text();
+          var myValue = $tokenLink.text();
 
           // IE support.
           if (document.selection) {
@@ -43,18 +73,19 @@ Backdrop.behaviors.tokenInsert = {
             var startPos = myField.selectionStart;
             var endPos = myField.selectionEnd;
             myField.value = myField.value.substring(0, startPos)
-                          + myValue
-                          + myField.value.substring(endPos, myField.value.length);
+              + myValue
+              + myField.value.substring(endPos, myField.value.length);
           }
           // Otherwise just tack to the end.
           else {
             myField.value += myValue;
           }
         }
+        else {
+          alert(Backdrop.t('First click a text field into which the token should be inserted.'));
+        }
         return false;
       });
-      $(this).html(newThis);
-    });
 
     var more = '&rtrif; ' + Backdrop.t('more');
     var less = '&dtrif; ' + Backdrop.t('less');
@@ -67,12 +98,14 @@ Backdrop.behaviors.tokenInsert = {
         $(this).html(more).siblings('.token-description').css('display', 'none');
       }
       return false;
-    }
-    $(context).find('.token-description').each(function() {
-      var $moreLink = $link.clone();
-      $moreLink.click(toggleDescription);
-      $(this).css('display', 'none').before(' ').before($moreLink);
-    });
+    };
+
+    $(context).find('table.token-click-insert').once('token-description')
+      .on('click', '.token-more', toggleDescription)
+      .find('.token-description').each(function() {
+        var $moreLink = $link.clone();
+        $(this).css('display', 'none').before(' ').before($moreLink);
+      });
   }
 };
 

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -127,6 +127,7 @@ function system_theme() {
         'show_restricted' => FALSE,
         'recursion_limit' => 3,
         'dialog' => FALSE,
+        'link_id' => NULL,
       ),
     ) + $base,
     'token_tree_link' => array(

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -569,29 +569,37 @@ function theme_token_tree_link($variables) {
     $variables['options']['attributes']['class'][] = 'use-ajax token-browser-link';
   }
 
-  $info = system_theme();
-  $tree_variables = array_intersect_key($variables, $info['token_tree']['variables']);
-  $tree_variables = backdrop_array_diff_assoc_recursive($tree_variables, $info['token_tree']['variables']);
-  if (!isset($variables['options']['query']['options'])) {
-    $variables['options']['query']['options'] = array();
+  if (empty($variables['options']['query'])) {
+    $variables['options']['query'] = array();
   }
-  $variables['options']['query']['options'] += $tree_variables;
 
-  // We should never pass the dialog option to theme_token_tree(). It is only
-  // used for this function.
-  unset($variables['options']['query']['options']['dialog']);
+  // Add an ID if none is specified so that this link can be identified by
+  // token.js to set field focus.
+  if (!isset($variables['options']['attributes']['id'])) {
+    $variables['options']['attributes']['id'] = 'token-browser-link--' . backdrop_random_key(6);
+  }
+
+  // Variables to pass to the theme_token_tree() in system_token_output().
+  $tree_variables = array(
+    'token_types' => $variables['token_types'],
+    'global_types' => $variables['global_types'],
+    'click_insert' => $variables['click_insert'],
+    'show_restricted' => $variables['show_restricted'],
+    'recursion_limit' => $variables['recursion_limit'],
+    'link_id' => $variables['options']['attributes']['id'],
+  );
 
   // Add a security token so that the tree page should only work when used
   // when the dialog link is output with theme('token_tree_link').
-  $variables['options']['query']['token'] = backdrop_get_token('token-tree:' . serialize($variables['options']['query']['options']));
+  $variables['options']['query']['token'] = backdrop_get_token('token-tree:' . serialize($tree_variables));
 
   // Because PHP converts query strings with arrays into a different syntax on
   // the next request, the options have to be encoded with JSON in the query
   // string so that we can reliably decode it for token comparison.
-  $variables['options']['query']['options'] = backdrop_json_encode($variables['options']['query']['options']);
+  $variables['options']['query']['options'] = backdrop_json_encode($tree_variables);
 
   // Set the token tree to open in a separate window.
-  $variables['options']['attributes'] + array('target' => '_blank');
+  $variables['options']['attributes'] += array('target' => '_blank');
 
   return l($variables['text'], 'token/tree', $variables['options']);
 }
@@ -682,11 +690,15 @@ function theme_token_tree($variables) {
     'rows' => $rows,
     'attributes' => array('class' => array('token-tree')),
     'empty' => t('No tokens available'),
+    'sticky' => FALSE,
   );
 
   if ($variables['click_insert']) {
     $table_variables['caption'] = t('Select a token to insert it into the current field.');
     $table_variables['attributes']['class'][] = 'token-click-insert';
+    if ($variables['link_id']) {
+      $table_variables['attributes']['data-token-link-id'] = $variables['link_id'];
+    }
   }
 
   backdrop_add_library('system', 'token');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4316

Rather than require an ID or property be specified between the link and the field, this assumes that the link to open the token browser is placed within the form-item wrapper, such as when the link is in the description of the element.