### PR TITLE
Issue #4559: prevent SQLSTATE when uninstalling Locale

### DIFF
--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -1043,8 +1043,8 @@ function backdrop_uninstall_modules($module_list = array(), $uninstall_dependent
     // Uninstall the module.
     module_load_install($module);
     module_invoke($module, 'uninstall');
-    backdrop_uninstall_schema($module);
     config_uninstall_config($module);
+    backdrop_uninstall_schema($module);
 
     watchdog('system', '%module module uninstalled.', array('%module' => $module), WATCHDOG_INFO);
     backdrop_set_installed_schema_version($module, SCHEMA_UNINSTALLED);

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -576,6 +576,10 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
           lock_release('locale_cache_' . $langcode);
         }
         catch (PDOException $e) {
+          // Throw exception for any problem except for missing database tables.
+          if ($e->getCode() !== '42S02') {
+            throw $e;
+          }
           return $string;
         }
       }

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -563,12 +563,21 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
         // Refresh database stored cache of translations for given language.
         // We only store short strings used in current version, to improve
         // performance and consume less memory.
-        $result = db_query("SELECT s.source, s.context, t.translation, t.language FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.version = :version AND LENGTH(s.source) < :length", array(':language' => $langcode, ':version' => BACKDROP_VERSION, ':length' => config_get('locale.settings', 'cache_length')));
-        foreach ($result as $data) {
-          $locale_t[$langcode][$data->context][$data->source] = (empty($data->translation) ? TRUE : $data->translation);
+        try {
+          $result = db_query("SELECT s.source, s.context, t.translation, t.language FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.version = :version AND LENGTH(s.source) < :length", array(
+            ':language' => $langcode,
+            ':version' => BACKDROP_VERSION,
+            ':length' => config_get('locale.settings', 'cache_length'),
+          ));
+          foreach ($result as $data) {
+            $locale_t[$langcode][$data->context][$data->source] = (empty($data->translation) ? TRUE : $data->translation);
+          }
+          cache()->set('locale:' . $langcode, $locale_t[$langcode]);
+          lock_release('locale_cache_' . $langcode);
         }
-        cache()->set('locale:' . $langcode, $locale_t[$langcode]);
-        lock_release('locale_cache_' . $langcode);
+        catch (PDOException $e) {
+          return $string;
+        }
       }
     }
   }

--- a/core/modules/simpletest/tests/module.test
+++ b/core/modules/simpletest/tests/module.test
@@ -290,6 +290,48 @@ class ModuleUninstallTestCase extends BackdropWebTestCase {
     $role = user_role_load(BACKDROP_AUTHENTICATED_ROLE);
     $this->assertFalse(in_array('module_test perm', $role->permissions), 'Test module permission removed upon uninstall.');
   }
+
+  /**
+   * Tests that uninstalling locale does not cause problems.
+   */
+  public function testUninstallLocale() {
+    // Enable Locale with dependencies, add a language and set it to default.
+    module_enable(array('language', 'locale'), FALSE);
+    $language = (object) array(
+      'langcode' => 'fr',
+      'name' => 'French',
+      'direction' => LANGUAGE_LTR,
+      'enabled' => TRUE,
+    );
+    language_save($language);
+    config_set('system.core', 'language_default', 'fr');
+    $prefixes = array(
+      'en' => 'en',
+      'fr' => '',
+    );
+    config_set('locale.settings', 'language_negotiation_url_prefixes', $prefixes);
+    // Defaults to "en" otherwise.
+    global $language;
+    $language = language_load('fr');
+
+    $this->admin_user = $this->backdropCreateUser(array(
+      'administer modules',
+    ));
+    $this->backdropLogin($this->admin_user);
+
+    module_disable(array('locale'), FALSE);
+    $edit = array(
+      'uninstall[locale]' => TRUE,
+    );
+    // This should not cause "PDOException: SQLSTATE[42S02]: Base table or view
+    // not found".
+    $this->backdropPost('admin/modules/uninstall', $edit, t('Uninstall'));
+    $this->backdropPost(NULL, array(), t('Uninstall'));
+
+    $this->backdropGet('admin/modules/uninstall');
+    $this->assertNoText('Uninstall Locale module', 'Module Locale has been successfully uninstalled');
+  }
+
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4559

- Wraps the query in try/catch.
- Also changes the uninstall order to kill the db tables after removing config.

For the latter also see https://github.com/backdrop/backdrop-issues/issues/4570