### PR TITLE
Issue #4685: Do not copy htaccess file to prevent exceptions

### DIFF
--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1630,12 +1630,12 @@ class BackdropWebTestCase extends BackdropTestCase {
    */
   private function recursiveCopy($src, $dst) {
     $dir = opendir($src);
-    if(!file_exists($dst)){
+    if (!file_exists($dst)) {
       mkdir($dst);
     }
-    while(false !== ( $file = readdir($dir)) ) {
+    while (false !== ($file = readdir($dir))) {
       if ($file != '.' && $file != '..' && $file != '.htaccess') {
-        if ( is_dir($src . '/' . $file) ) {
+        if (is_dir($src . '/' . $file)) {
           $this->recursiveCopy($src . '/' . $file, $dst . '/' . $file);
         }
         else {

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1627,13 +1627,17 @@ class BackdropWebTestCase extends BackdropTestCase {
   /**
    * Recursively copy one directory to another.
    *
+   * @param string $src
+   *   Source directory to copy.
+   * @param string $dst
+   *   Destination directory to copy files to.
    */
   private function recursiveCopy($src, $dst) {
     $dir = opendir($src);
     if (!file_exists($dst)) {
       mkdir($dst);
     }
-    while (false !== ($file = readdir($dir))) {
+    while (FALSE !== ($file = readdir($dir))) {
       if ($file != '.' && $file != '..' && $file != '.htaccess') {
         if (is_dir($src . '/' . $file)) {
           $this->recursiveCopy($src . '/' . $file, $dst . '/' . $file);

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1634,7 +1634,7 @@ class BackdropWebTestCase extends BackdropTestCase {
       mkdir($dst);
     }
     while(false !== ( $file = readdir($dir)) ) {
-      if (( $file != '.' ) && ( $file != '..' )) {
+      if ($file != '.' && $file != '..' && $file != '.htaccess') {
         if ( is_dir($src . '/' . $file) ) {
           $this->recursiveCopy($src . '/' . $file, $dst . '/' . $file);
         }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4685

The only change besides convention stuff is to add `$file != '.htaccess'` to the if clause.