### PR TITLE
Issue #4493: Page title of /user/register not translated

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -2985,7 +2985,7 @@ function user_form_field_ui_field_edit_form_submit($form, &$form_state) {
 function user_register_form($form, &$form_state) {
   global $user;
   // We need to set the page title bc this menu entry is a local task.
-  backdrop_set_title('Create new account');
+  backdrop_set_title(t('Create new account'));
 
   $admin = user_access('administer users');
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4493

Wraps the string in `t()`.