### PR TITLE
3402 admin label

### DIFF
--- a/core/modules/file/file.admin.inc
+++ b/core/modules/file/file.admin.inc
@@ -26,9 +26,10 @@ function file_list_types_page() {
     $weight++;
     $row = array(
       array(
-        'data' => theme('file_type_overview',
+        'data' => theme('machine_name_label__file',
           array(
-            'name' => $type->name,
+            'label' => $type->name,
+            'machine' => $type->type,
             'description' => $type->description,
           )
         ),

--- a/core/modules/file/file.theme.inc
+++ b/core/modules/file/file.theme.inc
@@ -339,6 +339,8 @@ function theme_file_formatter_table($variables) {
  * Returns HTML for the file type overview page.
  *
  * Specifically, this returns HTML for a file type name and description.
+ *
+ * @deprecated as of 1.16.0
  */
 function theme_file_type_overview($variables) {
   return check_plain($variables['name']) . '<div class="description">' . filter_xss_admin($variables['description']) . '</div>';

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -79,7 +79,9 @@ function filter_admin_overview($form) {
           'weight' => -10,
         );
       }
-      $form['formats'][$id]['name'] = array('#markup' => check_plain($format->name));
+      $machine_name_label_variables = array('label' => $format->name, 'machine' => $id);
+      $label = theme('machine_name_label__filter', $machine_name_label_variables);
+      $form['formats'][$id]['name'] = array('#markup' => $label);
       $roles = array();
       foreach (filter_get_roles_by_format($format) as $role_name) {
         $role = user_role_load($role_name);

--- a/core/modules/image/image.theme.inc
+++ b/core/modules/image/image.theme.inc
@@ -58,7 +58,7 @@ function theme_image_style_list($variables) {
   $rows = array();
   foreach ($styles as $style) {
     $row = array();
-    $row[] = l($style['label'], 'admin/config/media/image-styles/configure/' . $style['name']);
+    $row[] = theme('machine_name_label__image_style', array('label' => $style['label'], 'machine' => $style['name']));
 
     $links = array();
     $links['configure'] = array(

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -43,10 +43,6 @@
   margin-left: 0;
 }
 
-.layout-list .layout-title {
-  font-weight: bold;
-}
-
 /* Individual layout settings form. */
 .layout-settings-page .form-type-checkboxes,
 .layout-settings-form .form-type-radios {

--- a/core/modules/layout/layout.theme.inc
+++ b/core/modules/layout/layout.theme.inc
@@ -57,12 +57,19 @@ function theme_layout_info($variables) {
   // Create a link to the settings page
   $template = l($info['title'], 'admin/structure/layouts/manage/' . $layout->name . '/configure');
 
-  $output = '';
-  $output .= '<div class="layout-info">';
+  $label_variables = array(
+    'label' => $layout->title,
+    'machine' => $layout->name,
+  );
+  $label = theme('machine_name_label__layout', $label_variables);
+
+  $output  = '<div class="layout-info">';
   $output .= $preview;
   $output .= '<div class="layout-detail">';
-  $output .= '  <div class="layout-title">' . check_plain($layout->title) . '</div>';
-  $output .= '  <div class="layout-template description">' . t('<span class="priority-low">Template: </span>!title', array('!title' => $template)) . '</div>';
+  $output .= '  <div class="layout-title">' . $label . '</div>';
+  $output .= '  <div class="layout-template description">';
+  $output .= t('<span class="priority-low">Template: </span>!title', array('!title' => $template));
+  $output .= '  </div>';
   $output .= '</div></div>';
 
   return $output;

--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -14,7 +14,12 @@ function menu_overview_page() {
   $rows = array();
   foreach ($menus as $menu) {
     $row = array();
-    $row[] = theme('menu_admin_overview', array('title' => $menu['title'], 'name' => $menu['menu_name'], 'description' => $menu['description']));
+    $label_variables = array(
+      'label' => $menu['title'],
+      'machine' => $menu['menu_name'],
+      'description' => $menu['description'],
+    );
+    $row[] = theme('machine_name_label__menu', $label_variables);
     $links = array();
     $links['list'] = array(
       'title' => t('Manage links'),

--- a/core/modules/menu/menu.theme.inc
+++ b/core/modules/menu/menu.theme.inc
@@ -5,23 +5,6 @@
  */
 
 /**
- * Returns HTML for a menu title and description for the menu overview page.
- *
- * @param $variables
- *   An associative array containing:
- *   - title: The menu's title.
- *   - description: The menu's description.
- *
- * @ingroup themeable
- */
-function theme_menu_admin_overview($variables) {
-  $output = check_plain($variables['title']);
-  $output .= '<div class="description">' . filter_xss_admin($variables['description']) . '</div>';
-
-  return $output;
-}
-
-/**
  * Returns HTML for the menu overview form into a table.
  *
  * @param $variables

--- a/core/modules/node/node.theme.inc
+++ b/core/modules/node/node.theme.inc
@@ -161,6 +161,8 @@ function theme_node_add_list($variables) {
  *   - type: An object containing the 'type' (machine name) and 'description' of
  *     the content type.
  *
+ * @deprecated as of 1.16.0
+ *
  * @ingroup themeable
  */
 function theme_node_admin_overview($variables) {

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -22,7 +22,13 @@ function node_overview_types() {
   foreach ($names as $key => $name) {
     $type = $types[$key];
     $type_url_str = str_replace('_', '-', $type->type);
-    $row = array(theme('node_admin_overview', array('name' => $name, 'type' => $type)));
+    $label_variables = array(
+      'label' => $name,
+      'machine' => $type->type,
+      'description' => $type->description,
+    );
+    $label = theme('machine_name_label__node_type', $label_variables);
+    $row = array($label);
     $links = array();
     $links['configure'] = array(
       'title' => t('Configure'),

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -2342,7 +2342,6 @@ function system_date_delete_format_form_submit($form, &$form_state) {
 function system_date_time_formats() {
   $header = array(
     array('data' => t('Label')),
-    array('data' => t('Machine name')),
     array('data' => t('Pattern')),
     array('data' => t('Operations'))
   );
@@ -2353,9 +2352,13 @@ function system_date_time_formats() {
     foreach ($formats as $date_format_name => $format_info) {
       // Do not display date formats that are hidden.
       if (empty($format_info['hidden'])) {
+        $label_variables = array(
+          'label' => $format_info['label'],
+          'machine' => $date_format_name,
+        );
+
         $row = array();
-        $row[] = array('data' => check_plain($format_info['label']));
-        $row[] = array('data' => $date_format_name);
+        $row[] = array('data' => theme('machine_name_label__date_format', $label_variables));
         $row[] = array('data' => format_date(REQUEST_TIME, 'custom', $format_info['pattern']));
 
         // Prepare Operational links.

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -86,6 +86,9 @@ function system_theme() {
     'status_report' => array(
       'render element' => 'requirements',
     ) + $base,
+    'machine_name_label' => array(
+      'variables' => array('label' => NULL, 'machine' => NULL, 'description' => NULL, 'inline' => TRUE),
+    ) + $base,
     'admin_page' => array(
       'variables' => array('blocks' => NULL),
     ) + $base,

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -506,6 +506,42 @@ function theme_admin_block_content($variables) {
 }
 
 /**
+ * Returns HTML for the display of label with both Human and Machine names.
+ *
+ * @param $variables
+ *   An associative array containing:
+ *   - label: The human-readable name or label.
+ *   - machine: The machine-safe name or label.
+ *   - description: (optional) The description of the item.
+ *   - inline: TRUE if the machine name should be on the same line. Defaults to TRUE.
+ *
+ * @ingroup themeable
+ */
+function theme_admin_info($variables) {
+  $classes = array('admin-label');
+  if ($variables['inline']) {
+    $classes[] = 'inline';
+  }
+
+  $output  = '<div class="' . implode(' ', $classes) . '">';
+  $output .=   '<strong>' . check_plain($variables['label']) . '</strong>';
+  if (!empty($variables['machine'])) {
+    $machine_name = t('Machine name: @machine', array('@machine' => $variables['machine']));
+    if ($variables['inline']) {
+      $output .= '&nbsp;';
+    }
+    $output .=   '<small>(' . $machine_name . ')</small>';
+  }
+  $output .= '</div>';
+
+  if (isset($variables['description'])) {
+    $output .= '<div class="description">' . filter_xss_admin($variables['description']) . '</div>';
+  }
+
+  return $output;
+}
+
+/**
  * Returns HTML for the output of the dashboard page.
  *
  * @param $variables

--- a/core/modules/taxonomy/taxonomy.admin.inc
+++ b/core/modules/taxonomy/taxonomy.admin.inc
@@ -16,9 +16,17 @@ function taxonomy_overview_vocabularies($form) {
   $form['#tree'] = TRUE;
   $term_counts = db_query("SELECT vocabulary, count(tid) FROM {taxonomy_term_data} GROUP BY vocabulary")->fetchAllKeyed();
   foreach ($vocabularies as $vocabulary) {
+    $label_variables = array(
+      'label' => $vocabulary->name,
+      'machine' => $vocabulary->machine_name,
+      'description' => $vocabulary->description,
+    );
+    $label = theme('machine_name_label__vocabulary', $label_variables);
+
     $terms_count = array_key_exists($vocabulary->machine_name, $term_counts) ? $term_counts[$vocabulary->machine_name] : 0;
+
     $form[$vocabulary->machine_name]['#vocabulary'] = $vocabulary;
-    $form[$vocabulary->machine_name]['name'] = array('#markup' => check_plain($vocabulary->name));
+    $form[$vocabulary->machine_name]['name'] = array('#markup' => $label);
     $form[$vocabulary->machine_name]['items'] = array('#markup' => $terms_count);
     $form[$vocabulary->machine_name]['weight'] = array(
       '#type' => 'weight',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3402

This PR adds a new theme function `theme_admin_info()` into system module that can be used universally. 

* The function `theme_node_admin_overview()` is marked as deprecated.
* Node types listing now calls `theme_admin_info()` instead.
* Layout listing now calls `theme_admin_info()`.
* The function `theme_file_type_overview` is marked as deprecated.
* File types listing now calls `theme_admin_info()` instead.
* The function `theme_menu_admin_overview()' is marked as deprecated.
* Taxonomy vocabulary listing now calls `theme_admin_info()`.
* The menu listing now calls `theme_admin_info()` instead.
* The function `theme_views_ui_view_name()` is marked as deprecated.
* The views listing now calls `theme_admin_info()`.
* The image style listing now calls `theme_admin_info()`.
* The text format listing now calls `theme_admin_info()`.
* The date format listing now calls `theme_admin_info()`.
