### PR TITLE
Issue #4513: Broken views_handler_relationship_translation

### DIFF
--- a/core/modules/translation/views/views_handler_relationship_translation.inc
+++ b/core/modules/translation/views/views_handler_relationship_translation.inc
@@ -64,20 +64,20 @@ class views_handler_relationship_translation extends views_handler_relationship 
       switch ($this->options['language']) {
         case 'current':
           $def['extra'][] = array(
-            'field' => 'language',
+            'field' => 'langcode',
             'value' => '***CURRENT_LANGUAGE***',
           );
           break;
         case 'default':
           $def['extra'][] = array(
-            'field' => 'language',
+            'field' => 'langcode',
             'value' => '***DEFAULT_LANGUAGE***',
           );
           break;
         // Other values will be the language codes.
         default:
           $def['extra'][] = array(
-            'field' => 'language',
+            'field' => 'langcode',
             'value' => $this->options['language'],
           );
           break;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4513

The db tables of everything that's translatable in Backdrop uses "langcode" columns.