### PR TITLE
Issue #4111: Prevent warning Headers already sent

### DIFF
--- a/core/scripts/install.sh
+++ b/core/scripts/install.sh
@@ -187,7 +187,6 @@ define('MAINTENANCE_MODE', 'install');
 
 require_once './core/includes/install.core.inc';
 try {
-  print "Installing Backdrop. This may take a moment...\n";
   install_backdrop($settings);
   config_set('system.core', 'site_mail', $options['site-mail']);
   print "Backdrop installed successfully.\n";


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4111

That single line of text just isn't worth struggling with php warnings.