### PR TITLE
Issue #4850: Clean up unused db tables, if failed field creation

### DIFF
--- a/core/modules/field/modules/field_sql_storage/field_sql_storage.module
+++ b/core/modules/field/modules/field_sql_storage/field_sql_storage.module
@@ -241,8 +241,32 @@ function _field_sql_storage_schema($field) {
  */
 function field_sql_storage_field_storage_create_field($field) {
   $schema = _field_sql_storage_schema($field);
+  if (Database::getConnection()->supportsTransactionalDDL()) {
+    // If the database supports transactional DDL, we can go ahead and rely on
+    // it. If not, we will have to rollback manually if something fails.
+    $transaction = db_transaction();
+  }
+  else {
+    $created_tables = array();
+  }
+
   foreach ($schema as $name => $table) {
-    db_create_table($name, $table);
+    try {
+      db_create_table($name, $table);
+      $created_tables[] = $name;
+    }
+    catch (Exception $e) {
+      // We have to remove already created tables.
+      if (Database::getConnection()->supportsTransactionalDDL()) {
+        $transaction->rollback();
+      }
+      else {
+        foreach ($created_tables as $name) {
+          db_drop_table($name);
+        }
+      }
+      throw $e;
+    }
   }
   backdrop_get_schema(NULL, TRUE);
 }
@@ -250,8 +274,7 @@ function field_sql_storage_field_storage_create_field($field) {
 /**
  * Implements hook_field_update_forbid().
  *
- * Forbid any field update that changes column definitions if there is
- * any data.
+ * Forbid any field update that changes column definitions if there is any data.
  */
 function field_sql_storage_field_update_forbid($field, $prior_field, $has_data) {
   if ($has_data && $field['columns'] != $prior_field['columns']) {
@@ -266,8 +289,8 @@ function field_sql_storage_field_storage_update_field($field, $prior_field, $has
   if (!$has_data) {
     // There is no data. Re-create the tables completely.
     if (Database::getConnection()->supportsTransactionalDDL()) {
-      // If the database supports transactional DDL, we can go ahead and rely
-      // on it. If not, we will have to rollback manually if something fails.
+      // If the database supports transactional DDL, we can go ahead and rely on
+      // it. If not, we will have to rollback manually if something fails.
       $transaction = db_transaction();
     }
 

--- a/core/modules/field_ui/field_ui.admin.inc
+++ b/core/modules/field_ui/field_ui.admin.inc
@@ -852,7 +852,8 @@ function field_ui_field_overview_form_submit($form, &$form_state) {
     unset($_GET['destination']);
     $form_state['redirect'] = field_ui_get_destinations($destinations);
   }
-  else {
+  // Ιf there were no exceptions when trying to add the field/instance earlier.
+  elseif (!isset($e)) {
     backdrop_set_message(t('Your settings have been saved.'));
   }
 }

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -805,9 +805,9 @@ class FieldUIAlterTestCase extends BackdropWebTestCase {
       ),
     ));
 
-    // Test that field_test_field_widget_properties_alter() sets the size to
-    // 42 and that field_test_field_widget_form_alter() reports the correct
-    // size when the form is displayed.
+    // Test that field_test_field_widget_properties_alter() sets the size to 42,
+    // and that field_test_field_widget_form_alter() reports the correct size
+    // when the form is displayed.
     $this->backdropGet('admin/structure/types/manage/post/fields/alter_test_text');
     $this->assertText('Field size: 42', 'Altered field size is found in hook_field_widget_form_alter().');
 
@@ -834,15 +834,76 @@ class FieldUIAlterTestCase extends BackdropWebTestCase {
       )
     ));
 
-    // Test that field_test_field_widget_properties_user_alter() replaces
-    // the widget and that field_test_field_widget_form_alter() reports the
-    // correct widget name when the form is displayed.
+    // Test that field_test_field_widget_properties_user_alter() replaces the
+    // widget, and that field_test_field_widget_form_alter() reports the correct
+    // widget name when the form is displayed.
     $this->backdropGet('admin/config/people/manage/fields/alter_test_options');
     $this->assertText('Widget type: options_buttons', 'Widget type is altered for users in hook_field_widget_form_alter().');
 
     // Test that the widget is not altered on page nodes.
     $this->backdropGet('admin/structure/types/manage/page/fields/alter_test_options');
     $this->assertText('Widget type: options_select', 'Widget type is not altered for pages in hook_field_widget_form_alter().');
+  }
+}
+
+/**
+ * Tests for correct messaging, and DB cleanup when field creation fails.
+ *
+ * @see based on FieldUIManageFields class.
+ */
+class FieldUIManageFieldsFailTestCase extends BAckdropWebTestCase {
+  function setUp() {
+    parent::setUp();
+
+    $admin_user = $this->backdropCreateUser(array('access content', 'administer content types', 'administer users'));
+
+    $this->backdropLogin($admin_user);
+
+    // Create content type, with underscores.
+    $type_name = strtolower($this->randomName(8)) . '_test';
+    $type = $this->backdropCreateContentType(array('name' => $type_name, 'type' => $type_name));
+    $this->type = $type->type;
+
+    // Store a valid URL name, with hyphens instead of underscores.
+    $this->hyphen_type = str_replace('_', '-', $this->type);
+
+    $schema =  array(
+      'description' => 'Leftover sample table.',
+      'fields' => array(
+        'just_field' => array(
+          'type' => 'int',
+        ),
+      ),
+    );
+    $this->field_name_input = strtolower($this->randomName(5));
+    $this->table_name_data = 'field_data_field_' . $this->field_name_input;
+    $this->table_name_revision = 'field_revision_field_' . $this->field_name_input;
+    // Intentionally create a table that is a field revision table. That should
+    // break the field creation.
+    db_create_table($this->table_name_revision, $schema);
+  }
+
+  /**
+   * Create a new field through the Field UI.
+   */
+  function testCreateFieldFailureCleanup() {
+    $label = $this->randomName();
+    $field_name = $this->field_name_input;
+    $initial_edit = array(
+      'fields[_add_new_field][label]' => $label,
+      'fields[_add_new_field][field_name]' => $field_name,
+      'fields[_add_new_field][type]' => 'text',
+      'fields[_add_new_field][widget_type]' => 'text_textfield',
+    );
+
+    // Try creating a field, and assert it was not created.
+    $this->backdropPost('admin/structure/types/manage/' . $this->hyphen_type . '/fields',  $initial_edit, t('Save'));
+    $this->assertRaw(t('There was a problem creating field'), t('Message about field creation problem was displayed.'));
+    $this->assertNoRaw(t('Your settings have been saved.'), t('No success message, because there was an error.'));
+
+    // Check database tables.
+    $this->assertFalse(db_table_exists($this->table_name_data), t('Field tables consistency check. No new tables expected on field creation failure.'));
+    $this->assert(db_table_exists($this->table_name_revision), t('Previously-existing table still in place.'));
   }
 }
 

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -851,11 +851,11 @@ class FieldUIAlterTestCase extends BackdropWebTestCase {
  *
  * @see based on FieldUIManageFields class.
  */
-class FieldUIManageFieldsFailTestCase extends BAckdropWebTestCase {
+class FieldUIManageFieldsFailTestCase extends BackdropWebTestCase {
   function setUp() {
     parent::setUp();
 
-    $admin_user = $this->backdropCreateUser(array('access content', 'administer content types', 'administer users'));
+    $admin_user = $this->backdropCreateUser(array('access content', 'administer content types', 'administer fields', 'administer users'));
 
     $this->backdropLogin($admin_user);
 

--- a/core/modules/field_ui/tests/field_ui.tests.info
+++ b/core/modules/field_ui/tests/field_ui.tests.info
@@ -16,6 +16,12 @@ description = Test custom field widget hooks and callbacks on field administrati
 group = Field UI
 file = field_ui.test
 
+[FieldUIManageFieldsFailTestCase]
+name = Field add failures
+description = Test the system cleanup, in case of any DB failure while adding fields.
+group = Field UI
+file = field_ui.test
+
 [FieldUIViewModeFunctionalTest]
 name = Display modes
 description = Tests view mode functionality.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4850

Adapted from the patch in https://www.drupal.org/files/drupalcore-create-field-cleanup-1343330-5.diff