### PR TITLE
Issue 4524: Tab index: Password toggle should come after password field

### DIFF
--- a/core/modules/user/js/user.js
+++ b/core/modules/user/js/user.js
@@ -57,7 +57,7 @@ Backdrop.behaviors.passwordToggle = {
       }
 
       $passwordWrapper.addClass('password-hidden');
-      $passwordInput.before($passwordToggle);
+      $passwordInput.after($passwordToggle);
 
       var passwordToggle = function (e) {
         var showPassword = $passwordWrapper.is('.password-hidden');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4524