### PR TITLE
Issue #4511: Language names not translated to their native names

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -3527,7 +3527,7 @@ function language_multilingual() {
  * @return (stdClass|string)[]
  *   An associative array of languages, keyed by the language code.
  */
-function language_list($only_enabled = FALSE, $option_list = FALSE) {
+function language_list($only_enabled = FALSE, $option_list = FALSE, $native_names = FALSE) {
   $languages = &backdrop_static(__FUNCTION__);
   // Initialize master language list.
   if (!isset($languages)) {
@@ -3560,6 +3560,7 @@ function language_list($only_enabled = FALSE, $option_list = FALSE) {
       $languages['all']['en'] = (object) array(
         'langcode' => 'en',
         'name' => 'English',
+        'native' => 'English',
         'direction' => 0,
         'enabled' => TRUE,
         'weight' => 0,
@@ -3586,7 +3587,13 @@ function language_list($only_enabled = FALSE, $option_list = FALSE) {
     require_once __DIR__ . '/common.inc';
     backdrop_sort($this_list, array('weight' => SORT_NUMERIC, 'name' => SORT_STRING));
     foreach ($this_list as $language) {
-      $list[$language->langcode] = $language->name;
+      if ($native_names && isset($language->native)) {
+        $label = $language->native;
+      }
+      else {
+        $label = $language->name;
+      }
+      $list[$language->langcode] = $label;
     }
     return $list;
   }

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -3523,6 +3523,9 @@ function language_multilingual() {
  *   (optional) Whether to return a list of options instead of objects. This
  *   list is suitable for use in a select list #options array. This list is
  *   ordered by weight and then language name.
+ * @param bool $native_names
+ *   (optional) Whether the option_list labels should use the native name
+ *   instead of the English language name. Only applies if $option_list is TRUE.
  *
  * @return (stdClass|string)[]
  *   An associative array of languages, keyed by the language code.

--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1589,6 +1589,7 @@ function install_import_translations(&$install_state) {
     $language = (object) array(
       'langcode' => $langcode,
       'name' => $langcode,
+      'native' => $langcode,
       'default' => TRUE,
     );
     language_save($language);

--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -1585,7 +1585,7 @@ function install_import_translations(&$install_state) {
   $standard_languages = standard_language_list();
   if (!isset($standard_languages[$langcode])) {
     // Backdrop does not know about this language, so we prefill its values with
-    // our best guess. The user will be able to edit afterwards.
+    // our best guess. If required, this can be edited post-installation.
     $language = (object) array(
       'langcode' => $langcode,
       'name' => $langcode,

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -360,7 +360,7 @@ function locale_language_url_fallback($languages = NULL, $language_type = LANGUA
  */
 function locale_language_switcher_url($type, $path) {
   // Get the enabled languages only.
-  $language_list = language_list(TRUE, TRUE);
+  $language_list = language_list(TRUE, TRUE, TRUE);
   $links = array();
 
   foreach ($language_list as $langcode => $label) {
@@ -385,7 +385,7 @@ function locale_language_switcher_session($type, $path) {
   $language_query = isset($_SESSION[$param]) ? $_SESSION[$param] : $GLOBALS[$type]->langcode;
 
   // Get the enabled languages only.
-  $language_list = language_list(TRUE, TRUE);
+  $language_list = language_list(TRUE, TRUE, TRUE);
   $links = array();
 
   $query = $_GET;

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -2831,6 +2831,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
       $language = (object) array(
         'langcode' => 'l' . $i,
         'name' => $this->randomString(),
+        'native' => $this->randomString(),
       );
       language_save($language);
     }

--- a/core/modules/language/language.admin.inc
+++ b/core/modules/language/language.admin.inc
@@ -27,13 +27,19 @@ function language_admin_overview_form($form, &$form_state) {
   );
 
   foreach ($languages as $langcode => $language) {
+    if (isset($language->native)) {
+      $language_name = $language->native;
+    }
+    else {
+      $language_name = $language->name;
+    }
     $form['languages'][$langcode]['#weight'] = $language->weight;
     $form['languages'][$langcode]['name'] = array(
-      '#markup' => check_plain($language->name),
+      '#markup' => check_plain($language_name),
     );
     $form['languages'][$langcode]['enabled'] = array(
       '#type' => 'checkbox',
-      '#title' => t('Enable @title', array('@title' => $language->name)),
+      '#title' => t('Enable @title', array('@title' => $language_name)),
       '#title_display' => 'invisible',
       '#default_value' => (int) $language->enabled,
       '#disabled' => $langcode == $default->langcode,
@@ -41,7 +47,7 @@ function language_admin_overview_form($form, &$form_state) {
     $form['languages'][$langcode]['default'] = array(
       '#type' => 'radio',
       '#parents' => array('site_default'),
-      '#title' => t('Set @title as default', array('@title' => $language->name)),
+      '#title' => t('Set @title as default', array('@title' => $language_name)),
       '#title_display' => 'invisible',
       '#return_value' => $langcode,
       '#default_value' => ($langcode == $default->langcode ? $langcode : NULL),
@@ -49,7 +55,7 @@ function language_admin_overview_form($form, &$form_state) {
     );
     $form['languages'][$langcode]['weight'] = array(
       '#type' => 'weight',
-      '#title' => t('Weight for @title', array('@title' => $language->name)),
+      '#title' => t('Weight for @title', array('@title' => $language_name)),
       '#title_display' => 'invisible',
       '#default_value' => $language->weight,
       '#attributes' => array(
@@ -212,6 +218,14 @@ function _language_admin_common_controls(&$form, $language = NULL) {
     '#default_value' => @$language->name,
     '#required' => TRUE,
   );
+  $form['native'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Native language name'),
+    '#maxlength' => 64,
+    '#default_value' => isset($language->native) ? $language->native : '',
+    '#required' => TRUE,
+    '#description' => t('Name of the language in the language being added.'),
+  );
   $form['direction'] = array(
     '#type' => 'radios',
     '#title' => t('Direction'),
@@ -266,6 +280,7 @@ function language_admin_add_custom_form_submit($form, &$form_state) {
   $language = (object) array(
     'langcode' => $langcode,
     'name' => $form_state['values']['name'],
+    'native' => $form_state['values']['native'],
     'direction' => $form_state['values']['direction'],
   );
   language_save($language);

--- a/core/modules/language/language.admin.inc
+++ b/core/modules/language/language.admin.inc
@@ -28,7 +28,7 @@ function language_admin_overview_form($form, &$form_state) {
 
   foreach ($languages as $langcode => $language) {
     if (isset($language->native)) {
-      $language_name = $language->native;
+      $language_name = $language->name . ' (' . $language->native . ')';
     }
     else {
       $language_name = $language->name;

--- a/core/modules/language/language.admin.inc
+++ b/core/modules/language/language.admin.inc
@@ -315,6 +315,9 @@ function language_admin_edit_form_validate($form, &$form_state) {
   if ($form_state['values']['name'] != check_plain($form_state['values']['name'])) {
     form_set_error('name', t('%field cannot contain any markup.', array('%field' => $form['name']['#title'])));
   }
+  if ($form_state['values']['native'] != check_plain($form_state['values']['native'])) {
+    form_set_error('native', t('%field cannot contain any markup.', array('%field' => $form['native']['#title'])));
+  }
 }
 
 /**
@@ -326,6 +329,7 @@ function language_admin_edit_form_submit($form, &$form_state) {
   $langcode = $form_state['values']['langcode'];
   $language = $languages[$langcode];
   $language->name = $form_state['values']['name'];
+  $language->native = $form_state['values']['native'];
   $language->direction = $form_state['values']['direction'];
   language_save($language);
   // Display status messages for this form.

--- a/core/modules/language/language.admin.inc
+++ b/core/modules/language/language.admin.inc
@@ -213,7 +213,7 @@ function _language_admin_common_controls(&$form, $language = NULL) {
   }
   $form['name'] = array(
     '#type' => 'textfield',
-    '#title' => t('Language name'),
+    '#title' => t('Language name in English'),
     '#maxlength' => 64,
     '#default_value' => @$language->name,
     '#required' => TRUE,
@@ -224,7 +224,6 @@ function _language_admin_common_controls(&$form, $language = NULL) {
     '#maxlength' => 64,
     '#default_value' => isset($language->native) ? $language->native : '',
     '#required' => TRUE,
-    '#description' => t('Name of the language in the language being added.'),
   );
   $form['direction'] = array(
     '#type' => 'radios',

--- a/core/modules/language/language.install
+++ b/core/modules/language/language.install
@@ -176,6 +176,29 @@ function language_update_1002() {
 }
 
 /**
+ * Add the native name to all enabled languages.
+ */
+function language_update_1003() {
+  require_once BACKDROP_ROOT . '/core/includes/standard.inc';
+  $predefined = standard_language_list();
+  $config = config('language.settings');
+  $languages = $config->get('languages');
+
+  foreach ($languages as $langcode => $lang) {
+    if (!empty($lang['native'])) {
+      continue;
+    }
+    if (isset($predefined[$langcode][1])) {
+      $config->set('languages.' . $langcode . '.native', $predefined[$langcode][1]);
+    }
+    else {
+      $config->set('languages.' . $langcode . '.native', $lang['name']);
+    }
+  }
+  $config->save();
+}
+
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */

--- a/core/modules/language/language.module
+++ b/core/modules/language/language.module
@@ -111,12 +111,17 @@ function language_save($language) {
   $config = config('language.settings');
   $language->is_new = !$config->get('languages.' . $language->langcode);
 
-  // If name was not set, we add a predefined language.
-  if (!isset($language->name)) {
+  if (!isset($language->name) || !isset($language->native)) {
     include_once BACKDROP_ROOT . '/core/includes/standard.inc';
     $predefined = standard_language_list();
-    $language->name = $predefined[$language->langcode][0];
-    $language->direction = isset($predefined[$language->langcode][2]) ? $predefined[$language->langcode][2] : LANGUAGE_LTR;
+    // If name was not set, we add a predefined language.
+    if (!isset($language->name)) {
+      $language->name = $predefined[$language->langcode][0];
+      $language->direction = isset($predefined[$language->langcode][2]) ? $predefined[$language->langcode][2] : LANGUAGE_LTR;
+    }
+    if (!isset($language->native)) {
+      $language->native = $predefined[$language->langcode][1];
+    }
   }
 
   // Set to enabled for the default language and unless specified otherwise.
@@ -134,6 +139,7 @@ function language_save($language) {
   $defaults = array(
     'langcode' => '',
     'name' => '',
+    'native' => '',
     'direction' => 0,
     'enabled' => TRUE,
     'weight' => 0,

--- a/core/modules/language/language.module
+++ b/core/modules/language/language.module
@@ -120,7 +120,7 @@ function language_save($language) {
       $language->direction = isset($predefined[$language->langcode][2]) ? $predefined[$language->langcode][2] : LANGUAGE_LTR;
     }
     if (!isset($language->native)) {
-      $language->native = $predefined[$language->langcode][1];
+      $language->native = isset($predefined[$language->langcode][1]) ? $predefined[$language->langcode][1] : $language->name;
     }
   }
 

--- a/core/modules/language/tests/language.test
+++ b/core/modules/language/tests/language.test
@@ -42,6 +42,7 @@ class LanguageListTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $name,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -87,6 +88,7 @@ class LanguageListTest extends BackdropWebTestCase {
     $name = $this->randomName(16);
     $edit = array(
       'name' => $name,
+      'native' => $name,
     );
     $this->backdropPost('admin/config/regional/language/edit/' . $langcode, $edit, t('Save language'));
     $this->assertRaw($name, t('The language has been updated.'));
@@ -147,6 +149,7 @@ class LanguageListTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $name,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -169,7 +169,7 @@ function locale_config_info() {
 function locale_language_selector_form($user) {
   global $language;
   // Get list of enabled languages only.
-  $language_options = language_list(TRUE, TRUE);
+  $language_options = language_list(TRUE, TRUE, TRUE);
 
   // If the user is being created, we set the user language to the page language.
   $user_preferred_language = $user->uid ? user_preferred_language($user) : $language;

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -188,6 +188,8 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
     $langcode = 'xx';
     // The English name for the language. This will be translated.
     $name = $this->randomName(16);
+    // The native name for the language.
+    $native = $this->randomName(16);
     // This is the language indicator on the translation search screen for
     // untranslated strings. Copied straight from locale.inc.
     $language_indicator = "<em class=\"locale-untranslated\">$langcode</em> ";
@@ -201,6 +203,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $native,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -339,12 +342,15 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
     $langcode = 'xx';
     // The English name for the language. This will be translated.
     $name = $this->randomName(16);
+    // The native name for the language.
+    $native = $this->randomName(16);
 
     // Add custom language.
     $edit = array(
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $native,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -390,6 +396,8 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
     $langcode = 'xx';
     // The English name for the language. This will be translated.
     $name = $this->randomName(16);
+    // The native name for the language.
+    $native = $this->randomName(16);
     // This is the language indicator on the translation search screen for
     // untranslated strings. Copied straight from locale.inc.
     $language_indicator = "<em class=\"locale-untranslated\">$langcode</em> ";
@@ -408,6 +416,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $native,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -451,6 +460,8 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
     $langcode = 'xx';
     // The English name for the language. This will be translated.
     $name = $this->randomName(16);
+    // The native name for the language.
+    $native = $this->randomName(16);
     // This is the language indicator on the translation search screen for
     // untranslated strings. Copied straight from locale.inc.
     $language_indicator = "<em class=\"locale-untranslated\">$langcode</em> ";
@@ -463,6 +474,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $native,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -1948,7 +1948,8 @@ class LocaleContentFunctionalTest extends BackdropWebTestCase {
     // Edit the content and ensure correct language is selected.
     $path = 'node/' . $node->nid . '/edit';
     $this->backdropGet($path);
-    $this->assertRaw('<option value="' . $langcode . '" selected="selected">' .  $name . '</option>', 'Correct language selected.');
+    $label = $name . ' (' . $name . ')';
+    $this->assertRaw('<option value="' . $langcode . '" selected="selected">' .  $label . '</option>', 'Correct language selected.');
     // Ensure we can change the node language.
     $edit = array(
       'langcode' => 'en',

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -885,6 +885,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $name,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -1554,6 +1555,7 @@ class LocaleUserLanguageFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $name,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -1567,6 +1569,7 @@ class LocaleUserLanguageFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode_disabled,
       'name' => $name_disabled,
+      'native' => $name_disabled,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -1725,6 +1728,7 @@ class LocalePathFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $name,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -1881,6 +1885,7 @@ class LocaleContentFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode,
       'name' => $name,
+      'native' => $name,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -1894,6 +1899,7 @@ class LocaleContentFunctionalTest extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => $langcode_disabled,
       'name' => $name_disabled,
+      'native' => $name_disabled,
       'direction' => '0',
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));
@@ -2291,7 +2297,7 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
     // language.
     $args = array(':url' => base_path() . (config_get('system.core', 'clean_url') ? $langcode_browser_fallback : "?q=$langcode_browser_fallback"));
     $fields = $this->xpath('//*[contains(@class,"block-locale-language")]//a[@class="language-link active" and @href=:url]', $args);
-    $this->assertTrue($fields[0] == $languages[$langcode_browser_fallback]->name, 'The browser language is the URL active language');
+    $this->assertTrue($fields[0] == $languages[$langcode_browser_fallback]->native, 'The browser language is the URL active language');
 
     // Check that URLs are rewritten using the given browser language.
     $fields = $this->xpath('//*[contains(@class,"site-name")]//a[@rel="home" and @href=:url]//span', $args);

--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -187,7 +187,7 @@ function node_form($form, &$form_state, Node $node) {
 
   if ($node_type->settings['language'] && module_exists('language')) {
     $language_options = array();
-    foreach (language_list() as $langcode => $language) {
+    foreach (language_list(TRUE) as $langcode => $language) {
       $option_label = $language->name;
       if (isset($language->native)) {
         $option_label .= ' (' . $language->native . ')';

--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -186,7 +186,7 @@ function node_form($form, &$form_state, Node $node) {
   $form['#node'] = $node;
 
   if ($node_type->settings['language'] && module_exists('language')) {
-    $language_options = language_list(TRUE, TRUE);
+    $language_options = language_list(TRUE, TRUE, TRUE);
     $form['langcode'] = array(
       '#type' => 'select',
       '#title' => t('Language'),

--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -186,7 +186,14 @@ function node_form($form, &$form_state, Node $node) {
   $form['#node'] = $node;
 
   if ($node_type->settings['language'] && module_exists('language')) {
-    $language_options = language_list(TRUE, TRUE, TRUE);
+    $language_options = array();
+    foreach (language_list() as $langcode => $language) {
+      $option_label = $language->name;
+      if (isset($language->native)) {
+        $option_label .= ' (' . $language->native . ')';
+      }
+      $language_options[$langcode] = $option_label;
+    }
     $form['langcode'] = array(
       '#type' => 'select',
       '#title' => t('Language'),

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -2778,6 +2778,7 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
       'predefined_langcode' => 'custom',
       'langcode' => self::LANGCODE,
       'name' => self::LANGCODE,
+      'native' => self::LANGCODE,
       'direction' => LANGUAGE_LTR,
     );
     $this->backdropPost('admin/config/regional/language/add', $edit, t('Add custom language'));

--- a/core/modules/translation/tests/translation.test
+++ b/core/modules/translation/tests/translation.test
@@ -85,7 +85,7 @@ class TranslationTestCase extends BackdropWebTestCase {
     // Attempt to submit a duplicate translation by visiting the node/add page
     // with identical query string.
     $this->backdropGet('node/add/page', array('query' => array('translation' => $node->nid, 'target' => 'es')));
-    $this->assertRaw(t('A translation of %title in %language already exists', array('%title' => $node_title, '%language' => $languages['es']->name)), 'Message regarding attempted duplicate translation is displayed.');
+    $this->assertRaw(t('A translation of %title in %language already exists', array('%title' => $node_title, '%language' => $languages['es']->native)), 'Message regarding attempted duplicate translation is displayed.');
 
     // Attempt a resubmission of the form - this emulates using the back button
     // to return to the page then resubmitting the form without a refresh.
@@ -435,7 +435,11 @@ class TranslationTestCase extends BackdropWebTestCase {
     $this->backdropGet("node/$node->nid", array('language' => $page_language));
 
     foreach ($types as $type) {
-      $args = array('%translation_language' => $translation_language->name, '%page_language' => $page_language->name, '%type' => $type);
+      $args = array(
+        '%translation_language' => $translation_language->native,
+        '%page_language' => $page_language->native,
+        '%type' => $type,
+      );
       if ($find) {
         $message = format_string('[%page_language] Language switch item found for %translation_language language in the %type page area.', $args);
       }
@@ -462,7 +466,7 @@ class TranslationTestCase extends BackdropWebTestCase {
         }
       }
 
-      $found = $this->findContentByXPath($xpath, array(':type' => $type, ':url' => $url), $translation_language->name);
+      $found = $this->findContentByXPath($xpath, array(':type' => $type, ':url' => $url), $translation_language->native);
       $result = $this->assertTrue($found == $find, $message) && $result;
     }
 

--- a/core/modules/translation/translation.module
+++ b/core/modules/translation/translation.module
@@ -289,7 +289,7 @@ function translation_node_view(Node $node, $view_mode) {
         else {
           $links[$key] = array(
             'href' => "node/{$translation->nid}",
-            'title' => $language->name,
+            'title' => isset($language->native) ? $language->native : $language->name,
             'language' => $language,
           );
         }
@@ -347,7 +347,11 @@ function translation_node_prepare(Node $node) {
     if (!empty($source_node->tnid)) {
       $translations = translation_node_get_translations($source_node->tnid);
       if (isset($translations[$langcode])) {
-        backdrop_set_message(t('A translation of %title in %language already exists, a new %type will be created instead of a translation.', array('%title' => $source_node->title, '%language' => $language_list[$langcode]->name, '%type' => $node->type)), 'error');
+        backdrop_set_message(t('A translation of %title in %language already exists, a new %type will be created instead of a translation.', array(
+          '%title' => $source_node->title,
+          '%language' => $language_list[$langcode]->native,
+          '%type' => $node->type,
+        )), 'error');
         return;
       }
     }

--- a/core/modules/translation/translation.module
+++ b/core/modules/translation/translation.module
@@ -349,7 +349,7 @@ function translation_node_prepare(Node $node) {
       if (isset($translations[$langcode])) {
         backdrop_set_message(t('A translation of %title in %language already exists, a new %type will be created instead of a translation.', array(
           '%title' => $source_node->title,
-          '%language' => $language_list[$langcode]->native,
+          '%language' => isset($language_list[$langcode]->native) ? $language_list[$langcode]->native : $language_list[$langcode]->name,
           '%type' => $node->type,
         )), 'error');
         return;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4511

Restores the "native" property for language objects.