### PR TITLE
Issue #4634: Views: Hide 'CSS Class' button when setting 'HTML element' to 'None'

### DIFF
--- a/core/misc/states.js
+++ b/core/misc/states.js
@@ -144,6 +144,8 @@ states.Dependent.prototype = {
       return states.Dependent.comparisons[reference.constructor.name](reference, value);
     }
     else {
+      // If state is "notValue" return false if reference and value are equal.
+      if(state.name==="notValue") return !compare(reference, value);
       // Do a plain comparison otherwise.
       return compare(reference, value);
     }
@@ -398,6 +400,26 @@ states.Trigger.states = {
 
   // For radio buttons, only return the value if the radio button is selected.
   value: {
+    'keyup': function () {
+      // Radio buttons share the same :input[name="key"] selector.
+      if (this.length > 1) {
+        // Initial checked value of radios is undefined, so we return false.
+        return this.filter(':checked').val() || false;
+      }
+      return this.val();
+    },
+    'change': function () {
+      // Radio buttons share the same :input[name="key"] selector.
+      if (this.length > 1) {
+        // Initial checked value of radios is undefined, so we return false.
+        return this.filter(':checked').val() || false;
+      }
+      return this.val();
+    }
+  },
+
+  //"notValue" has same events as "value", but is used to check if a form input's value is not equal to a certain value
+  notValue:{
     'keyup': function () {
       // Radio buttons share the same :input[name="key"] selector.
       if (this.length > 1) {

--- a/core/modules/views/handlers/views_handler_field.inc
+++ b/core/modules/views/handlers/views_handler_field.inc
@@ -536,6 +536,7 @@ class views_handler_field extends views_handler {
       '#states' => array(
         'visible' => array(
           ':input[name="options[element_type_enable]"]' => array('checked' => TRUE),
+          ':input[name="options[element_type]"]' => array('notValue' => "0"),
         ),
       ),
       '#default_value' => !empty($this->options['element_class']) || (string) $this->options['element_class'] == '0',
@@ -550,6 +551,7 @@ class views_handler_field extends views_handler {
         'visible' => array(
           ':input[name="options[element_type_enable]"]' => array('checked' => TRUE),
           ':input[name="options[element_class_enable]"]' => array('checked' => TRUE),
+          ':input[name="options[element_type]"]' => array('notValue' => "0"),
         ),
       ),
       '#fieldset' => 'style_settings',
@@ -580,6 +582,7 @@ class views_handler_field extends views_handler {
       '#states' => array(
         'visible' => array(
           ':input[name="options[element_label_type_enable]"]' => array('checked' => TRUE),
+          ':input[name="options[element_label_type]"]' => array('notValue' => "0"),
         ),
       ),
       '#default_value' => !empty($this->options['element_label_class']) || (string) $this->options['element_label_class'] == '0',
@@ -594,6 +597,7 @@ class views_handler_field extends views_handler {
         'visible' => array(
           ':input[name="options[element_label_type_enable]"]' => array('checked' => TRUE),
           ':input[name="options[element_label_class_enable]"]' => array('checked' => TRUE),
+          ':input[name="options[element_label_type]"]' => array('notValue' => "0"),
         ),
       ),
       '#fieldset' => 'style_settings',
@@ -625,6 +629,7 @@ class views_handler_field extends views_handler {
       '#states' => array(
         'visible' => array(
           ':input[name="options[element_wrapper_type_enable]"]' => array('checked' => TRUE),
+          ':input[name="options[element_wrapper_type]"]' => array('notValue' => "0"),
         ),
       ),
       '#default_value' => !empty($this->options['element_wrapper_class']) || (string) $this->options['element_wrapper_class'] == '0',
@@ -639,6 +644,7 @@ class views_handler_field extends views_handler {
         'visible' => array(
           ':input[name="options[element_wrapper_class_enable]"]' => array('checked' => TRUE),
           ':input[name="options[element_wrapper_type_enable]"]' => array('checked' => TRUE),
+          ':input[name="options[element_wrapper_type]"]' => array('notValue' => "0"),
         ),
       ),
       '#fieldset' => 'style_settings',


### PR DESCRIPTION
fixes https://github.com/backdrop/backdrop-issues/issues/4634