### PR TITLE
Issue #4679: Set originalLanguageDefault in prepareEnvironment()

### DIFF
--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1531,6 +1531,7 @@ class BackdropWebTestCase extends BackdropTestCase {
 
     // Store necessary current values before switching to prefixed database.
     $this->originalLanguage = $language;
+    $this->originalLanguageDefault = language_default();
     $this->originalLanguageUrl = $language_url;
     $this->originalConfigDirectories = $config_directories;
     $this->originalFileDirectory = $site_config->get('file_public_path');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4679

Set originalLanguageDefault in prepareEnvironment(), as it is used in tearDown().