### PR TITLE
Issue #2637: Transliteration for language neutral content

### DIFF
--- a/core/modules/path/path.inc
+++ b/core/modules/path/path.inc
@@ -184,6 +184,12 @@ function path_clean_string($string, array $options = array()) {
   elseif (!empty($options['langcode'])) {
     $langcode = $options['langcode'];
   }
+  if ($langcode == LANGUAGE_NONE) {
+    // Paths for language neutral content get transliterated according to
+    // current language.
+    global $language;
+    $langcode = $language->langcode;
+  }
 
   // Check if the string has already been processed, and if so return the
   // cached result.

--- a/core/modules/path/path.inc
+++ b/core/modules/path/path.inc
@@ -188,6 +188,9 @@ function path_clean_string($string, array $options = array()) {
     // Paths for language neutral content get transliterated according to
     // current language.
     global $language;
+    // We are intentionally not using config_get('system.core', 'language_default')
+    // here. That can have unexpected behavior in cases such as on a multilingual
+    // site with language-neutral content types.
     $langcode = $language->langcode;
   }
 

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -813,13 +813,19 @@ class PathPatternLocaleTestCase extends PathPatternFunctionalTestHelper {
     $modules[] = 'translation';
     parent::setUp($modules, array('administer languages'));
 
-    // Add predefined French language and reset the locale cache.
-    $language = (object) array(
+    // Add predefined French and German languages and reset the locale cache.
+    $french = (object) array(
       'langcode' => 'fr',
       'name' => 'French',
       'direction' => LANGUAGE_LTR,
     );
-    language_save($language);
+    language_save($french);
+    $german = (object) array(
+      'langcode' => 'de',
+      'name' => 'German',
+      'direction' => LANGUAGE_LTR,
+    );
+    language_save($german);
     backdrop_language_initialize();
   }
 
@@ -858,6 +864,32 @@ class PathPatternLocaleTestCase extends PathPatternFunctionalTestHelper {
     $this->assertEntityAlias('node', $node, 'french-node', 'fr');
     $this->assertAliasExists(array('pid' => $english_alias['pid'], 'alias' => 'content/english-node-1'));
   }
+
+  /**
+   * Language neutral German node has the correct transliteration applied.
+   */
+  public function testNeutralTransliteration() {
+    $path_prefixes = array(
+      'en' => 'en',
+      'de' => '',
+      'fr' => 'fr',
+    );
+    config_set('system.core', 'language_default', 'de');
+    config_set('path.settings', 'transliterate', TRUE);
+    // Note: "ü" -> "ue", "ß" -> "ss".
+    $title = 'Lückenbüßer';
+    $edit = array(
+      'title' => $title,
+      'path[auto]' => TRUE,
+    );
+    // We need to get rid of the session.
+    $this->backdropLogout($this->admin_user);
+    $this->backdropLogin($this->admin_user);
+    $this->backdropPost('node/add/page', $edit, t('Save'));
+    $node = $this->backdropGetNodeByTitle($title);
+    $this->assertEntityAlias('node', $node, 'content/lueckenbuesser');
+  }
+
 }
 
 /**

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -208,6 +208,16 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
     $expected = 'add-accents'; // "a" and "the" is stripped out.
     $output = path_clean_string($input);
     $this->assertEqual($output, $expected, format_string("path_clean_string('@input') expected '@expected', actual '@output'", array('@input' => $input, '@expected' => $expected, '@output' => $output)));
+
+    // German transiteration: "Ä" -> "ae", "ü" -> "ue", "ö" -> "oe".
+    $input = 'Ärger im Büro ist möglich';
+    $expected = 'aerger-im-buero-ist-moeglich';
+    $output = path_clean_string($input, array('langcode' => 'de'));
+    $this->assertEqual($output, $expected, format_string("path_clean_string('@input') expected '@expected', actual '@output'", array(
+      '@input' => $input,
+      '@expected' => $expected,
+      '@output' => $output,
+    )));
   }
 
   /**

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -871,18 +871,25 @@ class PathPatternLocaleTestCase extends PathPatternFunctionalTestHelper {
   public function testNeutralTransliteration() {
     config_set('system.core', 'language_default', 'de');
     config_set('path.settings', 'transliterate', TRUE);
-    // Note: "ü" -> "ue", "ß" -> "ss".
-    $title = 'Lückenbüßer';
+    $title_de = 'Lückenbüßer stören DE';
+    $title_en = 'Lückenbüßer stören EN';
     $edit = array(
-      'title' => $title,
+      'title' => $title_de,
       'path[auto]' => TRUE,
     );
     // We need to get rid of the session.
     $this->backdropLogout($this->admin_user);
     $this->backdropLogin($this->admin_user);
     $this->backdropPost('node/add/page', $edit, t('Save'));
-    $node = $this->backdropGetNodeByTitle($title);
-    $this->assertEntityAlias('node', $node, 'content/lueckenbuesser');
+    $node = $this->backdropGetNodeByTitle($title_de);
+    // DE: "ü" -> "ue", "ß" -> "ss", "ö" -> "oe".
+    $this->assertEntityAlias('node', $node, 'content/lueckenbuesser-stoeren-de');
+    config_set('system.core', 'language_default', 'en');
+    $edit['title'] = $title_en;
+    $this->backdropPost('node/add/page', $edit, t('Save'));
+    $node = $this->backdropGetNodeByTitle($title_en);
+    // EN: "ü" -> "u", "ß" -> "ss", "ö" -> "o".
+    $this->assertEntityAlias('node', $node, 'content/luckenbusser-storen-en');
   }
 
 }

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -869,11 +869,6 @@ class PathPatternLocaleTestCase extends PathPatternFunctionalTestHelper {
    * Language neutral German node has the correct transliteration applied.
    */
   public function testNeutralTransliteration() {
-    $path_prefixes = array(
-      'en' => 'en',
-      'de' => '',
-      'fr' => 'fr',
-    );
     config_set('system.core', 'language_default', 'de');
     config_set('path.settings', 'transliterate', TRUE);
     // Note: "ü" -> "ue", "ß" -> "ss".


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2637

This PR handles transliteration for language neutral content paths like the D7 module does - by choosing the current language.