### PR TITLE
Issue #4535: Allow basic Markdown formatting in t()

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1975,11 +1975,11 @@ function t($string, array $args = array(), array $options = array()) {
     $string = format_string_markdown($string);
   }
 
-  if (!empty($args)) {
-    return format_string($string, $args);
+  if (empty($args)) {
+    return $string;
   }
   else {
-    return $string;
+    return format_string($string, $args);
   }
 
 }

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1967,12 +1967,8 @@ function t($string, array $args = array(), array $options = array()) {
   elseif ($options['langcode'] != LANGUAGE_SYSTEM && ($options['langcode'] != 'en' || $translate_english) && function_exists('locale')) {
     $string = locale($string, $options['context'], $options['langcode']);
   }
-  if (empty($args)) {
-    return $string;
-  }
-  else {
-    return format_string($string, $args);
-  }
+
+  return format_string($string, $args);
 }
 
 /**
@@ -2030,7 +2026,49 @@ function format_string($string, array $args = array()) {
         // Pass-through.
     }
   }
+
+  $string = format_string_markdown($string);
+
   return strtr($string, $args);
+}
+
+/**
+ * Formats a string containing basic Markdown for HTML display.
+ *
+ * Text wrapped in the following Markdown is converted:
+ *   - *** -> both bold and italics (<strong> and <em> HTML tags).
+ *   - ** -> bolded text (<strong> HTML tag).
+ *   - * -> italicized text (<em> HTML tag).
+ *   - ` -> monospaced text (<code> HTML tag).
+ *
+ * Literal asterisks and back-ticks in text can be escaped by adding a backslash
+ * before the asterisk/back-tick.
+ *
+ * Used automatically by format_string().
+ *
+ * @param $text
+ *   The text to format (plain-text).
+ *
+ * @return
+ *   The formatted text (HTML).
+ */
+function format_string_markdown($text) {
+  // Replace any non-escaped pairs of triple asterisks with both <strong> and
+  // <em> tags.
+  $text = preg_replace('/(?<!(\\\))\*(?<!(\\\))\*(?<!(\\\))\*(.+)(?<!(\\\))\*(?<!(\\\))\*(?<!(\\\))\*/', '<strong><em>\\4</em></strong>', $text);
+  // Replace any non-escaped pairs of double asterisks with <strong> tags.
+  $text = preg_replace('/(?<!(\\\))\*(?<!(\\\))\*(.+)(?<!(\\\))\*(?<!(\\\))\*/', '<strong>\\3</strong>', $text);
+  // Replace any non-escaped pairs of asterisks with <em> tags.
+  $text = preg_replace('/(?<!(\\\))\*(.+)(?<!(\\\))\*/', '<em>\\2</em>', $text);
+  // Replace any non-escaped pairs of back-ticks with <code> tags.
+  $text = preg_replace('/(?<!(\\\))`(.+)(?<!(\\\))`/', '<code>\\2</code>', $text);
+
+  // Remove any backslashes that may have been added in order to escape any
+  // literal asterisks and back-ticks.
+  $text = preg_replace('/\\\\\*/', '*', $text);
+  $text = preg_replace('/\\\\`/', '`', $text);
+
+  return $text;
 }
 
 /**

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1968,7 +1968,20 @@ function t($string, array $args = array(), array $options = array()) {
     $string = locale($string, $options['context'], $options['langcode']);
   }
 
-  return format_string($string, $args);
+  // If the string contains asterisks or back-ticks, run it through the
+  // markdown formatter.
+  // @todo: possibly support more Markdown in the future.
+  if (preg_match('/[*`]/', $string)) {
+    $string = format_string_markdown($string);
+  }
+
+  if (!empty($args)) {
+    return format_string($string, $args);
+  }
+  else {
+    return $string;
+  }
+
 }
 
 /**
@@ -2026,9 +2039,6 @@ function format_string($string, array $args = array()) {
         // Pass-through.
     }
   }
-
-  $string = format_string_markdown($string);
-
   return strtr($string, $args);
 }
 

--- a/core/modules/layout/plugins/access/path_layout_access.inc
+++ b/core/modules/layout/plugins/access/path_layout_access.inc
@@ -71,7 +71,7 @@ class PathLayoutAccess extends LayoutAccess {
       '#type' => 'textarea',
       '#title' => t('Paths'),
       '#default_value' => $this->settings['paths'],
-      '#description' => t('Enter one path per line. The "*" character is a wildcard. Example paths are "node/1" for an individual piece of content or "node/*" for every piece of content. "@front" is the front page.', array('@front' => '<front>')),
+      '#description' => t('Enter one path per line. The "\*" character is a wildcard. Example paths are "node/1" for an individual piece of content or "node/\*" for every piece of content. "@front" is the front page.', array('@front' => '<front>')),
       '#required' => TRUE,
     );
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4535

To test this in the PR sandbox:

1. install the Devel module (if not already installed)
2. head to http://3240.backdrop.backdrop.qa.backdropcms.org/admin/modules/install and enter the following php code in the text field:

```php
backdrop_set_message(t('`this is code` and \`this is not\`'));
backdrop_set_message(t('*italics* vs \*non-italics\*'));
backdrop_set_message(t('**bold** vs \*\*non-bold\*\*'));
backdrop_set_message(t('***bold and italicized*** vs \*\*\*regular text\*\*\*'));
backdrop_set_message(t('text with a single back-tick: ` (no need to be escaped)'));
backdrop_set_message(t('text with a double back-tick: `` (no need to be escaped)'));
backdrop_set_message(t('text with a triple back-tick: ``` (rendered as a single back-tick in monospace)'));
backdrop_set_message(t('text with an escaped triple back-tick: \`\`\`'));
backdrop_set_message(t('text with a quadruple back-tick: ```` (rendered as a pair of back-ticks in monospace)'));
backdrop_set_message(t('text with an escaped quadruple back-tick: \`\`\`\`'));
backdrop_set_message(t('text with a quintuple back-tick: ````` (rendered as a triplet of back-ticks in monospace)'));
backdrop_set_message(t('text with an escaped quintuple back-tick: \`\`\`\`\`'));
backdrop_set_message(t('text with a single asterisk: * (no need to be escaped)'));
backdrop_set_message(t('text with a double asterisk: ** (no need to be escaped)'));
backdrop_set_message(t('text with a triple asterisk: *** (rendered as a single italicized asterisk)'));
backdrop_set_message(t('text with an escaped triple asterisk: \*\*\*'));
backdrop_set_message(t('text with a quadruple asterisk: **** (rendered as a pair of asterisks in italics)'));
backdrop_set_message(t('text with an escaped quadruple asterisk: \*\*\*\*'));
backdrop_set_message(t('text with a quintuple asterisk: ***** (rendered as a single bolded asterisk)'));
backdrop_set_message(t('text with an escaped quintuple asterisk: \*\*\*\*\* (rendered as a single bolded asterisk)'));
backdrop_set_message(t('this is a @placeholder', array('@placeholder' => 'test')));
backdrop_set_message(t('this is **another** %placeholder', array('%placeholder' => 'test')));
```

3. Click the "Execute" button, and examine the result in the message that is shown.

Feel free to test various combinations of asterisks and back-ticks. If you manage to break things, report back to https://github.com/backdrop/backdrop-issues/issues/4535