### PR TITLE
Issue #2398: Use the Layout context info to load a complete User entity for the current user context.

### DIFF
--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1711,7 +1711,7 @@ function install_finished(&$install_state) {
   // Will also trigger indexing of profile-supplied content or feeds.
   backdrop_cron_run();
 
-  $message = st('Congratulations, you installed @profile!', array('@profile' => backdrop_install_profile_distribution_name()));
+  $message = st('Thank you for installing @profile!', array('@profile' => backdrop_install_profile_distribution_name()));
 
   if (!backdrop_is_cli()) {
     backdrop_set_message($message);

--- a/core/misc/ajax.js
+++ b/core/misc/ajax.js
@@ -21,7 +21,7 @@ Backdrop.settings.urlIsAjaxTrusted = Backdrop.settings.urlIsAjaxTrusted || {};
  */
 Backdrop.behaviors.AJAX = {
   attach: function (context, settings) {
-    
+
      function loadAjaxBehaviour(base) {
       if (!$('#' + base + '.ajax-processed').length) {
         var element_settings = settings.ajax[base];
@@ -195,7 +195,7 @@ Backdrop.ajax = function (base, element, element_settings) {
   var currentAjaxRequestNumber = 0;
   var ajax = this;
   ajax.options = {
-    url: ajax.url,
+    url: Backdrop.sanitizeAjaxUrl(ajax.url),
     data: ajax.submit,
     beforeSerialize: function (element_settings, options) {
       return ajax.beforeSerialize(element_settings, options);
@@ -247,6 +247,7 @@ Backdrop.ajax = function (base, element, element_settings) {
       }
     },
     dataType: 'json',
+    jsonp: false,
     accepts: {
       json: element_settings.accepts || 'application/vnd.backdrop-ajax'
     },

--- a/core/misc/autocomplete.js
+++ b/core/misc/autocomplete.js
@@ -320,8 +320,9 @@ Backdrop.ACDB.prototype.search = function (searchString) {
     // Ajax GET request for autocompletion.
     $.ajax({
       type: 'GET',
-      url: db.uri + '/' + encodeURIComponent(searchString),
+      url: Backdrop.sanitizeAjaxUrl(db.uri + '/' + encodeURIComponent(searchString)),
       dataType: 'json',
+      jsonp: false,
       success: function (matches) {
         if (typeof matches.status === 'undefined' || matches.status !== 0) {
           db.cache[searchString] = matches;

--- a/core/misc/backdrop.js
+++ b/core/misc/backdrop.js
@@ -414,6 +414,23 @@ Backdrop.relativeUrl = function (url) {
 };
 
 /**
+ * Sanitizes a URL for use with jQuery.ajax().
+ *
+ * @param url
+ *   The URL string to be sanitized.
+ *
+ * @return
+ *   The sanitized URL.
+ */
+Backdrop.sanitizeAjaxUrl = function (url) {
+  var regex = /\=\?(&|$)/;
+  while (url.match(regex)) {
+    url = url.replace(regex, '');
+  }
+  return url;
+}
+
+/**
  * Returns true if the URL is within Backdrop's base path.
  *
  * @param url

--- a/core/modules/ckeditor/js/plugins/backdropimagecaption/plugin.js
+++ b/core/modules/ckeditor/js/plugins/backdropimagecaption/plugin.js
@@ -168,6 +168,9 @@ CKEDITOR.plugins.add('backdropimagecaption', {
             var figure = new CKEDITOR.htmlParser.element('figure');
             caption = new CKEDITOR.htmlParser.fragment.fromHtml(caption, 'figcaption');
 
+            var captionFilter = new CKEDITOR.filter(widgetDefinition.editables.caption.allowedContent);
+            captionFilter.applyTo(caption);
+
             // Use Backdrop's data-placeholder attribute to insert a CSS-based,
             // translation-ready placeholder for empty captions. Note that it
             // also must to be done for new instances (see

--- a/core/modules/field/field.block.inc
+++ b/core/modules/field/field.block.inc
@@ -76,8 +76,8 @@ class FieldBlock extends Block {
     list($entity_type, $field_name) = explode('-', $this->childDelta);
     $entity = $this->contexts[$entity_type]->data;
 
-    // Do not render if the entity is not found on this layout.
-    if (empty($entity)) {
+    // Do not proceed if the entity is not an EntityInterface object
+    if (!is_a($entity, 'EntityInterface')) {
       return NULL;
     }
 

--- a/core/modules/file/tests/file.tests.info
+++ b/core/modules/file/tests/file.tests.info
@@ -64,12 +64,6 @@ description = Test file administration page functionality.
 group = File
 file = file.test
 
-[FileAdminTestCase]
-name = File administration
-description = Test file administration page functionality.
-group = File
-file = file.test
-
 [FileTestHelper]
 name = FileTestHelper
 description = FileTestHelper
@@ -91,12 +85,6 @@ file = file.test
 [FileEditTestCase]
 name = File edit
 description = Create a file and test file edit functionality.
-group = File
-file = file.test
-
-[FileAdminTestCase]
-name = File administration
-description = Test file administration page functionality.
 group = File
 file = file.test
 

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -53,10 +53,10 @@ class Layout {
   /**
    * The storage state of the layout.
    *
-   * This is the machine-version of the $type variable, which represents whether
-   * this view is has a default, user-created, or overridden configuration.
-   * Possible values for this variable include the constants
-   * LAYOUT_STORAGE_NORMAL, LAYOUT_STORAGE_OVERRIDE, or LAYOUT_STORAGE_DEFAULT.
+   * This represents whether this layout is has a default, user-created, or
+   * overridden configuration. Possible values for this variable include the
+   * constants LAYOUT_STORAGE_NORMAL, LAYOUT_STORAGE_OVERRIDE, or 
+   * LAYOUT_STORAGE_DEFAULT.
    *
    * @var int
    */

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -799,12 +799,7 @@ class Layout {
 
     // Add on the current user context, which is always available.
     if (!isset($this->contexts['current_user'])) {
-      $this->contexts['current_user'] = layout_create_context('user', array(
-        'name' => 'current_user',
-        'label' => t('Current user'),
-        'locked' => TRUE,
-      ));
-      $this->contexts['current_user']->setData($GLOBALS['user']);
+      $this->contexts['current_user'] = layout_current_user_context();
     }
 
     // Add on the overrides path context, which is always available.

--- a/core/modules/layout/includes/layout_menu_item.class.inc
+++ b/core/modules/layout/includes/layout_menu_item.class.inc
@@ -253,12 +253,7 @@ class LayoutMenuItem {
     }
 
     // Add on the current user context, which is always available.
-    $contexts['current_user'] = layout_create_context('user', array(
-      'name' => 'current_user',
-      'label' => t('Current user'),
-      'locked' => TRUE,
-    ));
-    $contexts['current_user']->setData($GLOBALS['user']);
+    $contexts['current_user'] = layout_current_user_context();
 
     $this->contexts += $contexts;
 

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1837,7 +1837,6 @@ function layout_current_user_context() {
   }
 
   $current_user = $load_function($user->uid);
-
   $current_user_context->setData($current_user);
 
   return $current_user_context;

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1824,18 +1824,19 @@ function layout_current_user_context() {
     'locked' => TRUE,
   ));
 
-  // Get a complete user entity
+  // Get a complete user entity.
+
   $context_info = layout_get_context_info('user');
+
+  // Check if a load function has been set by some other module. If not, default to user_load().
   if (isset($context_info['load callback']) && function_exists($context_info['load callback'])) {
-    // in case this has been set by other modules
     $load_function = $context_info['load callback'];
   }
   else {
-    // fall back to default
     $load_function = 'user_load';
   }
-  $current_user = $load_function($user->uid);
 
+  $current_user = $load_function($user->uid);
   $current_user_context->setData($current_user);
 
   return $current_user_context;

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1813,6 +1813,35 @@ function layout_context_required_by_path($path) {
 }
 
 /**
+ * Return the current user context, which is always available.
+ */
+function layout_current_user_context() {
+  global $user;
+
+  $current_user_context = layout_create_context('user', array(
+    'name' => 'current_user',
+    'label' => t('Current user'),
+    'locked' => TRUE,
+  ));
+
+  // Get a complete user entity
+  $context_info = layout_get_context_info('user');
+  if (isset($context_info['load callback']) && function_exists($context_info['load callback'])) {
+    // in case this has been set by other modules
+    $load_function = $context_info['load callback'];
+  }
+  else {
+    // fall back to default
+    $load_function = 'user_load';
+  }
+  $current_user = $load_function($user->uid);
+
+  $current_user_context->setData($current_user);
+
+  return $current_user_context;
+}
+
+/**
  * Determine if a block has the necessary contexts.
  *
  * @param Layout $layout

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1837,6 +1837,7 @@ function layout_current_user_context() {
   }
 
   $current_user = $load_function($user->uid);
+
   $current_user_context->setData($current_user);
 
   return $current_user_context;

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -1467,6 +1467,47 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   }
 
   /**
+   * Tests current user custom field block
+   */
+  function testCurrentUser() {
+    $field_name = 'field_field1';
+
+    $field_info = array('field_name' => $field_name, 'type' => 'text');
+    $field = field_create_field($field_info);
+    $instance = array(
+      'field_name' => $field_name,
+      'entity_type' => 'user',
+      'bundle' => 'user',
+      'label' => 'Field1',
+    );
+    field_create_instance($instance);
+
+    $this->backdropGet('admin/structure/layouts');
+    $this->clickLink(t('Add layout'));
+
+    // Create a new layout at a new path.
+    $layout_title = $this->randomName();
+    $layout_name = strtolower($layout_title);
+    $layout_url = 'layout-test-path';
+    $edit = array(
+      'title' => $layout_title,
+      'name' => $layout_name,
+      'layout_template' => 'moscone_flipped',
+      'path' => $layout_url,
+    );
+    $this->backdropPost(NULL, $edit, t('Create layout'));
+
+    // We should be taken to the layout content page next.
+    $this->assertText(t('Layout created. Blocks may now be added to this layout.'));
+
+    // Add a block to the sidebar.
+    $this->clickLink(t('Add block'), 3);
+    $this->clickLink(t('Field: Field1 (field_field1)'));
+    $edit = array();
+    $this->backdropPost(NULL, $edit, t('Add block'));
+  }
+
+  /**
    * Tests Taxonomy contexts within layouts.
    */
   function testTaxonomyContext() {

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -203,11 +203,9 @@ function callback_queue_worker($queue_item_data) {
  * Allows modules to declare their own Form API element types and specify their
  * default values.
  *
- * This hook allows modules to declare their own form element types and to
- * specify their default values. The values returned by this hook will be
- * merged with the elements returned by hook_form() implementations and so
- * can return defaults for any Form APIs keys in addition to those explicitly
- * mentioned below.
+ * The values returned by this hook will be merged with the elements returned by
+ * hook_form() implementations and so can return defaults for any Form APIs keys
+ * in addition to those explicitly mentioned below.
  *
  * Each of the form element types defined by this hook is assumed to have
  * a matching theme function, e.g. theme_elementtype(), which should be

--- a/core/modules/system/system.tests.info
+++ b/core/modules/system/system.tests.info
@@ -34,12 +34,6 @@ description = Test cron run.
 group = System
 file = tests/system.test
 
-[CronRunTestCase]
-name = Cron run
-description = Test cron run.
-group = System
-file = tests/system.test
-
 [CronQueueTestCase]
 name = Cron queue functionality
 description = Tests the cron queue runner.

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1335,7 +1335,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     // Set the user's role to be the administrator role.
     $edit = array();
     $edit['user_admin_role'] = $this->role_name;
-    $this->backdropPost('admin/config/people/roles', $edit, t('Save roles'));
+    $this->backdropPost('admin/config/people/roles', $edit, t('Save configuration'));
 
     // Enable book module and ensure the 'administer book outlines' permission
     // is assigned by default.
@@ -2211,7 +2211,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
 
     // Change the role weight and submit the form.
     $edit = array('roles['. $role_name .'][weight]' => $old_weight + 1);
-    $this->backdropPost('admin/config/people/roles', $edit, t('Save roles'));
+    $this->backdropPost('admin/config/people/roles', $edit, t('Save configuration'));
     $this->assertText(t('The role settings have been updated.'), 'The role settings form submitted successfully.');
 
     // Retrieve the saved role and compare its weight.

--- a/core/modules/user/user.actions.inc
+++ b/core/modules/user/user.actions.inc
@@ -55,8 +55,9 @@ function user_unblock_user_action($account, &$context) {
  * @ingroup actions
  */
 function user_cancel_user_action($account, &$context) {
-  // Save the list of nodes to be deleted in the session. Append to the existing
-  // list if within the last minute, otherwise start a new list of nodes.
+  // Save the list of user accounts to be deleted in the session. Append to 
+  // the existing list if within the last minute, otherwise start a new list
+  // of user accounts.
   $last_action_time = 0;
   if (isset($_SESSION['user_cancel_action'])) {
     $last_action_time = $_SESSION['user_cancel_action']['timestamp'];

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -615,7 +615,7 @@ function user_admin_roles($form, $form_state) {
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
-    '#value' => t('Save roles'),
+    '#value' => t('Save configuration'),
     '#limit_validation_errors' => array(array('roles'), array('user_admin_role'), array('anonymous')),
     '#submit' => array('user_admin_roles_order_submit'),
   );


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#2398  - check that the current_user context entity implements EntityInterface, and create a complete user entity for that context.