### PR TITLE
Issue #2585: createTable: drop empty db tables before trying to create them

### DIFF
--- a/core/includes/database/schema.inc
+++ b/core/includes/database/schema.inc
@@ -658,7 +658,7 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
    */
   public function createTable($name, $table) {
     if ($this->tableExists($name)) {
-	    if (db_select($name)->countQuery()->execute()->fetchField() == 0) {
+      if (db_select($name)->countQuery()->execute()->fetchField() == 0) {
         $this->dropTable($name);
         watchdog('database', 'Dropped empty, already existing table @name before recreating it.', array('@name' => $name));
       }

--- a/core/includes/database/schema.inc
+++ b/core/includes/database/schema.inc
@@ -658,7 +658,13 @@ abstract class DatabaseSchema implements QueryPlaceholderInterface {
    */
   public function createTable($name, $table) {
     if ($this->tableExists($name)) {
-      throw new DatabaseSchemaObjectExistsException(t('Table @name already exists.', array('@name' => $name)));
+	    if (db_select($name)->countQuery()->execute()->fetchField() == 0) {
+        $this->dropTable($name);
+        watchdog('database', 'Dropped empty, already existing table @name before recreating it.', array('@name' => $name));
+      }
+      else {
+        throw new DatabaseSchemaObjectExistsException(t('Table @name already exists and has data. Can\'t automatically recreate it.', array('@name' => $name)));
+      }
     }
     $statements = $this->createTableSql($name, $table);
     foreach ($statements as $statement) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2585

This is the exact same D7 backport of this patch: https://www.drupal.org/files/issues/2020-07-02/1551132-113.patch