### PR TITLE
Issue #4546: Odd text in the $break_points array in text_summary()

### DIFF
--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -411,12 +411,11 @@ function text_summary($text, $format_id = NULL, $size = 600) {
   }
   $break_points[] = $line_breaks;
 
-  // Typing a number after the ؟ character causes text to be reversed mid-line.
-  // Using this variable here as a workaround, to stop that from happening. See
-  // https://github.com/backdrop/backdrop-issues/issues/4546
-  $arabic_questionmark_offset = 1;
-  // If the first paragraph is too long, split at the end of a sentence.
-  $break_points[] = array('. ' => 1, '! ' => 1, '? ' => 1, '。' => 0, '؟ ' => $arabic_questionmark_offset);
+  // Typing a number after the ؟ character (Arabic question mark) causes text to
+  // be reversed mid-line. That's the reason why the last element in this array
+  // may seem odd. It actually produces valid code.
+  // See https://github.com/backdrop/backdrop-issues/issues/4546
+  $break_points[] = array('. ' => 1, '! ' => 1, '? ' => 1, '。' => 0, '؟ ' => 1);
 
   // Iterate over the groups of break points until a break point is found.
   foreach ($break_points as $points) {

--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -411,8 +411,12 @@ function text_summary($text, $format_id = NULL, $size = 600) {
   }
   $break_points[] = $line_breaks;
 
+  // Typing a number after the ؟ character causes text to be reversed mid-line.
+  // Using this variable here as a workaround, to stop that from happening. See
+  // https://github.com/backdrop/backdrop-issues/issues/4546
+  $arabic_questionmark_offset = 1;
   // If the first paragraph is too long, split at the end of a sentence.
-  $break_points[] = array('. ' => 1, '! ' => 1, '? ' => 1, '。' => 0, '؟ ' => 1);
+  $break_points[] = array('. ' => 1, '! ' => 1, '? ' => 1, '。' => 0, '؟ ' => $arabic_questionmark_offset);
 
   // Iterate over the groups of break points until a break point is found.
   foreach ($break_points as $points) {

--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -415,6 +415,7 @@ function text_summary($text, $format_id = NULL, $size = 600) {
   // be reversed mid-line. That's the reason why the last element in this array
   // may seem odd. It actually produces valid code.
   // See https://github.com/backdrop/backdrop-issues/issues/4546
+  // If the first paragraph is too long, split at the end of a sentence.
   $break_points[] = array('. ' => 1, '! ' => 1, '? ' => 1, '。' => 0, '؟ ' => 1);
 
   // Iterate over the groups of break points until a break point is found.

--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -411,11 +411,11 @@ function text_summary($text, $format_id = NULL, $size = 600) {
   }
   $break_points[] = $line_breaks;
 
+  // If the first paragraph is too long, split at the end of a sentence.
   // Typing a number after the ؟ character (Arabic question mark) causes text to
   // be reversed mid-line. That's the reason why the last element in this array
   // may seem odd. It actually produces valid code.
   // See https://github.com/backdrop/backdrop-issues/issues/4546
-  // If the first paragraph is too long, split at the end of a sentence.
   $break_points[] = array('. ' => 1, '! ' => 1, '? ' => 1, '。' => 0, '؟ ' => 1);
 
   // Iterate over the groups of break points until a break point is found.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4546