### PR TITLE
Issue #4768: Show anchor tag inline instead of block

### DIFF
--- a/core/modules/system/css/system.css
+++ b/core/modules/system/css/system.css
@@ -54,6 +54,7 @@
 .js .js-show {
   display: block;
 }
+.js a.js-show,
 .js span.js-show {
   display: inline;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4768