### PR TITLE
Issue #4357: prevent theme hook not found on date field creation

### DIFF
--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -416,9 +416,9 @@ function _date_field_widget_settings_form($field, $instance) {
     '#title' => t('Position of date part labels'),
     '#description' => $description,
   );
-  $form['advanced']['text_parts'] = array(
-    '#theme' => $widget['type'] == 'date_select' ? 'date_text_parts' : '',
-  );
+  if ($widget['type'] == 'date_select') {
+    $form['advanced']['text_parts']['#theme'] = 'date_text_parts';
+  }
   $text_parts = (array) $settings['text_parts'];
   foreach (date_granularity_names() as $key => $value) {
     if ($widget['type'] == 'date_select') {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4357

Do not set "#theme" at all on date widgets other than date_select.