### PR TITLE
Fixes https://github.com/backdrop/backdrop-issues/issues/4664 and htt…

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1303,7 +1303,7 @@ function system_site_information_settings($form, &$form_state) {
     '#default_value' => ($site_config->get('site_frontpage') != 'user' ? backdrop_get_path_alias($site_config->get('site_frontpage')) : ''),
     '#size' => 40,
     '#description' => t('Optionally, specify a relative URL to display as the home page. Leave this blank to display the default content feed.'),
-    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . (config_get('system.core', 'clean_url') ? '' : '?q='),
+    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . ($site_config->get('clean_url') ? '' : '?q='),
     '#autocomplete_path' => 'path-autocomplete',
   );
   $form['front_page']['default_nodes_main'] = array(
@@ -1311,7 +1311,7 @@ function system_site_information_settings($form, &$form_state) {
     '#default_value' => $site_config->get('default_nodes_main'),
     '#options' => backdrop_map_assoc(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30)),
     '#description' => t('The maximum number of posts displayed on overview pages such as the home page.'),
-    '#access' => (config_get('system.core', 'site_frontpage') == 'node'),
+    '#access' => ($site_config->get('site_frontpage') == 'node'),
   );
   $form['error_page'] = array(
     '#type' => 'fieldset',
@@ -1323,7 +1323,7 @@ function system_site_information_settings($form, &$form_state) {
     '#default_value' => ($site_config->get('site_403') != '' ? backdrop_get_path_alias($site_config->get('site_403')) : ''),
     '#size' => 40,
     '#description' => t('This page is displayed when the requested document is denied to the current user. Leave blank to display a generic "access denied" page.'),
-    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . (config_get('system.core', 'clean_url') ? '' : '?q='),
+    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . ($site_config->get('clean_url') ? '' : '?q='),
     '#autocomplete_path' => 'path-autocomplete',
   );
   $form['error_page']['site_404'] = array(
@@ -1332,7 +1332,7 @@ function system_site_information_settings($form, &$form_state) {
     '#default_value' => ($site_config->get('site_404') != '' ? backdrop_get_path_alias($site_config->get('site_404')) : ''),
     '#size' => 40,
     '#description' => t('This page is displayed when no other content matches the requested document. Leave blank to display a generic "page not found" page.'),
-    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . (config_get('system.core', 'clean_url') ? '' : '?q='),
+    '#field_prefix' => url(NULL, array('absolute' => TRUE)) . ($site_config->get('clean_url') ? '' : '?q='),
     '#autocomplete_path' => 'path-autocomplete',
   );
 
@@ -1355,7 +1355,7 @@ function system_site_information_settings($form, &$form_state) {
 
       // Prepare local file path for description.
       if ($original_path && isset($friendly_path)) {
-        $local_file = strtr($original_path, array('public:/' => config_get('system.core', 'file_public_path')));
+        $local_file = strtr($original_path, array('public:/' => $site_config->get('file_public_path')));
       }
       else {
         $local_file = path_to_theme() . '/' . $default;
@@ -1611,11 +1611,12 @@ function system_run_cron_submit($form, &$form_state) {
  * @see system_logging_settings_validate()
  */
 function system_logging_settings($form, &$form_state) {
+  $site_config = config('system.core');
   $form['#config'] = 'system.core';
   $form['error_level'] = array(
     '#type' => 'radios',
     '#title' => t('Error messages to display'),
-    '#default_value' => config_get('system.core', 'error_level'),
+    '#default_value' => $site_config->get('error_level'),
     '#options' => array(
       ERROR_REPORTING_HIDE => t('None'),
       ERROR_REPORTING_DISPLAY_SOME => t('Errors and warnings'),
@@ -1637,7 +1638,7 @@ function system_logging_settings($form, &$form_state) {
       WATCHDOG_DEBUG => t('Debug'),
       WATCHDOG_DEPRECATED => t('Deprecated'),
     ),
-    '#default_value' => config_get('system.core', 'watchdog_enabled_severity_levels'),
+    '#default_value' => $site_config->get('watchdog_enabled_severity_levels'),
     '#description' => t('The <em>debug</em> and <em>deprecated</em> severity levels are recommended for developer environments, but not on production sites.'),
   );
 
@@ -1789,11 +1790,13 @@ function system_clear_page_cache_submit($form, &$form_state) {
  * @ingroup forms
  */
 function system_file_system_settings() {
+  $config = config('system.core');
+
   $form['#config'] = 'system.core';
   $form['file_public_path'] = array(
     '#type' => 'textfield',
     '#title' => t('Public file system path'),
-    '#default_value' => config_get('system.core', 'file_public_path'),
+    '#default_value' => $config->get('file_public_path'),
     '#maxlength' => 255,
     '#description' => t('A local file system path where public files will be stored. This directory must exist and be writable by Backdrop. This directory must be relative to the Backdrop installation directory and be accessible over the web.'),
     '#after_build' => array('system_check_directory'),
@@ -1802,9 +1805,9 @@ function system_file_system_settings() {
   $form['file_private_path'] = array(
     '#type' => 'textfield',
     '#title' => t('Private file system path'),
-    '#default_value' => config_get('system.core', 'file_private_path'),
+    '#default_value' => $config->get('file_private_path'),
     '#maxlength' => 255,
-    '#description' => t('An existing local file system path for storing private files. It should be writable by Backdrop and not accessible over the web. See the online handbook for <a href="@handbook">more information about securing private files</a>.', array('@handbook' => 'https://www.drupal.org/docs/7/core/modules/file/overview')),
+    '#description' => t('An existing local file system path for storing private files. It should be writable by Backdrop and not accessible over the web. See the online handbook for <a href="@handbook">more information about securing private files</a>.', array('@handbook' => 'https://backdropcms.org/user-guide/file-system')),
     '#after_build' => array('system_check_directory'),
   );
 
@@ -1823,7 +1826,7 @@ function system_file_system_settings() {
   }
 
   if (!empty($options)) {
-    $default_scheme = config_get('system.core', 'file_default_scheme');
+    $default_scheme = $config->get('file_default_scheme');
     $default_scheme = isset($options[$default_scheme]) ? $default_scheme : key($options);
     $form['file_default_scheme'] = array(
       '#type' => 'radios',
@@ -1843,13 +1846,13 @@ function system_file_system_settings() {
     '#type' => 'checkbox',
     '#title' => t('Transliterate file names during upload'),
     '#description' => t('Enable to convert file names to US-ASCII character set for cross-platform compatibility. If you enable this setting later, you may want to <a href="@transliteration">retroactively transliterate existing file names</a>.', array('@transliteration' => url('admin/config/media/file-system/transliteration'))),
-    '#default_value' => config_get('system.core', 'file_transliterate_uploads'),
+    '#default_value' => $config->get('file_transliterate_uploads'),
   );
   $form['transliteration']['file_transliterate_uploads_display_name'] = array(
     '#type' => 'checkbox',
     '#title' => t('Transliterate the displayed file name'),
     '#description' => t('Enable to also convert the file name that is displayed within the site (for example, in link text).'),
-    '#default_value' => config_get('system.core', 'file_transliterate_uploads_display_name'),
+    '#default_value' => $config->get('file_transliterate_uploads_display_name'),
     '#states' => array(
       'invisible' => array(
         'input[name="file_transliterate_uploads"]' => array('checked' => FALSE),
@@ -1859,7 +1862,7 @@ function system_file_system_settings() {
   $form['transliteration']['file_transliterate_lowercase'] = array(
     '#type' => 'checkbox',
     '#title' => t('Lowercase transliterated file names'),
-    '#default_value' => config_get('system.core', 'file_transliterate_lowercase'),
+    '#default_value' => $config->get('file_transliterate_lowercase'),
     '#description' => t('Enable to convert file names to lowercase. This is recommended to prevent issues with case-insensitive file systems.'),
     '#states' => array(
       'invisible' => array(
@@ -2143,6 +2146,7 @@ function system_site_maintenance_mode_submit($form, &$form_state) {
  * @ingroup forms
  */
 function system_urls_settings($form, &$form_state) {
+  $config = config('system.core');
   $available = FALSE;
   $conflict = FALSE;
 
@@ -2168,7 +2172,7 @@ function system_urls_settings($form, &$form_state) {
 
       // If the test failed while clean URLs are enabled, make sure clean URLs
       // can be disabled.
-      if (config_get('system.core', 'clean_url')) {
+      if ($config->get('clean_url')) {
         $conflict = TRUE;
         // Warn the user of a conflicting situation, unless after processing
         // a submitted form.
@@ -2190,7 +2194,7 @@ function system_urls_settings($form, &$form_state) {
     $form['clean_url'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable clean URLs'),
-      '#default_value' => config_get('system.core', 'clean_url'),
+      '#default_value' => $config->get('clean_url'),
       '#description' => t('Use URLs like <code>example.com/user</code> instead of <code>example.com/?q=user</code>.'),
     );
     if ($conflict) {
@@ -2225,7 +2229,7 @@ function system_urls_settings($form, &$form_state) {
   $form['canonical_secure'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use HTTPS for canonical URLs'),
-    '#default_value' => config_get('system.core', 'canonical_secure'),
+    '#default_value' => $config->get('canonical_secure'),
     '#description' => t('This option makes Backdrop use HTTPS protocol for generated canonical URLs. Please note: to get it working in mixed-mode (both secure and insecure) sessions, the variable <code>https</code> should be set to <code>TRUE</code> in your file <code>settings.php</code>' ),
   );
 


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#4664 
Fixes backdrop/backdrop-issues#4665

I've replaced multiple occurrences of `config_get` in the same functions to `$config->get` leaving intact the single uses per function. Also I've replaced the link to drupal.org to respective documentation page on backdropcms.org. So this PR should take care of both https://github.com/backdrop/backdrop-issues/issues/4664 and https://github.com/backdrop/backdrop-issues/issues/4665