### PR TITLE
Issue #4514: Views link to node translation not showing

### DIFF
--- a/core/modules/translation/views/views_handler_field_node_link_translate.inc
+++ b/core/modules/translation/views/views_handler_field_node_link_translate.inc
@@ -15,7 +15,7 @@ class views_handler_field_node_link_translate extends views_handler_field_node_l
     // ensure user has access to edit this node.
     $node = $this->get_value($values);
     $node->status = 1; // unpublished nodes ignore access control
-    if (empty($node->langcode) || !translation_supported_type($node->type) || !node_access('view', $node) || !user_access('translate content')) {
+    if (empty($node->langcode) || $node->langcode == LANGUAGE_NONE || !translation_supported_type($node->type) || !node_access('view', $node) || !user_access('translate content')) {
       return;
     }
 

--- a/core/modules/translation/views/views_handler_field_node_link_translate.inc
+++ b/core/modules/translation/views/views_handler_field_node_link_translate.inc
@@ -15,7 +15,7 @@ class views_handler_field_node_link_translate extends views_handler_field_node_l
     // ensure user has access to edit this node.
     $node = $this->get_value($values);
     $node->status = 1; // unpublished nodes ignore access control
-    if (empty($node->language) || !translation_supported_type($node->type) || !node_access('view', $node) || !user_access('translate content')) {
+    if (empty($node->langcode) || !translation_supported_type($node->type) || !node_access('view', $node) || !user_access('translate content')) {
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4514

That if clause returns TRUE because `$node->language` isn't set - the actual property name is `langcode`.
And also: language neutral content isn't translatable.