### PR TITLE
Changed line 53 = 'parva statiya'

### DIFF
--- a/core/modules/simpletest/tests/transliteration.test
+++ b/core/modules/simpletest/tests/transliteration.test
@@ -50,7 +50,7 @@ class TransliterationTest extends BackdropUnitTestCase {
       array('en', '一個簡單的句子', 'yigejiandandejuzi'),
 
       // Bulgarian characters.
-      array('bg', 'първа статия', 'pyrva statija'),
+      array('bg', 'първа статия', 'parva statiya'),
     );
 
     include_once BACKDROP_ROOT . '/core/includes/transliteration.inc';


### PR DESCRIPTION

'parva statiya' is OK.

Maybe you want to fix that test yourself? (And become a real core contributor 😉 )

The only thing you have to do is changing the expected transliteration here and push your changes.

If you don't feel "adventurous" enough, we can do it for you.

https://github.com/backdrop/backdrop-issues/issues/1604#issuecomment-703667183