### PR TITLE
Issue #4389: php notice on List layouts page when permission is missing

### DIFF
--- a/core/modules/layout/plugins/access/user_permission_layout_access.inc
+++ b/core/modules/layout/plugins/access/user_permission_layout_access.inc
@@ -23,6 +23,11 @@ class UserPermissionLayoutAccess extends LayoutAccess {
     }
 
     $permissions = module_invoke_all('permission');
+    if (!array_key_exists($this->settings['permission'], $permissions)) {
+      return t('User has missing "@permission" permission (not provided by any module).', array(
+        '@permission' => $this->settings['permission'],
+      ));
+    }
     return t('User has "@permission" permission.', array('@permission' => $permissions[$this->settings['permission']]['title']));
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4389

Prevent PHP notice if permission is missing (disabled modules and the like).