### PR TITLE
Issue #4779: Change mention of system_elements() to system_element_info()

### DIFF
--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2685,7 +2685,7 @@ function template_preprocess_header(&$variables) {
 /**
  * Preprocess variables for page.tpl.php
  *
- * @see system_elements()
+ * @see system_element_info()
  * @see page.tpl.php
  */
 function template_preprocess_page(&$variables) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4779