### PR TITLE
Issue #4562: Rename the "Locale" module to "Interface Translation"

### DIFF
--- a/core/modules/locale/locale.info
+++ b/core/modules/locale/locale.info
@@ -1,4 +1,4 @@
-name = Locale
+name = Interface Translation
 description = Provides language negotiation functionality and user interface translation to languages other than English.
 package = Translation
 tags[] = Language


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4562