### PR TITLE
Issue #4678: href on the Manage Blocks form should just be the path

### DIFF
--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -902,7 +902,7 @@ function layout_content_form($form, &$form_state, Layout $layout, $renderer_name
     $form['top']['button']['#links'] = array(
       array(
         'title' => t('View page'),
-        'href' => url($link_path),
+        'href' => $link_path,
       )
     );
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4678

Remove duplicate base path addition.