### PR TITLE
#4276: Remove non-standard IE7 property 'zoom'

### DIFF
--- a/core/modules/system/css/system.css
+++ b/core/modules/system/css/system.css
@@ -26,7 +26,6 @@
   color: #000;
   cursor: default;
   white-space: pre;
-  zoom: 1; /* IE7 */
 }
 /* Animated throbber */
 .js input.form-autocomplete {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4276