### PR TITLE
Issue #4638: Rename `Save Roles` button to `Save Configuration`

### DIFF
--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1335,7 +1335,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     // Set the user's role to be the administrator role.
     $edit = array();
     $edit['user_admin_role'] = $this->role_name;
-    $this->backdropPost('admin/config/people/roles', $edit, t('Save roles'));
+    $this->backdropPost('admin/config/people/roles', $edit, t('Save configuration'));
 
     // Enable book module and ensure the 'administer book outlines' permission
     // is assigned by default.
@@ -2211,7 +2211,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
 
     // Change the role weight and submit the form.
     $edit = array('roles['. $role_name .'][weight]' => $old_weight + 1);
-    $this->backdropPost('admin/config/people/roles', $edit, t('Save roles'));
+    $this->backdropPost('admin/config/people/roles', $edit, t('Save configuration'));
     $this->assertText(t('The role settings have been updated.'), 'The role settings form submitted successfully.');
 
     // Retrieve the saved role and compare its weight.

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -615,7 +615,7 @@ function user_admin_roles($form, $form_state) {
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
-    '#value' => t('Save roles'),
+    '#value' => t('Save configuration'),
     '#limit_validation_errors' => array(array('roles'), array('user_admin_role'), array('anonymous')),
     '#submit' => array('user_admin_roles_order_submit'),
   );


### PR DESCRIPTION
fixes https://github.com/backdrop/backdrop-issues/issues/4638