### PR TITLE
Issue #4748: fix mod_brotli double compression

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -142,7 +142,7 @@ DirectoryIndex index.php index.html index.htm
     RewriteCond %{REQUEST_FILENAME}\.gz -s
     RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
 
-    # Serve correct content types, and prevent double compression from mod_deflate (gzip) and mod_brotli (br).
+    # Serve correct content types, and prevent double compression.
     RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1,E=no-brotli:1]
     RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1,E=no-brotli:1]
 

--- a/.htaccess
+++ b/.htaccess
@@ -142,9 +142,9 @@ DirectoryIndex index.php index.html index.htm
     RewriteCond %{REQUEST_FILENAME}\.gz -s
     RewriteRule ^(.*)\.js $1\.js\.gz [QSA]
 
-    # Serve correct content types, and prevent mod_deflate double gzip.
-    RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1]
-    RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1]
+    # Serve correct content types, and prevent double compression from mod_deflate (gzip) and mod_brotli (br).
+    RewriteRule \.css\.gz$ - [T=text/css,E=no-gzip:1,E=no-brotli:1]
+    RewriteRule \.js\.gz$ - [T=text/javascript,E=no-gzip:1,E=no-brotli:1]
 
     <FilesMatch "(\.js\.gz|\.css\.gz)$">
       # Serve correct encoding type.


### PR DESCRIPTION
Fixed: https://github.com/backdrop/backdrop-issues/issues/4748

Added support for Apache mod_brotli to prevent it from double compressing, compressed files such as .css.gzip or .js.gzip

Also updated the comment to reflect Brotli