### PR TITLE
Issue #4487: Remove legacy 'view the administrative theme' permission…

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -565,18 +565,18 @@ function layout_route_handler($router_item) {
 
   $selected_layout = layout_get_layout_by_path(NULL, $router_item);
 
-  // Safety check that we don't show an admin layout to a user who cannot view
-  // the admin theme. This may happen because the cached layout list does not
-  // include a permissions check on the admin theme.
-  if ($selected_layout->name === 'admin_default' && !user_access('view the administration theme')) {
+  // Safety check that we don't show an admin layout to anyone who cannot access
+  // administrative pages. This may happen because the cached layout list does
+  // not include a permissions check.
+  if ($selected_layout->name === 'admin_default' && !user_access('access administration pages')) {
     $selected_layout = layout_load('default');
   }
 
-  // Special handling for 404 and 403 pages to render in admin theme. The
-  // current path will be the 404/403 system path, and we need to check the
-  // original path, which is stored in "destination" by
+  // Special handling for when 404 and 403 pages should render in the admin
+  // theme. The current path will be the 404/403 system path, and we need to
+  // check the original path, which is stored in "destination" by
   // backdrop_deliver_html_page().
-  if (in_array(backdrop_get_http_header('Status'), array('404 Not Found', '403 Forbidden')) && user_access('view the administration theme')) {
+  if (in_array(backdrop_get_http_header('Status'), array('404 Not Found', '403 Forbidden')) && user_access('access administration pages')) {
     if (isset($_GET['destination']) && path_is_admin($_GET['destination'])) {
       $selected_layout = layout_load('admin_default');
     }
@@ -1259,7 +1259,7 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
 
     // If no layout matches at the path, use the default layout.
     if (!$selected_layout) {
-      if (path_is_admin($router_item['path']) && user_access('view the administration theme')) {
+      if (path_is_admin($router_item['path']) && user_access('access administration pages')) {
         $selected_layout = layout_load('admin_default');
       }
       else {

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -1392,11 +1392,13 @@ class LayoutBlockTest extends BackdropWebTestCase {
 
       // Create and login admin user.
       $this->admin_user = $this->backdropCreateUser(array(
-        'access administration pages',
         'administer layouts',
         'access user profiles',
-        'edit any page content',
         'administer nodes',
+        'edit any page content',
+        // We do not add the 'access administration pages' permission here,
+        // because tests below were written to test the `default` layout, not
+        // the admin_default.
       ));
       $this->backdropLogin($this->admin_user);
     }
@@ -1765,12 +1767,12 @@ class LayoutBlockTest extends BackdropWebTestCase {
     $page_title = $this->xpath('(//div[contains(@class, "l-page-title")])//h1["Your first post!"]');
     $this->assertEqual(count($page_title), 0, 'The page title was not found.');
     $tabs = $this->xpath('(//nav[contains(@class, "tabs")])//div[contains(@class, "tabs")]');
-    $this->assertEqual(count($tabs), 0, 'The tabs DIV was not found.');
+    $this->assertEqual(count($tabs), 0, 'The default tabs DIV was not found.');
 
     // Edit the node to get a system mesage.
     $this->backdropPost("node/1/edit", array(), t('Save'));
     $messages = $this->xpath('(//div[contains(@class, "l-wrapper")])//div[contains(@class, "l-messages")]');
-    $this->assertEqual(count($messages), 0, 'The messages DIV was not found.');
+    $this->assertEqual(count($messages), 0, 'The default messages DIV was not found.');
 
     // Check that the Combo block elements show.
     $combo_page_title = $this->xpath('(//div[contains(@class, "block-system-title-combo")])//h1[contains(@class, "title")]');
@@ -1805,17 +1807,17 @@ class LayoutBlockTest extends BackdropWebTestCase {
     // Check that the system message DIV no longer shows but the messages block
     // does.
     $messages = $this->xpath('(//div[contains(@class, "l-wrapper")])//div[contains(@class, "l-messages")]');
-    $this->assertEqual(count($messages), 0, 'The messages DIV was not found.');
+    $this->assertEqual(count($messages), 0, 'The default messages DIV was not found.');
     $block_messages = $this->xpath('(//div[contains(@class, "block-system-messages")])//div[contains(@class, "l-messages")]');
-    $this->assertEqual(count($block_messages), 1, 'The Page messages block was found.');
+    $this->assertEqual(count($block_messages), 1, 'The messages block was found.');
 
     // Go to the layouts list and check that the Local actions DIV no longer
     // shows but the block does.
     $this->backdropGet('admin/structure/layouts');
     $actions = $this->xpath('(//div[contains(@class, "l-wrapper")])//div[contains(@class, "l-action-links")]');
-    $this->assertEqual(count($actions), 0, 'The messages DIV was not found.');
+    $this->assertEqual(count($actions), 0, 'The default local actions DIV was not found.');
     $block_actions = $this->xpath('(//div[contains(@class, "block-system-action-links")])//ul[contains(@class, "action-links")]');
-    $this->assertEqual(count($block_actions), 1, 'The Page messages block was found.');
+    $this->assertEqual(count($block_actions), 1, 'The local actions block was found.');
   }
 }
 
@@ -1847,7 +1849,6 @@ class LayoutSelectionTest extends BackdropWebTestCase {
       'create ' . $this->content_type->type . ' content',
       'access administration pages',
       'administer content types',
-      'view the administration theme',
       'administer filters',
     ));
     $this->backdropLogin($this->admin_user);
@@ -1981,7 +1982,6 @@ class LayoutBlockTextTest extends BackdropWebTestCase {
       'access content',
       'access administration pages',
       'administer layouts',
-      'view the administration theme',
     ));
     $this->backdropLogin($this->admin_user);
   }
@@ -2063,7 +2063,6 @@ class LayoutCloneTest extends BackdropWebTestCase {
       'access content',
       'access administration pages',
       'administer layouts',
-      'view the administration theme',
     ));
     $this->backdropLogin($this->admin_user);
   }

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2773,7 +2773,7 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
   function setUp() {
     parent::setUp('locale');
     require_once BACKDROP_ROOT .'/core/includes/language.inc';
-    $admin_user = $this->backdropCreateUser(array('administer languages', 'access administration pages', 'view the administration theme'));
+    $admin_user = $this->backdropCreateUser(array('administer languages', 'access administration pages'));
     $this->backdropLogin($admin_user);
     $this->backdropPost('admin/config/regional/language/add', array('predefined_langcode' => 'it'), t('Add language'));
   }

--- a/core/modules/simpletest/tests/batch.test
+++ b/core/modules/simpletest/tests/batch.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Tests for the Batch API.
@@ -289,8 +288,8 @@ class BatchPageTestCase extends BackdropWebTestCase {
     // is using a different theme than would normally be used by the batch API.
     config_set('system.core', 'theme_default', 'bartik');
     config_set('system.core', 'admin_theme', 'seven');
-    // Log in as an administrator who can see the administrative theme.
-    $admin_user = $this->backdropCreateUser(array('view the administration theme'));
+    // Log in as an administrator who can see administrative pages.
+    $admin_user = $this->backdropCreateUser(array('access administration pages'));
     $this->backdropLogin($admin_user);
     // Visit an administrative page that runs a test batch, and check that the
     // theme that was used during batch execution (which the batch callback

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -169,10 +169,6 @@ function system_permission() {
     'access site in maintenance mode' => array(
       'title' => t('Use the site in maintenance mode'),
     ),
-    'view the administration theme' => array(
-      'title' => t('View the administration theme'),
-      'description' => config_get('system.core', 'admin_theme') ? '' : t('This is only used when the site is configured to use a separate administration theme on the <a href="@appearance-url">Appearance</a> page.', array('@appearance-url' => url('admin/appearance'))),
-    ),
     'access site reports' => array(
       'title' => t('View site reports'),
     ),
@@ -2352,7 +2348,7 @@ function system_add_module_assets() {
  * Implements hook_custom_theme().
  */
 function system_custom_theme() {
-  if (user_access('view the administration theme') && path_is_admin(current_path())) {
+  if (user_access('access administration pages') && path_is_admin(current_path())) {
     return config_get('system.core', 'admin_theme');
   }
 }

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1673,7 +1673,7 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
 
     $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
 
-    $this->admin_user = $this->backdropCreateUser(array('access administration pages', 'view the administration theme', 'administer themes', 'bypass node access', 'administer blocks'));
+    $this->admin_user = $this->backdropCreateUser(array('access administration pages', 'administer themes', 'bypass node access', 'administer blocks'));
     $this->backdropLogin($this->admin_user);
     $this->node = $this->backdropCreateNode();
   }

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -1786,8 +1786,8 @@ class TaxonomyThemeTestCase extends TaxonomyWebTestCase {
     config_set('system.core', 'admin_theme', 'seven');
 
     // Create and log in as a user who has permission to add and edit taxonomy
-    // terms and view the administrative theme.
-    $admin_user = $this->backdropCreateUser(array('administer taxonomy', 'view the administration theme'));
+    // terms.
+    $admin_user = $this->backdropCreateUser(array('administer taxonomy', 'access administration pages'));
     $this->backdropLogin($admin_user);
   }
 
@@ -1839,7 +1839,7 @@ class TaxonomyEFQTestCase extends TaxonomyWebTestCase {
     $result = $result['taxonomy_term'];
     asort($result);
     $this->assertEqual(array_keys($terms), array_keys($result), 'Taxonomy terms were retrieved by EntityFieldQuery.');
- 
+
     $first_result = reset($result);
     $term = _field_create_entity_from_ids($first_result);
     $this->assertEqual($term->tid, $first_result->entity_id, 'Taxonomy term can be created based on the IDs');

--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -388,7 +388,6 @@ function standard_install() {
     'delete own post content',
     'delete any post content',
     'access dashboard',
-    'view the administration theme',
     'access administration bar',
     'access content overview',
     'access administration pages',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4487

Steps to test:
- create an admin user (with `access administration pages` permission) and log in as that user.
- visit `/admin` and other pages under admin paths, check that you get the admin layout and admin theme
- log out
- visit `/admin` (the 403 page) and check that you get the front-end theme and layout
