### PR TITLE
Issue #4795: Use transated config group name as it is the array key

### DIFF
--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -637,7 +637,7 @@ function user_admin_roles($form, $form_state) {
         'title' => t('Export role'),
         'href' => 'admin/config/development/configuration/single/export',
         'query' => array(
-          'group' => 'User roles',
+          'group' => t('User roles'),
           'name' => 'user.role.' . $role_name,
         ),
       );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4795