### PR TITLE
Issue #4745: Different approach to escaping MySQL tables for multiple database compatibility.

### DIFF
--- a/core/includes/database/mysql/database.inc
+++ b/core/includes/database/mysql/database.inc
@@ -107,13 +107,32 @@ class DatabaseConnection_mysql extends DatabaseConnection {
   /**
    * {@inheritdoc}
    */
-  public function prepareQuery($query) {
-    // DatabaseConnection::prepareQuery() is responsible for applying database
-    // table prefixes where curly brackets are around tables. Use this as an
-    // opportunity to apply backticks around table names.
-    $query = str_replace('{', '`{', $query);
-    $query = str_replace('}', '}`', $query);
-    return parent::prepareQuery($query);
+  protected function setPrefix($prefix) {
+    if (is_array($prefix)) {
+      $this->prefixes = $prefix + array('default' => '');
+    }
+    else {
+      $this->prefixes = array('default' => $prefix);
+    }
+
+    // This differs from the parent class implementation in that all tables
+    // are escaped with back-ticks. First, do table-specific replacements.
+    $this->prefixSearch = array();
+    $this->prefixReplace = array();
+    foreach ($this->prefixes as $key => $val) {
+      if ($key != 'default') {
+        $this->prefixSearch[] = '{' . $key . '}';
+        // Add backticks around the entire table name to avoid MySQL keywords,
+        // but also add backticks within the prefix value, in the event
+        // different database names are used as a prefix.
+        $this->prefixReplace[] = '`' . str_replace('.', '`.`', $val) . $key . '`';
+      }
+    }
+    // Then replace remaining tables with the default prefix.
+    $this->prefixSearch[] = '{';
+    $this->prefixReplace[] = '`' . $this->prefixes['default'];
+    $this->prefixSearch[] = '}';
+    $this->prefixReplace[] = '`';
   }
 
   /**

--- a/core/includes/database/mysql/schema.inc
+++ b/core/includes/database/mysql/schema.inc
@@ -474,10 +474,12 @@ class DatabaseSchema_mysql extends DatabaseSchema {
     // Work around a bug in some versions of PDO, see http://bugs.php.net/bug.php?id=41125
     $comment = str_replace("'", '’', $comment);
 
+    // Prefix tables, but remove any back-ticks.
+    $comment = str_replace('`', '', $this->connection->prefixTables($comment));
+
     // Truncate comment to maximum comment length.
     if (isset($length)) {
-      // Add table prefixes before truncating.
-      $comment = truncate_utf8($this->connection->prefixTables($comment), $length, TRUE, TRUE);
+      $comment = truncate_utf8($comment, $length, TRUE, TRUE);
     }
 
     return $this->connection->quote($comment);
@@ -516,6 +518,14 @@ class DatabaseSchema_mysql extends DatabaseSchema {
     catch (Exception $e) {
       return FALSE;
     }
+  }
+
+  public function findTables($table_expression) {
+    // Back-ticks need to be removed when selecting from the information_schema
+    // table. These may be added if using DatabaseConnection::prefixTables() on
+    // a table name.
+    $table_expression = str_replace('`', '', $table_expression);
+    return parent::findTables($table_expression);
   }
 
   public function fieldExists($table, $column) {


### PR DESCRIPTION
A possible fix for https://github.com/backdrop/backdrop-issues/issues/4745

This PR switches the addition of backticks from the `prepareQuery()` method to `setPrefix()`, where it can add backticks around database names as well as tables, if both are specified in the prefixes.