### PR TITLE
Revert Issue #4425: Allow selecting an existing date format for log messages

### DIFF
--- a/core/modules/dblog/dblog.admin.inc
+++ b/core/modules/dblog/dblog.admin.inc
@@ -69,7 +69,7 @@ function dblog_overview() {
         // Cells
         array('class' => 'icon'),
         t($dblog->type),
-        format_date($dblog->timestamp, $log_date_format),
+        format_date($dblog->timestamp, 'custom', $log_date_format),
         dblog_format_message($dblog, TRUE),
         $user_info,
         filter_xss($dblog->link),

--- a/core/modules/dblog/dblog.install
+++ b/core/modules/dblog/dblog.install
@@ -107,3 +107,35 @@ function dblog_update_1001() {
   $short = system_date_format_load('short');
   config_set('system.core', 'log_date_format', $short['pattern']);
 }
+
+/**
+ * Convert the format for dates in the database log.
+ */
+function dblog_update_1002() {
+  // Removed. See https://github.com/backdrop/backdrop-issues/issues/4614
+}
+
+/**
+ * Restore the format for dates in the database log.
+ */
+function dblog_update_1003() {
+  // The "log_date_format" value may be a pattern or a named format.
+  $core_config = config('system.core');
+  $log_format = $core_config->get('log_date_format');
+
+  $date_format_config = config('system.date');
+  $date_formats = $date_format_config->get('formats');
+
+  // If a named pattern is in use, store its pattern directly.
+  if (isset($date_formats[$log_format])) {
+    $core_config->set('log_date_format', $date_formats[$log_format]['pattern']);
+    $core_config->save();
+  }
+
+  // Remove the previously created named format for logging.
+  if (isset($date_formats['dblog_date_format'])) {
+    unset($date_formats['dblog_date_format']);
+    $date_format_config->set('formats', $date_formats);
+    $date_format_config->save();
+  }
+}

--- a/core/modules/dblog/dblog.install
+++ b/core/modules/dblog/dblog.install
@@ -107,33 +107,3 @@ function dblog_update_1001() {
   $short = system_date_format_load('short');
   config_set('system.core', 'log_date_format', $short['pattern']);
 }
-
-/**
- * Convert the format for dates in the database log.
- */
-function dblog_update_1002() {
-  $t = get_t();
-  $config = config('system.core');
-  $log_format = $config->get('log_date_format');
-
-  // Look for a matching date format to use.
-  foreach (system_get_date_formats() as $date_format) {
-    if ($log_format == $date_format['pattern']) {
-      $config->set('log_date_format', $date_format['name']);
-      $config->save();
-      break;
-    }
-  }
-
-  // No matching date format found, so create a custom one.
-  if ($config->get('log_date_format') == $log_format) {
-    system_date_format_save(array(
-      'name' => 'dblog_date_format',
-      'label' => $t('Database log messages date'),
-      'pattern' => $log_format,
-      'module' => 'dblog',
-    ));
-    $config->set('log_date_format', 'dblog_date_format');
-    $config->save();
-  }
-}

--- a/core/modules/dblog/dblog.module
+++ b/core/modules/dblog/dblog.module
@@ -159,12 +159,23 @@ function dblog_form_system_logging_settings_alter(&$form, $form_state) {
     '#description' => t('The maximum number of messages to keep in the database log. Requires a <a href="@cron">cron maintenance task</a>.', array('@cron' => url('admin/reports/status')))
   );
 
+  $format = config_get('system.core', 'log_date_format');
+  $pattern = isset($form_state['values']['dblog_date_format']) ? $form_state['values']['dblog_date_format'] : $format;
+  $preview = !empty($pattern) ? t('Displayed as %date', array('%date' => format_date(REQUEST_TIME, 'custom', $pattern))) : '';
+
   $form['dblog_date_format'] = array(
-    '#type' => 'select',
+    '#type' => 'textfield',
     '#title' => t('Date format for log messages'),
-    '#description' => t('To add or edit options, visit <a href="@date-time-page">Date and time settings</a>.', array('@date-time-page' => url('admin/config/regional/date-time'))),
-    '#options' => date_format_type_options(),
-    '#default_value' => config_get('system.core', 'log_date_format'),
+    '#maxlength' => 100,
+    '#description' => t('A date format using PHP date and time codes. See the <a href="@url">PHP manual</a> for available options.', array('@url' => 'http://php.net/manual/function.date.php')),
+    '#default_value' => $pattern,
+    '#field_suffix' => '<small class="pattern-preview">' . $preview . '</small>',
+    '#ajax' => array(
+      'callback' => 'system_date_time_lookup',
+      'event' => 'keyup',
+      'progress' => array('type' => 'none', 'message' => NULL),
+      'disable' => FALSE,
+    ),
     '#required' => TRUE,
     '#wrapper_attributes' => array(
       'id' => 'date-format-pattern',

--- a/core/modules/dblog/tests/dblog.test
+++ b/core/modules/dblog/tests/dblog.test
@@ -83,13 +83,13 @@ class DBLogTestCase extends BackdropWebTestCase {
    *   The date format to display in the log.
    */
   private function verifyDateFormat($date_format) {
-    // Change the database log row limit.
+    // Change the log date format.
     $edit = array();
     $edit['dblog_date_format'] = $date_format;
     $this->backdropPost('admin/config/development/logging', $edit, t('Save configuration'));
     $this->assertResponse(200);
 
-    // Check row limit variable.
+    // Check date format config value.
     $current_format = config_get('system.core', 'log_date_format');
     $this->assertTrue($current_format == $date_format, format_string('[Cache] Date format of @current matches date format of @format', array('@current' => $current_format, '@format' => $date_format)));
   }

--- a/core/modules/dblog/tests/dblog.test
+++ b/core/modules/dblog/tests/dblog.test
@@ -47,7 +47,7 @@ class DBLogTestCase extends BackdropWebTestCase {
     $row_limit = 1000;
     $this->verifyRowLimit($row_limit);
     // Remove seconds from date so this test is more likely to always pass.
-    $date_format = 'dblog_date_format';
+    $date_format = 'M d, Y - j:ia';
     $this->verifyDateFormat($date_format);
     $this->verifyCron($row_limit);
     $this->verifyEvents();
@@ -83,13 +83,13 @@ class DBLogTestCase extends BackdropWebTestCase {
    *   The date format to display in the log.
    */
   private function verifyDateFormat($date_format) {
-    // Change the database log date format.
+    // Change the database log row limit.
     $edit = array();
     $edit['dblog_date_format'] = $date_format;
     $this->backdropPost('admin/config/development/logging', $edit, t('Save configuration'));
     $this->assertResponse(200);
 
-    // Check date format variable.
+    // Check row limit variable.
     $current_format = config_get('system.core', 'log_date_format');
     $this->assertTrue($current_format == $date_format, format_string('[Cache] Date format of @current matches date format of @format', array('@current' => $current_format, '@format' => $date_format)));
   }
@@ -263,13 +263,13 @@ class DBLogTestCase extends BackdropWebTestCase {
     // Default display includes name and email address; if too long, the email
     // address is replaced by three periods.
     $this->assertLogMessage(t('New user: %name (%email).', array('%name' => $name, '%email' => $user->mail)), 'DBLog event was recorded: [add user]');
-    $this->assertText(format_date($new_user_time, 'dblog_date_format'));
+    $this->assertText(format_date($new_user_time, 'custom', 'M d, Y - j:ia'));
     // Login user.
     $this->assertLogMessage(t('Session opened for %name.', array('%name' => $name)), 'DBLog event was recorded: [login user]');
-    $this->assertText(format_date($login_time, 'dblog_date_format'));
+    $this->assertText(format_date($login_time, 'custom', 'M d, Y - j:ia'));
     // Logout user.
     $this->assertLogMessage(t('Session closed for %name.', array('%name' => $name)), 'DBLog event was recorded: [logout user]');
-    $this->assertText(format_date($logout_time, 'dblog_date_format'));
+    $this->assertText(format_date($logout_time, 'custom', 'M d, Y - j:ia'));
     // Delete user.
     $message = t('Deleted user: %name %email.', array('%name' => $name, '%email' => '<' . $user->mail . '>'));
     $message_text = truncate_utf8(filter_xss($message, array()), 56, TRUE, TRUE);

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -39,7 +39,7 @@
     "language_count": 1,
     "language_default": "en",
     "log_row_limit": 1000,
-    "log_date_format": "dblog_date_format",
+    "log_date_format": "Y-M-d H:i:s",
     "log_identity": "backdrop",
     "log_facility": "",
     "log_format": "!base_url|!timestamp|!type|!ip|!request_uri|!referer|!uid|!link|!message",

--- a/core/modules/system/config/system.date.json
+++ b/core/modules/system/config/system.date.json
@@ -22,11 +22,6 @@
             "pattern": "m/d/Y - g:ia",
             "module": "system"
         },
-        "dblog_date_format": {
-            "label": "Database log messages date",
-            "pattern": "Y-M-d H:i:s",
-            "module": "dblog"
-        },
         "html_datetime": {
             "label": "HTML Datetime",
             "pattern": "Y-m-d\\TH:i:sO",


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4614