### PR TITLE
Revert "Issue #3930: Fix fieldset labels overflowing their container."

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -652,35 +652,31 @@ tr.selected td {
  *   to apply all padding to the inner .fieldset-wrapper instead.
  */
 fieldset {
+  position: relative;
   max-width: 100%;
   margin: 1em 0;
-  padding: 0;
+  padding: 3em 0 0 0;
+  border-radius: 4px;
   background-color: #fff;
-  border: none;
+  border: 2px solid #EAEAEA;
   min-width: 0;
 }
 fieldset .fieldset-legend {
-  display: block;
+  position: absolute;
+  left: 0; /* LTR */
+  top: 0;
+  width: 100%;
+  margin-top: .25em;
+  padding-left: 1em; /* LTR */
   box-sizing: border-box;
-  border: 2px solid #EAEAEA;
-  border-radius: 4px;
-  background-color: #fff;
 }
-fieldset:not(.collapsible) .fieldset-legend {
-  padding: .3em .3em .3em 1em; /* LTR */
+[dir="rtl"] fieldset .fieldset-legend {
+  right: 0;
+  padding-right: 1em;
+  padding-left: 0;
 }
-[dir="rtl"] fieldset:not(.collapsible) .fieldset-legend {
-  padding: .3em 1em .3em .3em;
-}
-fieldset:not(.collapsible) .fieldset-legend,
-fieldset.collapsible:not(.collapsed) .fieldset-legend {
-  border-bottom: none;
-}
-
 legend {
   font-size: 120%;
-  font-weight: normal;
-  width: 100%;
 }
 .fieldset-description {
   margin-bottom: 1em;
@@ -694,21 +690,24 @@ fieldset fieldset fieldset {
 /**
  * Collapsible Fieldsets
  */
+.js fieldset.collapsible {
+  position: relative;
+}
 fieldset .fieldset-wrapper {
-  padding: 15px 13px 13px 15px; /* LTR */
-  border-radius: 0 0 4px 4px;
-  border: 2px solid #EAEAEA;
-  border-top: none;
-  margin-top: -2px;
+  padding: 0 13px 13px 15px; /* LTR */
 }
 [dir="rtl"] fieldset .fieldset-wrapper {
-  padding: 15px 15px 13px 13px;
+  padding: 0 15px 13px 13px;
 }
 .js fieldset.collapsible .fieldset-title {
   position: relative;
   z-index: 1;
   display: block;
+  width: 94%; /* IE8 fallback */
+  width: calc(100% - 4em);
   padding: .3em .3em .3em 1.8em;
+  margin: 0 -.5em;
+  border-radius: 4px;
   background: transparent;
 }
 .js[dir="rtl"] fieldset.collapsible .fieldset-title {
@@ -716,14 +715,13 @@ fieldset .fieldset-wrapper {
   padding: .3em 1.8em .3em .3em;
 }
 .js fieldset.collapsible .fieldset-legend {
-  border-radius: 4px 4px 0 0;
   font-size: 1em;
 }
 .js fieldset.collapsible .fieldset-legend a:before {
   content: "";
   position: absolute;
-  left: .8em;
-  top: .9em;
+  left: .6em;
+  top: .8em;
   width: 0;
   height: 0;
   border: .32em solid transparent;
@@ -732,7 +730,7 @@ fieldset .fieldset-wrapper {
 }
 .js[dir="rtl"] fieldset.collapsible .fieldset-legend a:before {
   left: auto;
-  right: .8em;
+  right: .6em;
 }
 .fieldset-legend span.summary {
   position: absolute;
@@ -753,20 +751,17 @@ fieldset .fieldset-wrapper {
 }
 /* Collapsed state styles */
 .js fieldset.collapsed {
-  padding: 0;
-}
-.js fieldset.collapsed .fieldset-legend {
-  border-radius: 4px;
+  padding: 1.6em 0;
 }
 .js fieldset.collapsed .fieldset-legend a:before {
-  left: 1em;
+  left: .8em;
   top: .75em;
   border: .32em solid transparent;
   border-left-color: black;
 }
 .js[dir="rtl"] fieldset.collapsed .fieldset-legend a:before {
   left: auto;
-  right: 1em;
+  right: .8em;
   border-left-color: transparent;
   border-right-color: black;
 }


### PR DESCRIPTION
Temporarily fixes https://github.com/backdrop/backdrop-issues/issues/4758 by reverting the changes introduced with 3930

Not needed anymore, better solution is available.