### PR TITLE
Issue #4526: Additional image field validator to check the type

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1849,7 +1849,10 @@ function file_validate_is_image(File $file) {
   $errors = array();
 
   $info = image_get_info($file->uri);
-  if (!$info || empty($info['extension'])) {
+  if (!$info) {
+    $errors[] = t('The uploaded file is either corrupt or not an image.');
+  }
+  elseif (empty($info['extension'])) {
     $errors[] = t('Only JPEG, PNG and GIF images are allowed.');
   }
 

--- a/core/modules/image/image.field.inc
+++ b/core/modules/image/image.field.inc
@@ -440,6 +440,8 @@ function image_field_widget_form(&$form, &$form_state, $field, $instance, $langc
     $extensions = isset($elements[$delta]['#upload_validators']['file_validate_extensions'][0]) ? $elements[$delta]['#upload_validators']['file_validate_extensions'][0] : implode(' ', $supported_extensions);
     $extensions = array_intersect(explode(' ', $extensions), $supported_extensions);
     $elements[$delta]['#upload_validators']['file_validate_extensions'][0] = implode(' ', $extensions);
+    // Do not rely on file extension alone, also verify the type.
+    $elements[$delta]['#upload_validators']['file_validate_is_image'] = array();
 
     // Set any view used as a browser.
     if (!empty($instance['widget']['settings']['browser_view'])) {

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -992,7 +992,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
     // Try to upload a file that is not an image for the user picture.
     $not_an_image = current($this->backdropGetTestFiles('html'));
     $this->saveUserPicture($not_an_image);
-    $this->assertRaw(t('Only JPEG, PNG and GIF images are allowed.'), 'Non-image files are not accepted.');
+    $this->assertRaw(t('The uploaded file is either corrupt or not an image.'), 'Non-image files are not accepted.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4526

Core already ships with a handy image verification function. Use that in image fields, too.