### PR TITLE
fix broken database prefixes in MySQL on 1.17.2

### DIFF
--- a/core/includes/database/database.inc
+++ b/core/includes/database/database.inc
@@ -434,9 +434,9 @@ abstract class DatabaseConnection extends PDO {
     }
     // Then replace remaining tables with the default prefix.
     $this->prefixSearch[] = '{';
-    $this->prefixReplace[] = $this->prefixes['default'];
+    $this->prefixReplace[] = '`' . $this->prefixes['default'];
     $this->prefixSearch[] = '}';
-    $this->prefixReplace[] = '';
+    $this->prefixReplace[] = '`';
   }
 
   /**

--- a/core/includes/database/mysql/database.inc
+++ b/core/includes/database/mysql/database.inc
@@ -107,18 +107,6 @@ class DatabaseConnection_mysql extends DatabaseConnection {
   /**
    * {@inheritdoc}
    */
-  public function prepareQuery($query) {
-    // DatabaseConnection::prepareQuery() is responsible for applying database
-    // table prefixes where curly brackets are around tables. Use this as an
-    // opportunity to apply backticks around table names.
-    $query = str_replace('{', '`{', $query);
-    $query = str_replace('}', '}`', $query);
-    return parent::prepareQuery($query);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function escapeField($field) {
     $field = parent::escapeField($field);
     return $this->quoteIdentifier($field);


### PR DESCRIPTION
This references https://github.com/backdrop/backdrop-issues/issues/4745.

I don't otherwise use prefixes, so when I wrote this patch, it seemed to make sense.  However, I now realize prefixes aren't generally used to specify an alternate database.  So this patch is certainly wrong.  However, it can serve as a jumping-off point for discussing a more proper solution.