### PR TITLE
Issue #4559: Switch order of steps when uninstalling modules

### DIFF
--- a/core/includes/install.inc
+++ b/core/includes/install.inc
@@ -1043,8 +1043,8 @@ function backdrop_uninstall_modules($module_list = array(), $uninstall_dependent
     // Uninstall the module.
     module_load_install($module);
     module_invoke($module, 'uninstall');
-    backdrop_uninstall_schema($module);
     config_uninstall_config($module);
+    backdrop_uninstall_schema($module);
 
     watchdog('system', '%module module uninstalled.', array('%module' => $module), WATCHDOG_INFO);
     backdrop_set_installed_schema_version($module, SCHEMA_UNINSTALLED);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4559 by removing the config before db tables get dropped.

That's an alternate, more general approach.