### PR TITLE
Issue #4542: Dashboard: Allow 'access content overview' permission to access the "Manage content" link

### DIFF
--- a/core/modules/dashboard/includes/block.overview_content.inc
+++ b/core/modules/dashboard/includes/block.overview_content.inc
@@ -98,7 +98,7 @@ class DashboardOverviewContentBlock extends Block {
       '#theme' => 'item_list',
       '#items' => $items,
     );
-    if (user_access('administer nodes')) {
+    if (user_access('administer nodes') || user_access('access content overview')) {
       $panel['link'] = array(
         '#theme' => 'link',
         '#path' => 'admin/content',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4542