### PR TITLE
Issue4656

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3255,6 +3255,25 @@ function base_path() {
 }
 
 /**
+ * Returns an internal path without a leading '/'.
+ *
+ * @param $path
+ *  The path to be potentially transformed.
+ *
+ * @return
+ *  The provided path, with a leading base path removed if found.
+ */
+function internal_path($path) {
+  global $base_path;
+
+  if (backdrop_strpos($path, $base_path) === 0) {
+    $path = backdrop_substr($path, backdrop_strlen($base_path));
+  }
+
+  return $path;
+}
+
+/**
  * Adds a LINK tag with a distinct 'rel' attribute to the page's HEAD.
  *
  * This function can be called as long the HTML header hasn't been sent, which

--- a/core/includes/unicode.inc
+++ b/core/includes/unicode.inc
@@ -472,6 +472,41 @@ function decode_entities($text) {
 }
 
 /**
+ * Returns the position of the first occurrence of a UTF-8 string
+ *  in another UTF-8 string.
+ *
+ * @param $haystack
+ *  The string to be searched.
+ *
+ * @param $needle
+ *  The string to find in $haystack.
+ *
+ * @param $offset
+ *  (optional) If specified, start the search at this number of characters from the beginning.
+ *  Defaults to 0.
+ *
+ * @return int|FALSE
+ *  The position where $needle occurs in $haystack, always relative to the beginning
+ *  (independent of $offset), or FALSE if not found.
+ *  Note that a return value of 0 is not the same as FALSE.
+ */
+function backdrop_strpos($haystack, $needle, $offset = 0) {
+  global $multibyte;
+
+  if ($multibyte == UNICODE_MULTIBYTE) {
+    return mb_strpos($haystack, $needle, $offset);
+  }
+  else {
+
+    // Remove Unicode continuation characters, to be compatible with
+    // backdrop_strlen() and backdrop_substr().
+    $haystack = preg_replace("/[\x80-\xBF]/", '', $haystack);
+    $needle = preg_replace("/[\x80-\xBF]/", '', $needle);
+    return strpos($haystack, $needle, $offset);
+  }
+}
+
+/**
  * Counts the number of characters in a UTF-8 string.
  *
  * This is less than or equal to the byte count.

--- a/core/modules/dashboard/tests/dashboard.test
+++ b/core/modules/dashboard/tests/dashboard.test
@@ -272,7 +272,7 @@ class DashboardTest extends BackdropWebTestCase {
     // Check that the dashboard is not accessible once the layout is disabled.
     $this->backdropGet('admin/structure/layouts');
     $disable_link = $this->xpath('//a[starts-with(@href, "/admin/structure/layouts/manage/dashboard/disable")]');
-    $disable_url_parts = backdrop_parse_url($disable_link[0]['href']);
+    $disable_url_parts = backdrop_parse_url(internal_path($disable_link[0]['href']));
     $this->backdropGet($disable_url_parts['path'], $disable_url_parts);
 
     $this->backdropGet('admin/dashboard');
@@ -281,7 +281,7 @@ class DashboardTest extends BackdropWebTestCase {
     // Check that the dashboard is accessible once the layout is enabled again.
     $this->backdropGet('admin/structure/layouts');
     $enable_link = $this->xpath('//a[starts-with(@href, "/admin/structure/layouts/manage/dashboard/enable")]');
-    $enable_url_parts = backdrop_parse_url($enable_link[0]['href']);
+    $enable_url_parts = backdrop_parse_url(internal_path($enable_link[0]['href']));
     $this->backdropGet($enable_url_parts['path'], $enable_url_parts);
 
     $this->backdropGet('admin/dashboard');

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -3693,7 +3693,7 @@ class FieldTokenTestCase extends FieldTestCase {
 
     $this->backdropGet('admin/structure/types/manage/post/display');
     list($enable_link) = $this->xpath('//tr[contains(@class, "view-mode--token")]//a');
-    $enable_href_parts = backdrop_parse_url($enable_link['href']);
+    $enable_href_parts = backdrop_parse_url(internal_path($enable_link['href']));
     $this->backdropGet($enable_href_parts['path'], $enable_href_parts);
 
     // Create a text field.

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -664,7 +664,7 @@ class FieldUIManageDisplayTestCase extends FieldUITestCase {
     // directly using XPath.
     $this->backdropGet('admin/structure/types/manage/' . $this->hyphen_type . '/display');
     list($enable_link) = $this->xpath('//tr[contains(@class, "view-mode--rss")]//a');
-    $enable_href_parts = backdrop_parse_url($enable_link['href']);
+    $enable_href_parts = backdrop_parse_url(internal_path($enable_link['href']));
     $this->backdropGet($enable_href_parts['path'], $enable_href_parts);
     $this->assertNodeViewText($node, 'rss', $output['field_test_with_prepare_view'], "The field is displayed as expected in newly specialized 'rss' mode.");
 
@@ -978,7 +978,7 @@ class FieldUIViewModeFunctionalTest extends FieldUIViewModeTestHelper {
     // Enable the view-mode on the page content type.
     $this->backdropGet('admin/structure/types/manage/page/display');
     list($enable_link) = $this->xpath('//tr[contains(@class, "view-mode--custom-1")]//a');
-    $enable_href_parts = backdrop_parse_url($enable_link['href']);
+    $enable_href_parts = backdrop_parse_url(internal_path($enable_link['href']));
     $this->backdropGet($enable_href_parts['path'], $enable_href_parts);
     $this->assertViewModeExists('node', 'custom_1');
     $this->assertViewModeCustomDisplay('node', 'page', 'custom_1');

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -390,7 +390,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
     $this->backdropPost(NULL, array(), t('Save layout'));
 
@@ -1079,7 +1079,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@id="layout-edit-main"]//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $old_content_block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
 
     $this->backdropPost(NULL, array(), t('Save layout'));
@@ -1101,7 +1101,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $new_content_block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
 
     $this->backdropPost(NULL, array(), t('Save layout'));
@@ -1124,7 +1124,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $default_content_block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
 
     $this->backdropPost(NULL, array(), t('Save layout'));
@@ -1979,7 +1979,7 @@ class LayoutBlockTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $title_block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
     $this->backdropPost(NULL, array(), t('Save layout'));
 
@@ -2048,7 +2048,7 @@ class LayoutBlockTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $title_combo_block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
     $this->backdropPost(NULL, array(), t('Save layout'));
 
@@ -2299,7 +2299,7 @@ class LayoutBlockTextTest extends BackdropWebTestCase {
     $remove_link = $this->xpath('//*[@data-block-id=:uuid]//a[contains(@class,"remove-block")]', array(
       ':uuid' => $block_uuid,
     ));
-    $remove_url_parts = backdrop_parse_url($remove_link[0]['href']);
+    $remove_url_parts = backdrop_parse_url(internal_path($remove_link[0]['href']));
     $this->backdropGet($remove_url_parts['path'], $remove_url_parts);
     $this->backdropPost(NULL, array(), t('Save layout'));
 
@@ -2608,7 +2608,7 @@ class LayoutHookTestCase extends BackdropWebTestCase {
     state_set('layout_test', array());
     $this->backdropGet('admin/structure/layouts');
     $disable_link = $this->xpath('//*[contains(@class, "disable")]//a');
-    $disable_url_parts = backdrop_parse_url($disable_link[0]['href']);
+    $disable_url_parts = backdrop_parse_url(internal_path($disable_link[0]['href']));
     $this->backdropGet($disable_url_parts['path'], $disable_url_parts);
     $this->assertHookMessageOrder(array(
       'layout_test_layout_disable called',
@@ -2619,7 +2619,7 @@ class LayoutHookTestCase extends BackdropWebTestCase {
     // Re-enable the layout.
     $this->backdropGet('admin/structure/layouts/manage');
     $enable_link = $this->xpath('//li[contains(@class, "enable")]//a');
-    $enable_url_parts = backdrop_parse_url($enable_link[0]['href']);
+    $enable_url_parts = backdrop_parse_url(internal_path($enable_link[0]['href']));
     $this->backdropGet($enable_url_parts['path'], $enable_url_parts);
     $this->assertHookMessageOrder(array(
       'layout_test_layout_enable called',

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -960,7 +960,7 @@ class TaxonomyRSSTestCase extends TaxonomyWebTestCase {
     // RSS display must be added manually.
     $this->backdropGet("admin/structure/types/manage/post/display");
     list($enable_link) = $this->xpath('//tr[contains(@class, "view-mode--rss")]//a');
-    $enable_href_parts = backdrop_parse_url($enable_link['href']);
+    $enable_href_parts = backdrop_parse_url(internal_path($enable_link['href']));
     $this->backdropGet($enable_href_parts['path'], $enable_href_parts);
 
     // Change the format to 'RSS category'.


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#4656

- Create a backdrop_strpos() PHP wrapper for use with backdrop_strlen() and backdrop_substr().
- Create an internal_path() function to remove the base path from the beginning of a path string - eg, /my/backdrop/admin/config becomes admin/config.
- Update multiple tests to pass HREF values parsed from pages by xpath through internal_path() before parsing.