### PR TITLE
Issue #4625: Remove duplicate .drop-lounging CSS.

### DIFF
--- a/core/themes/basis/css/component/footer.css
+++ b/core/themes/basis/css/component/footer.css
@@ -58,6 +58,7 @@
 
 .drop-lounging {
   position: relative;
+  /* To make Drop larger/smaller, adjust the width below. */
   width: 7em;
 }
 

--- a/core/themes/basis/css/skin.css
+++ b/core/themes/basis/css/skin.css
@@ -421,17 +421,6 @@ fieldset .fieldset-legend {
   text-decoration: underline;
 }
 
-.drop-lounging {
-  /* To make Drop larger/smaller, adjust the width below. */
-  width: 7em;
-}
-
-.drop-lounging:before {
-  /* Uncomment below to remove Drop, or remove markup from block--system--powered-by.tpl.php */
-  /* display: none; */
-  background-image: url("../images/drop-lounging.png");
-}
-
 /**
  * Breadcrumb
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4625

Removes the duplicate CSS, moves a comment to footer.css.
