### PR TITLE
Issue #4492: CKEditor settings not respecting lang

### DIFF
--- a/core/modules/ckeditor/ckeditor.module
+++ b/core/modules/ckeditor/ckeditor.module
@@ -517,7 +517,7 @@ function ckeditor_get_settings($format, $existing_settings) {
     'coreStyles_strike' => array('element' => 'del'),
     'coreStyles_underline' => array('element' => 'span', 'attributes' => array('class' => 'underline')),
     //'format_tags' => implode(';', $format->editor_settings['format_list']),
-    'language' => isset($language->language) ? $language->language : '',
+    'language' => $language->langcode,
     'resize_dir' => 'vertical',
     'disableNativeSpellChecker' => FALSE,
   );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4492

Uses the correct property of the global $language object. No isset needed.