### PR TITLE
Issue #3213: Testing validation of Coding Standards with PHPCS on changed files

### DIFF
--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -1,0 +1,32 @@
+name: Backdrop Coding Standards
+
+# Run on all pull requests.
+on:
+  pull_request:
+    branches: [ 1.x ]
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Download PHP_CodeSniffer
+        run: |
+          sudo wget https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar -qO /usr/bin/phpcs
+          sudo wget https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar -qO /usr/bin/phpcbf
+          sudo chmod 755 /usr/bin/phpcs
+          sudo chmod 755 /usr/bin/phpcbf
+
+      - name: Run PHP CS on affected files
+        run: |
+          CHANGED_FILES=$(git diff --name-only origin/$GITHUB_BASE_REF..HEAD -- .)
+          sudo /usr/bin/phpcs --config-set installed_paths core/misc/code_sniffer
+          /usr/bin/phpcs \
+            --standard=Backdrop \
+            --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md,yml \
+            --ignore="misc/ckeditor,misc/ui,misc/jquery.*,misc/opensans,misc/smartmenus,misc/farbtastic,core/misc/code_sniffer" \
+            $CHANGED_FILES

--- a/core/misc/code_sniffer/Backdrop/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
+++ b/core/misc/code_sniffer/Backdrop/Docs/Functions/FunctionCallArgumentSpacingStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Parameter Spacing in Function Calls">
+    <standard>
+    <![CDATA[
+     There must be one space between a comma and a parameter in a function call.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: spaces between parameters">
+        <![CDATA[
+$var = foo($bar<em>, </em>$baz<em>, </em>$quux);
+        ]]>
+        </code>
+        <code title="Invalid: no space between commas and parameters">
+        <![CDATA[
+$var = foo($bar<em>,</em>$baz<em>,</em>$quux);
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/core/misc/code_sniffer/Backdrop/Docs/Functions/FunctionCallSignatureStandard.xml
+++ b/core/misc/code_sniffer/Backdrop/Docs/Functions/FunctionCallSignatureStandard.xml
@@ -1,0 +1,19 @@
+<documentation title="Function Calls">
+    <standard>
+    <![CDATA[
+      Functions should be called with no spaces between the function name, the opening parenthesis, and the first parameter; and no space between the last parameter, the closing parenthesis, and the semicolon.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: spaces between parameters">
+        <![CDATA[
+$var = foo($bar, $baz, $quux);
+        ]]>
+        </code>
+        <code title="Invalid: additional spaces used">
+        <![CDATA[
+$var = foo<em> </em>(<em> </em>$bar, $baz, $quux<em> </em>)<em> </em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/core/misc/code_sniffer/Backdrop/Docs/Functions/ValidDefaultValueStandard.xml
+++ b/core/misc/code_sniffer/Backdrop/Docs/Functions/ValidDefaultValueStandard.xml
@@ -1,0 +1,25 @@
+<documentation title="Default Values in Function Declarations">
+    <standard>
+    <![CDATA[
+    Arguments with default values go at the end of the argument list.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: argument with default value at end of declaration">
+        <![CDATA[
+function connect($dsn, <em>$persistent = false</em>)
+{
+    ...
+}
+        ]]>
+        </code>
+        <code title="Invalid: argument with default value at start of declaration">
+        <![CDATA[
+function connect(<em>$persistent = false</em>, $dsn)
+{
+    ...
+}
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Arrays/ArraySniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Arrays/ArraySniff.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Arrays\ArraySniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * ArraySniff.
+ *
+ * Checks if the array's are styled in the Backdrop way.
+ * - Comma after the last array element
+ * - Indentation is 2 spaces for multi line array definitions
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ArraySniff implements Sniff
+{
+
+
+    /**
+     * The limit that the length of a line should not exceed.
+     *
+     * This can be configured to have a different value but the default is 80.
+     *
+     * @var integer
+     */
+    public $lineLimit = 80;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_ARRAY,
+            T_OPEN_SHORT_ARRAY,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Support long and short syntax.
+        $parenthesisOpener = 'parenthesis_opener';
+        $parenthesisCloser = 'parenthesis_closer';
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+            $parenthesisOpener = 'bracket_opener';
+            $parenthesisCloser = 'bracket_closer';
+        }
+
+        // Sanity check: this can sometimes be NULL if the array was not correctly
+        // parsed.
+        if ($tokens[$stackPtr][$parenthesisCloser] === null) {
+            return;
+        }
+
+        $lastItem = $phpcsFile->findPrevious(
+            Tokens::$emptyTokens,
+            ($tokens[$stackPtr][$parenthesisCloser] - 1),
+            $stackPtr,
+            true
+        );
+
+        // Empty array.
+        if ($lastItem === $tokens[$stackPtr][$parenthesisOpener]) {
+            return;
+        }
+
+        // Inline array.
+        $isInlineArray = $tokens[$tokens[$stackPtr][$parenthesisOpener]]['line'] === $tokens[$tokens[$stackPtr][$parenthesisCloser]]['line'];
+
+        // Check if the last item in a multiline array has a "closing" comma.
+        if ($tokens[$lastItem]['code'] !== T_COMMA && $isInlineArray === false
+            && $tokens[($lastItem + 1)]['code'] !== T_CLOSE_PARENTHESIS
+            && $tokens[($lastItem + 1)]['code'] !== T_CLOSE_SHORT_ARRAY
+            && isset(Tokens::$heredocTokens[$tokens[$lastItem]['code']]) === false
+        ) {
+            $data = [$tokens[$lastItem]['content']];
+            $fix  = $phpcsFile->addFixableWarning('A comma should follow the last multiline array item. Found: %s', $lastItem, 'CommaLastItem', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->addContent($lastItem, ',');
+            }
+
+            return;
+        }
+
+        // Find the first token on this line.
+        $firstLineColumn = $tokens[$stackPtr]['column'];
+        for ($i = $stackPtr; $i >= 0; $i--) {
+            // If there is a PHP open tag then this must be a template file where we
+            // don't check indentation.
+            if ($tokens[$i]['code'] === T_OPEN_TAG) {
+                return;
+            }
+
+            // Record the first code token on the line.
+            if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                $firstLineColumn = $tokens[$i]['column'];
+                // This could be a multi line string or comment beginning with white
+                // spaces.
+                $trimmed = ltrim($tokens[$i]['content']);
+                if ($trimmed !== $tokens[$i]['content']) {
+                    $firstLineColumn = ($firstLineColumn + strpos($tokens[$i]['content'], $trimmed));
+                }
+            }
+
+            // It's the start of the line, so we've found our first php token.
+            if ($tokens[$i]['column'] === 1) {
+                break;
+            }
+        }//end for
+
+        $lineStart = $stackPtr;
+        // Iterate over all lines of this array.
+        while ($lineStart < $tokens[$stackPtr][$parenthesisCloser]) {
+            // Find next line start.
+            $newLineStart = $lineStart;
+            $currentLine  = $tokens[$newLineStart]['line'];
+            while ($currentLine >= $tokens[$newLineStart]['line']) {
+                $newLineStart = $phpcsFile->findNext(
+                    Tokens::$emptyTokens,
+                    ($newLineStart + 1),
+                    ($tokens[$stackPtr][$parenthesisCloser] + 1),
+                    true
+                );
+
+                if ($newLineStart === false) {
+                    break 2;
+                }
+
+                // Long array syntax: Skip nested arrays, they are checked in a next
+                // run.
+                if ($tokens[$newLineStart]['code'] === T_ARRAY) {
+                    $newLineStart = $tokens[$newLineStart]['parenthesis_closer'];
+                    $currentLine  = $tokens[$newLineStart]['line'];
+                }
+
+                // Short array syntax: Skip nested arrays, they are checked in a next
+                // run.
+                if ($tokens[$newLineStart]['code'] === T_OPEN_SHORT_ARRAY) {
+                    $newLineStart = $tokens[$newLineStart]['bracket_closer'];
+                    $currentLine  = $tokens[$newLineStart]['line'];
+                }
+
+                // Nested structures such as closures: skip those, they are checked
+                // in other sniffs. If the conditions of a token are different it
+                // means that it is in a different nesting level.
+                if ($tokens[$newLineStart]['conditions'] !== $tokens[$stackPtr]['conditions']) {
+                    // Jump to the end of the closure.
+                    $conditionKeys = array_keys($tokens[$newLineStart]['conditions']);
+                    $closureToken  = end($conditionKeys);
+                    if (isset($tokens[$closureToken]['scope_closer']) === true) {
+                        $newLineStart = $tokens[$closureToken]['scope_closer'];
+                        $currentLine  = $tokens[$closureToken]['line'];
+                    } else {
+                        $currentLine++;
+                    }
+                }
+            }//end while
+
+            if ($newLineStart === $tokens[$stackPtr][$parenthesisCloser]) {
+                // End of the array reached.
+                if ($tokens[$newLineStart]['column'] !== $firstLineColumn) {
+                    $error = 'Array closing indentation error, expected %s spaces but found %s';
+                    $data  = [
+                        ($firstLineColumn - 1),
+                        ($tokens[$newLineStart]['column'] - 1),
+                    ];
+                    $fix   = $phpcsFile->addFixableError($error, $newLineStart, 'ArrayClosingIndentation', $data);
+                    if ($fix === true) {
+                        if ($tokens[$newLineStart]['column'] === 1) {
+                            $phpcsFile->fixer->addContentBefore($newLineStart, str_repeat(' ', ($firstLineColumn - 1)));
+                        } else {
+                            $phpcsFile->fixer->replaceToken(($newLineStart - 1), str_repeat(' ', ($firstLineColumn - 1)));
+                        }
+                    }
+                }
+
+                break;
+            }
+
+            $expectedColumn = ($firstLineColumn + 2);
+            // If the line starts with "->" then we assume an additional level of
+            // indentation.
+            if ($tokens[$newLineStart]['code'] === T_OBJECT_OPERATOR) {
+                $expectedColumn += 2;
+            }
+
+            if ($tokens[$newLineStart]['column'] !== $expectedColumn) {
+                // Skip lines in nested structures such as a function call within an
+                // array, no defined coding standard for those.
+                $innerNesting = empty($tokens[$newLineStart]['nested_parenthesis']) === false
+                    && end($tokens[$newLineStart]['nested_parenthesis']) < $tokens[$stackPtr][$parenthesisCloser];
+                // Skip lines that are part of a multi-line string.
+                $isMultiLineString = $tokens[($newLineStart - 1)]['code'] === T_CONSTANT_ENCAPSED_STRING
+                    && substr($tokens[($newLineStart - 1)]['content'], -1) === $phpcsFile->eolChar;
+                // Skip NOWDOC or HEREDOC lines.
+                $nowDoc = isset(Tokens::$heredocTokens[$tokens[$newLineStart]['code']]);
+                if ($innerNesting === false && $isMultiLineString === false && $nowDoc === false) {
+                    $error = 'Array indentation error, expected %s spaces but found %s';
+                    $data  = [
+                        ($expectedColumn - 1),
+                        ($tokens[$newLineStart]['column'] - 1),
+                    ];
+                    $fix   = $phpcsFile->addFixableError($error, $newLineStart, 'ArrayIndentation', $data);
+                    if ($fix === true) {
+                        if ($tokens[$newLineStart]['column'] === 1) {
+                            $phpcsFile->fixer->addContentBefore($newLineStart, str_repeat(' ', ($expectedColumn - 1)));
+                        } else {
+                            $phpcsFile->fixer->replaceToken(($newLineStart - 1), str_repeat(' ', ($expectedColumn - 1)));
+                        }
+                    }
+                }
+            }//end if
+
+            $lineStart = $newLineStart;
+        }//end while
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/CSS/ClassDefinitionNameSpacingSniff.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * \Backdrop\Sniffs\CSS\ClassDefinitionNameSpacingSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Ensure there are no blank lines between the names of classes/IDs. Copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\CSS\ClassDefinitionNameSpacingSniff
+ * because we also check for comma separated selectors on their own line.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ClassDefinitionNameSpacingSniff implements Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array<string>
+     */
+    public $supportedTokenizers = ['CSS'];
+
+
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return array<int, int|string>
+     */
+    public function register()
+    {
+        return [T_OPEN_CURLY_BRACKET];
+
+    }//end register()
+
+
+    /**
+     * Processes the tokens that this sniff is interested in.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+     * @param int                         $stackPtr  The position in the stack where
+     *                                               the token was found.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Do not check nested style definitions as, for example, in @media style rules.
+        $nested = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1), $tokens[$stackPtr]['bracket_closer']);
+        if ($nested !== false) {
+            return;
+        }
+
+        // Find the first blank line before this opening brace, unless we get
+        // to another style definition, comment or the start of the file.
+        $endTokens  = [
+            T_OPEN_CURLY_BRACKET  => T_OPEN_CURLY_BRACKET,
+            T_CLOSE_CURLY_BRACKET => T_CLOSE_CURLY_BRACKET,
+            T_OPEN_TAG            => T_OPEN_TAG,
+        ];
+        $endTokens += Tokens::$commentTokens;
+
+        $foundContent = false;
+        $currentLine  = $tokens[$stackPtr]['line'];
+        for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+            if (isset($endTokens[$tokens[$i]['code']]) === true) {
+                break;
+            }
+
+            // A comma must be followed by a new line character.
+            if ($tokens[$i]['code'] === T_COMMA
+                && strpos($tokens[($i + 1)]['content'], $phpcsFile->eolChar) === false
+            ) {
+                $error = 'Multiple selectors should each be on a single line';
+                $fix   = $phpcsFile->addFixableError($error, ($i + 1), 'MultipleSelectors');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addNewline($i);
+                }
+            }
+
+            // Selectors must be on the same line.
+            if ($tokens[$i]['code'] === T_WHITESPACE
+                && strpos($tokens[$i]['content'], $phpcsFile->eolChar) !== false
+                && isset($endTokens[$tokens[($i - 1)]['code']]) === false
+                && in_array($tokens[($i - 1)]['code'], [T_WHITESPACE, T_COMMA]) === false
+            ) {
+                $error = 'Selectors must be on a single line';
+                $fix   = $phpcsFile->addFixableError($error, $i, 'SeletorSingleLine');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($i, str_replace($phpcsFile->eolChar, ' ', $tokens[$i]['content']));
+                }
+            }
+
+            if ($tokens[$i]['line'] === $currentLine) {
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $foundContent = true;
+                }
+
+                continue;
+            }
+
+            // We changed lines.
+            if ($foundContent === false) {
+                // Before we throw an error, make sure we are not looking
+                // at a gap before the style definition.
+                $prev = $phpcsFile->findPrevious(T_WHITESPACE, $i, null, true);
+                if ($prev !== false
+                    && isset($endTokens[$tokens[$prev]['code']]) === false
+                ) {
+                    $error = 'Blank lines are not allowed between class names';
+                    $fix   = $phpcsFile->addFixableError($error, ($i + 1), 'BlankLinesFound');
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($i + 1), '');
+                    }
+                }
+
+                break;
+            }
+
+            $foundContent = false;
+            $currentLine  = $tokens[$i]['line'];
+        }//end for
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/CSS/ColourDefinitionSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/CSS/ColourDefinitionSniff.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * \Backdrop\Sniffs\CSS\ColourDefinitionSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\CSS;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\CSS\ColourDefinitionSniff.
+ *
+ * Ensure colours are defined in lower-case.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ColourDefinitionSniff implements Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array<string>
+     */
+    public $supportedTokenizers = ['CSS'];
+
+
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_COLOUR];
+
+    }//end register()
+
+
+    /**
+     * Processes the tokens that this sniff is interested in.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where the token was found.
+     * @param int                         $stackPtr  The position in the stack where
+     *                                               the token was found.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $colour = $tokens[$stackPtr]['content'];
+
+        $expected = strtolower($colour);
+        if ($colour !== $expected) {
+            $error = 'CSS colours must be defined in lowercase; expected %s but found %s';
+            $data  = [
+                $expected,
+                $colour,
+            ];
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotLower', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $expected);
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/ClassCreateInstanceSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/ClassCreateInstanceSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Class create instance Test.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Class create instance Test.
+ *
+ * Checks the declaration of the class is correct.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ClassCreateInstanceSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_NEW];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $commaOrColon = $phpcsFile->findNext([T_SEMICOLON, T_COLON, T_COMMA], ($stackPtr + 1));
+        if ($commaOrColon === false) {
+            // Syntax error, nothing we can do.
+            return;
+        }
+
+        // Search for an opening parenthesis in the current statement until the
+        // next semicolon or comma.
+        $nextParenthesis = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), $commaOrColon);
+        if ($nextParenthesis === false) {
+            $error       = 'Calling class constructors must always include parentheses';
+            $constructor = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+            // We can invoke the fixer if we know this is a static constructor
+            // function call or constructor calls with namespaces, example
+            // "new \DOMDocument;" or constructor with class names in variables
+            // "new $controller;".
+            if ($tokens[$constructor]['code'] === T_STRING
+                || $tokens[$constructor]['code'] === T_NS_SEPARATOR
+                || ($tokens[$constructor]['code'] === T_VARIABLE
+                && $tokens[($constructor + 1)]['code'] === T_SEMICOLON)
+            ) {
+                // Scan to the end of possible string\namespace parts.
+                $nextConstructorPart = $constructor;
+                while (true) {
+                    $nextConstructorPart = $phpcsFile->findNext(
+                        Tokens::$emptyTokens,
+                        ($nextConstructorPart + 1),
+                        null,
+                        true,
+                        null,
+                        true
+                    );
+                    if ($nextConstructorPart === false
+                        || ($tokens[$nextConstructorPart]['code'] !== T_STRING
+                        && $tokens[$nextConstructorPart]['code'] !== T_NS_SEPARATOR)
+                    ) {
+                        break;
+                    }
+
+                    $constructor = $nextConstructorPart;
+                }
+
+                $fix = $phpcsFile->addFixableError($error, $constructor, 'ParenthesisMissing');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($constructor, '()');
+                }
+
+                // We can invoke the fixer if we know this is a
+                // constructor call with class names in an array
+                // example "new $controller[$i];".
+            } else if ($tokens[$constructor]['code'] === T_VARIABLE
+                && $tokens[($constructor + 1)]['code'] === T_OPEN_SQUARE_BRACKET
+            ) {
+                // Scan to the end of possible multilevel arrays.
+                $nextConstructorPart = $constructor;
+                do {
+                    $nextConstructorPart = $tokens[($nextConstructorPart + 1)]['bracket_closer'];
+                } while ($tokens[($nextConstructorPart + 1)]['code'] === T_OPEN_SQUARE_BRACKET);
+
+                $fix = $phpcsFile->addFixableError($error, $nextConstructorPart, 'ParenthesisMissing');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($nextConstructorPart, '()');
+                }
+            } else {
+                $phpcsFile->addError($error, $stackPtr, 'ParenthesisMissing');
+            }//end if
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/ClassDeclarationSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/ClassDeclarationSniff.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Class Declaration Test.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff as PSR2ClassDeclarationSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Class Declaration Test.
+ *
+ * Checks the declaration of the class is correct.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ClassDeclarationSniff extends PSR2ClassDeclarationSniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param integer                     $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $errorData = [strtolower($tokens[$stackPtr]['content'])];
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
+            $error = 'Possible parse error: %s missing opening or closing brace';
+            $phpcsFile->addWarning($error, $stackPtr, 'MissingBrace', $errorData);
+            return;
+        }
+
+        $openingBrace = $tokens[$stackPtr]['scope_opener'];
+
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($openingBrace + 1), null, true);
+        if ($tokens[$next]['line'] === $tokens[$openingBrace]['line'] && $tokens[$next]['code'] !== T_CLOSE_CURLY_BRACKET) {
+            $error = 'Opening brace must be the last content on the line';
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'ContentAfterBrace');
+            if ($fix === true) {
+                $phpcsFile->fixer->addNewline($openingBrace);
+            }
+        }
+
+        $previous        = $phpcsFile->findPrevious(T_WHITESPACE, ($openingBrace - 1), null, true);
+        $decalrationLine = $tokens[$previous]['line'];
+        $braceLine       = $tokens[$openingBrace]['line'];
+
+        $lineDifference = ($braceLine - $decalrationLine);
+
+        if ($lineDifference > 0) {
+            $error = 'Opening brace should be on the same line as the declaration';
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'BraceOnNewLine');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($previous + 1); $i < $openingBrace; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->addContent($previous, ' ');
+                $phpcsFile->fixer->endChangeset();
+            }
+
+            return;
+        }
+
+        $openingBrace = $tokens[$stackPtr]['scope_opener'];
+        if ($tokens[($openingBrace - 1)]['code'] !== T_WHITESPACE) {
+            $length = 0;
+        } else if ($tokens[($openingBrace - 1)]['content'] === "\t") {
+            $length = '\t';
+        } else {
+            $length = strlen($tokens[($openingBrace - 1)]['content']);
+        }
+
+        if ($length !== 1) {
+            $error = 'Expected 1 space before opening brace; found %s';
+            $data  = [$length];
+            $fix   = $phpcsFile->addFixableError($error, $openingBrace, 'SpaceBeforeBrace', $data);
+            if ($fix === true) {
+                if ($length === 0) {
+                    $phpcsFile->fixer->replaceToken(($openingBrace), ' {');
+                } else {
+                    $phpcsFile->fixer->replaceToken(($openingBrace - 1), ' ');
+                }
+            }
+        }
+
+        // Now call the open spacing method from PSR2.
+        $this->processOpen($phpcsFile, $stackPtr);
+
+        $this->processClose($phpcsFile, $stackPtr);
+
+    }//end process()
+
+
+    /**
+     * Processes the closing section of a class declaration.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function processClose(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Just in case.
+        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+            return;
+        }
+
+        // Check that the closing brace comes right after the code body.
+        $closeBrace  = $tokens[$stackPtr]['scope_closer'];
+        $prevContent = $phpcsFile->findPrevious(T_WHITESPACE, ($closeBrace - 1), null, true);
+        if ($prevContent !== $tokens[$stackPtr]['scope_opener']
+            && $tokens[$prevContent]['line'] !== ($tokens[$closeBrace]['line'] - 2)
+            // If the class only contains a comment no extra line is needed.
+            && isset(Tokens::$commentTokens[$tokens[$prevContent]['code']]) === false
+        ) {
+            $error = 'The closing brace for the %s must have an empty line before it';
+            $data  = [$tokens[$stackPtr]['content']];
+            $fix   = $phpcsFile->addFixableError($error, $closeBrace, 'CloseBraceAfterBody', $data);
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($prevContent + 1); $i < $closeBrace; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($closeBrace, $phpcsFile->eolChar.$phpcsFile->eolChar.$tokens[$closeBrace]['content']);
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }//end if
+
+        // Check the closing brace is on it's own line, but allow
+        // for comments like "//end class".
+        $nextContent = $phpcsFile->findNext(T_COMMENT, ($closeBrace + 1), null, true);
+        if ($tokens[$nextContent]['content'] !== $phpcsFile->eolChar
+            && $tokens[$nextContent]['line'] === $tokens[$closeBrace]['line']
+        ) {
+            $type  = strtolower($tokens[$stackPtr]['content']);
+            $error = 'Closing %s brace must be on a line by itself';
+            $data  = [$tokens[$stackPtr]['content']];
+            $phpcsFile->addError($error, $closeBrace, 'CloseBraceSameLine', $data);
+        }
+
+    }//end processClose()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/FullyQualifiedNamespaceSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/FullyQualifiedNamespaceSniff.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Classes\FullyQualifiedNamespaceSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that class references do not use FQN but use statements.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FullyQualifiedNamespaceSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_NS_SEPARATOR];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return $phpcsFile->numTokens + 1 to skip
+     *                  the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Skip this sniff in *api.php files because they want to have fully
+        // qualified names for documentation purposes.
+        if (substr($phpcsFile->getFilename(), -8) === '.api.php') {
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        // We are only interested in a backslash embedded between strings, which
+        // means this is a class reference with more than once namespace part.
+        if ($tokens[($stackPtr - 1)]['code'] !== T_STRING || $tokens[($stackPtr + 1)]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Check if this is a use statement and ignore those.
+        $before = $phpcsFile->findPrevious([T_STRING, T_NS_SEPARATOR, T_WHITESPACE, T_COMMA, T_AS], $stackPtr, null, true);
+        if ($tokens[$before]['code'] === T_USE || $tokens[$before]['code'] === T_NAMESPACE) {
+            return $phpcsFile->findNext([T_STRING, T_NS_SEPARATOR, T_WHITESPACE, T_COMMA, T_AS], ($stackPtr + 1), null, true);
+        } else {
+            $before = $phpcsFile->findPrevious([T_STRING, T_NS_SEPARATOR, T_WHITESPACE], $stackPtr, null, true);
+        }
+
+        // If this is a namespaced function call then ignore this because use
+        // statements for functions are not possible in PHP 5.5 and lower.
+        $after = $phpcsFile->findNext([T_STRING, T_NS_SEPARATOR, T_WHITESPACE], $stackPtr, null, true);
+        if ($tokens[$after]['code'] === T_OPEN_PARENTHESIS && $tokens[$before]['code'] !== T_NEW) {
+            return ($after + 1);
+        }
+
+        $fullName  = $phpcsFile->getTokensAsString(($before + 1), ($after - 1 - $before));
+        $fullName  = trim($fullName, "\ \n");
+        $parts     = explode('\\', $fullName);
+        $className = end($parts);
+
+        // Check if there is a use statement already for this class and
+        // namespace.
+        $conflict     = false;
+        $alreadyUsed  = false;
+        $aliasName    = false;
+        $useStatement = $phpcsFile->findNext(T_USE, 0);
+        while ($useStatement !== false && empty($tokens[$useStatement]['conditions']) === true) {
+            $endPtr      = $phpcsFile->findEndOfStatement($useStatement);
+            $useEnd      = ($phpcsFile->findNext([T_STRING, T_NS_SEPARATOR, T_WHITESPACE], ($useStatement + 1), null, true) - 1);
+            $useFullName = trim($phpcsFile->getTokensAsString(($useStatement + 1), ($useEnd - $useStatement)));
+
+            // Check if use statement contains an alias.
+            $asPtr = $phpcsFile->findNext(T_AS, ($useEnd + 1), $endPtr);
+            if ($asPtr !== false) {
+                $aliasName = trim($phpcsFile->getTokensAsString(($asPtr + 1), ($endPtr - 1 - $asPtr)));
+            }
+
+            if (strcasecmp($useFullName, $fullName) === 0) {
+                $alreadyUsed = true;
+                break;
+            }
+
+            $parts        = explode('\\', $useFullName);
+            $useClassName = end($parts);
+
+            // Check if the resulting classname would conflict with another
+            // use statement.
+            if ($aliasName === $className || $useClassName === $className) {
+                $conflict = true;
+                break;
+            }
+
+            $aliasName = false;
+            // Check if we're currently in a multi-use statement.
+            if ($tokens[$endPtr]['code'] === T_COMMA) {
+                $useStatement = $endPtr;
+                continue;
+            }
+
+            $useStatement = $phpcsFile->findNext(T_USE, ($endPtr + 1));
+        }//end while
+
+        if ($conflict === false) {
+            $classStatement = $phpcsFile->findNext(T_CLASS, 0);
+            while ($classStatement !== false) {
+                $afterClassStatement = $phpcsFile->findNext(T_WHITESPACE, ($classStatement + 1), null, true);
+                // Check for 'class ClassName' declarations.
+                if ($tokens[$afterClassStatement]['code'] === T_STRING) {
+                    $declaredName = $tokens[$afterClassStatement]['content'];
+                    if ($declaredName === $className) {
+                        $conflict = true;
+                        break;
+                    }
+                }
+
+                $classStatement = $phpcsFile->findNext(T_CLASS, ($classStatement + 1));
+            }
+        }
+
+        $error = 'Namespaced classes/interfaces/traits should be referenced with use statements';
+        if ($conflict === true) {
+            $fix = false;
+            $phpcsFile->addError($error, $stackPtr, 'UseStatementMissing');
+        } else {
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, 'UseStatementMissing');
+        }
+
+        if ($fix === true) {
+            $phpcsFile->fixer->beginChangeset();
+
+            // Replace the fully qualified name with the local name.
+            for ($i = ($before + 1); $i < $after; $i++) {
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+            }
+
+            // Use alias name if available.
+            if ($aliasName !== false) {
+                $phpcsFile->fixer->addContentBefore(($after - 1), $aliasName);
+            } else {
+                $phpcsFile->fixer->addContentBefore(($after - 1), $className);
+            }
+
+            // Insert use statement at the beginning of the file if it is not there
+            // already. Also check if another sniff (for example
+            // UnusedUseStatementSniff) has already deleted the use statement, then
+            // we need to add it back.
+            if ($alreadyUsed === false
+                || $phpcsFile->fixer->getTokenContent($useStatement) !== $tokens[$useStatement]['content']
+            ) {
+                if ($aliasName !== false) {
+                    $use = "use $fullName as $aliasName;";
+                } else {
+                    $use = "use $fullName;";
+                }
+
+                // Check if there is a group of use statements and add it there.
+                $useStatement = $phpcsFile->findNext(T_USE, 0);
+                if ($useStatement !== false && empty($tokens[$useStatement]['conditions']) === true) {
+                    $phpcsFile->fixer->addContentBefore($useStatement, "$use\n");
+                } else {
+                    // Check if there is an @file comment.
+                    $beginning   = 0;
+                    $fileComment = $phpcsFile->findNext(T_WHITESPACE, ($beginning + 1), null, true);
+                    if ($tokens[$fileComment]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                        $beginning = $tokens[$fileComment]['comment_closer'];
+                        $phpcsFile->fixer->addContent($beginning, "\n\n$use\n");
+                    } else {
+                        $phpcsFile->fixer->addContent($beginning, "$use\n");
+                    }
+                }
+            }//end if
+
+            $phpcsFile->fixer->endChangeset();
+        }//end if
+
+        // Continue after this class reference so that errors for this are not
+        // flagged multiple times.
+        return $phpcsFile->findNext([T_STRING, T_NS_SEPARATOR], ($stackPtr + 1), null, true);
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/InterfaceNameSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/InterfaceNameSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Classes\InterfaceNameSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that interface names end with "Interface".
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class InterfaceNameSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_INTERFACE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens  = $phpcsFile->getTokens();
+        $namePtr = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        $name    = $tokens[$namePtr]['content'];
+        if (substr($name, -9) !== 'Interface') {
+            $warn = 'Interface names should always have the suffix "Interface"';
+            $phpcsFile->addWarning($warn, $namePtr, 'InterfaceSuffix');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Verifies that properties are declared correctly.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Laregely copied from
+ * \PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff to have a fixer
+ * for the var keyword.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PropertyDeclarationSniff extends AbstractVariableSniff
+{
+
+
+    /**
+     * Processes the function tokens within the class.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processMemberVar(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['content'][1] === '_') {
+            $error = 'Property name "%s" should not be prefixed with an underscore to indicate visibility';
+            $data  = [$tokens[$stackPtr]['content']];
+            $phpcsFile->addWarning($error, $stackPtr, 'Underscore', $data);
+        }
+
+        // Detect multiple properties defined at the same time. Throw an error
+        // for this, but also only process the first property in the list so we don't
+        // repeat errors.
+        $find = Tokens::$scopeModifiers;
+        $find = array_merge($find, [T_VARIABLE, T_VAR, T_SEMICOLON]);
+        $prev = $phpcsFile->findPrevious($find, ($stackPtr - 1));
+        if ($tokens[$prev]['code'] === T_VARIABLE) {
+            return;
+        }
+
+        if ($tokens[$prev]['code'] === T_VAR) {
+            $error = 'The var keyword must not be used to declare a property';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'VarUsed');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($prev, 'public');
+            }
+        }
+
+        $next = $phpcsFile->findNext([T_VARIABLE, T_SEMICOLON], ($stackPtr + 1));
+        if ($tokens[$next]['code'] === T_VARIABLE) {
+            $error = 'There must not be more than one property declared per statement';
+            $phpcsFile->addError($error, $stackPtr, 'Multiple');
+        }
+
+        $modifier = $phpcsFile->findPrevious(Tokens::$scopeModifiers, $stackPtr);
+        if (($modifier === false) || ($tokens[$modifier]['line'] !== $tokens[$stackPtr]['line'])) {
+            $error = 'Visibility must be declared on property "%s"';
+            $data  = [$tokens[$stackPtr]['content']];
+            $phpcsFile->addError($error, $stackPtr, 'ScopeMissing', $data);
+        }
+
+    }//end processMemberVar()
+
+
+    /**
+     * Processes normal variables.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr)
+    {
+        /*
+            We don't care about normal variables.
+        */
+
+    }//end processVariable()
+
+
+    /**
+     * Processes variables in double quoted strings.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
+    {
+        /*
+            We don't care about normal variables.
+        */
+
+    }//end processVariableInString()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/UnusedUseStatementSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/UnusedUseStatementSniff.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Classes\UnusedUseStatementSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks for "use" statements that are not needed in a file.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class UnusedUseStatementSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_USE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Only check use statements in the global scope.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            return;
+        }
+
+        // Seek to the end of the statement and get the string before the semi colon.
+        $semiColon = $phpcsFile->findEndOfStatement($stackPtr);
+        if ($tokens[$semiColon]['code'] !== T_SEMICOLON) {
+            return;
+        }
+
+        $classPtr = $phpcsFile->findPrevious(
+            Tokens::$emptyTokens,
+            ($semiColon - 1),
+            null,
+            true
+        );
+
+        if ($tokens[$classPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Search where the class name is used. PHP treats class names case
+        // insensitive, that's why we cannot search for the exact class name string
+        // and need to iterate over all T_STRING tokens in the file.
+        $classUsed      = $phpcsFile->findNext(T_STRING, ($classPtr + 1));
+        $lowerClassName = strtolower($tokens[$classPtr]['content']);
+
+        // Check if the referenced class is in the same namespace as the current
+        // file. If it is then the use statement is not necessary.
+        $namespacePtr = $phpcsFile->findPrevious([T_NAMESPACE], $stackPtr);
+        // Check if the use statement does aliasing with the "as" keyword. Aliasing
+        // is allowed even in the same namespace.
+        $aliasUsed = $phpcsFile->findPrevious(T_AS, ($classPtr - 1), $stackPtr);
+
+        if ($namespacePtr !== false && $aliasUsed === false) {
+            $nsEnd     = $phpcsFile->findNext(
+                [
+                    T_NS_SEPARATOR,
+                    T_STRING,
+                    T_WHITESPACE,
+                ],
+                ($namespacePtr + 1),
+                null,
+                true
+            );
+            $namespace = trim($phpcsFile->getTokensAsString(($namespacePtr + 1), ($nsEnd - $namespacePtr - 1)));
+
+            $useNamespacePtr = $phpcsFile->findNext([T_STRING], ($stackPtr + 1));
+            $useNamespaceEnd = $phpcsFile->findNext(
+                [
+                    T_NS_SEPARATOR,
+                    T_STRING,
+                ],
+                ($useNamespacePtr + 1),
+                null,
+                true
+            );
+            $useNamespace    = rtrim($phpcsFile->getTokensAsString($useNamespacePtr, ($useNamespaceEnd - $useNamespacePtr - 1)), '\\');
+
+            if (strcasecmp($namespace, $useNamespace) === 0) {
+                $classUsed = false;
+            }
+        }//end if
+
+        while ($classUsed !== false) {
+            if (strtolower($tokens[$classUsed]['content']) === $lowerClassName) {
+                // If the name is used in a PHP 7 function return type declaration
+                // stop.
+                if ($tokens[$classUsed]['code'] === T_RETURN_TYPE) {
+                    return;
+                }
+
+                $beforeUsage = $phpcsFile->findPrevious(
+                    Tokens::$emptyTokens,
+                    ($classUsed - 1),
+                    null,
+                    true
+                );
+                // If a backslash is used before the class name then this is some other
+                // use statement.
+                if (in_array(
+                    $tokens[$beforeUsage]['code'],
+                    [
+                        T_USE,
+                        T_NS_SEPARATOR,
+                    // If an object operator is used then this is a method call
+                    // with the same name as the class name. Which means this is
+                    // not referring to the class.
+                        T_OBJECT_OPERATOR,
+                    // Function definition, not class invocation.
+                        T_FUNCTION,
+                    // Static method call, not class invocation.
+                        T_DOUBLE_COLON,
+                    ]
+                ) === false
+                ) {
+                    return;
+                }
+
+                // Trait use statement within a class.
+                if ($tokens[$beforeUsage]['code'] === T_USE && empty($tokens[$beforeUsage]['conditions']) === false) {
+                    return;
+                }
+            }//end if
+
+            $classUsed = $phpcsFile->findNext([T_STRING, T_RETURN_TYPE], ($classUsed + 1));
+        }//end while
+
+        $warning = 'Unused use statement';
+        $fix     = $phpcsFile->addFixableWarning($warning, $stackPtr, 'UnusedUse');
+        if ($fix === true) {
+            // Remove the whole use statement line.
+            $phpcsFile->fixer->beginChangeset();
+            for ($i = $stackPtr; $i <= $semiColon; $i++) {
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+
+            // Also remove whitespace after the semicolon (new lines).
+            while (isset($tokens[$i]) === true && $tokens[$i]['code'] === T_WHITESPACE) {
+                $phpcsFile->fixer->replaceToken($i, '');
+                if (strpos($tokens[$i]['content'], $phpcsFile->eolChar) !== false) {
+                    break;
+                }
+
+                $i++;
+            }
+
+            // Replace @var data types in doc comments with the fully qualified class
+            // name.
+            $useNamespacePtr = $phpcsFile->findNext([T_STRING], ($stackPtr + 1));
+            $useNamespaceEnd = $phpcsFile->findNext(
+                [
+                    T_NS_SEPARATOR,
+                    T_STRING,
+                ],
+                ($useNamespacePtr + 1),
+                null,
+                true
+            );
+            $fullNamespace   = $phpcsFile->getTokensAsString($useNamespacePtr, ($useNamespaceEnd - $useNamespacePtr));
+
+            $tag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($stackPtr + 1));
+
+            while ($tag !== false) {
+                if (($tokens[$tag]['content'] === '@var' || $tokens[$tag]['content'] === '@return')
+                    && isset($tokens[($tag + 1)]) === true
+                    && $tokens[($tag + 1)]['code'] === T_DOC_COMMENT_WHITESPACE
+                    && isset($tokens[($tag + 2)]) === true
+                    && $tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING
+                    && strpos($tokens[($tag + 2)]['content'], $tokens[$classPtr]['content']) === 0
+                ) {
+                    $replacement = '\\'.$fullNamespace.substr($tokens[($tag + 2)]['content'], strlen($tokens[$classPtr]['content']));
+                    $phpcsFile->fixer->replaceToken(($tag + 2), $replacement);
+                }
+
+                $tag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($tag + 1));
+            }
+
+            $phpcsFile->fixer->endChangeset();
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/UseGlobalClassSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/UseGlobalClassSniff.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Classes\UseGlobalClassSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks non-namespaced classes are referenced by FQN, not imported.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class UseGlobalClassSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_USE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return $phpcsFile->numTokens + 1 to skip
+     *                  the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Find the first declaration, marking the end of the use statements.
+        $bodyStart = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT, T_FUNCTION], 0);
+
+        // Ensure we are in the global scope, to exclude trait use statements.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            return;
+        }
+
+        // End of the full statement.
+        $stmtEnd = $phpcsFile->findNext(T_SEMICOLON, $stackPtr);
+
+        $lineStart = $stackPtr;
+        // Iterate through a potential multiline use statement.
+        while (false !== $lineEnd = $phpcsFile->findNext([T_SEMICOLON, T_COMMA], ($lineStart + 1), ($stmtEnd + 1))) {
+            // We are only interested in imports that contain no backslash,
+            // which means this is a class without a namespace.
+            // Also skip function imports.
+            if ($phpcsFile->findNext(T_NS_SEPARATOR, $lineStart, $lineEnd) !== false
+                || $phpcsFile->findNext(T_STRING, $lineStart, $lineEnd, false, 'function') !== false
+            ) {
+                $lineStart = $lineEnd;
+                continue;
+            }
+
+            // The first string token is the class name.
+            $class     = $phpcsFile->findNext(T_STRING, $lineStart, $lineEnd);
+            $className = $tokens[$class]['content'];
+            // If there is more than one string token, the last one is the alias.
+            $alias     = $phpcsFile->findPrevious(T_STRING, $lineEnd, $stackPtr);
+            $aliasName = $tokens[$alias]['content'];
+
+            $error = 'Non-namespaced classes/interfaces/traits should not be referenced with use statements';
+            $fix   = $phpcsFile->addFixableError($error, $class, 'RedundantUseStatement');
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+
+                // Remove the entire line by default.
+                $start = $lineStart;
+                $end   = $lineEnd;
+                $next  = $phpcsFile->findNext(T_WHITESPACE, ($end + 1), null, true);
+
+                if ($tokens[$lineStart]['code'] === T_COMMA) {
+                    // If there are lines before this one,
+                    // then leave the ending delimiter in place.
+                    $end = ($lineEnd - 1);
+                } else if ($tokens[$lineEnd]['code'] === T_COMMA) {
+                    // If there are lines after, but not before,
+                    // then leave the use keyword.
+                    $start = $class;
+                } else if ($tokens[$next]['code'] === T_USE) {
+                    // If the whole statement is removed, and there is one after it,
+                    // then also remove the linebreaks.
+                    $end = ($next - 1);
+                }
+
+                for ($i = $start; $i <= $end; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                // Find all usages of the class, and add a leading backslash.
+                // Only start looking after the end of the use statement block.
+                $i = $bodyStart;
+                while (false !== $i = $phpcsFile->findNext(T_STRING, ($i + 1), null, false, $aliasName)) {
+                    if ($tokens[($i - 1)]['code'] !== T_NS_SEPARATOR) {
+                        $phpcsFile->fixer->replaceToken($i, '\\'.$className);
+                    }
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }//end if
+
+            $lineStart = $lineEnd;
+        }//end while
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Classes/UseLeadingBackslashSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Classes/UseLeadingBackslashSniff.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Classes\UseLeadingBackslashSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Classes;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Use statements to import classes must not begin with "\".
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class UseLeadingBackslashSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_USE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Only check use statements in the global scope.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            return;
+        }
+
+        $startPtr = $phpcsFile->findNext(
+            Tokens::$emptyTokens,
+            ($stackPtr + 1),
+            null,
+            true
+        );
+
+        if ($startPtr !== false && $tokens[$startPtr]['code'] === T_NS_SEPARATOR) {
+            $error = 'When importing a class with "use", do not include a leading \\';
+            $fix   = $phpcsFile->addFixableError($error, $startPtr, 'SeparatorStart');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($startPtr, '');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/ClassCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/ClassCommentSniff.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Parses and verifies the class doc comment.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks that comment doc blocks exist on classes, interfaces and traits. Largely
+ * copied from PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\ClassCommentSniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2014 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ClassCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $find   = Tokens::$methodPrefixes;
+        $find[] = T_WHITESPACE;
+        $name   = $tokens[$stackPtr]['content'];
+
+        $commentEnd = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT
+        ) {
+            $fix = $phpcsFile->addFixableError('Missing %s doc comment', $stackPtr, 'Missing', [$name]);
+            if ($fix === true) {
+                $phpcsFile->fixer->addContent($commentEnd, "\n/**\n *\n */");
+            }
+
+            return;
+        }
+
+        // Try and determine if this is a file comment instead of a class comment.
+        if ($tokens[$commentEnd]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+            $start = ($tokens[$commentEnd]['comment_opener'] - 1);
+        } else {
+            $start = ($commentEnd - 1);
+        }
+
+        $fileTag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($start + 1), $commentEnd, false, '@file');
+        if ($fileTag !== false) {
+            // This is a file comment.
+            $fix = $phpcsFile->addFixableError('Missing %s doc comment', $stackPtr, 'Missing', [$name]);
+            if ($fix === true) {
+                $phpcsFile->fixer->addContent($commentEnd, "\n/**\n *\n */");
+            }
+
+            return;
+        }
+
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            $fix = $phpcsFile->addFixableError('You must use "/**" style comments for a %s comment', $stackPtr, 'WrongStyle', [$name]);
+            if ($fix === true) {
+                // Convert the comment into a doc comment.
+                $phpcsFile->fixer->beginChangeset();
+                $comment = '';
+                for ($i = $commentEnd; $tokens[$i]['code'] === T_COMMENT; $i--) {
+                    $comment = ' *'.ltrim($tokens[$i]['content'], '/* ').$comment;
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($commentEnd, "/**\n".rtrim($comment, "*/\n")."\n */");
+                $phpcsFile->fixer->endChangeset();
+            }
+
+            return;
+        }
+
+        if ($tokens[$commentEnd]['line'] !== ($tokens[$stackPtr]['line'] - 1)) {
+            $error = 'There must be exactly one newline after the %s comment';
+            $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'SpacingAfter', [$name]);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($commentEnd + 1); $tokens[$i]['code'] === T_WHITESPACE && $i < $stackPtr; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->addContent($commentEnd, "\n");
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        $comment = [];
+        for ($i = $start; $i < $commentEnd; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG) {
+                break;
+            }
+
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                $comment[] = $tokens[$i]['content'];
+            }
+        }
+
+        $words = explode(' ', implode(' ', $comment));
+        if (count($words) <= 2) {
+            $className = $phpcsFile->getDeclarationName($stackPtr);
+
+            foreach ($words as $word) {
+                // Check if the comment contains the class name.
+                if (strpos($word, $className) !== false) {
+                    $error = 'The class short comment should describe what the class does and not simply repeat the class name';
+                    $phpcsFile->addWarning($error, $commentEnd, 'Short');
+                    break;
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DataTypeNamespaceSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DataTypeNamespaceSniff.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Commenting\DataTypeNamespaceSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks that data types in param, return, var, and throws tags are fully namespaced.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class DataTypeNamespaceSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_USE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Only check use statements in the global scope.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            return;
+        }
+
+        // Seek to the end of the statement and get the string before the semi colon.
+        $semiColon = $phpcsFile->findEndOfStatement($stackPtr);
+        if ($tokens[$semiColon]['code'] !== T_SEMICOLON) {
+            return;
+        }
+
+        $classPtr = $phpcsFile->findPrevious(
+            Tokens::$emptyTokens,
+            ($semiColon - 1),
+            null,
+            true
+        );
+
+        if ($tokens[$classPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Replace @var data types in doc comments with the fully qualified class
+        // name.
+        $useNamespacePtr = $phpcsFile->findNext([T_STRING], ($stackPtr + 1));
+        $useNamespaceEnd = $phpcsFile->findNext(
+            [
+                T_NS_SEPARATOR,
+                T_STRING,
+            ],
+            ($useNamespacePtr + 1),
+            null,
+            true
+        );
+        $fullNamespace   = $phpcsFile->getTokensAsString($useNamespacePtr, ($useNamespaceEnd - $useNamespacePtr));
+
+        $tag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($stackPtr + 1));
+
+        while ($tag !== false) {
+            if (($tokens[$tag]['content'] === '@var'
+                || $tokens[$tag]['content'] === '@return'
+                || $tokens[$tag]['content'] === '@param'
+                || $tokens[$tag]['content'] === '@throws')
+                && isset($tokens[($tag + 1)]) === true
+                && $tokens[($tag + 1)]['code'] === T_DOC_COMMENT_WHITESPACE
+                && isset($tokens[($tag + 2)]) === true
+                && $tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING
+                && strpos($tokens[($tag + 2)]['content'], $tokens[$classPtr]['content']) === 0
+            ) {
+                $error = 'Data types in %s tags need to be fully namespaced';
+                $data  = [$tokens[$tag]['content']];
+                $fix   = $phpcsFile->addFixableError($error, ($tag + 2), 'DataTypeNamespace', $data);
+                if ($fix === true) {
+                    $replacement = '\\'.$fullNamespace.substr($tokens[($tag + 2)]['content'], strlen($tokens[$classPtr]['content']));
+                    $phpcsFile->fixer->replaceToken(($tag + 2), $replacement);
+                }
+            }
+
+            $tag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($tag + 1));
+        }//end while
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DeprecatedSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DeprecatedSniff.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Commenting\DeprecatedSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Config;
+
+/**
+ * Ensures standard format of @ deprecated tag text in docblock.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class DeprecatedSniff implements Sniff
+{
+
+    /**
+     * Show debug output for this sniff.
+     *
+     * Use phpcs --runtime-set deprecated_debug true
+     *
+     * @var boolean
+     */
+    private $debug = false;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        if (defined('PHP_CODESNIFFER_IN_TESTS') === true) {
+            $this->debug = false;
+        }
+
+        return [T_DOC_COMMENT_TAG];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $debug = Config::getConfigData('deprecated_debug');
+        if ($debug !== null) {
+            $this->debug = (bool) $debug;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Only process @deprecated tags.
+        if (strcasecmp($tokens[$stackPtr]['content'], '@deprecated') !== 0) {
+            return;
+        }
+
+        // Get the end point of the comment block which has the deprecated tag.
+        $commentEnd = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, ($stackPtr + 1));
+
+        // Get the full @deprecated text which may cover multiple lines.
+        $textItems = [];
+        $lastLine  = $tokens[($stackPtr + 1)]['line'];
+        for ($i = ($stackPtr + 1); $i < $commentEnd; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                if ($tokens[$i]['line'] <= ($lastLine + 1)) {
+                    $textItems[$i] = $tokens[$i]['content'];
+                    $lastLine      = $tokens[$i]['line'];
+                } else {
+                    break;
+                }
+            }
+
+            // Found another tag, so we have all the deprecation text.
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG) {
+                break;
+            }
+        }
+
+        // The standard format for the deprecation text is:
+        // @deprecated in %in-version% and is removed from %removal-version%. %extra-info%.
+        $standardFormat = "@deprecated in %%deprecation-version%% and is removed from %%removal-version%%. %%extra-info%%.";
+
+        // Use (?U) 'ungreedy' before the removal-version so that only the text
+        // up to the first dot+space is matched, as there may be more than one
+        // sentence in the extra-info part.
+        $fullText = trim(implode(' ', $textItems));
+        $matches  = [];
+        preg_match('/^in (.+) and is removed from (?U)(.+)(?:\. | |\.$|$)(.*)$/', $fullText, $matches);
+        // There should be 4 items in $matches: 0 is full text, 1 = in-version,
+        // 2 = removal-version, 3 = extra-info (can be blank at this stage).
+        if (count($matches) !== 4) {
+            // The full text does not match the standard. Try to find fixes by
+            // testing with a relaxed set of criteria, based on common
+            // formatting variations. This is designed for Core fixes only.
+            $error = "The text '@deprecated %s' does not match the standard format: ".$standardFormat;
+            // All of the standard text should be on the first comment line, so
+            // try to match with common formatting errors to allow an automatic
+            // fix. If not possible then report a normal error.
+            $matchesFix = [];
+            $fix        = null;
+            if (count($textItems) > 0) {
+                // Get just the first line of the text.
+                $key   = array_keys($textItems)[0];
+                $text1 = $textItems[$key];
+                // Matching on (backdrop|) here says that we are only attempting to provide
+                // automatic fixes for Backdrop core, and if the project is missing we are
+                // assuming it is Backdrop core. Deprecations for contrib projects are much
+                // less frequent and faults can be corrected manually.
+                preg_match('/^(.*)(as of|in) (backdrop|)( |:|)+([\d\.\-xdev\?]+)(,| |. |)(.*)(removed|removal)([ |from|before|in|the]*) (backdrop|)( |:|)([\d\-\.xdev]+)( |,|$)+(?:release|)(?:[\.,])*(.*)$/i', $text1, $matchesFix);
+
+                if (count($matchesFix) >= 12) {
+                    // It is a Backdrop core deprecation and is fixable.
+                    if (empty($matchesFix[1]) === false && $this->debug === true) {
+                        // For info, to check it is acceptable to remove the text in [1].
+                        echo('DEBUG: File: '.$phpcsFile->path.', line '.$tokens[($stackPtr)]['line'].PHP_EOL);
+                        echo('DEBUG: "@deprecated '.$text1.'"'.PHP_EOL);
+                        echo('DEBUG: Fix will remove: "'.$matchesFix[1].'"'.PHP_EOL);
+                    }
+
+                    $ver1 = str_Replace(['-dev', 'x'], ['', '0'], trim($matchesFix[5], '.'));
+                    $ver2 = str_Replace(['-dev', 'x'], ['', '0'], trim($matchesFix[12], '.'));
+                    // If the version is short, add enough '.0' to correct it.
+                    while (substr_count($ver1, '.') < 2) {
+                        $ver1 .= '.0';
+                    }
+
+                    while (substr_count($ver2, '.') < 2) {
+                        $ver2 .= '.0';
+                    }
+
+                    $correctedText = trim('in backdrop:'.$ver1.' and is removed from backdrop:'.$ver2.'. '.trim($matchesFix[14]));
+                    // If $correctedText is longer than 65 this will make the whole line
+                    // exceed 80 so give a warning if running with debug.
+                    if (strlen($correctedText) > 65 && $this->debug === true) {
+                        echo('WARNING: File '.$phpcsFile->path.', line '.$tokens[($stackPtr)]['line'].PHP_EOL);
+                        echo('WARNING: Original  = * @deprecated '.$text1.PHP_EOL);
+                        echo('WARNING: Corrected = * @deprecated '.$correctedText.PHP_EOL);
+                        echo('WARNING: New line length '.(strlen($correctedText) + 15).' exceeds standard 80 character limit'.PHP_EOL);
+                    }
+
+                    $fix = $phpcsFile->addFixableError($error, $key, 'IncorrectTextLayout', [$fullText]);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($key, $correctedText);
+                    }
+                }//end if
+            }//end if
+
+            if ($fix === null) {
+                // There was no automatic fix, so give a normal error.
+                $phpcsFile->addError($error, $stackPtr, 'IncorrectTextLayout', [$fullText]);
+            }
+        } else {
+            // The text follows the basic layout. Now check that the versions
+            // match backdrop:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n]
+            // or project:n.n.n or project:n.n.n-version[n].
+            // The text must be all lower case and numbers can be one or two digits.
+            foreach (['deprecation-version' => $matches[1], 'removal-version' => $matches[2]] as $name => $version) {
+                if (preg_match('/^[a-z\d_]+:(\d{1,2}\.\d{1,2}\.\d{1,2}|\d{1,2}\.x\-\d{1,2}\.\d{1,2})(-[a-z]{1,5}\d{1,2})?$/', $version) === 0) {
+                    $error = "The %s '%s' does not match the lower-case machine-name standard: backdrop:n.n.n or project:n.x-n.n or project:n.x-n.n-version[n] or project:n.n.n or project:n.n.n-version[n]";
+                    $phpcsFile->addWarning($error, $stackPtr, 'DeprecatedVersionFormat', [$name, $version]);
+                }
+            }
+
+            // The 'IncorrectTextLayout' above is designed to pass if all is ok
+            // except for missing extra info. This is a common fault so provide
+            // a separate check and message for this.
+            if ($matches[3] === '') {
+                $error = 'The @deprecated tag must have %extra-info%. The standard format is: '.str_replace('%%', '%', $standardFormat);
+                $phpcsFile->addError($error, $stackPtr, 'MissingExtraInfo', []);
+            }
+        }//end if
+
+        // The next tag in this comment block after @deprecated must be @see.
+        $seeTag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($stackPtr + 1), $commentEnd, false, '@see');
+        if ($seeTag === false) {
+            $error = 'Each @deprecated tag must have a @see tag immediately following it';
+            $phpcsFile->addError($error, $stackPtr, 'DeprecatedMissingSeeTag');
+            return;
+        }
+
+        // Check the format of the @see url.
+        $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, ($seeTag + 1), $commentEnd);
+        // If the @see tag exists but has no content then $string will be empty
+        // and $tokens[$string]['content'] will return '<?php' which makes the
+        // standards message confusing. Better to set crLink to blank here.
+        if ($string === false) {
+            $crLink = ' ';
+        } else {
+            $crLink = $tokens[$string]['content'];
+        }
+
+        // Allow for the alternative 'node' or 'project/aaa/issues' format.
+        preg_match('[^http(s*)://www.backdrop.org/(node|project/\w+/issues)/(\d+)([\.\?\;!]*)$]', $crLink, $matches);
+        if (isset($matches[4]) === true && empty($matches[4]) === false) {
+            // If matches[4] is not blank it means that the url is OK but it
+            // ends with punctuation. This is a common and fixable mistake.
+            $error = "The @see url '%s' should not end with punctuation";
+            $fix   = $phpcsFile->addFixableError($error, $string, 'DeprecatedPeriodAfterSeeUrl', [$crLink]);
+            if ($fix === true) {
+                // Remove all of the the trailing punctuation.
+                $content = substr($crLink, 0, -(strlen($matches[4])));
+                $phpcsFile->fixer->replaceToken($string, $content);
+            }//end if
+        } else if (empty($matches) === true) {
+            $error = "The @see url '%s' does not match the standard: http(s)://www.backdrop.org/node/n or http(s)://www.backdrop.org/project/aaa/issues/n";
+            $phpcsFile->addWarning($error, $seeTag, 'DeprecatedWrongSeeUrlFormat', [$crLink]);
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DocCommentAlignmentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DocCommentAlignmentSniff.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Commenting\DocCommentAlignmentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\DocCommentAlignmentSniff to also
+ * handle the "var" keyword. See
+ * https://github.com/squizlabs/PHP_CodeSniffer/pull/1212
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class DocCommentAlignmentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_DOC_COMMENT_OPEN_TAG];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // We are only interested in function/class/interface doc block comments.
+        $ignore = Tokens::$emptyTokens;
+        if ($phpcsFile->tokenizerType === 'JS') {
+            $ignore[] = T_EQUAL;
+            $ignore[] = T_STRING;
+            $ignore[] = T_OBJECT_OPERATOR;
+        }
+
+        $nextToken = $phpcsFile->findNext($ignore, ($stackPtr + 1), null, true);
+        $ignore    = [
+            T_CLASS     => true,
+            T_INTERFACE => true,
+            T_FUNCTION  => true,
+            T_PUBLIC    => true,
+            T_PRIVATE   => true,
+            T_PROTECTED => true,
+            T_STATIC    => true,
+            T_ABSTRACT  => true,
+            T_PROPERTY  => true,
+            T_OBJECT    => true,
+            T_PROTOTYPE => true,
+            T_VAR       => true,
+        ];
+
+        if (isset($ignore[$tokens[$nextToken]['code']]) === false) {
+            // Could be a file comment.
+            $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($tokens[$prevToken]['code'] !== T_OPEN_TAG) {
+                return;
+            }
+        }
+
+        // There must be one space after each star (unless it is an empty comment line)
+        // and all the stars must be aligned correctly.
+        $requiredColumn = ($tokens[$stackPtr]['column'] + 1);
+        $endComment     = $tokens[$stackPtr]['comment_closer'];
+        for ($i = ($stackPtr + 1); $i <= $endComment; $i++) {
+            if ($tokens[$i]['code'] !== T_DOC_COMMENT_STAR
+                && $tokens[$i]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            ) {
+                continue;
+            }
+
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_CLOSE_TAG) {
+                // Can't process the close tag if it is not the first thing on the line.
+                $prev = $phpcsFile->findPrevious(T_DOC_COMMENT_WHITESPACE, ($i - 1), $stackPtr, true);
+                if ($tokens[$prev]['line'] === $tokens[$i]['line']) {
+                    continue;
+                }
+            }
+
+            if ($tokens[$i]['column'] !== $requiredColumn) {
+                $error = 'Expected %s space(s) before asterisk; %s found';
+                $data  = [
+                    ($requiredColumn - 1),
+                    ($tokens[$i]['column'] - 1),
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $i, 'SpaceBeforeStar', $data);
+                if ($fix === true) {
+                    $padding = str_repeat(' ', ($requiredColumn - 1));
+                    if ($tokens[$i]['column'] === 1) {
+                        $phpcsFile->fixer->addContentBefore($i, $padding);
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($i - 1), $padding);
+                    }
+                }
+            }
+
+            if ($tokens[$i]['code'] !== T_DOC_COMMENT_STAR) {
+                continue;
+            }
+
+            if ($tokens[($i + 2)]['line'] !== $tokens[$i]['line']) {
+                // Line is empty.
+                continue;
+            }
+
+            if ($tokens[($i + 1)]['code'] !== T_DOC_COMMENT_WHITESPACE) {
+                $error = 'Expected 1 space after asterisk; 0 found';
+                $fix   = $phpcsFile->addFixableError($error, $i, 'NoSpaceAfterStar');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($i, ' ');
+                }
+            } else if ($tokens[($i + 2)]['code'] === T_DOC_COMMENT_TAG
+                && $tokens[($i + 1)]['content'] !== ' '
+                // Special @code/@endcode/@see tags can have more than 1 space.
+                && in_array(
+                    $tokens[($i + 2)]['content'],
+                    [
+                        '@param',
+                        '@return',
+                        '@throws',
+                        '@ingroup',
+                        '@var',
+                    ]
+                ) === true
+            ) {
+                $error = 'Expected 1 space after asterisk; %s found';
+                $data  = [strlen($tokens[($i + 1)]['content'])];
+                $fix   = $phpcsFile->addFixableError($error, $i, 'SpaceAfterStar', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($i + 1), ' ');
+                }
+            }//end if
+        }//end for
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DocCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DocCommentSniff.php
@@ -1,0 +1,531 @@
+<?php
+/**
+ * Ensures doc blocks follow basic formatting.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Ensures doc blocks follow basic formatting.
+ *
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\DocCommentSniff,
+ * but Backdrop @file comments are different.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class DocCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_DOC_COMMENT_OPEN_TAG];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $commentEnd   = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, ($stackPtr + 1));
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+
+        $empty = [
+            T_DOC_COMMENT_WHITESPACE,
+            T_DOC_COMMENT_STAR,
+        ];
+
+        $short = $phpcsFile->findNext($empty, ($stackPtr + 1), $commentEnd, true);
+        if ($short === false) {
+            // No content at all.
+            $error = 'Doc comment is empty';
+            $phpcsFile->addError($error, $stackPtr, 'Empty');
+            return;
+        }
+
+        // Ignore doc blocks in functions, this is handled by InlineCommentSniff.
+        if (empty($tokens[$stackPtr]['conditions']) === false && in_array(T_FUNCTION, $tokens[$stackPtr]['conditions']) === true) {
+            return;
+        }
+
+        // The first line of the comment should just be the /** code.
+        // In JSDoc there are cases with @lends that are on the same line as code.
+        if ($tokens[$short]['line'] === $tokens[$stackPtr]['line'] && $phpcsFile->tokenizerType !== 'JS') {
+            $error = 'The open comment tag must be the only content on the line';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'ContentAfterOpen');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->addNewline($stackPtr);
+                $phpcsFile->fixer->addContentBefore($short, '* ');
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        // The last line of the comment should just be the */ code.
+        $prev = $phpcsFile->findPrevious($empty, ($commentEnd - 1), $stackPtr, true);
+        if ($tokens[$commentEnd]['content'] !== '*/') {
+            $error = 'Wrong function doc comment end; expected "*/", found "%s"';
+            $phpcsFile->addError($error, $commentEnd, 'WrongEnd', [$tokens[$commentEnd]['content']]);
+        }
+
+        // Check for additional blank lines at the end of the comment.
+        if ($tokens[$prev]['line'] < ($tokens[$commentEnd]['line'] - 1)) {
+            $error = 'Additional blank lines found at end of doc comment';
+            $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'SpacingAfter');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($prev + 1); $i < $commentEnd; $i++) {
+                    if ($tokens[($i + 1)]['line'] === $tokens[$commentEnd]['line']) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        // The short description of @file comments is one line below.
+        if ($tokens[$short]['code'] === T_DOC_COMMENT_TAG && $tokens[$short]['content'] === '@file') {
+            $next = $phpcsFile->findNext($empty, ($short + 1), $commentEnd, true);
+            if ($next !== false) {
+                $fileShort = $short;
+                $short     = $next;
+            }
+        }
+
+        // Do not check defgroup sections, they have no short description. Also don't
+        // check PHPUnit tests doc blocks because they might not have a description.
+        if (in_array($tokens[$short]['content'], ['@defgroup', '@addtogroup', '@}', '@coversDefaultClass']) === true) {
+            return;
+        }
+
+        // Check for a comment description.
+        if ($tokens[$short]['code'] !== T_DOC_COMMENT_STRING) {
+            // JSDoc has many cases of @type declaration that don't have a
+            // description.
+            if ($phpcsFile->tokenizerType === 'JS') {
+                return;
+            }
+
+            // PHPUnit test methods are allowed to skip the short description and
+            // only provide an @covers annotation.
+            if ($tokens[$short]['content'] === '@covers') {
+                return;
+            }
+
+            $error = 'Missing short description in doc comment';
+            $phpcsFile->addError($error, $stackPtr, 'MissingShort');
+            return;
+        }
+
+        if (isset($fileShort) === true) {
+            $start = $fileShort;
+        } else {
+            $start = $stackPtr;
+        }
+
+        // No extra newline before short description.
+        if ($tokens[$short]['line'] !== ($tokens[$start]['line'] + 1)) {
+            $error = 'Doc comment short description must be on the first line';
+            $fix   = $phpcsFile->addFixableError($error, $short, 'SpacingBeforeShort');
+            if ($fix === true) {
+                // Move file comment short description to the next line.
+                if (isset($fileShort) === true && $tokens[$short]['line'] === $tokens[$start]['line']) {
+                    $phpcsFile->fixer->addContentBefore($fileShort, "\n *");
+                } else {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = $start; $i < $short; $i++) {
+                        if ($tokens[$i]['line'] === $tokens[$start]['line']) {
+                            continue;
+                        } else if ($tokens[$i]['line'] === $tokens[$short]['line']) {
+                            break;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+        }//end if
+
+        if ($tokens[($short - 1)]['content'] !== ' '
+            && strpos($tokens[($short - 1)]['content'], $phpcsFile->eolChar) === false
+        ) {
+            $error = 'Function comment short description must start with exactly one space';
+            $fix   = $phpcsFile->addFixableError($error, $short, 'ShortStartSpace');
+            if ($fix === true) {
+                if ($tokens[($short - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken(($short - 1), ' ');
+                } else {
+                    $phpcsFile->fixer->addContent(($short - 1), ' ');
+                }
+            }
+        }
+
+        // Account for the fact that a short description might cover
+        // multiple lines.
+        $shortContent = $tokens[$short]['content'];
+        $shortEnd     = $short;
+        for ($i = ($short + 1); $i < $commentEnd; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                if ($tokens[$i]['line'] === ($tokens[$shortEnd]['line'] + 1)) {
+                    $shortContent .= $tokens[$i]['content'];
+                    $shortEnd      = $i;
+                } else {
+                    break;
+                }
+            }
+
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG) {
+                break;
+            }
+        }
+
+        // Remove any trailing white spaces which are detected by other sniffs.
+        $shortContent = trim($shortContent);
+
+        if (preg_match('|\p{Lu}|u', $shortContent[0]) === 0
+            // Allow both variants of inheritdoc comments.
+            && $shortContent !== '{@inheritdoc}'
+            && $shortContent !== '{@inheritDoc}'
+            // Ignore Features module export files that just use the file name as
+            // comment.
+            && $shortContent !== basename($phpcsFile->getFilename())
+        ) {
+            $error = 'Doc comment short description must start with a capital letter';
+            // If we cannot capitalize the first character then we don't have a
+            // fixable error.
+            if ($tokens[$short]['content'] === ucfirst($tokens[$short]['content'])) {
+                $phpcsFile->addError($error, $short, 'ShortNotCapital');
+            } else {
+                $fix = $phpcsFile->addFixableError($error, $short, 'ShortNotCapital');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($short, ucfirst($tokens[$short]['content']));
+                }
+            }
+        }
+
+        $lastChar = substr($shortContent, -1);
+        // Allow these characters as valid line-ends not requiring to be fixed.
+        if (in_array($lastChar, ['.', '!', '?', ')']) === false
+            // Allow both variants of inheritdoc comments.
+            && $shortContent !== '{@inheritdoc}'
+            && $shortContent !== '{@inheritDoc}'
+            // Ignore Features module export files that just use the file name as
+            // comment.
+            && $shortContent !== basename($phpcsFile->getFilename())
+        ) {
+            $error = 'Doc comment short description must end with a full stop';
+            // If the last character is alphanumeric and the content is all on one line then fix it.
+            if (preg_match('/[a-zA-Z0-9]/', $lastChar) === 1
+                && $tokens[$short]['line'] === $tokens[$shortEnd]['line']
+            ) {
+                $fix = $phpcsFile->addFixableError($error, $shortEnd, 'ShortFullStop');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($shortEnd, '.');
+                }
+            } else {
+                // The correct fix is not obvious, so report an error and leave for manual correction.
+                $phpcsFile->addError($error, $shortEnd, 'ShortFullStop');
+            }
+        }
+
+        if ($tokens[$short]['line'] !== $tokens[$shortEnd]['line']) {
+            $error = 'Doc comment short description must be on a single line, further text should be a separate paragraph';
+            $phpcsFile->addError($error, $shortEnd, 'ShortSingleLine');
+        }
+
+        $long = $phpcsFile->findNext($empty, ($shortEnd + 1), ($commentEnd - 1), true);
+        if ($long === false) {
+            return;
+        }
+
+        if ($tokens[$long]['code'] === T_DOC_COMMENT_STRING) {
+            if ($tokens[$long]['line'] !== ($tokens[$shortEnd]['line'] + 2)) {
+                $error = 'There must be exactly one blank line between descriptions in a doc comment';
+                $fix   = $phpcsFile->addFixableError($error, $long, 'SpacingBetween');
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($shortEnd + 1); $i < $long; $i++) {
+                        if ($tokens[$i]['line'] === $tokens[$shortEnd]['line']) {
+                            continue;
+                        } else if ($tokens[$i]['line'] === ($tokens[$long]['line'] - 1)) {
+                            break;
+                        }
+
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+
+            if (preg_match('|\p{Lu}|u', $tokens[$long]['content'][0]) === 0
+                && $tokens[$long]['content'] !== ucfirst($tokens[$long]['content'])
+            ) {
+                $error = 'Doc comment long description must start with a capital letter';
+                $fix   = $phpcsFile->addFixableError($error, $long, 'LongNotCapital');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken($long, ucfirst($tokens[$long]['content']));
+                }
+            }
+
+            // Account for the fact that a description might cover multiple lines.
+            $longContent = $tokens[$long]['content'];
+            $longEnd     = $long;
+            for ($i = ($long + 1); $i < $commentEnd; $i++) {
+                if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                    if ($tokens[$i]['line'] <= ($tokens[$longEnd]['line'] + 1)) {
+                        $longContent .= $tokens[$i]['content'];
+                        $longEnd      = $i;
+                    } else {
+                        break;
+                    }
+                }
+
+                if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG) {
+                    if ($tokens[$i]['line'] <= ($tokens[$longEnd]['line'] + 1)
+                        // Allow link tags within the long comment itself.
+                        && ($tokens[$i]['content'] === '@link' || $tokens[$i]['content'] === '@endlink')
+                    ) {
+                        $longContent .= $tokens[$i]['content'];
+                        $longEnd      = $i;
+                    } else {
+                        break;
+                    }
+                }
+            }//end for
+
+            // Remove any trailing white spaces which are detected by other sniffs.
+            $longContent = trim($longContent);
+
+            if (preg_match('/[a-zA-Z]$/', $longContent) === 1) {
+                $error = 'Doc comment long description must end with a full stop';
+                $fix   = $phpcsFile->addFixableError($error, $longEnd, 'LongFullStop');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContent($longEnd, '.');
+                }
+            }
+        }//end if
+
+        if (empty($tokens[$commentStart]['comment_tags']) === true) {
+            // No tags in the comment.
+            return;
+        }
+
+        $firstTag = $tokens[$commentStart]['comment_tags'][0];
+        $prev     = $phpcsFile->findPrevious($empty, ($firstTag - 1), $stackPtr, true);
+        // This does not apply to @file, @code, @link and @endlink tags.
+        if ($tokens[$firstTag]['line'] !== ($tokens[$prev]['line'] + 2)
+            && isset($fileShort) === false
+            && in_array($tokens[$firstTag]['content'], ['@code', '@link', '@endlink']) === false
+        ) {
+            $error = 'There must be exactly one blank line before the tags in a doc comment';
+            $fix   = $phpcsFile->addFixableError($error, $firstTag, 'SpacingBeforeTags');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($prev + 1); $i < $firstTag; $i++) {
+                    if ($tokens[$i]['line'] === $tokens[$firstTag]['line']) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $indent = str_repeat(' ', $tokens[$stackPtr]['column']);
+                $phpcsFile->fixer->addContent($prev, $phpcsFile->eolChar.$indent.'*'.$phpcsFile->eolChar);
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        // Break out the tags into groups and check alignment within each.
+        // A tag group is one where there are no blank lines between tags.
+        // The param tag group is special as it requires all @param tags to be inside.
+        $tagGroups    = [];
+        $groupid      = 0;
+        $paramGroupid = null;
+        $currentTag   = null;
+        $previousTag  = null;
+        $isNewGroup   = null;
+        $checkTags    = [
+            '@param',
+            '@return',
+            '@throws',
+        ];
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($pos > 0) {
+                // If this tag is not in the same column as the initial tag then
+                // it must be an inline comment tag and should be ignored here.
+                if ($tokens[$tag]['column'] !== $tokens[$firstTag]['column']) {
+                    continue;
+                }
+
+                $prev = $phpcsFile->findPrevious(
+                    T_DOC_COMMENT_STRING,
+                    ($tag - 1),
+                    $tokens[$commentStart]['comment_tags'][($pos - 1)]
+                );
+
+                if ($prev === false) {
+                    $prev = $tokens[$commentStart]['comment_tags'][($pos - 1)];
+                }
+
+                $isNewGroup = $tokens[$prev]['line'] !== ($tokens[$tag]['line'] - 1);
+                if ($isNewGroup === true) {
+                    $groupid++;
+                }
+            }//end if
+
+            $currentTag = $tokens[$tag]['content'];
+            if ($currentTag === '@param') {
+                if (($paramGroupid === null
+                    && empty($tagGroups[$groupid]) === false)
+                    || ($paramGroupid !== null
+                    && $paramGroupid !== $groupid)
+                ) {
+                    $error = 'Parameter tags must be grouped together in a doc comment';
+                    $phpcsFile->addError($error, $tag, 'ParamGroup');
+                }
+
+                if ($paramGroupid === null) {
+                    $paramGroupid = $groupid;
+                }
+
+                // All of the $checkTags sections should be separated by a blank
+                // line both before and after the sections.
+            } else if ($isNewGroup === false
+                && (in_array($currentTag, $checkTags) === true || in_array($previousTag, $checkTags) === true)
+                && $previousTag !== $currentTag
+            ) {
+                $error = 'Separate the %s and %s sections by a blank line.';
+                $fix   = $phpcsFile->addFixableError($error, $tag, 'TagGroupSpacing', [$previousTag, $currentTag]);
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($tag - 1), "\n".str_repeat(' ', ($tokens[$tag]['column'] - 3)).'* ');
+                }
+            }//end if
+
+            $previousTag           = $currentTag;
+            $tagGroups[$groupid][] = $tag;
+        }//end foreach
+
+        foreach ($tagGroups as $group) {
+            $maxLength = 0;
+            $paddings  = [];
+            $pos       = 0;
+            foreach ($group as $pos => $tag) {
+                $tagLength = strlen($tokens[$tag]['content']);
+                if ($tagLength > $maxLength) {
+                    $maxLength = $tagLength;
+                }
+
+                // Check for a value. No value means no padding needed.
+                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
+                if ($string !== false && $tokens[$string]['line'] === $tokens[$tag]['line']) {
+                    $paddings[$tag] = strlen($tokens[($tag + 1)]['content']);
+                }
+            }
+
+            // Check that there was single blank line after the tag block
+            // but account for a multi-line tag comments.
+            $lastTag = $group[$pos];
+            $next    = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($lastTag + 3), $commentEnd);
+            if ($next !== false && $tokens[$next]['column'] === $tokens[$firstTag]['column']) {
+                $prev = $phpcsFile->findPrevious([T_DOC_COMMENT_TAG, T_DOC_COMMENT_STRING], ($next - 1), $commentStart);
+                if ($tokens[$next]['line'] !== ($tokens[$prev]['line'] + 2)) {
+                    $error = 'There must be a single blank line after a tag group';
+                    $fix   = $phpcsFile->addFixableError($error, $lastTag, 'SpacingAfterTagGroup');
+                    if ($fix === true) {
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = ($prev + 1); $i < $next; $i++) {
+                            if ($tokens[$i]['line'] === $tokens[$next]['line']) {
+                                break;
+                            }
+
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $indent = str_repeat(' ', $tokens[$stackPtr]['column']);
+                        $phpcsFile->fixer->addContent($prev, $phpcsFile->eolChar.$indent.'*'.$phpcsFile->eolChar);
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }
+            }//end if
+
+            // Now check paddings.
+            foreach ($paddings as $tag => $padding) {
+                if ($padding !== 1) {
+                    $error = 'Tag value indented incorrectly; expected 1 space but found %s';
+                    $data  = [$padding];
+
+                    $fix = $phpcsFile->addFixableError($error, ($tag + 1), 'TagValueIndent', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($tag + 1), ' ');
+                    }
+                }
+            }
+        }//end foreach
+
+        // If there is a param group, it needs to be first; with the exception of
+        // @code, @todo and link tags.
+        if ($paramGroupid !== null && $paramGroupid !== 0
+            && in_array($tokens[$tokens[$commentStart]['comment_tags'][0]]['content'], ['@code', '@todo', '@link', '@endlink', '@codingStandardsIgnoreStart']) === false
+            // In JSDoc we can have many other valid tags like @function or
+            // @constructor before the param tags.
+            && $phpcsFile->tokenizerType !== 'JS'
+        ) {
+            $error = 'Parameter tags must be defined first in a doc comment';
+            $phpcsFile->addError($error, $tagGroups[$paramGroupid][0], 'ParamNotFirst');
+        }
+
+        $foundTags = [];
+        $lastPos   = 0;
+        foreach ($tokens[$stackPtr]['comment_tags'] as $pos => $tag) {
+            $tagName = $tokens[$tag]['content'];
+            // Skip code tags, they can be anywhere.
+            if (in_array($tagName, $checkTags) === false) {
+                continue;
+            }
+
+            if (isset($foundTags[$tagName]) === true) {
+                $lastTag = $tokens[$stackPtr]['comment_tags'][$lastPos];
+                if ($tokens[$lastTag]['content'] !== $tagName) {
+                    $error = 'Tags must be grouped together in a doc comment';
+                    $phpcsFile->addError($error, $tag, 'TagsNotGrouped');
+                }
+            }
+
+            $foundTags[$tagName] = true;
+            $lastPos = $pos;
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DocCommentStarSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/DocCommentStarSniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Commenting\DocCommentStarSniff
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that a doc comment block has a doc comment star on every line.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class DocCommentStarSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_DOC_COMMENT_OPEN_TAG];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $lastLineChecked = $tokens[$stackPtr]['line'];
+        for ($i = ($stackPtr + 1); $i < ($tokens[$stackPtr]['comment_closer'] - 1); $i++) {
+            // We are only interested in the beginning of the line.
+            if ($tokens[$i]['line'] === $lastLineChecked) {
+                continue;
+            }
+
+            // The first token on the line must be a whitespace followed by a star.
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                if ($tokens[($i + 1)]['code'] !== T_DOC_COMMENT_STAR) {
+                    $error = 'Doc comment star missing';
+                    $fix   = $phpcsFile->addFixableError($error, $i, 'StarMissing');
+                    if ($fix === true) {
+                        if (strpos($tokens[$i]['content'], $phpcsFile->eolChar) !== false) {
+                            $phpcsFile->fixer->replaceToken($i, str_repeat(' ', $tokens[$stackPtr]['column'])."* \n");
+                        } else {
+                            $phpcsFile->fixer->replaceToken($i, str_repeat(' ', $tokens[$stackPtr]['column']).'* ');
+                        }
+
+                        // Ordering of lines might have changed - stop here. The
+                        // fixer will restart the sniff if there are remaining fixes.
+                        return;
+                    }
+                }
+            } else if ($tokens[$i]['code'] !== T_DOC_COMMENT_STAR) {
+                $error = 'Doc comment star missing';
+                $fix   = $phpcsFile->addFixableError($error, $i, 'StarMissing');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addContentBefore($i, str_repeat(' ', $tokens[$stackPtr]['column']).'* ');
+                }
+            }//end if
+
+            $lastLineChecked = $tokens[$i]['line'];
+        }//end for
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/FileCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/FileCommentSniff.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Parses and verifies the doc comments for files.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Parses and verifies the doc comments for files.
+ *
+ * Verifies that :
+ * <ul>
+ *  <li>A doc comment exists.</li>
+ *  <li>There is a blank newline after the @file statement.</li>
+ * </ul>
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+class FileCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_OPEN_TAG];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $commentStart = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+
+        // Files containing exactly one class, interface or trait are allowed to
+        // ommit a file doc block. If a namespace is used then the file comment must
+        // be omitted.
+        $oopKeyword = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT], $stackPtr);
+        if ($oopKeyword !== false) {
+            $namespace = $phpcsFile->findNext(T_NAMESPACE, $stackPtr);
+            // Check if the file contains multiple classes/interfaces/traits - then a
+            // file doc block is allowed.
+            $secondOopKeyword = $phpcsFile->findNext([T_CLASS, T_INTERFACE, T_TRAIT], ($oopKeyword + 1));
+            // Namespaced classes, interfaces and traits should not have an @file doc
+            // block.
+            if (($tokens[$commentStart]['code'] === T_DOC_COMMENT_OPEN_TAG
+                || $tokens[$commentStart]['code'] === T_COMMENT)
+                && $secondOopKeyword === false
+                && $namespace !== false
+            ) {
+                if ($tokens[$commentStart]['code'] === T_COMMENT) {
+                    $phpcsFile->addError('Namespaced classes, interfaces and traits should not begin with a file doc comment', $commentStart, 'NamespaceNoFileDoc');
+                } else {
+                    $fix = $phpcsFile->addFixableError('Namespaced classes, interfaces and traits should not begin with a file doc comment', $commentStart, 'NamespaceNoFileDoc');
+                    if ($fix === true) {
+                        $phpcsFile->fixer->beginChangeset();
+
+                        for ($i = $commentStart; $i <= ($tokens[$commentStart]['comment_closer'] + 1); $i++) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        // If, after removing the comment, there are two new lines
+                        // remove them.
+                        if ($tokens[($commentStart - 1)]['content'] === "\n" && $tokens[$i]['content'] === "\n") {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }
+            }//end if
+
+            if ($namespace !== false) {
+                return ($phpcsFile->numTokens + 1);
+            }
+
+            // Search for global functions before and after the class.
+            $function = $phpcsFile->findPrevious(T_FUNCTION, ($oopKeyword - 1));
+            if ($function === false) {
+                $function = $phpcsFile->findNext(T_FUNCTION, ($tokens[$oopKeyword]['scope_closer'] + 1));
+            }
+
+            $fileTag = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($commentStart + 1), null, false, '@file');
+
+            // No other classes, no other global functions and no explicit @file tag
+            // anywhere means it is ok to skip the file comment.
+            if ($secondOopKeyword === false && $function === false && $fileTag === false) {
+                return ($phpcsFile->numTokens + 1);
+            }
+        }//end if
+
+        if ($tokens[$commentStart]['code'] === T_COMMENT) {
+            $fix = $phpcsFile->addFixableError('You must use "/**" style comments for a file comment', $commentStart, 'WrongStyle');
+            if ($fix === true) {
+                $content = $tokens[$commentStart]['content'];
+
+                // If the comment starts with something like "/**" then we just
+                // insert a space after the stars.
+                if (strpos($content, '/**') === 0) {
+                    $phpcsFile->fixer->replaceToken($commentStart, str_replace('/**', '/** ', $content));
+                } else if (strpos($content, '/*') === 0) {
+                    // Just turn the /* ... */ style comment into a /** ... */ style
+                    // comment.
+                    $phpcsFile->fixer->replaceToken($commentStart, str_replace('/*', '/**', $content));
+                } else {
+                    $content = trim(ltrim($tokens[$commentStart]['content'], '/# '));
+                    $phpcsFile->fixer->replaceToken($commentStart, "/**\n * @file\n * $content\n */\n");
+                }
+            }
+
+            return ($phpcsFile->numTokens + 1);
+        } else if ($commentStart === false || $tokens[$commentStart]['code'] !== T_DOC_COMMENT_OPEN_TAG) {
+            $fix = $phpcsFile->addFixableError('Missing file doc comment', 0, 'Missing');
+            if ($fix === true) {
+                // Only PHP has a real opening tag, additional newline at the
+                // beginning here.
+                if ($phpcsFile->tokenizerType === 'PHP') {
+                    // In templates add the file doc block to the very beginning of
+                    // the file.
+                    if ($tokens[0]['code'] === T_INLINE_HTML) {
+                        $phpcsFile->fixer->addContentBefore(0, "<?php\n\n/**\n * @file\n */\n?>\n");
+                    } else {
+                        $phpcsFile->fixer->addContent($stackPtr, "\n/**\n * @file\n */\n");
+                    }
+                } else {
+                    $phpcsFile->fixer->addContent($stackPtr, "/**\n * @file\n */\n");
+                }
+            }
+
+            return ($phpcsFile->numTokens + 1);
+        }//end if
+
+        $commentEnd = $tokens[$commentStart]['comment_closer'];
+        $fileTag    = $phpcsFile->findNext(T_DOC_COMMENT_TAG, ($commentStart + 1), $commentEnd, false, '@file');
+        $next       = $phpcsFile->findNext(T_WHITESPACE, ($commentEnd + 1), null, true);
+
+        // If there is no @file tag and the next line is a function or class
+        // definition then the file docblock is mising.
+        if ($tokens[$next]['line'] === ($tokens[$commentEnd]['line'] + 1)
+            && $tokens[$next]['code'] === T_FUNCTION
+        ) {
+            if ($fileTag === false) {
+                $fix = $phpcsFile->addFixableError('Missing file doc comment', $stackPtr, 'Missing');
+                if ($fix === true) {
+                    // Only PHP has a real opening tag, additional newline at the
+                    // beginning here.
+                    if ($phpcsFile->tokenizerType === 'PHP') {
+                        $phpcsFile->fixer->addContent($stackPtr, "\n/**\n * @file\n */\n");
+                    } else {
+                        $phpcsFile->fixer->addContent($stackPtr, "/**\n * @file\n */\n");
+                    }
+                }
+
+                return ($phpcsFile->numTokens + 1);
+            }
+        }//end if
+
+        if ($fileTag === false || $tokens[$fileTag]['line'] !== ($tokens[$commentStart]['line'] + 1)) {
+            $secondLine = $phpcsFile->findNext([T_DOC_COMMENT_STAR, T_DOC_COMMENT_CLOSE_TAG], ($commentStart + 1), $commentEnd);
+            $fix        = $phpcsFile->addFixableError('The second line in the file doc comment must be "@file"', $secondLine, 'FileTag');
+            if ($fix === true) {
+                if ($fileTag === false) {
+                    $phpcsFile->fixer->addContent($commentStart, "\n * @file");
+                } else {
+                    // Delete the @file tag at its current position and insert one
+                    // after the beginning of the comment.
+                    $phpcsFile->fixer->beginChangeset();
+                    $phpcsFile->fixer->addContent($commentStart, "\n * @file");
+                    $phpcsFile->fixer->replaceToken($fileTag, '');
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        // Exactly one blank line after the file comment.
+        if ($tokens[$next]['line'] !== ($tokens[$commentEnd]['line'] + 2)
+            && $next !== false && $tokens[$next]['code'] !== T_CLOSE_TAG
+        ) {
+            $error = 'There must be exactly one blank line after the file comment';
+            $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'SpacingAfterComment');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $uselessLine = ($commentEnd + 1);
+                while ($uselessLine < $next) {
+                    $phpcsFile->fixer->replaceToken($uselessLine, '');
+                    $uselessLine++;
+                }
+
+                $phpcsFile->fixer->addContent($commentEnd, "\n\n");
+                $phpcsFile->fixer->endChangeset();
+            }
+
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        // Template file: no blank line after the file comment.
+        if ($tokens[$next]['line'] !== ($tokens[$commentEnd]['line'] + 1)
+            && $tokens[$next]['line'] > $tokens[$commentEnd]['line']
+            && $tokens[$next]['code'] === T_CLOSE_TAG
+        ) {
+            $error = 'There must be no blank line after the file comment in a template';
+            $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'TeamplateSpacingAfterComment');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $uselessLine = ($commentEnd + 1);
+                while ($uselessLine < $next) {
+                    $phpcsFile->fixer->replaceToken($uselessLine, '');
+                    $uselessLine++;
+                }
+
+                $phpcsFile->fixer->addContent($commentEnd, "\n");
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        // Ignore the rest of the file.
+        return ($phpcsFile->numTokens + 1);
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/FunctionCommentSniff.php
@@ -1,0 +1,1088 @@
+<?php
+/**
+ * Parses and verifies the doc comments for functions.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Parses and verifies the doc comments for functions. Largely copied from
+ * PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\FunctionCommentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FunctionCommentSniff implements Sniff
+{
+
+    /**
+     * A map of invalid data types to valid ones for param and return documentation.
+     *
+     * @var array<string, string>
+     */
+    public static $invalidTypes = [
+        'Array'     => 'array',
+        'array()'   => 'array',
+        '[]'        => 'array',
+        'boolean'   => 'bool',
+        'Boolean'   => 'bool',
+        'integer'   => 'int',
+        'str'       => 'string',
+        'stdClass'  => 'object',
+        '\stdClass' => 'object',
+        'number'    => 'int',
+        'String'    => 'string',
+        'type'      => 'mixed',
+        'NULL'      => 'null',
+        'FALSE'     => 'false',
+        'TRUE'      => 'true',
+        'Bool'      => 'bool',
+        'Int'       => 'int',
+        'Integer'   => 'int',
+        'TRUEFALSE' => 'bool',
+    ];
+
+    /**
+     * An array of variable types for param/var we will check.
+     *
+     * @var array<string>
+     */
+    public $allowedTypes = [
+        'array',
+        'mixed',
+        'object',
+        'resource',
+        'callable',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $find   = Tokens::$methodPrefixes;
+        $find[] = T_WHITESPACE;
+
+        $commentEnd       = $phpcsFile->findPrevious($find, ($stackPtr - 1), null, true);
+        $beforeCommentEnd = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($commentEnd - 1), null, true);
+        if (($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT)
+            || ($beforeCommentEnd !== false
+            // If there is something more on the line than just the comment then the
+            // comment does not belong to the function.
+            && $tokens[$beforeCommentEnd]['line'] === $tokens[$commentEnd]['line'])
+        ) {
+            $fix = $phpcsFile->addFixableError('Missing function doc comment', $stackPtr, 'Missing');
+            if ($fix === true) {
+                $before = $phpcsFile->findNext(T_WHITESPACE, ($commentEnd + 1), ($stackPtr + 1), true);
+                $phpcsFile->fixer->addContentBefore($before, "/**\n *\n */\n");
+            }
+
+            return;
+        }
+
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            $fix = $phpcsFile->addFixableError('You must use "/**" style comments for a function comment', $stackPtr, 'WrongStyle');
+            if ($fix === true) {
+                // Convert the comment into a doc comment.
+                $phpcsFile->fixer->beginChangeset();
+                $comment = '';
+                for ($i = $commentEnd; $tokens[$i]['code'] === T_COMMENT; $i--) {
+                    $comment = ' *'.ltrim($tokens[$i]['content'], '/* ').$comment;
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($commentEnd, "/**\n".rtrim($comment, "*/\n")."\n */\n");
+                $phpcsFile->fixer->endChangeset();
+            }
+
+            return;
+        }
+
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            // This is a file comment, not a function comment.
+            if ($tokens[$tag]['content'] === '@file') {
+                $fix = $phpcsFile->addFixableError('Missing function doc comment', $stackPtr, 'Missing');
+                if ($fix === true) {
+                    $before = $phpcsFile->findNext(T_WHITESPACE, ($commentEnd + 1), ($stackPtr + 1), true);
+                    $phpcsFile->fixer->addContentBefore($before, "/**\n *\n */\n");
+                }
+
+                return;
+            }
+
+            if ($tokens[$tag]['content'] === '@see') {
+                // Make sure the tag isn't empty.
+                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
+                if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
+                    $error = 'Content missing for @see tag in function comment';
+                    $phpcsFile->addError($error, $tag, 'EmptySees');
+                }
+            }
+        }//end foreach
+
+        if ($tokens[$commentEnd]['line'] !== ($tokens[$stackPtr]['line'] - 1)) {
+            $error = 'There must be no blank lines after the function comment';
+            $fix   = $phpcsFile->addFixableError($error, $commentEnd, 'SpacingAfter');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($commentEnd + 1), '');
+            }
+        }
+
+        $this->processReturn($phpcsFile, $stackPtr, $commentStart);
+        $this->processThrows($phpcsFile, $stackPtr, $commentStart);
+        $this->processParams($phpcsFile, $stackPtr, $commentStart);
+        $this->processSees($phpcsFile, $stackPtr, $commentStart);
+
+    }//end process()
+
+
+    /**
+     * Process the return comment of this function comment.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processReturn(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Skip constructor and destructor.
+        $className = '';
+        foreach ($tokens[$stackPtr]['conditions'] as $condPtr => $condition) {
+            if ($condition === T_CLASS || $condition === T_INTERFACE) {
+                $className = $phpcsFile->getDeclarationName($condPtr);
+                $className = strtolower(ltrim($className, '_'));
+            }
+        }
+
+        $methodName      = $phpcsFile->getDeclarationName($stackPtr);
+        $isSpecialMethod = ($methodName === '__construct' || $methodName === '__destruct');
+        $methodName      = strtolower(ltrim($methodName, '_'));
+
+        $return = null;
+        $end    = $stackPtr;
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] === '@return') {
+                if ($return !== null) {
+                    $error = 'Only 1 @return tag is allowed in a function comment';
+                    $phpcsFile->addError($error, $tag, 'DuplicateReturn');
+                    return;
+                }
+
+                $return = $tag;
+                // Any strings until the next tag belong to this comment.
+                if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                    $skipTags = [
+                        '@code',
+                        '@endcode',
+                    ];
+                    $skipPos  = ($pos + 1);
+                    while (isset($tokens[$commentStart]['comment_tags'][$skipPos]) === true
+                        && in_array($tokens[$commentStart]['comment_tags'][$skipPos], $skipTags) === true
+                    ) {
+                        $skipPos++;
+                    }
+
+                    $end = $tokens[$commentStart]['comment_tags'][$skipPos];
+                } else {
+                    $end = $tokens[$commentStart]['comment_closer'];
+                }
+            }//end if
+        }//end foreach
+
+        $type = null;
+        if ($isSpecialMethod === false) {
+            if ($return !== null) {
+                $type = trim($tokens[($return + 2)]['content']);
+                if (empty($type) === true || $tokens[($return + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                    $error = 'Return type missing for @return tag in function comment';
+                    $phpcsFile->addError($error, $return, 'MissingReturnType');
+                } else if (strpos($type, ' ') === false) {
+                    // Check return type (can be multiple, separated by '|').
+                    $typeNames      = explode('|', $type);
+                    $suggestedNames = [];
+                    $hasNull        = false;
+
+                    foreach ($typeNames as $i => $typeName) {
+                        if (strtolower($typeName) === 'null') {
+                            $hasNull = true;
+                        }
+
+                        $suggestedName = static::suggestType($typeName);
+                        if (in_array($suggestedName, $suggestedNames) === false) {
+                            $suggestedNames[] = $suggestedName;
+                        }
+                    }
+
+                    $suggestedType = implode('|', $suggestedNames);
+                    if ($type !== $suggestedType) {
+                        $error = 'Expected "%s" but found "%s" for function return type';
+                        $data  = [
+                            $suggestedType,
+                            $type,
+                        ];
+                        $fix   = $phpcsFile->addFixableError($error, $return, 'InvalidReturn', $data);
+                        if ($fix === true) {
+                            $content = $suggestedType;
+                            $phpcsFile->fixer->replaceToken(($return + 2), $content);
+                        }
+                    }//end if
+
+                    if ($type === 'void') {
+                        $error = 'If there is no return value for a function, there must not be a @return tag.';
+                        $phpcsFile->addError($error, $return, 'VoidReturn');
+                    } else if ($type !== 'mixed') {
+                        // If return type is not void, there needs to be a return statement
+                        // somewhere in the function that returns something.
+                        if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+                            $endToken           = $tokens[$stackPtr]['scope_closer'];
+                            $foundReturnToken   = false;
+                            $searchStart        = $stackPtr;
+                            $foundNonVoidReturn = false;
+                            do {
+                                $returnToken = $phpcsFile->findNext([T_RETURN, T_YIELD, T_YIELD_FROM], $searchStart, $endToken);
+                                if ($returnToken === false && $foundReturnToken === false) {
+                                    $error = '@return doc comment specified, but function has no return statement';
+                                    $phpcsFile->addError($error, $return, 'InvalidNoReturn');
+                                } else {
+                                    // Check for return token as the last loop after the last return
+                                    // in the function will enter this else condition
+                                    // but without the returnToken.
+                                    if ($returnToken !== false) {
+                                        $foundReturnToken = true;
+                                        $semicolon        = $phpcsFile->findNext(T_WHITESPACE, ($returnToken + 1), null, true);
+                                        if ($tokens[$semicolon]['code'] === T_SEMICOLON) {
+                                            // Void return is allowed if the @return type has null in it.
+                                            if ($hasNull === false) {
+                                                $error = 'Function return type is not void, but function is returning void here';
+                                                $phpcsFile->addError($error, $returnToken, 'InvalidReturnNotVoid');
+                                            }
+                                        } else {
+                                            $foundNonVoidReturn = true;
+                                        }//end if
+
+                                        $searchStart = ($returnToken + 1);
+                                    }//end if
+                                }//end if
+                            } while ($returnToken !== false);
+
+                            if ($foundNonVoidReturn === false && $foundReturnToken === true) {
+                                $error = 'Function return type is not void, but function does not have a non-void return statement';
+                                $phpcsFile->addError($error, $return, 'InvalidReturnNotVoid');
+                            }
+                        }//end if
+                    }//end if
+                }//end if
+
+                $comment = '';
+                for ($i = ($return + 3); $i < $end; $i++) {
+                    if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                        $indent = 0;
+                        if ($tokens[($i - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                            $indent = strlen($tokens[($i - 1)]['content']);
+                        }
+
+                        $comment       .= ' '.$tokens[$i]['content'];
+                        $commentLines[] = [
+                            'comment' => $tokens[$i]['content'],
+                            'token'   => $i,
+                            'indent'  => $indent,
+                        ];
+                        if ($indent < 3) {
+                            $error = 'Return comment indentation must be 3 spaces, found %s spaces';
+                            $fix   = $phpcsFile->addFixableError($error, $i, 'ReturnCommentIndentation', [$indent]);
+                            if ($fix === true) {
+                                $phpcsFile->fixer->replaceToken(($i - 1), '   ');
+                            }
+                        }
+                    }
+                }//end for
+
+                // The first line of the comment must be indented no more than 3
+                // spaces, the following lines can be more so we only check the first
+                // line.
+                if (empty($commentLines[0]['indent']) === false && $commentLines[0]['indent'] > 3) {
+                    $error = 'Return comment indentation must be 3 spaces, found %s spaces';
+                    $fix   = $phpcsFile->addFixableError($error, ($commentLines[0]['token'] - 1), 'ReturnCommentIndentation', [$commentLines[0]['indent']]);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($commentLines[0]['token'] - 1), '   ');
+                    }
+                }
+
+                if ($comment === '' && $type !== '$this' && $type !== 'static') {
+                    if (strpos($type, ' ') !== false) {
+                        $error = 'Description for the @return value must be on the next line';
+                    } else {
+                        $error = 'Description for the @return value is missing';
+                    }
+
+                    $phpcsFile->addError($error, $return, 'MissingReturnComment');
+                } else if (strpos($type, ' ') !== false) {
+                    if (preg_match('/^([^\s]+)[\s]+(\$[^\s]+)[\s]*$/', $type, $matches) === 1) {
+                        $error = 'Return type must not contain variable name "%s"';
+                        $data  = [$matches[2]];
+                        $fix   = $phpcsFile->addFixableError($error, ($return + 2), 'ReturnVarName', $data);
+                        if ($fix === true) {
+                            $phpcsFile->fixer->replaceToken(($return + 2), $matches[1]);
+                        }
+                    } else {
+                        $error = 'Return type "%s" must not contain spaces';
+                        $data  = [$type];
+                        $phpcsFile->addError($error, $return, 'ReturnTypeSpaces', $data);
+                    }
+                }//end if
+            }//end if
+        }//end if
+
+    }//end processReturn()
+
+
+    /**
+     * Process any throw tags that this function comment has.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processThrows(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] !== '@throws') {
+                continue;
+            }
+
+            if ($tokens[($tag + 2)]['code'] !== T_DOC_COMMENT_STRING) {
+                $error = 'Exception type missing for @throws tag in function comment';
+                $phpcsFile->addError($error, $tag, 'InvalidThrows');
+            } else {
+                // Any strings until the next tag belong to this comment.
+                if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                    $end = $tokens[$commentStart]['comment_tags'][($pos + 1)];
+                } else {
+                    $end = $tokens[$commentStart]['comment_closer'];
+                }
+
+                $comment    = '';
+                $throwStart = null;
+                for ($i = ($tag + 3); $i < $end; $i++) {
+                    if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                        if ($throwStart === null) {
+                            $throwStart = $i;
+                        }
+
+                        $indent = 0;
+                        if ($tokens[($i - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                            $indent = strlen($tokens[($i - 1)]['content']);
+                        }
+
+                        $comment .= ' '.$tokens[$i]['content'];
+                        if ($indent < 3) {
+                            $error = 'Throws comment indentation must be 3 spaces, found %s spaces';
+                            $phpcsFile->addError($error, $i, 'TrhowsCommentIndentation', [$indent]);
+                        }
+                    }
+                }
+
+                $comment = trim($comment);
+
+                if ($comment === '') {
+                    if (str_word_count($tokens[($tag + 2)]['content'], 0, '\\_') > 1) {
+                        $error = '@throws comment must be on the next line';
+                        $phpcsFile->addError($error, $tag, 'ThrowsComment');
+                    }
+
+                    return;
+                }
+
+                // Starts with a capital letter and ends with a fullstop.
+                $firstChar = $comment[0];
+                if (strtoupper($firstChar) !== $firstChar) {
+                    $error = '@throws tag comment must start with a capital letter';
+                    $phpcsFile->addError($error, $throwStart, 'ThrowsNotCapital');
+                }
+
+                $lastChar = substr($comment, -1);
+                if (in_array($lastChar, ['.', '!', '?']) === false) {
+                    $error = '@throws tag comment must end with a full stop';
+                    $phpcsFile->addError($error, $throwStart, 'ThrowsNoFullStop');
+                }
+            }//end if
+        }//end foreach
+
+    }//end processThrows()
+
+
+    /**
+     * Process the function parameter comments.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processParams(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $params  = [];
+        $maxType = 0;
+        $maxVar  = 0;
+        foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+            if ($tokens[$tag]['content'] !== '@param') {
+                continue;
+            }
+
+            $type         = '';
+            $typeSpace    = 0;
+            $var          = '';
+            $varSpace     = 0;
+            $comment      = '';
+            $commentLines = [];
+            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
+                $matches = [];
+                preg_match('/([^$&]*)(?:((?:\$|&)[^\s]+)(?:(\s+)(.*))?)?/', $tokens[($tag + 2)]['content'], $matches);
+
+                $typeLen   = strlen($matches[1]);
+                $type      = trim($matches[1]);
+                $typeSpace = ($typeLen - strlen($type));
+                $typeLen   = strlen($type);
+                if ($typeLen > $maxType) {
+                    $maxType = $typeLen;
+                }
+
+                // If there is more than one word then it is a comment that should be
+                // on the next line.
+                if (isset($matches[4]) === true && ($typeLen > 0
+                    || preg_match('/[^\s]+[\s]+[^\s]+/', $matches[4]) === 1)
+                ) {
+                    $comment = $matches[4];
+                    $error   = 'Parameter comment must be on the next line';
+                    $fix     = $phpcsFile->addFixableError($error, ($tag + 2), 'ParamCommentNewLine');
+                    if ($fix === true) {
+                        $parts = $matches;
+                        unset($parts[0]);
+                        $parts[3] = "\n *   ";
+                        $phpcsFile->fixer->replaceToken(($tag + 2), implode('', $parts));
+                    }
+                }
+
+                if (isset($matches[2]) === true) {
+                    $var = $matches[2];
+                } else {
+                    $var = '';
+                }
+
+                if (substr($var, -1) === '.') {
+                    $error = 'Doc comment parameter name "%s" must not end with a dot';
+                    $fix   = $phpcsFile->addFixableError($error, ($tag + 2), 'ParamNameDot', [$var]);
+                    if ($fix === true) {
+                        $content = $type.' '.substr($var, 0, -1);
+                        $phpcsFile->fixer->replaceToken(($tag + 2), $content);
+                    }
+
+                    // Continue with the next parameter to avoid confusing
+                    // overlapping errors further down.
+                    continue;
+                }
+
+                $varLen = strlen($var);
+                if ($varLen > $maxVar) {
+                    $maxVar = $varLen;
+                }
+
+                // Any strings until the next tag belong to this comment.
+                if (isset($tokens[$commentStart]['comment_tags'][($pos + 1)]) === true) {
+                    // Ignore code tags and include them within this comment.
+                    $skipTags = [
+                        '@code',
+                        '@endcode',
+                        '@link',
+                    ];
+                    $skipPos  = $pos;
+                    while (isset($tokens[$commentStart]['comment_tags'][($skipPos + 1)]) === true) {
+                        $skipPos++;
+                        if (in_array($tokens[$tokens[$commentStart]['comment_tags'][$skipPos]]['content'], $skipTags) === false
+                            // Stop when we reached the next tag on the outer @param level.
+                            && $tokens[$tokens[$commentStart]['comment_tags'][$skipPos]]['column'] === $tokens[$tag]['column']
+                        ) {
+                            break;
+                        }
+                    }
+
+                    if ($tokens[$tokens[$commentStart]['comment_tags'][$skipPos]]['column'] === ($tokens[$tag]['column'] + 2)) {
+                        $end = $tokens[$commentStart]['comment_closer'];
+                    } else {
+                        $end = $tokens[$commentStart]['comment_tags'][$skipPos];
+                    }
+                } else {
+                    $end = $tokens[$commentStart]['comment_closer'];
+                }//end if
+
+                for ($i = ($tag + 3); $i < $end; $i++) {
+                    if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                        $indent = 0;
+                        if ($tokens[($i - 1)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                            $indent = strlen($tokens[($i - 1)]['content']);
+                            // There can be @code or @link tags within an @param comment.
+                            if ($tokens[($i - 2)]['code'] === T_DOC_COMMENT_TAG) {
+                                $indent = 0;
+                                if ($tokens[($i - 3)]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                                    $indent = strlen($tokens[($i - 3)]['content']);
+                                }
+                            }
+                        }
+
+                        $comment       .= ' '.$tokens[$i]['content'];
+                        $commentLines[] = [
+                            'comment' => $tokens[$i]['content'],
+                            'token'   => $i,
+                            'indent'  => $indent,
+                        ];
+                        if ($indent < 3) {
+                            $error = 'Parameter comment indentation must be 3 spaces, found %s spaces';
+                            $fix   = $phpcsFile->addFixableError($error, $i, 'ParamCommentIndentation', [$indent]);
+                            if ($fix === true) {
+                                $phpcsFile->fixer->replaceToken(($i - 1), '   ');
+                            }
+                        }
+                    }//end if
+                }//end for
+
+                // The first line of the comment must be indented no more than 3
+                // spaces, the following lines can be more so we only check the first
+                // line.
+                if (empty($commentLines[0]['indent']) === false && $commentLines[0]['indent'] > 3) {
+                    $error = 'Parameter comment indentation must be 3 spaces, found %s spaces';
+                    $fix   = $phpcsFile->addFixableError($error, ($commentLines[0]['token'] - 1), 'ParamCommentIndentation', [$commentLines[0]['indent']]);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken(($commentLines[0]['token'] - 1), '   ');
+                    }
+                }
+
+                if ($comment === '') {
+                    $error = 'Missing parameter comment';
+                    $phpcsFile->addError($error, $tag, 'MissingParamComment');
+                    $commentLines[] = ['comment' => ''];
+                }//end if
+
+                $variableArguments = false;
+                // Allow the "..." @param doc for a variable number of parameters.
+                // This could happen with type defined as @param array ... or
+                // without type defined as @param ...
+                if ($tokens[($tag + 2)]['content'] === '...'
+                    || (substr($tokens[($tag + 2)]['content'], -3) === '...'
+                    && count(explode(' ', $tokens[($tag + 2)]['content'])) === 2)
+                ) {
+                    $variableArguments = true;
+                }
+
+                if ($typeLen === 0) {
+                    $error = 'Missing parameter type';
+                    // If there is just one word as comment at the end of the line
+                    // then this is probably the data type. Move it before the
+                    // variable name.
+                    if (isset($matches[4]) === true && preg_match('/[^\s]+[\s]+[^\s]+/', $matches[4]) === 0) {
+                        $fix = $phpcsFile->addFixableError($error, $tag, 'MissingParamType');
+                        if ($fix === true) {
+                            $phpcsFile->fixer->replaceToken(($tag + 2), $matches[4].' '.$var);
+                        }
+                    } else {
+                        $phpcsFile->addError($error, $tag, 'MissingParamType');
+                    }
+                }
+
+                if (empty($matches[2]) === true && $variableArguments === false) {
+                    $error = 'Missing parameter name';
+                    $phpcsFile->addError($error, $tag, 'MissingParamName');
+                }
+            } else {
+                $error = 'Missing parameter type';
+                $phpcsFile->addError($error, $tag, 'MissingParamType');
+            }//end if
+
+            $params[] = [
+                'tag'          => $tag,
+                'type'         => $type,
+                'var'          => $var,
+                'comment'      => $comment,
+                'commentLines' => $commentLines,
+                'type_space'   => $typeSpace,
+                'var_space'    => $varSpace,
+            ];
+        }//end foreach
+
+        $realParams  = $phpcsFile->getMethodParameters($stackPtr);
+        $foundParams = [];
+
+        $checkPos = 0;
+        foreach ($params as $pos => $param) {
+            if ($param['var'] === '') {
+                continue;
+            }
+
+            $foundParams[] = $param['var'];
+
+            // If the type is empty, the whole line is empty.
+            if ($param['type'] === '') {
+                continue;
+            }
+
+            // Make sure the param name is correct.
+            $matched = false;
+            // Parameter documentation can be omitted for some parameters, so we have
+            // to search the rest for a match.
+            $realName = '<undefined>';
+            while (isset($realParams[($checkPos)]) === true) {
+                $realName = $realParams[$checkPos]['name'];
+
+                if ($realName === $param['var'] || ($realParams[$checkPos]['pass_by_reference'] === true
+                    && ('&'.$realName) === $param['var'])
+                ) {
+                    $matched = true;
+                    break;
+                }
+
+                $checkPos++;
+            }
+
+            // Check the param type value. This could also be multiple parameter
+            // types separated by '|'.
+            $typeNames      = explode('|', $param['type']);
+            $suggestedNames = [];
+            foreach ($typeNames as $i => $typeName) {
+                $suggestedNames[] = static::suggestType($typeName);
+            }
+
+            $suggestedType = implode('|', $suggestedNames);
+            if (preg_match('/\s/', $param['type']) === 1) {
+                $error = 'Parameter type "%s" must not contain spaces';
+                $data  = [$param['type']];
+                $phpcsFile->addError($error, $param['tag'], 'ParamTypeSpaces', $data);
+            } else if ($param['type'] !== $suggestedType) {
+                $error = 'Expected "%s" but found "%s" for parameter type';
+                $data  = [
+                    $suggestedType,
+                    $param['type'],
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $param['tag'], 'IncorrectParamVarName', $data);
+                if ($fix === true) {
+                    $content  = $suggestedType;
+                    $content .= str_repeat(' ', $param['type_space']);
+                    $content .= $param['var'];
+                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
+                }
+            }
+
+            $suggestedName = '';
+            $typeName      = '';
+            if (count($typeNames) === 1) {
+                $typeName      = $param['type'];
+                $suggestedName = static::suggestType($typeName);
+            }
+
+            // This runs only if there is only one type name and the type name
+            // is not one of the disallowed type names.
+            if (count($typeNames) === 1 && $typeName === $suggestedName) {
+                // Check type hint for array and custom type.
+                $suggestedTypeHint = '';
+                if (strpos($suggestedName, 'array') !== false) {
+                    $suggestedTypeHint = 'array';
+                } else if (strpos($suggestedName, 'callable') !== false) {
+                    $suggestedTypeHint = 'callable';
+                } else if (substr($suggestedName, -2) === '[]') {
+                    $suggestedTypeHint = 'array';
+                } else if ($suggestedName === 'object') {
+                    $suggestedTypeHint = '';
+                } else if (in_array($typeName, $this->allowedTypes) === false) {
+                    $suggestedTypeHint = $suggestedName;
+                }
+
+                if ($suggestedTypeHint !== '' && isset($realParams[$checkPos]) === true) {
+                    $typeHint = $realParams[$checkPos]['type_hint'];
+                    // Primitive type hints are allowed to be omitted.
+                    if ($typeHint === '' && in_array($suggestedTypeHint, ['string', 'int', 'float', 'bool']) === false) {
+                        $error = 'Type hint "%s" missing for %s';
+                        $data  = [
+                            $suggestedTypeHint,
+                            $param['var'],
+                        ];
+                        $phpcsFile->addError($error, $stackPtr, 'TypeHintMissing', $data);
+                    } else if ($typeHint !== $suggestedTypeHint && $typeHint !== '') {
+                        // The type hint could be fully namespaced, so we check
+                        // for the part after the last "\".
+                        $nameParts = explode('\\', $suggestedTypeHint);
+                        $lastPart  = end($nameParts);
+                        if ($lastPart !== $typeHint && $this->isAliasedType($typeHint, $suggestedTypeHint, $phpcsFile) === false) {
+                            $error = 'Expected type hint "%s"; found "%s" for %s';
+                            $data  = [
+                                $lastPart,
+                                $typeHint,
+                                $param['var'],
+                            ];
+                            $phpcsFile->addError($error, $stackPtr, 'IncorrectTypeHint', $data);
+                        }
+                    }//end if
+                } else if ($suggestedTypeHint === ''
+                    && isset($realParams[$checkPos]) === true
+                ) {
+                    $typeHint = $realParams[$checkPos]['type_hint'];
+                    if ($typeHint !== ''
+                        && $typeHint !== 'stdClass'
+                        && $typeHint !== '\stdClass'
+                        // As of PHP 7.2, object is a valid type hint.
+                        && $typeHint !== 'object'
+                    ) {
+                        $error = 'Unknown type hint "%s" found for %s';
+                        $data  = [
+                            $typeHint,
+                            $param['var'],
+                        ];
+                        $phpcsFile->addError($error, $stackPtr, 'InvalidTypeHint', $data);
+                    }
+                }//end if
+            }//end if
+
+            // Check number of spaces after the type.
+            $spaces = 1;
+            if ($param['type_space'] !== $spaces) {
+                $error = 'Expected %s spaces after parameter type; %s found';
+                $data  = [
+                    $spaces,
+                    $param['type_space'],
+                ];
+
+                $fix = $phpcsFile->addFixableError($error, $param['tag'], 'SpacingAfterParamType', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+
+                    $content  = $param['type'];
+                    $content .= str_repeat(' ', $spaces);
+                    $content .= $param['var'];
+                    $content .= str_repeat(' ', $param['var_space']);
+                    // At this point there is no description expected in the
+                    // @param line so no need to append comment.
+                    $phpcsFile->fixer->replaceToken(($param['tag'] + 2), $content);
+
+                    // Fix up the indent of additional comment lines.
+                    foreach ($param['commentLines'] as $lineNum => $line) {
+                        if ($lineNum === 0
+                            || $param['commentLines'][$lineNum]['indent'] === 0
+                        ) {
+                            continue;
+                        }
+
+                        $newIndent = ($param['commentLines'][$lineNum]['indent'] + $spaces - $param['type_space']);
+                        $phpcsFile->fixer->replaceToken(
+                            ($param['commentLines'][$lineNum]['token'] - 1),
+                            str_repeat(' ', $newIndent)
+                        );
+                    }
+
+                    $phpcsFile->fixer->endChangeset();
+                }//end if
+            }//end if
+
+            if ($matched === false) {
+                if ($checkPos >= $pos) {
+                    $code = 'ParamNameNoMatch';
+                    $data = [
+                        $param['var'],
+                        $realName,
+                    ];
+
+                    $error = 'Doc comment for parameter %s does not match ';
+                    if (strtolower($param['var']) === strtolower($realName)) {
+                        $error .= 'case of ';
+                        $code   = 'ParamNameNoCaseMatch';
+                    }
+
+                    $error .= 'actual variable name %s';
+
+                    $phpcsFile->addError($error, $param['tag'], $code, $data);
+                    // Reset the parameter position to check for following
+                    // parameters.
+                    $checkPos = ($pos - 1);
+                } else if (substr($param['var'], -4) !== ',...') {
+                    // We must have an extra parameter comment.
+                    $error = 'Superfluous parameter comment';
+                    $phpcsFile->addError($error, $param['tag'], 'ExtraParamComment');
+                }//end if
+            }//end if
+
+            $checkPos++;
+
+            if ($param['comment'] === '') {
+                continue;
+            }
+
+            // Param comments must start with a capital letter and end with the full stop.
+            if (isset($param['commentLines'][0]['comment']) === true) {
+                $firstChar = $param['commentLines'][0]['comment'];
+            } else {
+                $firstChar = $param['comment'];
+            }
+
+            if (preg_match('|\p{Lu}|u', $firstChar) === 0) {
+                $error = 'Parameter comment must start with a capital letter';
+                if (isset($param['commentLines'][0]['token']) === true) {
+                    $commentToken = $param['commentLines'][0]['token'];
+                } else {
+                    $commentToken = $param['tag'];
+                }
+
+                $phpcsFile->addError($error, $commentToken, 'ParamCommentNotCapital');
+            }
+
+            $lastChar = substr($param['comment'], -1);
+            if (in_array($lastChar, ['.', '!', '?', ')']) === false) {
+                $error = 'Parameter comment must end with a full stop';
+                if (empty($param['commentLines']) === true) {
+                    $commentToken = ($param['tag'] + 2);
+                } else {
+                    $lastLine     = end($param['commentLines']);
+                    $commentToken = $lastLine['token'];
+                }
+
+                // Don't show an error if the end of the comment is in a code
+                // example.
+                if ($this->isInCodeExample($phpcsFile, $commentToken, $param['tag']) === false) {
+                    $fix = $phpcsFile->addFixableError($error, $commentToken, 'ParamCommentFullStop');
+                    if ($fix === true) {
+                        // Add a full stop as the last character of the comment.
+                        $phpcsFile->fixer->addContent($commentToken, '.');
+                    }
+                }
+            }
+        }//end foreach
+
+        // Missing parameters only apply to methods and not function because on
+        // functions it is allowed to leave out param comments for form constructors
+        // for example.
+        // It is also allowed to ommit pram tags completely, in which case we don't
+        // throw errors. Only throw errors if param comments exists but are
+        // incomplete on class methods.
+        if ($tokens[$stackPtr]['level'] > 0 && empty($foundParams) === false) {
+            foreach ($realParams as $realParam) {
+                $realParamKeyName = $realParam['name'];
+                if (in_array($realParamKeyName, $foundParams) === false
+                    && ($realParam['pass_by_reference'] === true
+                    && in_array("&$realParamKeyName", $foundParams) === true) === false
+                ) {
+                    $error = 'Parameter %s is not described in comment';
+                    $phpcsFile->addError($error, $commentStart, 'ParamMissingDefinition', [$realParam['name']]);
+                }
+            }
+        }
+
+    }//end processParams()
+
+
+    /**
+     * Process the function "see" comments.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position in the stack where the comment started.
+     *
+     * @return void
+     */
+    protected function processSees(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] !== '@see') {
+                continue;
+            }
+
+            if ($tokens[($tag + 2)]['code'] === T_DOC_COMMENT_STRING) {
+                $comment = $tokens[($tag + 2)]['content'];
+                if (strpos($comment, ' ') !== false) {
+                    $error = 'The @see reference should not contain any additional text';
+                    $phpcsFile->addError($error, $tag, 'SeeAdditionalText');
+                    continue;
+                }
+
+                if (preg_match('/[\.!\?]$/', $comment) === 1) {
+                    $error = 'Trailing punctuation for @see references is not allowed.';
+                    $fix   = $phpcsFile->addFixableError($error, $tag, 'SeePunctuation');
+                    if ($fix === true) {
+                        // Replace the last character from the comment which is
+                        // already tested to be a punctuation.
+                        $content = substr($comment, 0, -1);
+                        $phpcsFile->fixer->replaceToken(($tag + 2), $content);
+                    }//end if
+                }
+            }
+        }//end foreach
+
+    }//end processSees()
+
+
+    /**
+     * Returns a valid variable type for param/var tag.
+     *
+     * @param string $type The variable type to process.
+     *
+     * @return string
+     */
+    public static function suggestType($type)
+    {
+        if (isset(static::$invalidTypes[$type]) === true) {
+            return static::$invalidTypes[$type];
+        }
+
+        if ($type === '$this') {
+            return $type;
+        }
+
+        $type = preg_replace('/[^a-zA-Z0-9_\\\[\]]/', '', $type);
+
+        return $type;
+
+    }//end suggestType()
+
+
+    /**
+     * Checks if a used type hint is an alias defined by a "use" statement.
+     *
+     * @param string                      $typeHint          The type hint used.
+     * @param string                      $suggestedTypeHint The fully qualified type to
+     *                                                       check against.
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile         The file being checked.
+     *
+     * @return boolean
+     */
+    protected function isAliasedType($typeHint, $suggestedTypeHint, File $phpcsFile)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Iterate over all "use" statements in the file.
+        $usePtr = 0;
+        while ($usePtr !== false) {
+            $usePtr = $phpcsFile->findNext(T_USE, ($usePtr + 1));
+            if ($usePtr === false) {
+                return false;
+            }
+
+            // Only check use statements in the global scope.
+            if (empty($tokens[$usePtr]['conditions']) === false) {
+                continue;
+            }
+
+            // Now comes the original class name, possibly with namespace
+            // backslashes.
+            $originalClass = $phpcsFile->findNext(Tokens::$emptyTokens, ($usePtr + 1), null, true);
+            if ($originalClass === false || ($tokens[$originalClass]['code'] !== T_STRING
+                && $tokens[$originalClass]['code'] !== T_NS_SEPARATOR)
+            ) {
+                continue;
+            }
+
+            $originalClassName = '';
+            while (in_array($tokens[$originalClass]['code'], [T_STRING, T_NS_SEPARATOR]) === true) {
+                $originalClassName .= $tokens[$originalClass]['content'];
+                $originalClass++;
+            }
+
+            if (ltrim($originalClassName, '\\') !== ltrim($suggestedTypeHint, '\\')) {
+                continue;
+            }
+
+            // Now comes the "as" keyword signaling an alias name for the class.
+            $asPtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($originalClass + 1), null, true);
+            if ($asPtr === false || $tokens[$asPtr]['code'] !== T_AS) {
+                continue;
+            }
+
+            // Now comes the name the class is aliased to.
+            $aliasPtr = $phpcsFile->findNext(Tokens::$emptyTokens, ($asPtr + 1), null, true);
+            if ($aliasPtr === false || $tokens[$aliasPtr]['code'] !== T_STRING
+                || $tokens[$aliasPtr]['content'] !== $typeHint
+            ) {
+                continue;
+            }
+
+            // We found a use statement that aliases the used type hint!
+            return true;
+        }//end while
+
+    }//end isAliasedType()
+
+
+    /**
+     * Determines if a comment line is part of an @code/@endcode example.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the current token
+     *                                                  in the stack passed in $tokens.
+     * @param int                         $commentStart The position of the start of the comment
+     *                                                  in the stack passed in $tokens.
+     *
+     * @return boolean Returns true if the comment line is within a @code block,
+     *                 false otherwise.
+     */
+    protected function isInCodeExample(File $phpcsFile, $stackPtr, $commentStart)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if (strpos($tokens[$stackPtr]['content'], '@code') !== false) {
+            return true;
+        }
+
+        $prevTag = $phpcsFile->findPrevious([T_DOC_COMMENT_TAG], ($stackPtr - 1), $commentStart);
+        if ($prevTag === false) {
+            return false;
+        }
+
+        if ($tokens[$prevTag]['content'] === '@code') {
+            return true;
+        }
+
+        return false;
+
+    }//end isInCodeExample()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/GenderNeutralCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/GenderNeutralCommentSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Parses and verifies comment language.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Parses and verifies that comments use gender neutral language.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class GenderNeutralCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT_STRING,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ((bool) preg_match('/(^|\W)(he|her|hers|him|his|she)($|\W)/i', $tokens[$stackPtr]['content']) === true) {
+            $phpcsFile->addError('Unnecessarily gendered language in a comment', $stackPtr, 'GenderNeutral');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/HookCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/HookCommentSniff.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Ensures hook comments on function are correct.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Ensures hook comments on function are correct.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class HookCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // We are only interested in the most outer scope, ignore methods in classes for example.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            return;
+        }
+
+        $commentEnd = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return;
+        }
+
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+
+        $empty = [
+            T_DOC_COMMENT_WHITESPACE,
+            T_DOC_COMMENT_STAR,
+        ];
+
+        $short = $phpcsFile->findNext($empty, ($commentStart + 1), $commentEnd, true);
+        if ($short === false) {
+            // No content at all.
+            return;
+        }
+
+        // Account for the fact that a short description might cover
+        // multiple lines.
+        $shortContent = $tokens[$short]['content'];
+        $shortEnd     = $short;
+        for ($i = ($short + 1); $i < $commentEnd; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
+                if ($tokens[$i]['line'] === ($tokens[$shortEnd]['line'] + 1)) {
+                    $shortContent .= $tokens[$i]['content'];
+                    $shortEnd      = $i;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Check if a hook implementation doc block is formatted correctly.
+        if (preg_match('/^[\s]*Implement[^\n]+?hook_[^\n]+/i', $shortContent, $matches) === 1) {
+            if (strstr($matches[0], 'Implements ') === false || strstr($matches[0], 'Implements of') !== false
+                || preg_match('/ (drush_)?hook_[a-zA-Z0-9_]+\(\)( for .+)?\.$/', $matches[0]) !== 1
+            ) {
+                $phpcsFile->addWarning('Format should be "* Implements hook_foo().", "* Implements hook_foo_BAR_ID_bar() for xyz_bar().",, "* Implements hook_foo_BAR_ID_bar() for xyz-bar.html.twig.", "* Implements hook_foo_BAR_ID_bar() for xyz-bar.tpl.php.", or "* Implements hook_foo_BAR_ID_bar() for block templates."', $short, 'HookCommentFormat');
+            } else {
+                // Check that a hook implementation does not duplicate @param and
+                // @return documentation.
+                foreach ($tokens[$commentStart]['comment_tags'] as $pos => $tag) {
+                    if ($tokens[$tag]['content'] === '@param') {
+                        $warn = 'Hook implementations should not duplicate @param documentation';
+                        $phpcsFile->addWarning($warn, $tag, 'HookParamDoc');
+                    }
+
+                    if ($tokens[$tag]['content'] === '@return') {
+                        $warn = 'Hook implementations should not duplicate @return documentation';
+                        $phpcsFile->addWarning($warn, $tag, 'HookReturnDoc');
+                    }
+                }
+            }//end if
+
+            return;
+        }//end if
+
+        // Check if the doc block just repeats the function name with
+        // "Implements example_hook_name()".
+        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($functionName !== null && preg_match("/^[\s]*Implements $functionName\(\)\.$/i", $shortContent) === 1) {
+            $error = 'Hook implementations must be documented with "Implements hook_example()."';
+            $fix   = $phpcsFile->addFixableError($error, $short, 'HookRepeat');
+            if ($fix === true) {
+                $newComment = preg_replace('/Implements [^_]+/', 'Implements hook', $shortContent);
+                $phpcsFile->fixer->replaceToken($short, $newComment);
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/InlineCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/InlineCommentSniff.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Commenting\InlineCommentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * \Backdrop\Sniffs\Commenting\InlineCommentSniff.
+ *
+ * Checks that no perl-style comments are used. Checks that inline comments ("//")
+ * have a space after //, start capitalized and end with proper punctuation.
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\InlineCommentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class InlineCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT_OPEN_TAG,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int|void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // If this is a function/class/interface doc block comment, skip it.
+        // We are only interested in inline doc block comments, which are
+        // not allowed.
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+            $nextToken = $phpcsFile->findNext(
+                Tokens::$emptyTokens,
+                ($stackPtr + 1),
+                null,
+                true
+            );
+
+            $ignore = [
+                T_CLASS,
+                T_INTERFACE,
+                T_TRAIT,
+                T_FUNCTION,
+                T_CLOSURE,
+                T_PUBLIC,
+                T_PRIVATE,
+                T_PROTECTED,
+                T_FINAL,
+                T_STATIC,
+                T_ABSTRACT,
+                T_CONST,
+                T_PROPERTY,
+                T_INCLUDE,
+                T_INCLUDE_ONCE,
+                T_REQUIRE,
+                T_REQUIRE_ONCE,
+                T_VAR,
+            ];
+
+            // Also ignore all doc blocks defined in the outer scope (no scope
+            // conditions are set).
+            if (in_array($tokens[$nextToken]['code'], $ignore, true) === true
+                || empty($tokens[$stackPtr]['conditions']) === true
+            ) {
+                return;
+            }
+
+            if ($phpcsFile->tokenizerType === 'JS') {
+                // We allow block comments if a function or object
+                // is being assigned to a variable.
+                $ignore    = Tokens::$emptyTokens;
+                $ignore[]  = T_EQUAL;
+                $ignore[]  = T_STRING;
+                $ignore[]  = T_OBJECT_OPERATOR;
+                $nextToken = $phpcsFile->findNext($ignore, ($nextToken + 1), null, true);
+                if ($tokens[$nextToken]['code'] === T_FUNCTION
+                    || $tokens[$nextToken]['code'] === T_CLOSURE
+                    || $tokens[$nextToken]['code'] === T_OBJECT
+                    || $tokens[$nextToken]['code'] === T_PROTOTYPE
+                ) {
+                    return;
+                }
+            }
+
+            $prevToken = $phpcsFile->findPrevious(
+                Tokens::$emptyTokens,
+                ($stackPtr - 1),
+                null,
+                true
+            );
+
+            if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
+                return;
+            }
+
+            // Inline doc blocks are allowed in JSDoc.
+            if ($tokens[$stackPtr]['content'] === '/**' && $phpcsFile->tokenizerType !== 'JS') {
+                // The only exception to inline doc blocks is the /** @var */
+                // declaration. Allow that in any form.
+                $varTag = $phpcsFile->findNext([T_DOC_COMMENT_TAG], ($stackPtr + 1), $tokens[$stackPtr]['comment_closer'], false, '@var');
+                if ($varTag === false) {
+                    $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
+                    $phpcsFile->addError($error, $stackPtr, 'DocBlock');
+                }
+            }
+        }//end if
+
+        if ($tokens[$stackPtr]['content'][0] === '#') {
+            $error = 'Perl-style comments are not allowed; use "// Comment" instead';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'WrongStyle');
+            if ($fix === true) {
+                $comment = ltrim($tokens[$stackPtr]['content'], "# \t");
+                $phpcsFile->fixer->replaceToken($stackPtr, "// $comment");
+            }
+        }
+
+        // We don't want end of block comments. Check if the last token before the
+        // comment is a closing curly brace.
+        $previousContent = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($tokens[$previousContent]['line'] === $tokens[$stackPtr]['line']) {
+            if ($tokens[$previousContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+                return;
+            }
+
+            // Special case for JS files.
+            if ($tokens[$previousContent]['code'] === T_COMMA
+                || $tokens[$previousContent]['code'] === T_SEMICOLON
+            ) {
+                $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($previousContent - 1), null, true);
+                if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+                    return;
+                }
+            }
+        }
+
+        // Only want inline comments.
+        if (substr($tokens[$stackPtr]['content'], 0, 2) !== '//') {
+            return;
+        }
+
+        // Ignore code example lines.
+        if ($this->isInCodeExample($phpcsFile, $stackPtr) === true) {
+            return;
+        }
+
+        $commentTokens = [$stackPtr];
+
+        $nextComment = $stackPtr;
+        $lastComment = $stackPtr;
+        while (($nextComment = $phpcsFile->findNext(T_COMMENT, ($nextComment + 1), null, false)) !== false) {
+            if ($tokens[$nextComment]['line'] !== ($tokens[$lastComment]['line'] + 1)) {
+                break;
+            }
+
+            // Only want inline comments.
+            if (substr($tokens[$nextComment]['content'], 0, 2) !== '//') {
+                break;
+            }
+
+            // There is a comment on the very next line. If there is
+            // no code between the comments, they are part of the same
+            // comment block.
+            $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextComment - 1), $lastComment, true);
+            if ($prevNonWhitespace !== $lastComment) {
+                break;
+            }
+
+            // A comment starting with "@" means a new comment section.
+            if (preg_match('|^//[\s]*@|', $tokens[$nextComment]['content']) === 1) {
+                break;
+            }
+
+            $commentTokens[] = $nextComment;
+            $lastComment     = $nextComment;
+        }//end while
+
+        $commentText      = '';
+        $lastCommentToken = $stackPtr;
+        foreach ($commentTokens as $lastCommentToken) {
+            $comment = rtrim($tokens[$lastCommentToken]['content']);
+
+            if (trim(substr($comment, 2)) === '') {
+                continue;
+            }
+
+            $spaceCount = 0;
+            $tabFound   = false;
+
+            $commentLength = strlen($comment);
+            for ($i = 2; $i < $commentLength; $i++) {
+                if ($comment[$i] === "\t") {
+                    $tabFound = true;
+                    break;
+                }
+
+                if ($comment[$i] !== ' ') {
+                    break;
+                }
+
+                $spaceCount++;
+            }
+
+            $fix = false;
+            if ($tabFound === true) {
+                $error = 'Tab found before comment text; expected "// %s" but found "%s"';
+                $data  = [
+                    ltrim(substr($comment, 2)),
+                    $comment,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'TabBefore', $data);
+            } else if ($spaceCount === 0) {
+                $error = 'No space found before comment text; expected "// %s" but found "%s"';
+                $data  = [
+                    substr($comment, 2),
+                    $comment,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'NoSpaceBefore', $data);
+            }//end if
+
+            if ($fix === true) {
+                $newComment = '// '.ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+            }
+
+            if ($spaceCount > 1) {
+                // Check if there is a comment on the previous line that justifies the
+                // indentation.
+                $prevComment = $phpcsFile->findPrevious([T_COMMENT], ($lastCommentToken - 1), null, false);
+                if (($prevComment !== false) && (($tokens[$prevComment]['line']) === ($tokens[$lastCommentToken]['line'] - 1))) {
+                    $prevCommentText = rtrim($tokens[$prevComment]['content']);
+                    $prevSpaceCount  = 0;
+                    for ($i = 2; $i < strlen($prevCommentText); $i++) {
+                        if ($prevCommentText[$i] !== ' ') {
+                            break;
+                        }
+
+                        $prevSpaceCount++;
+                    }
+
+                    if ($spaceCount > $prevSpaceCount && $prevSpaceCount > 0) {
+                        // A previous comment could be a list item or @todo.
+                        $indentationStarters = [
+                            '-',
+                            '@todo',
+                        ];
+                        $words        = preg_split('/\s+/', $prevCommentText);
+                        $numberedList = (bool) preg_match('/^[0-9]+\./', $words[1]);
+                        if (in_array($words[1], $indentationStarters) === true) {
+                            if ($spaceCount !== ($prevSpaceCount + 2)) {
+                                $error = 'Comment indentation error after %s element, expected %s spaces';
+                                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$words[1], ($prevSpaceCount + 2)]);
+                                if ($fix === true) {
+                                    $newComment = '//'.str_repeat(' ', ($prevSpaceCount + 2)).ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+                                }
+                            }
+                        } else if ($numberedList === true) {
+                            $expectedSpaceCount = ($prevSpaceCount + strlen($words[1]) + 1);
+                            if ($spaceCount !== $expectedSpaceCount) {
+                                $error = 'Comment indentation error, expected %s spaces';
+                                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$expectedSpaceCount]);
+                                if ($fix === true) {
+                                    $newComment = '//'.str_repeat(' ', $expectedSpaceCount).ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+                                }
+                            }
+                        } else {
+                            $error = 'Comment indentation error, expected only %s spaces';
+                            $phpcsFile->addError($error, $lastCommentToken, 'SpacingBefore', [$prevSpaceCount]);
+                        }//end if
+                    }//end if
+                } else {
+                    $error = '%s spaces found before inline comment; expected "// %s" but found "%s"';
+                    $data  = [
+                        $spaceCount,
+                        substr($comment, (2 + $spaceCount)),
+                        $comment,
+                    ];
+                    $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($lastCommentToken, '// '.substr($comment, (2 + $spaceCount)).$phpcsFile->eolChar);
+                    }
+                }//end if
+            }//end if
+
+            $commentText .= trim(substr($tokens[$lastCommentToken]['content'], 2));
+        }//end foreach
+
+        if ($commentText === '') {
+            $error = 'Blank comments are not allowed';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Empty');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, '');
+            }
+
+            return ($lastCommentToken + 1);
+        }
+
+        $words = preg_split('/\s+/', $commentText);
+        if (preg_match('/^\p{Ll}/u', $commentText) === 1) {
+            // Allow special lower cased words that contain non-alpha characters
+            // (function references, machine names with underscores etc.).
+            $matches = [];
+            preg_match('/[a-z]+/', $words[0], $matches);
+            if (isset($matches[0]) === true && $matches[0] === $words[0]) {
+                $error = 'Inline comments must start with a capital letter';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotCapital');
+                if ($fix === true) {
+                    $newComment = preg_replace("/$words[0]/", ucfirst($words[0]), $tokens[$stackPtr]['content'], 1);
+                    $phpcsFile->fixer->replaceToken($stackPtr, $newComment);
+                }
+            }
+        }
+
+        // Only check the end of comment character if the start of the comment
+        // is a letter, indicating that the comment is just standard text.
+        if (preg_match('/^\p{L}/u', $commentText) === 1) {
+            $commentCloser   = $commentText[(strlen($commentText) - 1)];
+            $acceptedClosers = [
+                'full-stops'             => '.',
+                'exclamation marks'      => '!',
+                'question marks'         => '?',
+                'colons'                 => ':',
+                'or closing parentheses' => ')',
+            ];
+
+            // Allow special last words like URLs or function references
+            // without punctuation.
+            $lastWord = $words[(count($words) - 1)];
+            $matches  = [];
+            preg_match('/https?:\/\/.+/', $lastWord, $matches);
+            $isUrl = isset($matches[0]) === true;
+            preg_match('/[$a-zA-Z_]+\([$a-zA-Z_]*\)/', $lastWord, $matches);
+            $isFunction = isset($matches[0]) === true;
+
+            // Also allow closing tags like @endlink or @endcode.
+            $isEndTag = $lastWord[0] === '@';
+
+            if (in_array($commentCloser, $acceptedClosers, true) === false
+                && $isUrl === false && $isFunction === false && $isEndTag === false
+            ) {
+                $error = 'Inline comments must end in %s';
+                $ender = '';
+                foreach ($acceptedClosers as $closerName => $symbol) {
+                    $ender .= ' '.$closerName.',';
+                }
+
+                $ender = trim($ender, ' ,');
+                $data  = [$ender];
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'InvalidEndChar', $data);
+                if ($fix === true) {
+                    $newContent = preg_replace('/(\s+)$/', '.$1', $tokens[$lastCommentToken]['content']);
+                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newContent);
+                }
+            }
+        }//end if
+
+        // Finally, the line below the last comment cannot be empty if this inline
+        // comment is on a line by itself.
+        if ($tokens[$previousContent]['line'] < $tokens[$stackPtr]['line']) {
+            $next = $phpcsFile->findNext(T_WHITESPACE, ($lastCommentToken + 1), null, true);
+            if ($next === false) {
+                // Ignore if the comment is the last non-whitespace token in a file.
+                return ($lastCommentToken + 1);
+            }
+
+            if ($tokens[$next]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                // If this inline comment is followed by a docblock,
+                // ignore spacing as docblock/function etc spacing rules
+                // are likely to conflict with our rules.
+                return ($lastCommentToken + 1);
+            }
+
+            $errorCode = 'SpacingAfter';
+
+            if (isset($tokens[$stackPtr]['conditions']) === true) {
+                $conditions   = $tokens[$stackPtr]['conditions'];
+                $type         = end($conditions);
+                $conditionPtr = key($conditions);
+
+                if (($type === T_FUNCTION || $type === T_CLOSURE)
+                    && $tokens[$conditionPtr]['scope_closer'] === $next
+                ) {
+                    $errorCode = 'SpacingAfterAtFunctionEnd';
+                }
+            }
+
+            for ($i = ($lastCommentToken + 1); $i < $phpcsFile->numTokens; $i++) {
+                if ($tokens[$i]['line'] === ($tokens[$lastCommentToken]['line'] + 1)) {
+                    if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                        return ($lastCommentToken + 1);
+                    }
+                } else if ($tokens[$i]['line'] > ($tokens[$lastCommentToken]['line'] + 1)) {
+                    break;
+                }
+            }
+
+            $error = 'There must be no blank line following an inline comment';
+            $fix   = $phpcsFile->addFixableWarning($error, $lastCommentToken, $errorCode);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($lastCommentToken + 1); $i < $next; $i++) {
+                    if ($tokens[$i]['line'] === $tokens[$next]['line']) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }//end if
+
+        return ($lastCommentToken + 1);
+
+    }//end process()
+
+
+    /**
+     * Determines if a comment line is part of an @code/@endcode example.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return boolean Returns true if the comment line is within a @code block,
+     *                 false otherwise.
+     */
+    protected function isInCodeExample(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content'] === '// @code'.$phpcsFile->eolChar) {
+            return true;
+        }
+
+        $prevComment = $stackPtr;
+        $lastComment = $stackPtr;
+        while (($prevComment = $phpcsFile->findPrevious([T_COMMENT], ($lastComment - 1), null, false)) !== false) {
+            if ($tokens[$prevComment]['line'] !== ($tokens[$lastComment]['line'] - 1)) {
+                return false;
+            }
+
+            if ($tokens[$prevComment]['content'] === '// @code'.$phpcsFile->eolChar) {
+                return true;
+            }
+
+            if ($tokens[$prevComment]['content'] === '// @endcode'.$phpcsFile->eolChar) {
+                return false;
+            }
+
+            $lastComment = $prevComment;
+        }
+
+        return false;
+
+    }//end isInCodeExample()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/InlineVariableCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/InlineVariableCommentSniff.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * \Backdrop\Sniffs\Commenting\InlineVariableCommentSniff
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks for the correct usage of inline variable type declarations.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class InlineVariableCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT_TAG,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $ignore = [
+            T_CLASS,
+            T_INTERFACE,
+            T_TRAIT,
+            T_FUNCTION,
+            T_CLOSURE,
+            T_PUBLIC,
+            T_PRIVATE,
+            T_PROTECTED,
+            T_FINAL,
+            T_STATIC,
+            T_ABSTRACT,
+            T_CONST,
+            T_PROPERTY,
+            T_INCLUDE,
+            T_INCLUDE_ONCE,
+            T_REQUIRE,
+            T_REQUIRE_ONCE,
+            T_VAR,
+        ];
+
+        // If this is a function/class/interface doc block comment, skip it.
+        $nextToken = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if (in_array($tokens[$nextToken]['code'], $ignore, true) === true) {
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_COMMENT) {
+            if (strpos($tokens[$stackPtr]['content'], '@var') !== false) {
+                $warning = 'Inline @var declarations should use the /** */ delimiters';
+
+                if (strpos($tokens[$stackPtr]['content'], '#') === 0 || strpos($tokens[$stackPtr]['content'], '//') === 0) {
+                    // If this comment contains '*/' then the developer is mixing
+                    // inline comment styles. This could be commented out code,
+                    // so leave this line alone completely.
+                    if (strpos($tokens[$stackPtr]['content'], '*/') !== false) {
+                        return;
+                    }
+
+                    if ($phpcsFile->addFixableWarning($warning, $stackPtr, 'VarInline') === true) {
+                        // Hashtag and slash based comments contain a trailing
+                        // new line.
+                        $varContent = rtrim($tokens[$stackPtr]['content']);
+
+                        // Remove all leading hashtags and slashes.
+                        $varContent = ltrim($varContent, '/# ');
+
+                        $phpcsFile->fixer->replaceToken($stackPtr, ('/** '.$varContent." */\n"));
+                    }
+                } else {
+                    if ($phpcsFile->addFixableWarning($warning, $stackPtr, 'VarInline') === true) {
+                        $phpcsFile->fixer->replaceToken($stackPtr, substr_replace($tokens[$stackPtr]['content'], '/**', 0, 2));
+                    }
+                }//end if
+            }//end if
+
+            return;
+        }//end if
+
+        // Skip if it's not a variable declaration.
+        if ($tokens[$stackPtr]['content'] !== '@var') {
+            return;
+        }
+
+        // Get the content of the @var tag to determine the order.
+        $varContent    = '';
+        $varContentPtr = $phpcsFile->findNext(T_DOC_COMMENT_STRING, ($stackPtr + 1));
+        if ($varContentPtr !== false) {
+            $varContent = $tokens[$varContentPtr]['content'];
+        }
+
+        if (strpos($varContent, '$') === 0) {
+            $warning = 'The variable name should be defined after the type';
+
+            $parts = explode(' ', $varContent, 3);
+            if (isset($parts[1]) === true) {
+                if ($phpcsFile->addFixableWarning($warning, $varContentPtr, 'VarInlineOrder') === true) {
+                    // Switch type and variable name.
+                    $replace = [
+                        $parts[1],
+                        $parts[0],
+                    ];
+                    if (isset($parts[2]) === true) {
+                        $replace[] = $parts[2];
+                    }
+
+                    $phpcsFile->fixer->replaceToken($varContentPtr, implode(' ', $replace));
+                }
+            } else {
+                $phpcsFile->addWarning($warning, $varContentPtr, 'VarInlineOrder');
+            }
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/PostStatementCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/PostStatementCommentSniff.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Commenting\PostStatementCommentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\PostStatementCommentSniff
+ * but we want the fixer to move the comment to the previous line.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PostStatementCommentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_COMMENT];
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (substr($tokens[$stackPtr]['content'], 0, 2) !== '//') {
+            return;
+        }
+
+        $commentLine = $tokens[$stackPtr]['line'];
+        $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+
+        if ($tokens[$lastContent]['line'] !== $commentLine) {
+            return;
+        }
+
+        if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+            return;
+        }
+
+        // Special case for JS files.
+        if ($tokens[$lastContent]['code'] === T_COMMA
+            || $tokens[$lastContent]['code'] === T_SEMICOLON
+        ) {
+            $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($lastContent - 1), null, true);
+            if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+                return;
+            }
+        }
+
+        $error = 'Comments may not appear after statements';
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Found');
+        if ($fix === true) {
+            if ($tokens[$lastContent]['code'] === T_OPEN_TAG) {
+                $phpcsFile->fixer->addNewlineBefore($stackPtr);
+                return;
+            }
+
+            $lineStart = $stackPtr;
+            while ($tokens[$lineStart]['line'] === $tokens[$stackPtr]['line']
+                && $tokens[$lineStart]['code'] !== T_OPEN_TAG
+            ) {
+                $lineStart--;
+            }
+
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->addContent($lineStart, $tokens[$stackPtr]['content']);
+            $phpcsFile->fixer->replaceToken($stackPtr, $phpcsFile->eolChar);
+            $phpcsFile->fixer->endChangeset();
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/TodoCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/TodoCommentSniff.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Parses and verifies comment language.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Config;
+
+/**
+ * Parses and verifies that comments use the correct @todo format.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class TodoCommentSniff implements Sniff
+{
+
+    /**
+     * Show debug output for this sniff.
+     *
+     * Use phpcs --runtime-set todo_debug true
+     *
+     * @var boolean
+     */
+    private $debug = false;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        if (defined('PHP_CODESNIFFER_IN_TESTS') === true) {
+            $this->debug = false;
+        }
+
+        return [
+            T_COMMENT,
+            T_DOC_COMMENT_TAG,
+            T_DOC_COMMENT_STRING,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $debug = Config::getConfigData('todo_debug');
+        if ($debug !== null) {
+            $this->debug = (bool) $debug;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if ($this->debug === true) {
+            echo "\n------\n\$tokens[$stackPtr] = ".print_r($tokens[$stackPtr], true).PHP_EOL;
+            echo 'code = '.$tokens[$stackPtr]['code'].', type = '.$tokens[$stackPtr]['type']."\n";
+        }
+
+        // Standard comments and multi-line comments where the "@" is missing so
+        // it does not register as a T_DOC_COMMENT_TAG.
+        if ($tokens[$stackPtr]['code'] === T_COMMENT || $tokens[$stackPtr]['code'] === T_DOC_COMMENT_STRING) {
+            $comment = $tokens[$stackPtr]['content'];
+            if ($this->debug === true) {
+                echo "Getting \$comment from \$tokens[$stackPtr]['content']\n";
+            }
+
+            $this->checkTodoFormat($phpcsFile, $stackPtr, $comment, $tokens);
+        } else if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG) {
+            // Document comment tag (i.e. comments that begin with "@").
+            // Determine if this is related at all and build the full comment line
+            // from the various segments that the line is parsed into.
+            $expression = '/^@to/i';
+            $comment    = $tokens[$stackPtr]['content'];
+            if ((bool) preg_match($expression, $comment) === true) {
+                if ($this->debug === true) {
+                    echo "Attempting to build comment\n";
+                }
+
+                $index = ($stackPtr + 1);
+                while ($tokens[$index]['line'] === $tokens[$stackPtr]['line']) {
+                    $comment .= $tokens[$index]['content'];
+                    $index++;
+                }
+
+                if ($this->debug === true) {
+                    echo "Result comment = $comment\n";
+                }
+
+                $this->checkTodoFormat($phpcsFile, $stackPtr, $comment, $tokens);
+            }//end if
+        }//end if
+
+    }//end process()
+
+
+    /**
+     * Checks a comment string for the correct syntax.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     * @param string                      $comment   The comment text.
+     * @param array<array>                $tokens    The token data.
+     *
+     * @return void
+     */
+    private function checkTodoFormat(File $phpcsFile, int $stackPtr, string $comment, array $tokens)
+    {
+        if ($this->debug === true) {
+            echo "Checking \$comment = '$comment'\n";
+        }
+
+        $expression = '/(?x)   # Set free-space mode to allow this commenting.
+            ^(\/|\s)*          # At the start optionally match any forward slashes and spaces
+            (?i)               # set case-insensitive mode.
+            (?=(               # Start a positive non-consuming look-ahead to find all possible todos
+              @+to(-|\s|)+do   # if one or more @ allow spaces and - between the to and do.
+              \h*(-|:)*        # Also match the trailing "-" or ":" so they can be replaced.
+              |                # or
+              to(-)*do         # If no @ then only accept todo or to-do or to--do, etc, no spaces.
+              (\s-|:)*         # Also match the trailing "-" or ":" so they can be replaced.
+            ))
+            (?-i)              # Reset to case-sensitive
+            (?!                # Start another non-consuming look-ahead, this time negative
+              @todo\s          # It has to match lower-case @todo followed by one space
+              (?!-|:)\S        # and then any non-space except "-" or ":".
+            )/m';
+
+        if ((bool) preg_match($expression, $comment, $matches) === true) {
+            if ($this->debug === true) {
+                echo "Failed regex - give message\n";
+            }
+
+            $commentTrimmed = trim($comment, " /\r\n");
+            if ($commentTrimmed === '@todo') {
+                // We can't fix a comment that doesn't have any text.
+                $phpcsFile->addWarning("'%s' should match the format '@todo Fix problem X here.'", $stackPtr, 'TodoFormat', [$commentTrimmed]);
+                $fix = false;
+            } else {
+                // Comments with description text are fixable.
+                $fix = $phpcsFile->addFixableWarning("'%s' should match the format '@todo Fix problem X here.'", $stackPtr, 'TodoFormat', [$commentTrimmed]);
+            }
+
+            if ($fix === true) {
+                if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_TAG) {
+                    // Rewrite the comment past the token content to an empty
+                    // string as part of it may be part of the match, but not in
+                    // the token content. Then replace the token content with
+                    // the fixed comment from the matched content.
+                    $phpcsFile->fixer->beginChangeset();
+                    $index = ($stackPtr + 1);
+                    while ($tokens[$index]['line'] === $tokens[$stackPtr]['line']) {
+                        $phpcsFile->fixer->replaceToken($index, '');
+                        $index++;
+                    }
+
+                    $fixedTodo = str_replace($matches[2], '@todo ', $comment);
+                    $phpcsFile->fixer->replaceToken($stackPtr, $fixedTodo);
+                    $phpcsFile->fixer->endChangeset();
+                } else {
+                    // The full comment line text is available here, so the
+                    // replacement is fairly straightforward.
+                    $fixedTodo = str_replace($matches[2], '@todo ', $tokens[$stackPtr]['content']);
+                    $phpcsFile->fixer->replaceToken($stackPtr, $fixedTodo);
+                }//end if
+            }//end if
+        }//end if
+
+    }//end checkTodoFormat()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/VariableCommentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Commenting/VariableCommentSniff.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Parses and verifies class property doc comments.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+
+/**
+ * Parses and verifies class property doc comments.
+ *
+ * Laregely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Commenting\VariableCommentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class VariableCommentSniff extends AbstractVariableSniff
+{
+
+
+    /**
+     * Called to process class member vars.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function processMemberVar(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $ignore = [
+            T_PUBLIC,
+            T_PRIVATE,
+            T_PROTECTED,
+            T_VAR,
+            T_STATIC,
+            T_WHITESPACE,
+            T_STRING,
+            T_NS_SEPARATOR,
+            T_NULLABLE,
+        ];
+
+        $commentEnd = $phpcsFile->findPrevious($ignore, ($stackPtr - 1), null, true);
+        if ($commentEnd === false
+            || ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG
+            && $tokens[$commentEnd]['code'] !== T_COMMENT)
+        ) {
+            $phpcsFile->addError('Missing member variable doc comment', $stackPtr, 'Missing');
+            return;
+        }
+
+        if ($tokens[$commentEnd]['code'] === T_COMMENT) {
+            $fix = $phpcsFile->addFixableError('You must use "/**" style comments for a member variable comment', $stackPtr, 'WrongStyle');
+            if ($fix === true) {
+                // Convert the comment into a doc comment.
+                $phpcsFile->fixer->beginChangeset();
+                $comment = '';
+                for ($i = $commentEnd; $tokens[$i]['code'] === T_COMMENT; $i--) {
+                    $comment = ' *'.ltrim($tokens[$i]['content'], '/* ').$comment;
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($commentEnd, "/**\n".rtrim($comment, "*/\n")."\n */\n");
+                $phpcsFile->fixer->endChangeset();
+            }
+
+            return;
+        } else if ($tokens[$commentEnd]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return;
+        } else {
+            // Make sure the comment we have found belongs to us.
+            $commentFor = $phpcsFile->findNext([T_VARIABLE, T_CLASS, T_INTERFACE], ($commentEnd + 1));
+            if ($commentFor !== $stackPtr) {
+                return;
+            }
+        }//end if
+
+        $commentStart = $tokens[$commentEnd]['comment_opener'];
+
+        // Ignore variable comments that use inheritdoc, allow both variants.
+        $commentContent = $phpcsFile->getTokensAsString($commentStart, ($commentEnd - $commentStart));
+        if (strpos($commentContent, '{@inheritdoc}') !== false
+            || strpos($commentContent, '{@inheritDoc}') !== false
+        ) {
+            return;
+        }
+
+        $foundVar = null;
+        foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
+            if ($tokens[$tag]['content'] === '@var') {
+                if ($foundVar !== null) {
+                    $error = 'Only one @var tag is allowed in a member variable comment';
+                    $phpcsFile->addError($error, $tag, 'DuplicateVar');
+                } else {
+                    $foundVar = $tag;
+                }
+            } else if ($tokens[$tag]['content'] === '@see') {
+                // Make sure the tag isn't empty.
+                $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $tag, $commentEnd);
+                if ($string === false || $tokens[$string]['line'] !== $tokens[$tag]['line']) {
+                    $error = 'Content missing for @see tag in member variable comment';
+                    $phpcsFile->addError($error, $tag, 'EmptySees');
+                }
+            }//end if
+        }//end foreach
+
+        // The @var tag is the only one we require.
+        if ($foundVar === null) {
+            $error = 'Missing @var tag in member variable comment';
+            $phpcsFile->addError($error, $commentEnd, 'MissingVar');
+            return;
+        }
+
+        $firstTag = $tokens[$commentStart]['comment_tags'][0];
+        if ($foundVar !== null && $tokens[$firstTag]['content'] !== '@var') {
+            $error = 'The @var tag must be the first tag in a member variable comment';
+            $phpcsFile->addError($error, $foundVar, 'VarOrder');
+        }
+
+        // Make sure the tag isn't empty and has the correct padding.
+        $string = $phpcsFile->findNext(T_DOC_COMMENT_STRING, $foundVar, $commentEnd);
+        if ($string === false || $tokens[$string]['line'] !== $tokens[$foundVar]['line']) {
+            $error = 'Content missing for @var tag in member variable comment';
+            $phpcsFile->addError($error, $foundVar, 'EmptyVar');
+            return;
+        }
+
+        $varType = $tokens[($foundVar + 2)]['content'];
+
+        // There may be multiple types separated by pipes.
+        $suggestedTypes = [];
+        foreach (explode('|', $varType) as $type) {
+            $suggestedTypes[] = FunctionCommentSniff::suggestType($type);
+        }
+
+        $suggestedType = implode('|', $suggestedTypes);
+
+        // Detect and auto-fix the common mistake that the variable name is
+        // appended to the type declaration.
+        $matches = [];
+        if (preg_match('/^([^\s]+)(\s+\$.+)$/', $varType, $matches) === 1) {
+            $error = 'Do not append variable name "%s" to the type declaration in a member variable comment';
+            $data  = [
+                trim($matches[2]),
+            ];
+            $fix   = $phpcsFile->addFixableError($error, ($foundVar + 2), 'InlineVariableName', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($foundVar + 2), $matches[1]);
+            }
+        } else if ($varType !== $suggestedType) {
+            $error = 'Expected "%s" but found "%s" for @var tag in member variable comment';
+            $data  = [
+                $suggestedType,
+                $varType,
+            ];
+            $fix   = $phpcsFile->addFixableError($error, ($foundVar + 2), 'IncorrectVarType', $data);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($foundVar + 2), $suggestedType);
+            }
+        }//end if
+
+    }//end processMemberVar()
+
+
+    /**
+     * Called to process a normal variable.
+     *
+     * Not required for this sniff.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this token was found.
+     * @param int                         $stackPtr  The position where the double quoted
+     *                                               string was found.
+     *
+     * @return void
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr)
+    {
+
+    }//end processVariable()
+
+
+    /**
+     * Called to process variables found in double quoted strings.
+     *
+     * Not required for this sniff.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where this token was found.
+     * @param int                         $stackPtr  The position where the double quoted
+     *                                               string was found.
+     *
+     * @return void
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
+    {
+
+    }//end processVariableInString()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Verifies that control statements conform to their coding standards.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Verifies that control statements conform to their coding standards.
+ *
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\ControlStructures\ControlSignatureSniff
+ * and adapted for Backdrop's else on new lines.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ControlSignatureSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return int[]
+     */
+    public function register()
+    {
+        return [
+            T_TRY,
+            T_CATCH,
+            T_DO,
+            T_WHILE,
+            T_FOR,
+            T_IF,
+            T_FOREACH,
+            T_ELSE,
+            T_ELSEIF,
+            T_SWITCH,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[($stackPtr + 1)]) === false) {
+            return;
+        }
+
+        // Single space after the keyword.
+        $found = 1;
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+            $found = 0;
+        } else if ($tokens[($stackPtr + 1)]['content'] !== ' ') {
+            if (strpos($tokens[($stackPtr + 1)]['content'], $phpcsFile->eolChar) !== false) {
+                $found = 'newline';
+            } else {
+                $found = strlen($tokens[($stackPtr + 1)]['content']);
+            }
+        }
+
+        if ($found !== 1) {
+            $error = 'Expected 1 space after %s keyword; %s found';
+            $data  = [
+                strtoupper($tokens[$stackPtr]['content']),
+                $found,
+            ];
+
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpaceAfterKeyword', $data);
+            if ($fix === true) {
+                if ($found === 0) {
+                    $phpcsFile->fixer->addContent($stackPtr, ' ');
+                } else {
+                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+                }
+            }
+        }
+
+        // Single space after closing parenthesis.
+        if (isset($tokens[$stackPtr]['parenthesis_closer']) === true
+            && isset($tokens[$stackPtr]['scope_opener']) === true
+        ) {
+            $closer  = $tokens[$stackPtr]['parenthesis_closer'];
+            $opener  = $tokens[$stackPtr]['scope_opener'];
+            $content = $phpcsFile->getTokensAsString(($closer + 1), ($opener - $closer - 1));
+
+            if ($content !== ' ') {
+                $error = 'Expected 1 space after closing parenthesis; found %s';
+                if (trim($content) === '') {
+                    $found = strlen($content);
+                } else {
+                    $found = '"'.str_replace($phpcsFile->eolChar, '\n', $content).'"';
+                }
+
+                $fix = $phpcsFile->addFixableError($error, $closer, 'SpaceAfterCloseParenthesis', [$found]);
+                if ($fix === true) {
+                    if ($closer === ($opener - 1)) {
+                        $phpcsFile->fixer->addContent($closer, ' ');
+                    } else {
+                        $phpcsFile->fixer->beginChangeset();
+                        $phpcsFile->fixer->addContent($closer, ' '.$tokens[$opener]['content']);
+                        $phpcsFile->fixer->replaceToken($opener, '');
+
+                        if ($tokens[$opener]['line'] !== $tokens[$closer]['line']) {
+                            $next = $phpcsFile->findNext(T_WHITESPACE, ($opener + 1), null, true);
+                            if ($tokens[$next]['line'] !== $tokens[$opener]['line']) {
+                                for ($i = ($opener + 1); $i < $next; $i++) {
+                                    $phpcsFile->fixer->replaceToken($i, '');
+                                }
+                            }
+                        }
+
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }
+            }//end if
+        }//end if
+
+        // Single newline after opening brace.
+        if (isset($tokens[$stackPtr]['scope_opener']) === true) {
+            $opener = $tokens[$stackPtr]['scope_opener'];
+            for ($next = ($opener + 1); $next < $phpcsFile->numTokens; $next++) {
+                $code = $tokens[$next]['code'];
+
+                if ($code === T_WHITESPACE
+                    || ($code === T_INLINE_HTML
+                    && trim($tokens[$next]['content']) === '')
+                ) {
+                    continue;
+                }
+
+                // Skip all empty tokens on the same line as the opener.
+                if ($tokens[$next]['line'] === $tokens[$opener]['line']
+                    && (isset(Tokens::$emptyTokens[$code]) === true
+                    || $code === T_CLOSE_TAG)
+                ) {
+                    continue;
+                }
+
+                // We found the first bit of a code, or a comment on the
+                // following line.
+                break;
+            }//end for
+
+            if ($tokens[$next]['line'] === $tokens[$opener]['line']) {
+                $error = 'Newline required after opening brace';
+                $fix   = $phpcsFile->addFixableError($error, $opener, 'NewlineAfterOpenBrace');
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    for ($i = ($opener + 1); $i < $next; $i++) {
+                        if (trim($tokens[$i]['content']) !== '') {
+                            break;
+                        }
+
+                        // Remove whitespace.
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+
+                    $phpcsFile->fixer->addContent($opener, $phpcsFile->eolChar);
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }//end if
+        } else if ($tokens[$stackPtr]['code'] === T_WHILE) {
+            // Zero spaces after parenthesis closer.
+            $closer = $tokens[$stackPtr]['parenthesis_closer'];
+            $found  = 0;
+            if ($tokens[($closer + 1)]['code'] === T_WHITESPACE) {
+                if (strpos($tokens[($closer + 1)]['content'], $phpcsFile->eolChar) !== false) {
+                    $found = 'newline';
+                } else {
+                    $found = strlen($tokens[($closer + 1)]['content']);
+                }
+            }
+
+            if ($found !== 0) {
+                $error = 'Expected 0 spaces before semicolon; %s found';
+                $data  = [$found];
+                $fix   = $phpcsFile->addFixableError($error, $closer, 'SpaceBeforeSemicolon', $data);
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($closer + 1), '');
+                }
+            }
+        }//end if
+
+        // Only want to check multi-keyword structures from here on.
+        if ($tokens[$stackPtr]['code'] === T_DO) {
+            $closer = false;
+            if (isset($tokens[$stackPtr]['scope_closer']) === true) {
+                $closer = $tokens[$stackPtr]['scope_closer'];
+            }
+
+            // Do-while loops should have curly braces. This is optional in
+            // Javascript.
+            if ($closer === false && $tokens[$stackPtr]['code'] === T_DO && $phpcsFile->tokenizerType === 'JS') {
+                $error  = 'The code block in a do-while loop should be surrounded by curly braces';
+                $fix    = $phpcsFile->addFixableError($error, $stackPtr, 'DoWhileCurlyBraces');
+                $closer = $phpcsFile->findNext(T_WHILE, $stackPtr);
+                if ($fix === true) {
+                    $phpcsFile->fixer->beginChangeset();
+                    // Append an opening curly brace followed by a newline after
+                    // the DO.
+                    $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+                    if ($next !== ($stackPtr + 1)) {
+                        $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+                    }
+
+                    $phpcsFile->fixer->addContent($stackPtr, ' {'.$phpcsFile->eolChar);
+
+                    // Prepend a closing curly brace before the WHILE and ensure
+                    // it is on a new line.
+                    $prepend = $phpcsFile->eolChar;
+                    if ($tokens[($closer - 1)]['code'] === T_WHITESPACE) {
+                        $prepend = '';
+                        if ($tokens[($closer - 1)]['content'] !== $phpcsFile->eolChar) {
+                            $phpcsFile->fixer->replaceToken(($closer - 1), $phpcsFile->eolChar);
+                        }
+                    }
+
+                    $phpcsFile->fixer->addContentBefore($closer, $prepend.'} ');
+                    $phpcsFile->fixer->endChangeset();
+                }//end if
+            }//end if
+        } else if ($tokens[$stackPtr]['code'] === T_ELSE
+            || $tokens[$stackPtr]['code'] === T_ELSEIF
+            || $tokens[$stackPtr]['code'] === T_CATCH
+        ) {
+            $closer = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($closer === false || $tokens[$closer]['code'] !== T_CLOSE_CURLY_BRACKET) {
+                return;
+            }
+        } else {
+            return;
+        }//end if
+
+        if ($tokens[$stackPtr]['code'] === T_DO) {
+            // Single space after closing brace.
+            $found = 1;
+            if ($tokens[($closer + 1)]['code'] !== T_WHITESPACE) {
+                $found = 0;
+            } else if ($tokens[($closer + 1)]['content'] !== ' ') {
+                if (strpos($tokens[($closer + 1)]['content'], $phpcsFile->eolChar) !== false) {
+                    $found = 'newline';
+                } else {
+                    $found = strlen($tokens[($closer + 1)]['content']);
+                }
+            }
+
+            if ($found !== 1) {
+                $error = 'Expected 1 space after closing brace; %s found';
+                $data  = [$found];
+                $fix   = $phpcsFile->addFixableError($error, $closer, 'SpaceAfterCloseBrace', $data);
+                if ($fix === true) {
+                    if ($found === 0) {
+                        $phpcsFile->fixer->addContent($closer, ' ');
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($closer + 1), ' ');
+                    }
+                }
+            }
+        } else {
+            // New line after closing brace.
+            $found = 'newline';
+            if ($tokens[($closer + 1)]['code'] !== T_WHITESPACE) {
+                $found = 'none';
+            } else if (strpos($tokens[($closer + 1)]['content'], "\n") === false) {
+                $found = 'spaces';
+            }
+
+            if ($found !== 'newline') {
+                $error = 'Expected newline after closing brace';
+                $fix   = $phpcsFile->addFixableError($error, $closer, 'NewlineAfterCloseBrace');
+                if ($fix === true) {
+                    if ($found === 'none') {
+                        $phpcsFile->fixer->addContent($closer, "\n");
+                    } else {
+                        $phpcsFile->fixer->replaceToken(($closer + 1), "\n");
+                    }
+                }
+            }
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/ControlStructures/ElseIfSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/ControlStructures/ElseIfSniff.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Verifies that control statements conform to their coding standards.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that "elseif" is used instead of "else if".
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ElseIfSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_ELSE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonWhiteSpace = $phpcsFile->findNext(
+            T_WHITESPACE,
+            ($stackPtr + 1),
+            null,
+            true,
+            null,
+            true
+        );
+
+        if ($tokens[$nextNonWhiteSpace]['code'] === T_IF) {
+            $fix = $phpcsFile->addFixableError('Use "elseif" in place of "else if"', $nextNonWhiteSpace, 'ElseIfDeclaration');
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($stackPtr, 'elseif');
+                for ($i = ($stackPtr + 1); $i < $nextNonWhiteSpace; $i++) {
+                    if ($tokens[$i]['code'] === T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                    }
+                }
+
+                $phpcsFile->fixer->replaceToken($nextNonWhiteSpace, '');
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * \Backdrop\Sniffs\ControlStructures\InlineControlStructureSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\ControlStructures\InlineControlStructureSniff as GenericInlineControlStructureSniff;
+
+/**
+ * \Backdrop\Sniffs\ControlStructures\InlineControlStructureSniff.
+ *
+ * Verifies that inline control statements are not present. This Sniff overides
+ * the generic sniff because Backdrop template files may use the alternative
+ * syntax for control structures. See
+ * http://www.php.net/manual/en/control-structures.alternative-syntax.php
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class InlineControlStructureSniff extends GenericInlineControlStructureSniff
+{
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the alternate syntax for control structures with colons (:).
+        if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
+            $start = $tokens[$stackPtr]['parenthesis_closer'];
+        } else {
+            $start = $stackPtr;
+        }
+
+        $scopeOpener = $phpcsFile->findNext(T_WHITESPACE, ($start + 1), null, true);
+        if ($tokens[$scopeOpener]['code'] === T_COLON) {
+            return;
+        }
+
+        parent::process($phpcsFile, $stackPtr);
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Files/EndFileNewlineSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Files/EndFileNewlineSniff.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Files\EndFileNewlineSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Ensures the file ends with a newline character.
+ *
+ * Largely copied from PSR2, but we need to run it on *.txt files and templates as
+ * well.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class EndFileNewlineSniff implements Sniff
+{
+
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array<string>
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+        'CSS',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_OPEN_TAG,
+            T_INLINE_HTML,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return int|void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Skip to the end of the file.
+        $tokens = $phpcsFile->getTokens();
+        if ($phpcsFile->tokenizerType === 'PHP') {
+            $lastToken = ($phpcsFile->numTokens - 1);
+        } else {
+            // JS and CSS have an artificial token at the end which we have to
+            // ignore.
+            $lastToken = ($phpcsFile->numTokens - 2);
+        }
+
+        // Hard-coding the expected \n in this sniff as it is PSR-2 specific and
+        // PSR-2 enforces the use of unix style newlines.
+        if (substr($tokens[$lastToken]['content'], -1) !== "\n") {
+            $error = 'Expected 1 newline at end of file; 0 found';
+            $fix   = $phpcsFile->addFixableError($error, $lastToken, 'NoneFound');
+            if ($fix === true) {
+                $phpcsFile->fixer->addNewline($lastToken);
+            }
+
+            $phpcsFile->recordMetric($stackPtr, 'Number of newlines at EOF', '0');
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        // Go looking for the last non-empty line.
+        $lastLine = $tokens[$lastToken]['line'];
+        if ($tokens[$lastToken]['code'] === T_WHITESPACE) {
+            $lastCode = $phpcsFile->findPrevious(T_WHITESPACE, ($lastToken - 1), null, true);
+        } else if ($tokens[$lastToken]['code'] === T_INLINE_HTML) {
+            $lastCode = $lastToken;
+            while ($lastCode > 0 && trim($tokens[$lastCode]['content']) === '') {
+                $lastCode--;
+            }
+        } else {
+            $lastCode = $lastToken;
+        }
+
+        $lastCodeLine = $tokens[$lastCode]['line'];
+        $blankLines   = (string) ($lastLine - $lastCodeLine + 1);
+        $phpcsFile->recordMetric($stackPtr, 'Number of newlines at EOF', $blankLines);
+
+        if ($blankLines > 1) {
+            $error = 'Expected 1 newline at end of file; %s found';
+            $data  = [$blankLines];
+            $fix   = $phpcsFile->addFixableError($error, $lastCode, 'TooMany', $data);
+
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($lastCode, rtrim($tokens[$lastCode]['content']));
+                for ($i = ($lastCode + 1); $i < $lastToken; $i++) {
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->replaceToken($lastToken, $phpcsFile->eolChar);
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+
+        // Skip the rest of the file.
+        return ($phpcsFile->numTokens + 1);
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Files/FileEncodingSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Files/FileEncodingSniff.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Files\FileEncodingSniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Klaus Purer <klaus.purer@mail.com>
+ * @copyright 2016 Klaus Purer
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\Files\FileEncodingSniff.
+ *
+ * Validates the encoding of a file against a white list of allowed encodings.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Klaus Purer <klaus.purer@mail.com>
+ * @copyright 2016 Klaus Purer
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FileEncodingSniff implements Sniff
+{
+
+    /**
+     * List of encodings that files may be encoded with.
+     *
+     * Any other detected encodings will throw a warning.
+     *
+     * @var array<string>
+     */
+    public $allowedEncodings = ['UTF-8'];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_INLINE_HTML,
+            T_OPEN_TAG,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return int|void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Not all PHP installs have the multi byte extension - nothing we can do.
+        if (function_exists('mb_check_encoding') === false) {
+            return $phpcsFile->numTokens;
+        }
+
+        $fileContent = $phpcsFile->getTokensAsString(0, $phpcsFile->numTokens);
+
+        $validEncodingFound = false;
+        foreach ($this->allowedEncodings as $encoding) {
+            if (mb_check_encoding($fileContent, $encoding) === true) {
+                $validEncodingFound = true;
+            }
+        }
+
+        if ($validEncodingFound === false) {
+            $warning = 'File encoding is invalid, expected %s';
+            $data    = [implode(' or ', $this->allowedEncodings)];
+            $phpcsFile->addWarning($warning, $stackPtr, 'InvalidEncoding', $data);
+        }
+
+        return $phpcsFile->numTokens;
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Files/LineLengthSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Files/LineLengthSniff.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Files\LineLengthSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff as GenericLineLengthSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks comment lines in the file, and throws warnings if they are over 80
+ * characters in length.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class LineLengthSniff extends GenericLineLengthSniff
+{
+
+    /**
+     * The limit that the length of a line should not exceed.
+     *
+     * @var integer
+     */
+    public $lineLimit = 80;
+
+    /**
+     * The limit that the length of a line must not exceed.
+     * But just check the line length of comments....
+     *
+     * Set to zero (0) to disable.
+     *
+     * @var integer
+     */
+    public $absoluteLineLimit = 0;
+
+
+    /**
+     * Checks if a line is too long.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param array<int, array>           $tokens    The token stack.
+     * @param int                         $stackPtr  The first token on the next line.
+     *
+     * @return void
+     */
+    protected function checkLineLength($phpcsFile, $tokens, $stackPtr)
+    {
+        if (isset(Tokens::$commentTokens[$tokens[($stackPtr - 1)]['code']]) === true) {
+            $docCommentTag = $phpcsFile->findFirstOnLine(T_DOC_COMMENT_TAG, ($stackPtr - 1));
+            if ($docCommentTag !== false) {
+                // Allow doc comment tags such as long @param tags to exceed the 80
+                // character limit.
+                return;
+            }
+
+            if ($tokens[($stackPtr - 1)]['code'] === T_COMMENT
+                // Allow @link and @see documentation to exceed the 80 character
+                // limit.
+                && (preg_match('/^[[:space:]]*\/\/ @.+/', $tokens[($stackPtr - 1)]['content']) === 1
+                // Allow anything that does not contain spaces (like URLs) to be
+                // longer.
+                || strpos(trim($tokens[($stackPtr - 1)]['content'], "/ \n"), ' ') === false)
+            ) {
+                return;
+            }
+
+            // Code examples between @code and @endcode are allowed to exceed 80
+            // characters.
+            if (isset($tokens[$stackPtr]) === true && $tokens[$stackPtr]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                $tag = $phpcsFile->findPrevious([T_DOC_COMMENT_TAG, T_DOC_COMMENT_OPEN_TAG], ($stackPtr - 1));
+                if ($tokens[$tag]['content'] === '@code') {
+                    return;
+                }
+            }
+
+            // Backdrop 8 annotations can have long translatable descriptions and we
+            // allow them to exceed 80 characters.
+            if ($tokens[($stackPtr - 2)]['code'] === T_DOC_COMMENT_STRING
+                && (strpos($tokens[($stackPtr - 2)]['content'], '@Translation(') !== false
+                // Also allow anything without whitespace (like URLs) to exceed 80
+                // characters.
+                || strpos($tokens[($stackPtr - 2)]['content'], ' ') === false
+                // Allow long "Contains ..." comments in @file doc blocks.
+                || preg_match('/^Contains [a-zA-Z_\\\\.]+$/', $tokens[($stackPtr - 2)]['content']) === 1
+                // Allow long paths or namespaces in annotations such as
+                // "list_builder" = "Backdrop\rules\Entity\Controller\RulesReactionListBuilder"
+                // cardinality = \Backdrop\webform\WebformHandlerInterface::CARDINALITY_UNLIMITED.
+                || preg_match('#= ("|\')?\S+[\\\\/]\S+("|\')?,*$#', $tokens[($stackPtr - 2)]['content']) === 1)
+                // Allow @link tags in lists.
+                || strpos($tokens[($stackPtr - 2)]['content'], '- @link') !== false
+                // Allow hook implementation line to exceed 80 characters.
+                || preg_match('/^Implements hook_[a-zA-Z0-9_]+\(\)/', $tokens[($stackPtr - 2)]['content']) === 1
+            ) {
+                return;
+            }
+
+            parent::checkLineLength($phpcsFile, $tokens, $stackPtr);
+        }//end if
+
+    }//end checkLineLength()
+
+
+    /**
+     * Returns the length of a defined line.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $currentLine The current line.
+     *
+     * @return int
+     */
+    public function getLineLength(File $phpcsFile, $currentLine)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $tokenCount         = 0;
+        $currentLineContent = '';
+
+        $trim = (strlen($phpcsFile->eolChar) * -1);
+        for (; $tokenCount < $phpcsFile->numTokens; $tokenCount++) {
+            if ($tokens[$tokenCount]['line'] === $currentLine) {
+                $currentLineContent .= $tokens[$tokenCount]['content'];
+            }
+        }
+
+        return strlen($currentLineContent);
+
+    }//end getLineLength()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Files/TxtFileLineLengthSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Files/TxtFileLineLengthSniff.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Files\TxtFileLineLengthSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Files;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\Files\TxtFileLineLengthSniff.
+ *
+ * Checks all lines in a *.txt or *.md file and throws warnings if they are over 80
+ * characters in length.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class TxtFileLineLengthSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_INLINE_HTML];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -3));
+        if ($fileExtension === 'txt' || $fileExtension === '.md') {
+            $tokens = $phpcsFile->getTokens();
+
+            $content    = rtrim($tokens[$stackPtr]['content']);
+            $lineLength = mb_strlen($content, 'UTF-8');
+            if ($lineLength > 80) {
+                // Often text files contain long URLs that need to be preceded
+                // with certain textual elements that are significant for
+                // preserving the formatting of the document - e.g. a long link
+                // in a bulleted list. If we find that the line does not contain
+                // any spaces after the 40th character we'll allow it.
+                if (preg_match('/\s+/', mb_substr($content, 40)) === 0) {
+                    return;
+                }
+
+                // Lines without spaces are allowed to be longer.
+                // Markdown allowed to be longer for lines
+                // - without spaces
+                // - starting with #
+                // - starting with | (tables)
+                // - containing a link.
+                if (preg_match('/^([^ ]+$|#|\||.*\[.+\]\(.+\))/', $content) === 0) {
+                    $data    = [
+                        80,
+                        $lineLength,
+                    ];
+                    $warning = 'Line exceeds %s characters; contains %s characters';
+                    $phpcsFile->addWarning($warning, $stackPtr, 'TooLong', $data);
+                }
+            }//end if
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/MultiLineAssignmentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/MultiLineAssignmentSniff.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Formatting\MultiLineAssignmentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\Formatting\MultiLineAssignmentSniff.
+ *
+ * If an assignment goes over two lines, ensure the equal sign is indented.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: 1.2.0RC3
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class MultiLineAssignmentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_EQUAL];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Equal sign can't be the last thing on the line.
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($next === false) {
+            // Bad assignment.
+            return;
+        }
+
+        // Make sure it is the first thing on the line, otherwise we ignore it.
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($prev === false) {
+            // Bad assignment.
+            return;
+        }
+
+        if ($tokens[$prev]['line'] === $tokens[$stackPtr]['line']) {
+            return;
+        }
+
+        // Find the required indent based on the ident of the previous line.
+        $assignmentIndent = 0;
+        $prevLine         = $tokens[$prev]['line'];
+        for ($i = ($prev - 1); $i >= 0; $i--) {
+            if ($tokens[$i]['line'] !== $prevLine) {
+                $i++;
+                break;
+            }
+        }
+
+        if ($tokens[$i]['code'] === T_WHITESPACE) {
+            $assignmentIndent = strlen($tokens[$i]['content']);
+        }
+
+        // Find the actual indent.
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1));
+
+        $expectedIndent = ($assignmentIndent + 2);
+        $foundIndent    = strlen($tokens[$prev]['content']);
+        if ($foundIndent !== $expectedIndent) {
+            $error = "Multi-line assignment not indented correctly; expected $expectedIndent spaces but found $foundIndent";
+            $phpcsFile->addError($error, $stackPtr, 'MultiLineAssignmentIndent');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/MultipleStatementAlignmentSniff.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Formatting\MultipleStatementAlignmentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\MultipleStatementAlignmentSniff as GenericMultipleStatementAlignmentSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks alignment of multiple assignments.Largely copied from
+ * \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\MultipleStatementAlignmentSniff
+ * but also allows multiple single space assignments.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class MultipleStatementAlignmentSniff extends GenericMultipleStatementAlignmentSniff
+{
+
+
+    /**
+     * If true, an error will be thrown; otherwise a warning.
+     *
+     * @var boolean
+     */
+    public $error = true;
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     * @param int                         $end       The token where checking should end.
+     *                                               If NULL, the entire file will be checked.
+     *
+     * @return int
+     */
+    public function checkAlignment($phpcsFile, $stackPtr, $end=null)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $assignments = [];
+        $prevAssign  = null;
+        $lastLine    = $tokens[$stackPtr]['line'];
+        $maxPadding  = null;
+        $stopped     = null;
+        $lastCode    = $stackPtr;
+        $lastSemi    = null;
+        $arrayEnd    = null;
+
+        if ($end === null) {
+            $end = $phpcsFile->numTokens;
+        }
+
+        $find = Tokens::$assignmentTokens;
+        unset($find[T_DOUBLE_ARROW]);
+
+        $scopes = Tokens::$scopeOpeners;
+        unset($scopes[T_CLOSURE]);
+        unset($scopes[T_ANON_CLASS]);
+        unset($scopes[T_OBJECT]);
+
+        for ($assign = $stackPtr; $assign < $end; $assign++) {
+            if ($tokens[$assign]['level'] < $tokens[$stackPtr]['level']) {
+                // Statement is in a different context, so the block is over.
+                break;
+            }
+
+            if (isset($scopes[$tokens[$assign]['code']]) === true
+                && isset($tokens[$assign]['scope_opener']) === true
+                && $tokens[$assign]['level'] === $tokens[$stackPtr]['level']
+            ) {
+                break;
+            }
+
+            if ($assign === $arrayEnd) {
+                $arrayEnd = null;
+            }
+
+            if (isset($find[$tokens[$assign]['code']]) === false) {
+                // A blank line indicates that the assignment block has ended.
+                if (isset(Tokens::$emptyTokens[$tokens[$assign]['code']]) === false
+                    && ($tokens[$assign]['line'] - $tokens[$lastCode]['line']) > 1
+                    && $tokens[$assign]['level'] === $tokens[$stackPtr]['level']
+                    && $arrayEnd === null
+                ) {
+                    break;
+                }
+
+                if ($tokens[$assign]['code'] === T_CLOSE_TAG) {
+                    // Breaking out of PHP ends the assignment block.
+                    break;
+                }
+
+                if ($tokens[$assign]['code'] === T_OPEN_SHORT_ARRAY
+                    && isset($tokens[$assign]['bracket_closer']) === true
+                ) {
+                    $arrayEnd = $tokens[$assign]['bracket_closer'];
+                }
+
+                if ($tokens[$assign]['code'] === T_ARRAY
+                    && isset($tokens[$assign]['parenthesis_opener']) === true
+                    && isset($tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer']) === true
+                ) {
+                    $arrayEnd = $tokens[$tokens[$assign]['parenthesis_opener']]['parenthesis_closer'];
+                }
+
+                if (isset(Tokens::$emptyTokens[$tokens[$assign]['code']]) === false) {
+                    $lastCode = $assign;
+
+                    if ($tokens[$assign]['code'] === T_SEMICOLON) {
+                        if ($tokens[$assign]['conditions'] === $tokens[$stackPtr]['conditions']) {
+                            if ($lastSemi !== null && $prevAssign !== null && $lastSemi > $prevAssign) {
+                                // This statement did not have an assignment operator in it.
+                                break;
+                            } else {
+                                $lastSemi = $assign;
+                            }
+                        } else if ($tokens[$assign]['level'] < $tokens[$stackPtr]['level']) {
+                            // Statement is in a different context, so the block is over.
+                            break;
+                        }
+                    }
+                }//end if
+
+                continue;
+            } else if ($assign !== $stackPtr && $tokens[$assign]['line'] === $lastLine) {
+                // Skip multiple assignments on the same line. We only need to
+                // try and align the first assignment.
+                continue;
+            }//end if
+
+            if ($assign !== $stackPtr) {
+                if ($tokens[$assign]['level'] > $tokens[$stackPtr]['level']) {
+                    // Has to be nested inside the same conditions as the first assignment.
+                    // We've gone one level down, so process this new block.
+                    $assign   = $this->checkAlignment($phpcsFile, $assign);
+                    $lastCode = $assign;
+                    continue;
+                } else if ($tokens[$assign]['level'] < $tokens[$stackPtr]['level']) {
+                    // We've gone one level up, so the block we are processing is done.
+                    break;
+                } else if ($arrayEnd !== null) {
+                    // Assignments inside arrays are not part of
+                    // the original block, so process this new block.
+                    $assign   = ($this->checkAlignment($phpcsFile, $assign, $arrayEnd) - 1);
+                    $arrayEnd = null;
+                    $lastCode = $assign;
+                    continue;
+                }
+
+                // Make sure it is not assigned inside a condition (eg. IF, FOR).
+                if (isset($tokens[$assign]['nested_parenthesis']) === true) {
+                    foreach ($tokens[$assign]['nested_parenthesis'] as $start => $end) {
+                        if (isset($tokens[$start]['parenthesis_owner']) === true) {
+                            break(2);
+                        }
+                    }
+                }
+            }//end if
+
+            $var = $phpcsFile->findPrevious(
+                Tokens::$emptyTokens,
+                ($assign - 1),
+                null,
+                true
+            );
+
+            // Make sure we wouldn't break our max padding length if we
+            // aligned with this statement, or they wouldn't break the max
+            // padding length if they aligned with us.
+            $varEnd    = $tokens[($var + 1)]['column'];
+            $assignLen = $tokens[$assign]['length'];
+            if ($assign !== $stackPtr) {
+                if ($prevAssign === null) {
+                    // Processing an inner block but no assignments found.
+                    break;
+                }
+
+                if (($varEnd + 1) > $assignments[$prevAssign]['assign_col']) {
+                    $padding      = 1;
+                    $assignColumn = ($varEnd + 1);
+                } else {
+                    $padding = ($assignments[$prevAssign]['assign_col'] - $varEnd + $assignments[$prevAssign]['assign_len'] - $assignLen);
+                    if ($padding <= 0) {
+                        $padding = 1;
+                    }
+
+                    if ($padding > $this->maxPadding) {
+                        $stopped = $assign;
+                        break;
+                    }
+
+                    $assignColumn = ($varEnd + $padding);
+                }//end if
+
+                if (($assignColumn + $assignLen) > ($assignments[$maxPadding]['assign_col'] + $assignments[$maxPadding]['assign_len'])) {
+                    $newPadding = ($varEnd - $assignments[$maxPadding]['var_end'] + $assignLen - $assignments[$maxPadding]['assign_len'] + 1);
+                    if ($newPadding > $this->maxPadding) {
+                        $stopped = $assign;
+                        break;
+                    } else {
+                        // New alignment settings for previous assignments.
+                        foreach ($assignments as $i => $data) {
+                            if ($i === $assign) {
+                                break;
+                            }
+
+                            $newPadding = ($varEnd - $data['var_end'] + $assignLen - $data['assign_len'] + 1);
+                            $assignments[$i]['expected']   = $newPadding;
+                            $assignments[$i]['assign_col'] = ($data['var_end'] + $newPadding);
+                        }
+
+                        $padding      = 1;
+                        $assignColumn = ($varEnd + 1);
+                    }
+                } else if ($padding > $assignments[$maxPadding]['expected']) {
+                    $maxPadding = $assign;
+                }//end if
+            } else {
+                $padding      = 1;
+                $assignColumn = ($varEnd + 1);
+                $maxPadding   = $assign;
+            }//end if
+
+            $found = 0;
+            if ($tokens[($var + 1)]['code'] === T_WHITESPACE) {
+                $found = $tokens[($var + 1)]['length'];
+                if ($found === 0) {
+                    // This means a newline was found.
+                    $found = 1;
+                }
+            }
+
+            $assignments[$assign] = [
+                'var_end'    => $varEnd,
+                'assign_len' => $assignLen,
+                'assign_col' => $assignColumn,
+                'expected'   => $padding,
+                'found'      => $found,
+            ];
+
+            $lastLine   = $tokens[$assign]['line'];
+            $prevAssign = $assign;
+        }//end for
+
+        if (empty($assignments) === true) {
+            return $stackPtr;
+        }
+
+        // If there is at least one assignment that uses more than two spaces then it
+        // appears that the assignments should all be aligned right.
+        $alignRight = false;
+        foreach ($assignments as $assignment => $data) {
+            if ($data['found'] > 2) {
+                $alignRight = true;
+                break;
+            }
+        }
+
+        $numAssignments = count($assignments);
+
+        $errorGenerated = false;
+        foreach ($assignments as $assignment => $data) {
+            // Missing space is already covered by
+            // Backdrop.WhiteSpace.OperatorSpacing.NoSpaceBefore.
+            if ($data['found'] === 0) {
+                continue;
+            }
+
+            if ($alignRight === false && $data['found'] !== $data['expected']) {
+                $data['expected'] = 1;
+            }
+
+            if ($data['found'] === $data['expected']) {
+                continue;
+            }
+
+            $expectedText = $data['expected'].' space';
+            if ($data['expected'] !== 1) {
+                $expectedText .= 's';
+            }
+
+            if ($data['found'] === null) {
+                $foundText = 'a new line';
+            } else {
+                $foundText = $data['found'].' space';
+                if ($data['found'] !== 1) {
+                    $foundText .= 's';
+                }
+            }
+
+            if ($numAssignments === 1) {
+                $type  = 'Incorrect';
+                $error = 'Equals sign not aligned correctly; expected %s but found %s';
+            } else {
+                $type  = 'NotSame';
+                $error = 'Equals sign not aligned with surrounding assignments; expected %s but found %s';
+            }
+
+            $errorData = [
+                $expectedText,
+                $foundText,
+            ];
+
+            if ($this->error === true) {
+                $fix = $phpcsFile->addFixableError($error, $assignment, $type, $errorData);
+            } else {
+                $fix = $phpcsFile->addFixableWarning($error, $assignment, $type.'Warning', $errorData);
+            }
+
+            $errorGenerated = true;
+
+            if ($fix === true && $data['found'] !== null) {
+                $newContent = str_repeat(' ', $data['expected']);
+                if ($data['found'] === 0) {
+                    $phpcsFile->fixer->addContentBefore($assignment, $newContent);
+                } else {
+                    $phpcsFile->fixer->replaceToken(($assignment - 1), $newContent);
+                }
+            }
+        }//end foreach
+
+        if ($numAssignments > 1) {
+            if ($errorGenerated === true) {
+                $phpcsFile->recordMetric($stackPtr, 'Adjacent assignments aligned', 'no');
+            } else {
+                $phpcsFile->recordMetric($stackPtr, 'Adjacent assignments aligned', 'yes');
+            }
+        }
+
+        if ($stopped !== null) {
+            return $this->checkAlignment($phpcsFile, $stopped);
+        } else {
+            return $assign;
+        }
+
+    }//end checkAlignment()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/SpaceInlineIfSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/SpaceInlineIfSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Formatting\SpaceInlineIfSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that there is no space between "?" and ":" inline if/else statements.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class SpaceInlineIfSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_INLINE_ELSE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Handle the short ternary operator (?:) introduced in PHP 5.3.
+        $previous = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($tokens[$previous]['code'] === T_INLINE_THEN) {
+            if ($previous !== ($stackPtr - 1)) {
+                $error = 'There must be no space between ? and :';
+                $phpcsFile->addError($error, $stackPtr, 'SpaceInlineElse');
+            }
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/SpaceUnaryOperatorSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Formatting/SpaceUnaryOperatorSniff.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Formatting\SpaceUnaryOperatorSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * \PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\SpaceUnaryOperatorSniff.
+ *
+ * Ensures there are no spaces on increment / decrement statements or on +/- sign
+ * operators or "!" boolean negators.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class SpaceUnaryOperatorSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+         return [
+             T_DEC,
+             T_INC,
+             T_MINUS,
+             T_PLUS,
+             T_BOOLEAN_NOT,
+         ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in
+     *                                               the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check decrement / increment.
+        if ($tokens[$stackPtr]['code'] === T_DEC || $tokens[$stackPtr]['code'] === T_INC) {
+            $previous   = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $modifyLeft = in_array(
+                $tokens[$previous]['code'],
+                [
+                    T_VARIABLE,
+                    T_CLOSE_SQUARE_BRACKET,
+                    T_CLOSE_PARENTHESIS,
+                    T_STRING,
+                ]
+            );
+
+            if ($modifyLeft === true && $tokens[($stackPtr - 1)]['code'] === T_WHITESPACE) {
+                $error = 'There must not be a single space before a unary operator statement';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncDecLeft');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($stackPtr - 1), '');
+                }
+
+                return;
+            }
+
+            if ($modifyLeft === false && $tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+                $error = 'A unary operator statement must not be followed by a single space';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'IncDecRight');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+                }
+
+                return;
+            }
+        }//end if
+
+        // Check "!" operator.
+        if ($tokens[$stackPtr]['code'] === T_BOOLEAN_NOT && $tokens[($stackPtr + 1)]['code'] === T_WHITESPACE) {
+            $error = 'A unary operator statement must not be followed by a space';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'BooleanNot');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+            }
+
+            return;
+        }
+
+        // Find the last syntax item to determine if this is an unary operator.
+        $lastSyntaxItem        = $phpcsFile->findPrevious(
+            [T_WHITESPACE],
+            ($stackPtr - 1),
+            (($tokens[$stackPtr]['column']) * -1),
+            true,
+            null,
+            true
+        );
+        $operatorSuffixAllowed = in_array(
+            $tokens[$lastSyntaxItem]['code'],
+            [
+                T_LNUMBER,
+                T_DNUMBER,
+                T_CLOSE_PARENTHESIS,
+                T_CLOSE_CURLY_BRACKET,
+                T_CLOSE_SQUARE_BRACKET,
+                T_CLOSE_SHORT_ARRAY,
+                T_VARIABLE,
+                T_STRING,
+            ]
+        );
+
+        // Check plus / minus value assignments or comparisons.
+        if ($tokens[$stackPtr]['code'] === T_MINUS || $tokens[$stackPtr]['code'] === T_PLUS) {
+            if ($operatorSuffixAllowed === false
+                && $tokens[($stackPtr + 1)]['code'] === T_WHITESPACE
+            ) {
+                $error = 'A unary operator statement must not be followed by a space';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'PlusMinus');
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Functions/DiscouragedFunctionsSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Functions/DiscouragedFunctionsSniff.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Functions\DiscouragedFunctionsSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Functions;
+
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
+
+/**
+ * Discourage the use of debug functions.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class DiscouragedFunctionsSniff extends ForbiddenFunctionsSniff
+{
+
+    /**
+     * A list of forbidden functions with their alternatives.
+     *
+     * The value is NULL if no alternative exists, i.e., the function should
+     * just not be used.
+     *
+     * @var array<string, null>
+     */
+    public $forbiddenFunctions = [
+                                     // Devel module debugging functions.
+        'dargs'               => null,
+        'dcp'                 => null,
+        'dd'                  => null,
+        'ddebug_backtrace'    => null,
+        'ddm'                 => null,
+        'dfb'                 => null,
+        'dfbt'                => null,
+        'dpm'                 => null,
+        'dpq'                 => null,
+        'dpr'                 => null,
+        'dprint_r'            => null,
+        'backdrop_debug'        => null,
+        'dsm'                 => null,
+        'dvm'                 => null,
+        'dvr'                 => null,
+        'kdevel_print_object' => null,
+        'kint'                => null,
+        'ksm'                 => null,
+        'kpr'                 => null,
+        'kprint_r'            => null,
+        'sdpm'                => null,
+                                  // Functions which are not available on all
+                                  // PHP builds.
+        'fnmatch'             => null,
+                                  // Functions which are a security risk.
+        'eval'                => null,
+    ];
+
+    /**
+     * If true, an error will be thrown; otherwise a warning.
+     *
+     * @var boolean
+     */
+    public $error = false;
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/InfoFiles/AutoAddedKeysSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/InfoFiles/AutoAddedKeysSniff.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * \Backdrop\Sniffs\InfoFiles\RequiredSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\InfoFiles;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * "version", "project" and "timestamp" are added automatically by backdrop.org
+ * packaging scripts.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class AutoAddedKeysSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_INLINE_HTML];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Only run this sniff once per info file.
+        if (preg_match('/\.info$/', $phpcsFile->getFilename()) === 1) {
+            // Backdrop 7 style info file.
+            $contents = file_get_contents($phpcsFile->getFilename());
+            $info     = ClassFilesSniff::backdropParseInfoFormat($contents);
+        } else if (preg_match('/\.info\.yml$/', $phpcsFile->getFilename()) === 1) {
+            // Backdrop 8 style info.yml file.
+            $contents = file_get_contents($phpcsFile->getFilename());
+            try {
+                $info = \Symfony\Component\Yaml\Yaml::parse($contents);
+            } catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
+                // If the YAML is invalid we ignore this file.
+                return ($phpcsFile->numTokens + 1);
+            }
+        } else {
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        if (isset($info['project']) === true) {
+            $warning = 'Remove "project" from the info file, it will be added by backdrop.org packaging automatically';
+            $phpcsFile->addWarning($warning, $stackPtr, 'Project');
+        }
+
+        if (isset($info['datestamp']) === true) {
+            $warning = 'Remove "datestamp" from the info file, it will be added by backdrop.org packaging automatically';
+            $phpcsFile->addWarning($warning, $stackPtr, 'Timestamp');
+        }
+
+        // "version" is special: we want to allow it in core, but not anywhere else.
+        if (isset($info['version']) === true && strpos($phpcsFile->getFilename(), '/core/') === false) {
+            $warning = 'Remove "version" from the info file, it will be added by backdrop.org packaging automatically';
+            $phpcsFile->addWarning($warning, $stackPtr, 'Version');
+        }
+
+        return ($phpcsFile->numTokens + 1);
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/InfoFiles/ClassFilesSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/InfoFiles/ClassFilesSniff.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * \Backdrop\Sniffs\InfoFiles\ClassFilesSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\InfoFiles;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks files[] entries in info files. Only files containing classes/interfaces
+ * should be listed.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ClassFilesSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_INLINE_HTML];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Only run this sniff once per info file.
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -4));
+        if ($fileExtension !== 'info') {
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        $contents = file_get_contents($phpcsFile->getFilename());
+        $info     = self::backdropParseInfoFormat($contents);
+        if (isset($info['files']) === true && is_array($info['files']) === true) {
+            foreach ($info['files'] as $file) {
+                $fileName = dirname($phpcsFile->getFilename()).'/'.$file;
+                if (file_exists($fileName) === false) {
+                    // We need to find the position of the offending line in the
+                    // info file.
+                    $ptr   = self::getPtr('files[]', $file, $phpcsFile);
+                    $error = 'Declared file was not found';
+                    $phpcsFile->addError($error, $ptr, 'DeclaredFileNotFound');
+                    continue;
+                }
+
+                // Read the file, parse its tokens and check if it actually contains
+                // a class or interface definition.
+                $searchTokens = token_get_all(file_get_contents($fileName));
+                foreach ($searchTokens as $token) {
+                    if (is_array($token) === true
+                        && in_array($token[0], [T_CLASS, T_INTERFACE, T_TRAIT]) === true
+                    ) {
+                        continue 2;
+                    }
+                }
+
+                $ptr   = self::getPtr('files[]', $file, $phpcsFile);
+                $error = "It's only necessary to declare files[] if they declare a class or interface.";
+                $phpcsFile->addError($error, $ptr, 'UnecessaryFileDeclaration');
+            }//end foreach
+        }//end if
+
+        return ($phpcsFile->numTokens + 1);
+
+    }//end process()
+
+
+    /**
+     * Helper function that returns the position of the key in the info file.
+     *
+     * @param string                      $key      Key name to search for.
+     * @param string                      $value    Corresponding value to search for.
+     * @param \PHP_CodeSniffer\Files\File $infoFile Info file to search in.
+     *
+     * @return int|false Returns the stack position if the file name is found, false
+     *                                      otherwise.
+     */
+    public static function getPtr($key, $value, File $infoFile)
+    {
+        foreach ($infoFile->getTokens() as $ptr => $tokenInfo) {
+            if (preg_match('@^[\s]*'.preg_quote($key).'[\s]*=[\s]*["\']?'.preg_quote($value).'["\']?@', $tokenInfo['content']) === 1) {
+                return $ptr;
+            }
+        }
+
+        return false;
+
+    }//end getPtr()
+
+
+    /**
+     * Parses a Backdrop info file. Copied from Backdrop core backdrop_parse_info_format().
+     *
+     * @param string $data The contents of the info file to parse
+     *
+     * @return array<mixed> The info array.
+     */
+    public static function backdropParseInfoFormat($data)
+    {
+        $info      = [];
+        $constants = get_defined_constants();
+
+        if (preg_match_all(
+            '
+          @^\s*                           # Start at the beginning of a line, ignoring leading whitespace
+          ((?:
+            [^=;\[\]]|                    # Key names cannot contain equal signs, semi-colons or square brackets,
+            \[[^\[\]]*\]                  # unless they are balanced and not nested
+          )+?)
+          \s*=\s*                         # Key/value pairs are separated by equal signs (ignoring white-space)
+          (?:
+            ("(?:[^"]|(?<=\\\\)")*")|     # Double-quoted string, which may contain slash-escaped quotes/slashes
+            (\'(?:[^\']|(?<=\\\\)\')*\')| # Single-quoted string, which may contain slash-escaped quotes/slashes
+            ([^\r\n]*?)                   # Non-quoted string
+          )\s*$                           # Stop at the next end of a line, ignoring trailing whitespace
+          @msx',
+            $data,
+            $matches,
+            PREG_SET_ORDER
+        ) !== false
+        ) {
+            foreach ($matches as $match) {
+                // Fetch the key and value string.
+                $i = 0;
+                foreach (['key', 'value1', 'value2', 'value3'] as $var) {
+                    if (isset($match[++$i]) === true) {
+                        $$var = $match[$i];
+                    } else {
+                        $$var = '';
+                    }
+                }
+
+                $value = stripslashes(substr($value1, 1, -1)).stripslashes(substr($value2, 1, -1)).$value3;
+
+                // Parse array syntax.
+                $keys   = preg_split('/\]?\[/', rtrim($key, ']'));
+                $last   = array_pop($keys);
+                $parent = &$info;
+
+                // Create nested arrays.
+                foreach ($keys as $key) {
+                    if ($key === '') {
+                        $key = count($parent);
+                    }
+
+                    if (isset($parent[$key]) === false || is_array($parent[$key]) === false) {
+                        $parent[$key] = [];
+                    }
+
+                    $parent = &$parent[$key];
+                }
+
+                // Handle PHP constants.
+                if (isset($constants[$value]) === true) {
+                    $value = $constants[$value];
+                }
+
+                // Insert actual value.
+                if ($last === '') {
+                    $last = count($parent);
+                }
+
+                $parent[$last] = $value;
+            }//end foreach
+        }//end if
+
+        return $info;
+
+    }//end backdropParseInfoFormat()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/InfoFiles/RequiredSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/InfoFiles/RequiredSniff.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * \Backdrop\Sniffs\InfoFiles\RequiredSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\InfoFiles;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * "name", "description" and "core are required fields in Backdrop info files. Also
+ * checks the "php" minimum requirement for Backdrop 7.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class RequiredSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_INLINE_HTML];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Only run this sniff once per info file.
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -4));
+        if ($fileExtension !== 'info') {
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        $contents = file_get_contents($phpcsFile->getFilename());
+        $info     = ClassFilesSniff::backdropParseInfoFormat($contents);
+        if (isset($info['name']) === false) {
+            $error = '"name" property is missing in the info file';
+            $phpcsFile->addError($error, $stackPtr, 'Name');
+        }
+
+        if (isset($info['description']) === false) {
+            $error = '"description" property is missing in the info file';
+            $phpcsFile->addError($error, $stackPtr, 'Description');
+        }
+
+        if (isset($info['backdrop']) === false) {
+            $error = '"backdrop" property is missing in the info file';
+            $phpcsFile->addError($error, $stackPtr, 'Core version');
+        }
+
+        return ($phpcsFile->numTokens + 1);
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Methods/MethodDeclarationSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Methods/MethodDeclarationSniff.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Methods\MethodDeclarationSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Methods;
+
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff as PSR2MethodDeclarationSniff;
+
+/**
+ * Checks that the method declaration is correct.
+ *
+ * Extending
+ * \PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff
+ * to also support traits.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class MethodDeclarationSniff extends PSR2MethodDeclarationSniff
+{
+
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        AbstractScopeSniff::__construct([T_CLASS, T_INTERFACE, T_TRAIT], [T_FUNCTION]);
+
+    }//end __construct()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidClassNameSniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidClassNameSniff.
+ *
+ * Ensures class and interface names start with a capital letter
+ * and do not use _ separators.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: 1.2.0RC3
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ValidClassNameSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_CLASS,
+            T_INTERFACE,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being processed.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $className = $phpcsFile->findNext(T_STRING, $stackPtr);
+        $name      = trim($tokens[$className]['content']);
+        $errorData = [ucfirst($tokens[$stackPtr]['content'])];
+
+        // Make sure the first letter is a capital.
+        if (preg_match('|^[A-Z]|', $name) === 0) {
+            $error = '%s name must begin with a capital letter';
+            $phpcsFile->addError($error, $stackPtr, 'StartWithCaptial', $errorData);
+        }
+
+        // Search for underscores.
+        if (strpos($name, '_') !== false) {
+            $error = '%s name must use UpperCamel naming without underscores';
+            $phpcsFile->addError($error, $stackPtr, 'NoUnderscores', $errorData);
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidFunctionNameSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff;
+use PHP_CodeSniffer\Util\Common;
+
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidFunctionNameSniff.
+ *
+ * Extends
+ * \PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff
+ * to also check global function names outside the scope of classes and to not
+ * allow methods beginning with an underscore.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ValidFunctionNameSniff extends CamelCapsFunctionNameSniff
+{
+
+
+    /**
+     * Processes the tokens within the scope.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+     * @param int                         $stackPtr  The position where this token was
+     *                                               found.
+     * @param int                         $currScope The position of the current scope.
+     *
+     * @return void
+     */
+    protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
+    {
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($methodName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        $className = $phpcsFile->getDeclarationName($currScope);
+        $errorData = [$className.'::'.$methodName];
+
+        // Is this a magic method. i.e., is prefixed with "__" ?
+        if (preg_match('|^__|', $methodName) !== 0) {
+            $magicPart = strtolower(substr($methodName, 2));
+            if (isset($this->magicMethods[$magicPart]) === false
+                && isset($this->methodsDoubleUnderscore[$magicPart]) === false
+            ) {
+                $error = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
+                $phpcsFile->addError($error, $stackPtr, 'MethodDoubleUnderscore', $errorData);
+            }
+
+            return;
+        }
+
+        $methodProps = $phpcsFile->getMethodProperties($stackPtr);
+        if (Common::isCamelCaps($methodName, false, true, $this->strict) === false) {
+            if ($methodProps['scope_specified'] === true) {
+                $error = '%s method name "%s" is not in lowerCamel format';
+                $data  = [
+                    ucfirst($methodProps['scope']),
+                    $errorData[0],
+                ];
+                $phpcsFile->addError($error, $stackPtr, 'ScopeNotCamelCaps', $data);
+            } else {
+                $error = 'Method name "%s" is not in lowerCamel format';
+                $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $errorData);
+            }
+
+            $phpcsFile->recordMetric($stackPtr, 'CamelCase method name', 'no');
+            return;
+        } else {
+            $phpcsFile->recordMetric($stackPtr, 'CamelCase method name', 'yes');
+        }
+
+    }//end processTokenWithinScope()
+
+
+    /**
+     * Processes the tokens outside the scope.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+     * @param int                         $stackPtr  The position where this token was
+     *                                               found.
+     *
+     * @return void
+     */
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
+    {
+        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($functionName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        $isApiFile     = substr($phpcsFile->getFilename(), -8) === '.api.php';
+        $isHookExample = substr($functionName, 0, 5) === 'hook_';
+        if ($isApiFile === true && $isHookExample === true) {
+            // Ignore for examaple hook_ENTITY_TYPE_insert() functions in .api.php
+            // files.
+            return;
+        }
+
+        if ($functionName !== strtolower($functionName)) {
+            $expected = strtolower(preg_replace('/([^_])([A-Z])/', '$1_$2', $functionName));
+            $error    = 'Invalid function name, expected %s but found %s';
+            $data     = [
+                $expected,
+                $functionName,
+            ];
+            $phpcsFile->addError($error, $stackPtr, 'InvalidName', $data);
+        }
+
+    }//end processTokenOutsideScope()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidGlobalSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidGlobalSniff.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidGlobalSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Ensures that global variables start with an underscore.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ValidGlobalSniff implements Sniff
+{
+
+    /**
+     * List of allowed Backdrop core global variable names.
+     *
+     * @var array<string>
+     */
+    public $coreGlobals = [
+        '$argc',
+        '$argv',
+        '$base_insecure_url',
+        '$base_path',
+        '$base_root',
+        '$base_secure_url',
+        '$base_theme_info',
+        '$base_url',
+        '$channel',
+        '$conf',
+        '$config',
+        '$config_directories',
+        '$cookie_domain',
+        '$databases',
+        '$db_prefix',
+        '$db_type',
+        '$db_url',
+        '$backdrop_hash_salt',
+        '$backdrop_test_info',
+        '$element',
+        '$forum_topic_list_header',
+        '$image',
+        '$install_state',
+        '$installed_profile',
+        '$is_https',
+        '$is_https_mock',
+        '$item',
+        '$items',
+        '$language',
+        '$language_content',
+        '$language_url',
+        '$locks',
+        '$menu_admin',
+        '$multibyte',
+        '$pager_limits',
+        '$pager_page_array',
+        '$pager_total',
+        '$pager_total_items',
+        '$tag',
+        '$theme',
+        '$theme_engine',
+        '$theme_info',
+        '$theme_key',
+        '$theme_path',
+        '$timers',
+        '$update_free_access',
+        '$update_rewrite_settings',
+        '$user',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_GLOBAL];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being processed.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $varToken = $stackPtr;
+        // Find variable names until we hit a semicolon.
+        $ignore   = Tokens::$emptyTokens;
+        $ignore[] = T_SEMICOLON;
+        while (($varToken = $phpcsFile->findNext($ignore, ($varToken + 1), null, true, null, true)) !== false) {
+            if ($tokens[$varToken]['code'] === T_VARIABLE
+                && in_array($tokens[$varToken]['content'], $this->coreGlobals) === false
+                && $tokens[$varToken]['content'][1] !== '_'
+            ) {
+                $error = 'global variables should start with a single underscore followed by the module and another underscore';
+                $phpcsFile->addError($error, $varToken, 'GlobalUnderScore');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidVariableNameSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
+
+/**
+ * \Backdrop\Sniffs\NamingConventions\ValidVariableNameSniff.
+ *
+ * Checks the naming of member variables.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ValidVariableNameSniff extends AbstractVariableSniff
+{
+
+
+    /**
+     * Processes class member variables.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processMemberVar(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $memberProps = $phpcsFile->getMemberProperties($stackPtr);
+        if (empty($memberProps) === true) {
+            return;
+        }
+
+        // Check if the class extends another class and get the name of the class
+        // that is extended.
+        if (empty($tokens[$stackPtr]['conditions']) === false) {
+            $classPtr    = key($tokens[$stackPtr]['conditions']);
+            $extendsName = $phpcsFile->findExtendedClassName($classPtr);
+
+            // Special case config entities: those are allowed to have underscores in
+            // their class property names. If a class extends something like
+            // ConfigEntityBase then we consider it a config entity class and allow
+            // underscores.
+            if ($extendsName !== false && strpos($extendsName, 'ConfigEntity') !== false) {
+                return;
+            }
+
+            // Plugin annotations may have underscores in class properties.
+            // For example, see \Backdrop\Core\Field\Annotation\FieldFormatter.
+            // The only class named "Plugin" in Backdrop core is
+            // \Backdrop\Component\Annotation\Plugin while many Views plugins
+            // extend \Backdrop\views\Annotation\ViewsPluginAnnotationBase.
+            if ($extendsName !== false && in_array(
+                $extendsName,
+                [
+                    'Plugin',
+                    'ViewsPluginAnnotationBase',
+                ]
+            ) !== false
+            ) {
+                return;
+            }
+
+            $implementsNames = $phpcsFile->findImplementedInterfaceNames($classPtr);
+            if ($implementsNames !== false && in_array('AnnotationInterface', $implementsNames) !== false) {
+                return;
+            }
+        }//end if
+
+        // The name of a property must start with a lowercase letter, properties
+        // with underscores are not allowed, except the cases handled above.
+        $memberName = ltrim($tokens[$stackPtr]['content'], '$');
+        if (preg_match('/^[a-z]/', $memberName) === 1 && strpos($memberName, '_') === false) {
+            return;
+        }
+
+        $error = 'Class property %s should use lowerCamel naming without underscores';
+        $data  = [$tokens[$stackPtr]['content']];
+        $phpcsFile->addError($error, $stackPtr, 'LowerCamelName', $data);
+
+    }//end processMemberVar()
+
+
+    /**
+     * Processes normal variables.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processVariable(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $varName = ltrim($tokens[$stackPtr]['content'], '$');
+
+        $phpReservedVars = [
+            '_SERVER',
+            '_GET',
+            '_POST',
+            '_REQUEST',
+            '_SESSION',
+            '_ENV',
+            '_COOKIE',
+            '_FILES',
+            'GLOBALS',
+        ];
+
+        // If it's a php reserved var, then its ok.
+        if (in_array($varName, $phpReservedVars) === true) {
+            return;
+        }
+
+        // If it is a static public variable of a class, then its ok.
+        if ($tokens[($stackPtr - 1)]['code'] === T_DOUBLE_COLON) {
+            return;
+        }
+
+        if (preg_match('/^[A-Z]/', $varName) === 1) {
+            $error = "Variable \"$varName\" starts with a capital letter, but only \$lowerCamelCase or \$snake_case is allowed";
+            $phpcsFile->addError($error, $stackPtr, 'LowerStart');
+        }
+
+    }//end processVariable()
+
+
+    /**
+     * Processes variables in double quoted strings.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     *
+     * @return void
+     */
+    protected function processVariableInString(File $phpcsFile, $stackPtr)
+    {
+        // We don't care about variables in strings.
+        return;
+
+    }//end processVariableInString()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Scope/MethodScopeSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Scope/MethodScopeSniff.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Verifies that class/interface/trait methods have scope modifiers.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Scope;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Verifies that class/interface/trait methods have scope modifiers.
+ *
+ * Laregely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MethodScopeSniff to work on
+ * traits and have a fixer.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class MethodScopeSniff extends AbstractScopeSniff
+{
+
+
+    /**
+     * Constructs a
+     * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Scope\MethodScopeSniff.
+     */
+    public function __construct()
+    {
+        parent::__construct([T_CLASS, T_INTERFACE, T_TRAIT], [T_FUNCTION]);
+
+    }//end __construct()
+
+
+    /**
+     * Processes the function tokens within the class.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position where the token was found.
+     * @param int                         $currScope The current scope opener token.
+     *
+     * @return void
+     */
+    protected function processTokenWithinScope(File $phpcsFile, $stackPtr, $currScope)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($methodName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        if ($phpcsFile->hasCondition($stackPtr, T_FUNCTION) === true) {
+            // Ignore nested functions.
+            return;
+        }
+
+        $modifier = null;
+        for ($i = ($stackPtr - 1); $i > 0; $i--) {
+            if ($tokens[$i]['line'] < $tokens[$stackPtr]['line']) {
+                break;
+            } else if (isset(Tokens::$scopeModifiers[$tokens[$i]['code']]) === true) {
+                $modifier = $i;
+                break;
+            }
+        }
+
+        if ($modifier === null) {
+            $error = 'Visibility must be declared on method "%s"';
+            $data  = [$methodName];
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Missing', $data);
+
+            if ($fix === true) {
+                // No scope modifier means the method is public in PHP, fix that
+                // to be explicitly public.
+                $phpcsFile->fixer->addContentBefore($stackPtr, 'public ');
+            }
+        }
+
+    }//end processTokenWithinScope()
+
+
+    /**
+     * Processes a token that is found outside the scope that this test is
+     * listening to.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file where this token was found.
+     * @param int                         $stackPtr  The position in the stack where this
+     *                                               token was found.
+     *
+     * @return void
+     */
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
+    {
+
+    }//end processTokenOutsideScope()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/ConstantNameSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/ConstantNameSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\ConstantNameSniff
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Checks that constants introduced with define() in module or install files start
+ * with the module's name.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ConstantNameSniff extends FunctionCall
+{
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return ['define'];
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        File $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+        $nameParts     = explode('.', basename($phpcsFile->getFilename()));
+        $fileExtension = end($nameParts);
+        // Only check in *.module files.
+        if ($fileExtension !== 'module' && $fileExtension !== 'install') {
+            return;
+        }
+
+        $tokens   = $phpcsFile->getTokens();
+        $argument = $this->getArgument(1);
+        if ($tokens[$argument['start']]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+            // Not a string literal, so this is some obscure constant that we ignore.
+            return;
+        }
+
+        $moduleName    = reset($nameParts);
+        $expectedStart = strtoupper($moduleName);
+        // Remove the quotes around the string litral.
+        $constant = substr($tokens[$argument['start']]['content'], 1, -1);
+        if (strpos($constant, $expectedStart) !== 0) {
+            $warning = 'All constants defined by a module must be prefixed with the module\'s name, expected "%s" but found "%s"';
+            $data    = [
+                $expectedStart."_$constant",
+                $constant,
+            ];
+            $phpcsFile->addWarning($warning, $stackPtr, 'ConstantStart', $data);
+        }
+
+    }//end processFunctionCall()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/EmptyInstallSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/EmptyInstallSniff.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\EmptyInstallSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Throws an error if hook_install() or hook_uninstall() definitions are empty.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class EmptyInstallSniff extends FunctionDefinition
+{
+
+
+    /**
+     * Process this function definition.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the function name in the stack.
+     *                                                 name in the stack.
+     * @param int                         $functionPtr The position of the function keyword in the stack.
+     *                                                 keyword in the stack.
+     *
+     * @return void
+     */
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
+    {
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -7));
+        // Only check in *.install files.
+        if ($fileExtension !== 'install') {
+            return;
+        }
+
+        $fileName = substr(basename($phpcsFile->getFilename()), 0, -8);
+        $tokens   = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content'] === ($fileName.'_install')
+            || $tokens[$stackPtr]['content'] === ($fileName.'_uninstall')
+        ) {
+            // Check if there is a function body.
+            $bodyPtr = $phpcsFile->findNext(
+                Tokens::$emptyTokens,
+                ($tokens[$functionPtr]['scope_opener'] + 1),
+                $tokens[$functionPtr]['scope_closer'],
+                true
+            );
+            if ($bodyPtr === false) {
+                $error = 'Empty installation hooks are not necessary';
+                $phpcsFile->addError($error, $stackPtr, 'EmptyInstall');
+            }
+        }
+
+    }//end processFunction()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionAliasSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionAliasSniff.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\FunctionAliasSniff
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Checks that no PHP function name aliases are used.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FunctionAliasSniff extends FunctionCall
+{
+
+    /**
+     * Holds all PHP function name aliases (keys) and originals (values). See
+     * http://php.net/manual/en/aliases.php
+     *
+     * @var array<string, string>
+     */
+    protected $aliases = [
+        '_'                          => 'gettext',
+        'chop'                       => 'rtrim',
+        'close'                      => 'closedir',
+        'com_get'                    => 'com_propget',
+        'com_propset'                => 'com_propput',
+        'com_set'                    => 'com_propput',
+        'die'                        => 'exit',
+        'diskfreespace'              => 'disk_free_space',
+        'doubleval'                  => 'floatval',
+        'fbsql'                      => 'fbsql_db_query',
+        'fputs'                      => 'fwrite',
+        'gzputs'                     => 'gzwrite',
+        'i18n_convert'               => 'mb_convert_encoding',
+        'i18n_discover_encoding'     => 'mb_detect_encoding',
+        'i18n_http_input'            => 'mb_http_input',
+        'i18n_http_output'           => 'mb_http_output',
+        'i18n_internal_encoding'     => 'mb_internal_encoding',
+        'i18n_ja_jp_hantozen'        => 'mb_convert_kana',
+        'i18n_mime_header_decode'    => 'mb_decode_mimeheader',
+        'i18n_mime_header_encode'    => 'mb_encode_mimeheader',
+        'imap_create'                => 'imap_createmailbox',
+        'imap_fetchtext'             => 'imap_body',
+        'imap_getmailboxes'          => 'imap_list_full',
+        'imap_getsubscribed'         => 'imap_lsub_full',
+        'imap_header'                => 'imap_headerinfo',
+        'imap_listmailbox'           => 'imap_list',
+        'imap_listsubscribed'        => 'imap_lsub',
+        'imap_rename'                => 'imap_renamemailbox',
+        'imap_scan'                  => 'imap_listscan',
+        'imap_scanmailbox'           => 'imap_listscan',
+        'ini_alter'                  => 'ini_set',
+        'is_double'                  => 'is_float',
+        'is_integer'                 => 'is_int',
+        'is_long'                    => 'is_int',
+        'is_real'                    => 'is_float',
+        'is_writeable'               => 'is_writable',
+        'join'                       => 'implode',
+        'key_exists'                 => 'array_key_exists',
+        'ldap_close'                 => 'ldap_unbind',
+        'magic_quotes_runtime'       => 'set_magic_quotes_runtime',
+        'mbstrcut'                   => 'mb_strcut',
+        'mbstrlen'                   => 'mb_strlen',
+        'mbstrpos'                   => 'mb_strpos',
+        'mbstrrpos'                  => 'mb_strrpos',
+        'mbsubstr'                   => 'mb_substr',
+        'ming_setcubicthreshold'     => 'ming_setCubicThreshold',
+        'ming_setscale'              => 'ming_setScale',
+        'msql'                       => 'msql_db_query',
+        'msql_createdb'              => 'msql_create_db',
+        'msql_dbname'                => 'msql_result',
+        'msql_dropdb'                => 'msql_drop_db',
+        'msql_fieldflags'            => 'msql_field_flags',
+        'msql_fieldlen'              => 'msql_field_len',
+        'msql_fieldname'             => 'msql_field_name',
+        'msql_fieldtable'            => 'msql_field_table',
+        'msql_fieldtype'             => 'msql_field_type',
+        'msql_freeresult'            => 'msql_free_result',
+        'msql_listdbs'               => 'msql_list_dbs',
+        'msql_listfields'            => 'msql_list_fields',
+        'msql_listtables'            => 'msql_list_tables',
+        'msql_numfields'             => 'msql_num_fields',
+        'msql_numrows'               => 'msql_num_rows',
+        'msql_regcase'               => 'sql_regcase',
+        'msql_selectdb'              => 'msql_select_db',
+        'msql_tablename'             => 'msql_result',
+        'mssql_affected_rows'        => 'sybase_affected_rows',
+        'mssql_close'                => 'sybase_close',
+        'mssql_connect'              => 'sybase_connect',
+        'mssql_data_seek'            => 'sybase_data_seek',
+        'mssql_fetch_array'          => 'sybase_fetch_array',
+        'mssql_fetch_field'          => 'sybase_fetch_field',
+        'mssql_fetch_object'         => 'sybase_fetch_object',
+        'mssql_fetch_row'            => 'sybase_fetch_row',
+        'mssql_field_seek'           => 'sybase_field_seek',
+        'mssql_free_result'          => 'sybase_free_result',
+        'mssql_get_last_message'     => 'sybase_get_last_message',
+        'mssql_min_client_severity'  => 'sybase_min_client_severity',
+        'mssql_min_error_severity'   => 'sybase_min_error_severity',
+        'mssql_min_message_severity' => 'sybase_min_message_severity',
+        'mssql_min_server_severity'  => 'sybase_min_server_severity',
+        'mssql_num_fields'           => 'sybase_num_fields',
+        'mssql_num_rows'             => 'sybase_num_rows',
+        'mssql_pconnect'             => 'sybase_pconnect',
+        'mssql_query'                => 'sybase_query',
+        'mssql_result'               => 'sybase_result',
+        'mssql_select_db'            => 'sybase_select_db',
+        'mysql'                      => 'mysql_db_query',
+        'mysql_createdb'             => 'mysql_create_db',
+        'mysql_db_name'              => 'mysql_result',
+        'mysql_dbname'               => 'mysql_result',
+        'mysql_dropdb'               => 'mysql_drop_db',
+        'mysql_fieldflags'           => 'mysql_field_flags',
+        'mysql_fieldlen'             => 'mysql_field_len',
+        'mysql_fieldname'            => 'mysql_field_name',
+        'mysql_fieldtable'           => 'mysql_field_table',
+        'mysql_fieldtype'            => 'mysql_field_type',
+        'mysql_freeresult'           => 'mysql_free_result',
+        'mysql_listdbs'              => 'mysql_list_dbs',
+        'mysql_listfields'           => 'mysql_list_fields',
+        'mysql_listtables'           => 'mysql_list_tables',
+        'mysql_numfields'            => 'mysql_num_fields',
+        'mysql_numrows'              => 'mysql_num_rows',
+        'mysql_selectdb'             => 'mysql_select_db',
+        'mysql_tablename'            => 'mysql_result',
+        'oci8append'                 => 'ocicollappend',
+        'oci8assign'                 => 'ocicollassign',
+        'oci8assignelem'             => 'ocicollassignelem',
+        'oci8close'                  => 'ocicloselob',
+        'oci8free'                   => 'ocifreedesc',
+        'oci8getelem'                => 'ocicollgetelem',
+        'oci8load'                   => 'ociloadlob',
+        'oci8max'                    => 'ocicollmax',
+        'oci8ocifreecursor'          => 'ocifreestatement',
+        'oci8save'                   => 'ocisavelob',
+        'oci8savefile'               => 'ocisavelobfile',
+        'oci8size'                   => 'ocicollsize',
+        'oci8trim'                   => 'ocicolltrim',
+        'oci8writetemporary'         => 'ociwritetemporarylob',
+        'oci8writetofile'            => 'ociwritelobtofile',
+        'odbc_do'                    => 'odbc_exec',
+        'odbc_field_precision'       => 'odbc_field_len',
+        'pdf_add_outline'            => 'pdf_add_bookmark',
+        'pg_clientencoding'          => 'pg_client_encoding',
+        'pg_setclientencoding'       => 'pg_set_client_encoding',
+        'pos'                        => 'current',
+        'recode'                     => 'recode_string',
+        'show_source'                => 'highlight_file',
+        'sizeof'                     => 'count',
+        'snmpwalkoid'                => 'snmprealwalk',
+        'strchr'                     => 'strstr',
+        'xptr_new_context'           => 'xpath_new_context',
+    ];
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return array_keys($this->aliases);
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        File $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+        $tokens = $phpcsFile->getTokens();
+        $error  = '%s() is a function name alias, use %s() instead';
+        $name   = $tokens[$stackPtr]['content'];
+        $data   = [
+            $name,
+            $this->aliases[$name],
+        ];
+        $phpcsFile->addError($error, $stackPtr, 'FunctionAlias', $data);
+
+    }//end processFunctionCall()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionCall.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionCall.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\FunctionCall.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Helper class to sniff for specific function calls.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+abstract class FunctionCall implements Sniff
+{
+
+    /**
+     * The currently processed file.
+     *
+     * @var \PHP_CodeSniffer\Files\File
+     */
+    protected $phpcsFile;
+
+    /**
+     * The token position of the function call.
+     *
+     * @var integer
+     */
+    protected $functionCall;
+
+    /**
+     * The token position of the opening bracket of the function call.
+     *
+     * @var integer
+     */
+    protected $openBracket;
+
+    /**
+     * The token position of the closing bracket of the function call.
+     *
+     * @var integer
+     */
+    protected $closeBracket;
+
+    /**
+     * Internal cache to save the calculated arguments of the function call.
+     *
+     * @var array<int, array>
+     */
+    protected $arguments;
+
+    /**
+     * Whether method invocations with the same function name should be processed,
+     * too.
+     *
+     * @var boolean
+     */
+    protected $includeMethodCalls = false;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_STRING];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens       = $phpcsFile->getTokens();
+        $functionName = $tokens[$stackPtr]['content'];
+        if (in_array($functionName, $this->registerFunctionNames()) === false) {
+            // Not interested in this function.
+            return;
+        }
+
+        if ($this->isFunctionCall($phpcsFile, $stackPtr) === false) {
+            return;
+        }
+
+        // Find the next non-empty token.
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+        $this->phpcsFile    = $phpcsFile;
+        $this->functionCall = $stackPtr;
+        $this->openBracket  = $openBracket;
+        $this->closeBracket = $tokens[$openBracket]['parenthesis_closer'];
+        $this->arguments    = [];
+
+        $this->processFunctionCall($phpcsFile, $stackPtr, $openBracket, $this->closeBracket);
+
+    }//end process()
+
+
+    /**
+     * Checks if this is a function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return bool
+     */
+    protected function isFunctionCall(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        // Find the next non-empty token.
+        $openBracket = $phpcsFile->findNext(Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+        if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
+            // Not a function call.
+            return false;
+        }
+
+        if (isset($tokens[$openBracket]['parenthesis_closer']) === false) {
+            // Not a function call.
+            return false;
+        }
+
+        // Find the previous non-empty token.
+        $search   = Tokens::$emptyTokens;
+        $search[] = T_BITWISE_AND;
+        $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
+        if ($tokens[$previous]['code'] === T_FUNCTION) {
+            // It's a function definition, not a function call.
+            return false;
+        }
+
+        if ($tokens[$previous]['code'] === T_OBJECT_OPERATOR && $this->includeMethodCalls === false) {
+            // It's a method invocation, not a function call.
+            return false;
+        }
+
+        if ($tokens[$previous]['code'] === T_DOUBLE_COLON && $this->includeMethodCalls === false) {
+            // It's a static method invocation, not a function call.
+            return false;
+        }
+
+        return true;
+
+    }//end isFunctionCall()
+
+
+    /**
+     * Returns start and end token for a given argument number.
+     *
+     * @param int $number Indicates which argument should be examined, starting with
+     *                    1 for the first argument.
+     *
+     * @return array<string, int>|false
+     */
+    public function getArgument($number)
+    {
+        // Check if we already calculated the tokens for this argument.
+        if (isset($this->arguments[$number]) === true) {
+            return $this->arguments[$number];
+        }
+
+        $tokens = $this->phpcsFile->getTokens();
+        // Start token of the first argument.
+        $start = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($this->openBracket + 1), null, true);
+        if ($start === $this->closeBracket) {
+            // Function call has no arguments, so return false.
+            return false;
+        }
+
+        // End token of the last argument.
+        $end           = $this->phpcsFile->findPrevious(Tokens::$emptyTokens, ($this->closeBracket - 1), null, true);
+        $lastArgEnd    = $end;
+        $nextSeperator = $this->openBracket;
+        $counter       = 1;
+        while (($nextSeperator = $this->phpcsFile->findNext(T_COMMA, ($nextSeperator + 1), $this->closeBracket)) !== false) {
+            // Make sure the comma belongs directly to this function call,
+            // and is not inside a nested function call or array.
+            $brackets    = $tokens[$nextSeperator]['nested_parenthesis'];
+            $lastBracket = array_pop($brackets);
+            if ($lastBracket !== $this->closeBracket) {
+                continue;
+            }
+
+            // Update the end token of the current argument.
+            $end = $this->phpcsFile->findPrevious(Tokens::$emptyTokens, ($nextSeperator - 1), null, true);
+            // Save the calculated findings for the current argument.
+            $this->arguments[$counter] = [
+                'start' => $start,
+                'end'   => $end,
+            ];
+            if ($counter === $number) {
+                break;
+            }
+
+            $counter++;
+            $start = $this->phpcsFile->findNext(Tokens::$emptyTokens, ($nextSeperator + 1), null, true);
+            $end   = $lastArgEnd;
+        }//end while
+
+        // If the counter did not reach the passed number something is wrong.
+        if ($counter !== $number) {
+            return false;
+        }
+
+        $this->arguments[$counter] = [
+            'start' => $start,
+            'end'   => $end,
+        ];
+        return $this->arguments[$counter];
+
+    }//end getArgument()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionDefinition.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionDefinition.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\FunctionDefinition.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Helper class to sniff for function definitions.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+abstract class FunctionDefinition implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_STRING];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        // Check if this is a function definition.
+        $functionPtr = $phpcsFile->findPrevious(
+            Tokens::$emptyTokens,
+            ($stackPtr - 1),
+            null,
+            true
+        );
+        if ($tokens[$functionPtr]['code'] === T_FUNCTION) {
+            $this->processFunction($phpcsFile, $stackPtr, $functionPtr);
+        }
+
+    }//end process()
+
+
+    /**
+     * Process this function definition.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the function name in the stack.
+     *                                                 name in the stack.
+     * @param int                         $functionPtr The position of the function keyword in the stack.
+     *                                                 keyword in the stack.
+     *
+     * @return void
+     */
+    abstract public function processFunction(File $phpcsFile, $stackPtr, $functionPtr);
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionTSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionTSniff.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\FunctionTSniff
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Check the usage of the t() function to not escape translateable strings with back
+ * slashes. Also checks that the first argument does not use string concatenation.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FunctionTSniff extends FunctionCall
+{
+
+    /**
+     * We also want to catch $this->t() calls in Backdrop 8.
+     *
+     * @var boolean
+     */
+    protected $includeMethodCalls = true;
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return [
+            't',
+            'TranslatableMarkup',
+            'TranslationWrapper',
+        ];
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        File $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+        $tokens   = $phpcsFile->getTokens();
+        $argument = $this->getArgument(1);
+
+        if ($argument === false) {
+            $error = 'Empty calls to t() are not allowed';
+            $phpcsFile->addError($error, $stackPtr, 'EmptyT');
+            return;
+        }
+
+        if ($tokens[$argument['start']]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+            // Not a translatable string literal.
+            $warning = 'Only string literals should be passed to t() where possible';
+            $phpcsFile->addWarning($warning, $argument['start'], 'NotLiteralString');
+            return;
+        }
+
+        $string = $tokens[$argument['start']]['content'];
+        if ($string === '""' || $string === "''") {
+            $warning = 'Do not pass empty strings to t()';
+            $phpcsFile->addWarning($warning, $argument['start'], 'EmptyString');
+            return;
+        }
+
+        $concatAfter = $phpcsFile->findNext(Tokens::$emptyTokens, ($closeBracket + 1), null, true, null, true);
+        if ($concatAfter !== false && $tokens[$concatAfter]['code'] === T_STRING_CONCAT) {
+            $stringAfter = $phpcsFile->findNext(Tokens::$emptyTokens, ($concatAfter + 1), null, true, null, true);
+            if ($stringAfter !== false
+                && $tokens[$stringAfter]['code'] === T_CONSTANT_ENCAPSED_STRING
+                && $this->checkConcatString($tokens[$stringAfter]['content']) === false
+            ) {
+                $warning = 'Do not concatenate strings to translatable strings, they should be part of the t() argument and you should use placeholders';
+                $phpcsFile->addWarning($warning, $stringAfter, 'ConcatString');
+            }
+        }
+
+        $lastChar = substr($string, -1);
+        if ($lastChar === '"' || $lastChar === "'") {
+            $message = substr($string, 1, -1);
+            if ($message !== trim($message)) {
+                $warning = 'Translatable strings must not begin or end with white spaces, use placeholders with t() for variables';
+                $phpcsFile->addWarning($warning, $argument['start'], 'WhiteSpace');
+            }
+        }
+
+        $concatFound = $phpcsFile->findNext(T_STRING_CONCAT, $argument['start'], $argument['end']);
+        if ($concatFound !== false) {
+            $error = 'Concatenating translatable strings is not allowed, use placeholders instead and only one string literal';
+            $phpcsFile->addError($error, $concatFound, 'Concat');
+        }
+
+        // Check if there is a backslash escaped single quote in the string and
+        // if the string makes use of double quotes.
+        if ($string[0] === "'" && strpos($string, "\'") !== false
+            && strpos($string, '"') === false
+        ) {
+            $warn = 'Avoid backslash escaping in translatable strings when possible, use "" quotes instead';
+            $phpcsFile->addWarning($warn, $argument['start'], 'BackslashSingleQuote');
+            return;
+        }
+
+        if ($string[0] === '"' && strpos($string, '\"') !== false
+            && strpos($string, "'") === false
+        ) {
+            $warn = "Avoid backslash escaping in translatable strings when possible, use '' quotes instead";
+            $phpcsFile->addWarning($warn, $argument['start'], 'BackslashDoubleQuote');
+        }
+
+    }//end processFunctionCall()
+
+
+    /**
+     * Checks if a string can be concatenated with a translatable string.
+     *
+     * @param string $string The string that is concatenated to a t() call.
+     *
+     * @return bool
+     *   TRUE if the string is allowed to be concatenated with a translatable
+     *   string, FALSE if not.
+     */
+    protected function checkConcatString($string)
+    {
+        // Remove outer quotes, spaces and HTML tags from the original string.
+        $string = trim($string, '"\'');
+        $string = trim(strip_tags($string));
+
+        if ($string === '') {
+            return true;
+        }
+
+        $allowedItems = [
+            '(',
+            ')',
+            '[',
+            ']',
+            '-',
+            '<',
+            '>',
+            '«',
+            '»',
+            '\n',
+        ];
+        foreach ($allowedItems as $item) {
+            if ($item === $string) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end checkConcatString()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionTriggerErrorSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionTriggerErrorSniff.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semanitcs\FunctionTriggerErrorSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Checks that the trigger_error deprecation text message adheres to standards.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FunctionTriggerErrorSniff extends FunctionCall
+{
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return ['trigger_error'];
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        file $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+
+        $tokens = $phpcsFile->getTokens();
+
+        // If no second argument then quit.
+        if ($this->getArgument(2) === false) {
+            return;
+        }
+
+        // Only check deprecation messages.
+        if (strcasecmp($tokens[$this->getArgument(2)['start']]['content'], 'E_USER_DEPRECATED') !== 0) {
+            return;
+        }
+
+        // Get the first argument passed to trigger_error().
+        $argument = $this->getArgument(1);
+
+        // Extract the message text to check. If if it formed using sprintf()
+        // then find the single overall string using ->findNext.
+        if ($tokens[$argument['start']]['code'] === T_STRING
+            && strcasecmp($tokens[$argument['start']]['content'], 'sprintf') === 0
+        ) {
+            $messagePosition = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $argument['start']);
+            // Remove the quotes using substr, because trim would take multiple
+            // quotes away and possibly not report a faulty message.
+            $messageText = substr($tokens[$messagePosition]['content'], 1, ($tokens[$messagePosition]['length'] - 2));
+        } else {
+            $messageParts = [];
+            // If not sprintf() then extract and store all the items except
+            // whitespace, concatenation operators and comma. This will give all
+            // real content such as concatenated strings and constants.
+            for ($i = $argument['start']; $i <= $argument['end']; $i++) {
+                if (in_array($tokens[$i]['code'], [T_WHITESPACE, T_STRING_CONCAT, T_COMMA]) === false) {
+                    // For strings, remove the quotes using substr not trim.
+                    // Simple strings are T_CONSTANT_ENCAPSED_STRING and strings
+                    // with variable interpolation are T_DOUBLE_QUOTED_STRING.
+                    if ($tokens[$i]['code'] === T_CONSTANT_ENCAPSED_STRING || $tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+                        $messageParts[] = substr($tokens[$i]['content'], 1, ($tokens[$i]['length'] - 2));
+                    } else {
+                        $messageParts[] = $tokens[$i]['content'];
+                    }
+                }
+            }
+
+            $messageText = implode(' ', $messageParts);
+        }//end if
+
+        // Check if there is a @deprecated tag in an associated doc comment
+        // block. If the @trigger_error was level 0 (entire class or file) then
+        // try to find a doc comment after the trigger_error also at level 0.
+        // If the @trigger_error was at level > 0 it means it is inside a
+        // function so search backwards for the function comment block, which
+        // will be at one level lower.
+        $strictStandard    = false;
+        $triggerErrorLevel = $tokens[$stackPtr]['level'];
+        if ($triggerErrorLevel === 0) {
+            $requiredLevel = 0;
+            $block         = $phpcsFile->findNext(T_DOC_COMMENT_OPEN_TAG, $argument['start']);
+        } else {
+            $requiredLevel = ($triggerErrorLevel - 1);
+            $block         = $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $argument['start']);
+        }
+
+        if (isset($tokens[$block]['level']) === true
+            && $tokens[$block]['level'] === $requiredLevel
+            && isset($tokens[$block]['comment_tags']) === true
+        ) {
+            foreach ($tokens[$block]['comment_tags'] as $tag) {
+                $strictStandard = $strictStandard || (strtolower($tokens[$tag]['content']) === '@deprecated');
+            }
+        }
+
+        // The string standard format for @trigger_error() is:
+        // %thing% is deprecated in %deprecation-version% and is removed in
+        // %removal-version%. %extra-info%. See %cr-link%
+        // For the 'relaxed' standard the 'and is removed in' can be replaced
+        // with any text.
+        $matches = [];
+        if ($strictStandard === true) {
+            // Use (?U) 'ungreedy' before the version so that only the text up
+            // to the first period followed by a space is matched, as there may
+            // be more than one sentence in the extra-info part.
+            preg_match('/(.+) is deprecated in (\S+) (and is removed from) (?U)(.+)\. (.*)\. See (\S+)$/', $messageText, $matches);
+            $sniff = 'TriggerErrorTextLayoutStrict';
+            $error = "The trigger_error message '%s' does not match the strict standard format: %%thing%% is deprecated in %%deprecation-version%% and is removed from %%removal-version%%. %%extra-info%%. See %%cr-link%%";
+        } else {
+            // Allow %extra-info% to be empty as this is optional in the relaxed
+            // version.
+            preg_match('/(.+) is deprecated in (\S+) (?U)(.+) (\S+)\. (.*)See (\S+)$/', $messageText, $matches);
+            $sniff = 'TriggerErrorTextLayoutRelaxed';
+            $error = "The trigger_error message '%s' does not match the relaxed standard format: %%thing%% is deprecated in %%deprecation-version%% any free text %%removal-version%%. %%extra-info%%. See %%cr-link%%";
+        }
+
+        // There should be 7 items in $matches: 0 is full text, 1 = thing,
+        // 2 = deprecation-version, 3 = middle text, 4 = removal-version,
+        // 5 = extra-info, 6 = cr-link.
+        if (count($matches) !== 7) {
+            $phpcsFile->addError($error, $argument['start'], $sniff, [$messageText]);
+        } else {
+            // The text follows the basic layout. Now check that the version
+            // matches backdrop:n.n.n or project:n.x-n.n. The text must be all
+            // lower case and numbers can be one or two digits.
+            foreach (['deprecation-version' => $matches[2], 'removal-version' => $matches[4]] as $name => $version) {
+                if (preg_match('/^backdrop:\d{1,2}\.\d{1,2}\.\d{1,2}$/', $version) === 0
+                    && preg_match('/^[a-z\d_]+:\d{1,2}\.x\-\d{1,2}\.\d{1,2}$/', $version) === 0
+                ) {
+                    $error = "The %s '%s' does not match the lower-case machine-name standard: backdrop:n.n.n or project:n.x-n.n";
+                    $phpcsFile->addWarning($error, $argument['start'], 'TriggerErrorVersion', [$name, $version]);
+                }
+            }
+
+            // Check the 'See' link.
+            $crLink = $matches[6];
+            // Allow for the alternative 'node' or 'project/aaa/issues' format.
+            preg_match('[^http(s*)://www.backdrop.org/(node|project/\w+/issues)/(\d+)(\.*)$]', $crLink, $crMatches);
+            // If cr_matches[4] is not blank it means that the url is correct
+            // but it ends with a period. As this can be a common mistake give a
+            // specific message to assist in fixing.
+            if (isset($crMatches[4]) === true && empty($crMatches[4]) === false) {
+                $error = "The url '%s' should not end with a period.";
+                $phpcsFile->addWarning($error, $argument['start'], 'TriggerErrorPeriodAfterSeeUrl', [$crLink]);
+            } else if (empty($crMatches) === true) {
+                $error = "The url '%s' does not match the standard: http(s)://www.backdrop.org/node/n or http(s)://www.backdrop.org/project/aaa/issues/n";
+                $phpcsFile->addWarning($error, $argument['start'], 'TriggerErrorSeeUrlFormat', [$crLink]);
+            }
+        }//end if
+
+    }//end processFunctionCall()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionWatchdogSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/FunctionWatchdogSniff.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\FunctionWatchdogSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Checks that the second argument to watchdog() is not enclosed with t().
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class FunctionWatchdogSniff extends FunctionCall
+{
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return ['watchdog'];
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        File $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+        $tokens = $phpcsFile->getTokens();
+        // Get the second argument passed to watchdog().
+        $argument = $this->getArgument(2);
+        if ($argument === false) {
+            $error = 'The second argument to watchdog() is missing';
+            $phpcsFile->addError($error, $stackPtr, 'WatchdogArgument');
+            return;
+        }
+
+        if ($tokens[$argument['start']]['code'] === T_STRING
+            && $tokens[$argument['start']]['content'] === 't'
+        ) {
+            $error = 'The second argument to watchdog() should not be enclosed with t()';
+            $phpcsFile->addError($error, $argument['start'], 'WatchdogT');
+        }
+
+        $concatFound = $phpcsFile->findNext(T_STRING_CONCAT, $argument['start'], $argument['end']);
+        if ($concatFound !== false) {
+            $error = 'Concatenating translatable strings is not allowed, use placeholders instead and only one string literal';
+            $phpcsFile->addError($error, $concatFound, 'Concat');
+        }
+
+    }//end processFunctionCall()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/InstallHooksSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/InstallHooksSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\InstallHooksSniff
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Checks that hook_disable(), hook_enable(), hook_install(), hook_uninstall(),
+ * hook_requirements() and hook_schema() are not defined in the module file.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class InstallHooksSniff extends FunctionDefinition
+{
+
+
+    /**
+     * Process this function definition.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the function name in the stack.
+     *                                                 name in the stack.
+     * @param int                         $functionPtr The position of the function keyword in the stack.
+     *                                                 keyword in the stack.
+     *
+     * @return void
+     */
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
+    {
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -6));
+        // Only check in *.module files.
+        if ($fileExtension !== 'module') {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $fileName = substr(basename($phpcsFile->getFilename()), 0, -7);
+        if ($tokens[$stackPtr]['content'] === ($fileName.'_install')
+            || $tokens[$stackPtr]['content'] === ($fileName.'_uninstall')
+            || $tokens[$stackPtr]['content'] === ($fileName.'_requirements')
+            || $tokens[$stackPtr]['content'] === ($fileName.'_schema')
+            || $tokens[$stackPtr]['content'] === ($fileName.'_enable')
+            || $tokens[$stackPtr]['content'] === ($fileName.'_disable')
+        ) {
+            $error = '%s() is an installation hook and must be declared in an install file';
+            $data  = [$tokens[$stackPtr]['content']];
+            $phpcsFile->addError($error, $stackPtr, 'InstallHook', $data);
+        }
+
+    }//end processFunction()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/LStringTranslatableSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/LStringTranslatableSniff.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\LStringTranslatableSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Checks that string literals passed to l() are translatable.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class LStringTranslatableSniff extends FunctionCall
+{
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return ['l'];
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        File $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+        $tokens = $phpcsFile->getTokens();
+        // Get the first argument passed to l().
+        $argument = $this->getArgument(1);
+        if ($tokens[$argument['start']]['code'] === T_CONSTANT_ENCAPSED_STRING
+            // If the string starts with a HTML tag we don't complain.
+            && $tokens[$argument['start']]['content'][1] !== '<'
+        ) {
+            $error = 'The $text argument to l() should be enclosed within t() so that it is translatable';
+            $phpcsFile->addError($error, $stackPtr, 'LArg');
+        }
+
+    }//end processFunctionCall()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/PregSecuritySniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/PregSecuritySniff.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\PregSecuritySniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * Check the usage of the preg functions to ensure the insecure /e flag isn't
+ * used: https://www.backdrop.org/node/750148
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class PregSecuritySniff extends FunctionCall
+{
+
+
+    /**
+     * Returns an array of function names this test wants to listen for.
+     *
+     * @return array<string>
+     */
+    public function registerFunctionNames()
+    {
+        return [
+            'preg_filter',
+            'preg_grep',
+            'preg_match',
+            'preg_match_all',
+            'preg_replace',
+            'preg_replace_callback',
+            'preg_split',
+        ];
+
+    }//end registerFunctionNames()
+
+
+    /**
+     * Processes this function call.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile    The file being scanned.
+     * @param int                         $stackPtr     The position of the function call in
+     *                                                  the stack.
+     * @param int                         $openBracket  The position of the opening
+     *                                                  parenthesis in the stack.
+     * @param int                         $closeBracket The position of the closing
+     *                                                  parenthesis in the stack.
+     *
+     * @return void
+     */
+    public function processFunctionCall(
+        File $phpcsFile,
+        $stackPtr,
+        $openBracket,
+        $closeBracket
+    ) {
+        $tokens   = $phpcsFile->getTokens();
+        $argument = $this->getArgument(1);
+
+        if ($argument === false) {
+            return;
+        }
+
+        if ($tokens[$argument['start']]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+            // Not a string literal.
+            // @TODO: Extend code to recognize patterns in variables.
+            return;
+        }
+
+        $pattern = $tokens[$argument['start']]['content'];
+        $quote   = substr($pattern, 0, 1);
+        // Check that the pattern is a string.
+        if ($quote === '"' || $quote === "'") {
+            // Get the delimiter - first char after the enclosing quotes.
+            $delimiter = preg_quote(substr($pattern, 1, 1), '/');
+            // Check if there is the evil e flag.
+            if (preg_match('/'.$delimiter.'[\w]{0,}e[\w]{0,}$/', substr($pattern, 0, -1)) === 1) {
+                $warn = 'Using the e flag in %s is a possible security risk. For details see https://www.backdrop.org/node/750148';
+                $phpcsFile->addError(
+                    $warn,
+                    $argument['start'],
+                    'PregEFlag',
+                    [$tokens[$stackPtr]['content']]
+                );
+                return;
+            }
+        }
+
+    }//end processFunctionCall()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/RemoteAddressSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/RemoteAddressSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\RemoteAddressSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Make sure that ip_address() or Backdrop::request()->getClientIp() is used instead of
+ * $_SERVER['REMOTE_ADDR'].
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class RemoteAddressSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_VARIABLE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The current file being processed.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $string           = $phpcsFile->getTokensAsString($stackPtr, 4);
+        $startOfStatement = $phpcsFile->findStartOfStatement($stackPtr);
+        if (($string === '$_SERVER["REMOTE_ADDR"]' || $string === '$_SERVER[\'REMOTE_ADDR\']') && $stackPtr !== $startOfStatement) {
+            $error = 'Use ip_address() or Backdrop::request()->getClientIp() instead of $_SERVER[\'REMOTE_ADDR\']';
+            $phpcsFile->addError($error, $stackPtr, 'RemoteAddress');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/TInHookMenuSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/TInHookMenuSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\TInHookMenuSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks that t() is not used in hook_menu().
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class TInHookMenuSniff extends FunctionDefinition
+{
+
+
+    /**
+     * Process this function definition.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the function name in the stack.
+     *                                                 name in the stack.
+     * @param int                         $functionPtr The position of the function keyword in the stack.
+     *                                                 keyword in the stack.
+     *
+     * @return void
+     */
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
+    {
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -6));
+        // Only check in *.module files.
+        if ($fileExtension !== 'module') {
+            return;
+        }
+
+        $fileName = substr(basename($phpcsFile->getFilename()), 0, -7);
+        $tokens   = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content'] !== ($fileName.'_menu')) {
+            return;
+        }
+
+        // Search in the function body for t() calls.
+        $string = $phpcsFile->findNext(
+            T_STRING,
+            $tokens[$functionPtr]['scope_opener'],
+            $tokens[$functionPtr]['scope_closer']
+        );
+        while ($string !== false) {
+            if ($tokens[$string]['content'] === 't') {
+                $opener = $phpcsFile->findNext(
+                    Tokens::$emptyTokens,
+                    ($string + 1),
+                    null,
+                    true
+                );
+                if ($opener !== false
+                    && $tokens[$opener]['code'] === T_OPEN_PARENTHESIS
+                ) {
+                    $error = 'Do not use t() in hook_menu()';
+                    $phpcsFile->addError($error, $string, 'TFound');
+                }
+            }
+
+            $string = $phpcsFile->findNext(
+                T_STRING,
+                ($string + 1),
+                $tokens[$functionPtr]['scope_closer']
+            );
+        }//end while
+
+    }//end processFunction()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/TInHookSchemaSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Semantics/TInHookSchemaSniff.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Semantics\TInHookSchemaSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Semantics;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks that t() is not used in hook_schema().
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class TInHookSchemaSniff extends FunctionDefinition
+{
+
+
+    /**
+     * Process this function definition.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile   The file being scanned.
+     * @param int                         $stackPtr    The position of the function name in the stack.
+     *                                                 name in the stack.
+     * @param int                         $functionPtr The position of the function keyword in the stack.
+     *                                                 keyword in the stack.
+     *
+     * @return void
+     */
+    public function processFunction(File $phpcsFile, $stackPtr, $functionPtr)
+    {
+        $fileExtension = strtolower(substr($phpcsFile->getFilename(), -7));
+        // Only check in *.install files.
+        if ($fileExtension !== 'install') {
+            return;
+        }
+
+        $fileName = substr(basename($phpcsFile->getFilename()), 0, -8);
+        $tokens   = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content'] !== ($fileName.'_schema')) {
+            return;
+        }
+
+        // Search in the function body for t() calls.
+        $string = $phpcsFile->findNext(
+            T_STRING,
+            $tokens[$functionPtr]['scope_opener'],
+            $tokens[$functionPtr]['scope_closer']
+        );
+        while ($string !== false) {
+            if ($tokens[$string]['content'] === 't') {
+                $opener = $phpcsFile->findNext(
+                    Tokens::$emptyTokens,
+                    ($string + 1),
+                    null,
+                    true
+                );
+                if ($opener !== false
+                    && $tokens[$opener]['code'] === T_OPEN_PARENTHESIS
+                ) {
+                    $error = 'Do not use t() in hook_schema(), this will only generate overhead for translators';
+                    $phpcsFile->addError($error, $string, 'TFound');
+                }
+            }
+
+            $string = $phpcsFile->findNext(
+                T_STRING,
+                ($string + 1),
+                $tokens[$functionPtr]['scope_closer']
+            );
+        }//end while
+
+    }//end processFunction()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/Strings/UnnecessaryStringConcatSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/Strings/UnnecessaryStringConcatSniff.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * \Backdrop\Sniffs\Strings\UnnecessaryStringConcatSniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\Strings;
+
+use Backdrop\Sniffs\Files\LineLengthSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryStringConcatSniff as GenericUnnecessaryStringConcatSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks that two strings are not concatenated together; suggests using one string instead.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006-2015 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class UnnecessaryStringConcatSniff extends GenericUnnecessaryStringConcatSniff
+{
+
+
+    /**
+     * Processes this sniff, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Work out which type of file this is for.
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['code'] === T_STRING_CONCAT) {
+            if ($phpcsFile->tokenizerType === 'JS') {
+                return;
+            }
+        } else {
+            if ($phpcsFile->tokenizerType === 'PHP') {
+                return;
+            }
+        }
+
+        $prev = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        $next = $phpcsFile->findNext(T_WHITESPACE, ($stackPtr + 1), null, true);
+        if ($prev === false || $next === false) {
+            return;
+        }
+
+        $stringTokens = Tokens::$stringTokens;
+        if (in_array($tokens[$prev]['code'], $stringTokens) === true
+            && in_array($tokens[$next]['code'], $stringTokens) === true
+        ) {
+            if ($tokens[$prev]['content'][0] === $tokens[$next]['content'][0]) {
+                // Before we throw an error for PHP, allow strings to be
+                // combined if they would have < and ? next to each other because
+                // this trick is sometimes required in PHP strings.
+                if ($phpcsFile->tokenizerType === 'PHP') {
+                    $prevChar = substr($tokens[$prev]['content'], -2, 1);
+                    $nextChar = $tokens[$next]['content'][1];
+                    $combined = $prevChar.$nextChar;
+                    if ($combined === '?'.'>' || $combined === '<'.'?') {
+                        return;
+                    }
+                }
+
+                // Before we throw an error check if the string is longer than
+                // the line length limit.
+                $lineLengthLimitSniff = new LineLengthSniff;
+
+                $lineLenght   = $lineLengthLimitSniff->getLineLength($phpcsFile, $tokens[$prev]['line']);
+                $stringLength = ($lineLenght + strlen($tokens[$next]['content']) - 4);
+                if ($stringLength > $lineLengthLimitSniff->lineLimit) {
+                    return;
+                }
+
+                $error = 'String concat is not required here; use a single string instead';
+                if ($this->error === true) {
+                    $phpcsFile->addError($error, $stackPtr, 'Found');
+                } else {
+                    $phpcsFile->addWarning($error, $stackPtr, 'Found');
+                }
+            }//end if
+        }//end if
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/CloseBracketSpacingSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/CloseBracketSpacingSniff.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\CloseBracketSpacingSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Checks that there is no white space before a closing bracket, for ")" and "}".
+ * Square Brackets are handled by
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class CloseBracketSpacingSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_CLOSE_CURLY_BRACKET,
+            T_CLOSE_PARENTHESIS,
+            T_CLOSE_SHORT_ARRAY,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Ignore curly brackets in javascript files.
+        if ($tokens[$stackPtr]['code'] === T_CLOSE_CURLY_BRACKET
+            && $phpcsFile->tokenizerType === 'JS'
+        ) {
+            return;
+        }
+
+        if (isset($tokens[($stackPtr - 1)]) === true
+            && $tokens[($stackPtr - 1)]['code'] === T_WHITESPACE
+        ) {
+            $before = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if ($before !== false && $tokens[$stackPtr]['line'] === $tokens[$before]['line']) {
+                $error = 'There should be no white space before a closing "%s"';
+                $fix   = $phpcsFile->addFixableError(
+                    $error,
+                    ($stackPtr - 1),
+                    'ClosingWhitespace',
+                    [$tokens[$stackPtr]['content']]
+                );
+                if ($fix === true) {
+                    $phpcsFile->fixer->replaceToken(($stackPtr - 1), '');
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/CommaSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/CommaSniff.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\CommaSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\WhiteSpace\CommaSniff.
+ *
+ * Checks that there is one space after a comma.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class CommaSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_COMMA];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[($stackPtr + 1)]) === false) {
+            return;
+        }
+
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE
+            && $tokens[($stackPtr + 1)]['code'] !== T_COMMA
+            && $tokens[($stackPtr + 1)]['code'] !== T_CLOSE_PARENTHESIS
+        ) {
+            $error = 'Expected one space after the comma, 0 found';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NoSpace');
+            if ($fix === true) {
+                $phpcsFile->fixer->addContent($stackPtr, ' ');
+            }
+
+            return;
+        }
+
+        if ($tokens[($stackPtr + 1)]['code'] === T_WHITESPACE
+            && isset($tokens[($stackPtr + 2)]) === true
+            && $tokens[($stackPtr + 2)]['line'] === $tokens[($stackPtr + 1)]['line']
+            && $tokens[($stackPtr + 1)]['content'] !== ' '
+        ) {
+            $error = 'Expected one space after the comma, %s found';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'TooManySpaces', [strlen($tokens[($stackPtr + 1)]['content'])]);
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/EmptyLinesSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/EmptyLinesSniff.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\EmptyLinesSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * \Backdrop\Sniffs\WhiteSpace\EmptyLinesSniff.
+ *
+ * Checks that there are not more than 2 empty lines following each other.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class EmptyLinesSniff implements Sniff
+{
+
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array<string>
+     */
+    public $supportedTokenizers = [
+        'PHP',
+        'JS',
+        'CSS',
+    ];
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_WHITESPACE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$stackPtr]['content'] === $phpcsFile->eolChar
+            && isset($tokens[($stackPtr + 1)]) === true
+            && $tokens[($stackPtr + 1)]['content'] === $phpcsFile->eolChar
+            && isset($tokens[($stackPtr + 2)]) === true
+            && $tokens[($stackPtr + 2)]['content'] === $phpcsFile->eolChar
+            && isset($tokens[($stackPtr + 3)]) === true
+            && $tokens[($stackPtr + 3)]['content'] === $phpcsFile->eolChar
+        ) {
+            $error = 'More than 2 empty lines are not allowed';
+            $phpcsFile->addError($error, ($stackPtr + 3), 'EmptyLines');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/NamespaceSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/NamespaceSniff.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\NamespaceSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that there is exactly one space after the namespace keyword.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class NamespaceSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_NAMESPACE];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[($stackPtr + 1)]['content'] !== ' ') {
+            $error = 'There must be exactly one space after the namepace keyword';
+            $fix   = $phpcsFile->addFixableError($error, ($stackPtr + 1), 'OneSpace');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr + 1), ' ');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorIndentSniff.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\ObjectOperatorIndentSniff.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * \Backdrop\Sniffs\WhiteSpace\ObjectOperatorIndentSniff.
+ *
+ * Checks that object operators are indented 2 spaces if they are the first
+ * thing on a line.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: 1.2.0RC3
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ObjectOperatorIndentSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_OBJECT_OPERATOR];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check that there is only whitespace before the object operator and there
+        // is nothing else on the line.
+        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE || $tokens[($stackPtr - 1)]['column'] !== 1) {
+            return;
+        }
+
+        $previousLine = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 2), null, true, null, true);
+
+        if ($previousLine === false) {
+            return;
+        }
+
+        // Check if the line before is in the same scope and go back if necessary.
+        $scopeDiff   = [$previousLine => $previousLine];
+        $startOfLine = $stackPtr;
+        while (empty($scopeDiff) === false) {
+            // Find the first non whitespace character on the previous line.
+            $startOfLine      = $this->findStartOfline($phpcsFile, $previousLine);
+            $startParenthesis = [];
+            if (isset($tokens[$startOfLine]['nested_parenthesis']) === true) {
+                $startParenthesis = $tokens[$startOfLine]['nested_parenthesis'];
+            }
+
+            $operatorParenthesis = [];
+            if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
+                $operatorParenthesis = $tokens[$stackPtr]['nested_parenthesis'];
+            }
+
+            $scopeDiff = array_diff_assoc($startParenthesis, $operatorParenthesis);
+            if (empty($scopeDiff) === false) {
+                $previousLine = key($scopeDiff);
+            }
+        }
+
+        // Closing parenthesis can be indented in several ways, so rather use the
+        // line that opended the parenthesis.
+        if ($tokens[$startOfLine]['code'] === T_CLOSE_PARENTHESIS) {
+            $startOfLine = $this->findStartOfline($phpcsFile, $tokens[$startOfLine]['parenthesis_opener']);
+        }
+
+        if ($tokens[$startOfLine]['code'] === T_OBJECT_OPERATOR) {
+            // If there is some wrapping in function calls then there should be an
+            // additional level of indentation.
+            if (isset($tokens[$stackPtr]['nested_parenthesis']) === true
+                && (empty($tokens[$startOfLine]['nested_parenthesis']) === true
+                || $tokens[$startOfLine]['nested_parenthesis'] !== $tokens[$stackPtr]['nested_parenthesis'])
+            ) {
+                $additionalIndent = 2;
+            } else {
+                $additionalIndent = 0;
+            }
+        } else {
+            $additionalIndent = 2;
+        }
+
+        if ($tokens[$stackPtr]['column'] !== ($tokens[$startOfLine]['column'] + $additionalIndent)) {
+            $error          = 'Object operator not indented correctly; expected %s spaces but found %s';
+            $expectedIndent = ($tokens[$startOfLine]['column'] + $additionalIndent - 1);
+            $data           = [
+                $expectedIndent,
+                ($tokens[$stackPtr]['column'] - 1),
+            ];
+            $fix            = $phpcsFile->addFixableError($error, $stackPtr, 'Indent', $data);
+
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr - 1), str_repeat(' ', $expectedIndent));
+            }
+        }
+
+    }//end process()
+
+
+    /**
+     * Returns the first non whitespace token on the line.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return int
+     */
+    protected function findStartOfline(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Find the first non whitespace character on the previous line.
+        $startOfLine = $stackPtr;
+        while ($tokens[($startOfLine - 1)]['line'] === $tokens[$startOfLine]['line']) {
+            $startOfLine--;
+        }
+
+        if ($tokens[$startOfLine]['code'] === T_WHITESPACE) {
+            $startOfLine++;
+        }
+
+        return $startOfLine;
+
+    }//end findStartOfline()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ObjectOperatorSpacingSniff.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Ensure that there are no white spaces before and after the object operator.
+ *
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ObjectOperatorSpacingSniff
+ * but modified to not throw errors on multi line statements.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ObjectOperatorSpacingSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [T_OBJECT_OPERATOR];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[($stackPtr - 1)]['code'] !== T_WHITESPACE) {
+            $before = 0;
+        } else {
+            if ($tokens[($stackPtr - 2)]['line'] !== $tokens[$stackPtr]['line']) {
+                $before = 'newline';
+            } else {
+                $before = $tokens[($stackPtr - 1)]['length'];
+            }
+        }
+
+        if ($tokens[($stackPtr + 1)]['code'] !== T_WHITESPACE) {
+            $after = 0;
+        } else {
+            if ($tokens[($stackPtr + 2)]['line'] !== $tokens[$stackPtr]['line']) {
+                $after = 'newline';
+            } else {
+                $after = $tokens[($stackPtr + 1)]['length'];
+            }
+        }
+
+        $phpcsFile->recordMetric($stackPtr, 'Spacing before object operator', $before);
+        $phpcsFile->recordMetric($stackPtr, 'Spacing after object operator', $after);
+
+        $prevToken = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        // Line breaks are allowed before an object operator.
+        if ($before !== 0 && $tokens[$stackPtr]['line'] === $tokens[$prevToken]['line']) {
+            $error = 'Space found before object operator';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Before');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr - 1), '');
+            }
+        }
+
+        if ($after !== 0) {
+            $error = 'Space found after object operator';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'After');
+            if ($fix === true) {
+                if ($after === 'newline') {
+                    // Delete the operator on this line and insert it before the
+                    // token on the next line.
+                    $phpcsFile->fixer->beginChangeset();
+                    $phpcsFile->fixer->replaceToken($stackPtr, '');
+                    $phpcsFile->fixer->addContentBefore(($stackPtr + 2), '->');
+                    $phpcsFile->fixer->endChangeset();
+                } else {
+                    $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+                }
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/OpenBracketSpacingSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/OpenBracketSpacingSniff.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\OpenBracketSpacingSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks that there is no white space after an opening bracket, for "(" and "{".
+ * Square Brackets are handled by
+ * \PHP_CodeSniffer\Standards\Squiz\Sniffs\Arrays\ArrayBracketSpacingSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class OpenBracketSpacingSniff implements Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return [
+            T_OPEN_CURLY_BRACKET,
+            T_OPEN_PARENTHESIS,
+            T_OPEN_SHORT_ARRAY,
+        ];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Ignore curly brackets in javascript files.
+        if ($tokens[$stackPtr]['code'] === T_OPEN_CURLY_BRACKET
+            && $phpcsFile->tokenizerType === 'JS'
+        ) {
+            return;
+        }
+
+        if (isset($tokens[($stackPtr + 1)]) === true
+            && $tokens[($stackPtr + 1)]['code'] === T_WHITESPACE
+            && strpos($tokens[($stackPtr + 1)]['content'], $phpcsFile->eolChar) === false
+            // Allow spaces in template files where the PHP close tag is used.
+            && isset($tokens[($stackPtr + 2)]) === true
+            && $tokens[($stackPtr + 2)]['code'] !== T_CLOSE_TAG
+        ) {
+            $error = 'There should be no white space after an opening "%s"';
+            $fix   = $phpcsFile->addFixableError(
+                $error,
+                ($stackPtr + 1),
+                'OpeningWhitespace',
+                [$tokens[$stackPtr]['content']]
+            );
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken(($stackPtr + 1), '');
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeClosingBraceSniff.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\ScopeClosingBraceSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://Backdrop.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Copied from \PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeClosingBraceSniff to allow empty methods
+ * and classes.
+ *
+ * Checks that the closing braces of scopes are aligned correctly.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ScopeClosingBraceSniff implements Sniff
+{
+
+    /**
+     * The number of spaces code should be indented.
+     *
+     * @var integer
+     */
+    public $indent = 2;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        return Tokens::$scopeOpeners;
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // If this is an inline condition (ie. there is no scope opener), then
+        // return, as this is not a new scope.
+        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+            return;
+        }
+
+        $scopeStart = $tokens[$stackPtr]['scope_opener'];
+        $scopeEnd   = $tokens[$stackPtr]['scope_closer'];
+
+        // If the scope closer doesn't think it belongs to this scope opener
+        // then the opener is sharing its closer with other tokens. We only
+        // want to process the closer once, so skip this one.
+        if (isset($tokens[$scopeEnd]['scope_condition']) === false
+            || $tokens[$scopeEnd]['scope_condition'] !== $stackPtr
+        ) {
+            return;
+        }
+
+        // We need to actually find the first piece of content on this line,
+        // because if this is a method with tokens before it (public, static etc)
+        // or an if with an else before it, then we need to start the scope
+        // checking from there, rather than the current token.
+        $lineStart = ($stackPtr - 1);
+        for ($lineStart; $lineStart > 0; $lineStart--) {
+            if (strpos($tokens[$lineStart]['content'], $phpcsFile->eolChar) !== false) {
+                break;
+            }
+        }
+
+        $lineStart++;
+
+        $startColumn = 1;
+        if ($tokens[$lineStart]['code'] === T_WHITESPACE) {
+            $startColumn = $tokens[($lineStart + 1)]['column'];
+        } else if ($tokens[$lineStart]['code'] === T_INLINE_HTML) {
+            $trimmed = ltrim($tokens[$lineStart]['content']);
+            if ($trimmed === '') {
+                $startColumn = $tokens[($lineStart + 1)]['column'];
+            } else {
+                $startColumn = (strlen($tokens[$lineStart]['content']) - strlen($trimmed));
+            }
+        }
+
+        // Check that the closing brace is on it's own line.
+        $lastContent = $phpcsFile->findPrevious(
+            [
+                T_WHITESPACE,
+                T_INLINE_HTML,
+                T_OPEN_TAG,
+            ],
+            ($scopeEnd - 1),
+            $scopeStart,
+            true
+        );
+
+        if ($tokens[$lastContent]['line'] === $tokens[$scopeEnd]['line']) {
+            // Only allow empty classes and methods.
+            if (($tokens[$tokens[$scopeEnd]['scope_condition']]['code'] !== T_CLASS
+                && $tokens[$tokens[$scopeEnd]['scope_condition']]['code'] !== T_INTERFACE
+                && in_array(T_CLASS, $tokens[$scopeEnd]['conditions']) === false
+                && in_array(T_INTERFACE, $tokens[$scopeEnd]['conditions']) === false)
+                || $tokens[$lastContent]['code'] !== T_OPEN_CURLY_BRACKET
+            ) {
+                $error = 'Closing brace must be on a line by itself';
+                $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'Line');
+                if ($fix === true) {
+                    $phpcsFile->fixer->addNewlineBefore($scopeEnd);
+                }
+            }
+
+            return;
+        }
+
+        // Check now that the closing brace is lined up correctly.
+        $lineStart = ($scopeEnd - 1);
+        for ($lineStart; $lineStart > 0; $lineStart--) {
+            if (strpos($tokens[$lineStart]['content'], $phpcsFile->eolChar) !== false) {
+                break;
+            }
+        }
+
+        $lineStart++;
+
+        $braceIndent = 0;
+        if ($tokens[$lineStart]['code'] === T_WHITESPACE) {
+            $braceIndent = ($tokens[($lineStart + 1)]['column'] - 1);
+        } else if ($tokens[$lineStart]['code'] === T_INLINE_HTML) {
+            $trimmed = ltrim($tokens[$lineStart]['content']);
+            if ($trimmed === '') {
+                $braceIndent = ($tokens[($lineStart + 1)]['column'] - 1);
+            } else {
+                $braceIndent = (strlen($tokens[$lineStart]['content']) - strlen($trimmed) - 1);
+            }
+        }
+
+        $fix = false;
+        if ($tokens[$stackPtr]['code'] === T_CASE
+            || $tokens[$stackPtr]['code'] === T_DEFAULT
+        ) {
+            // BREAK statements should be indented n spaces from the
+            // CASE or DEFAULT statement.
+            $expectedIndent = ($startColumn + $this->indent - 1);
+            if ($braceIndent !== $expectedIndent) {
+                $error = 'Case breaking statement indented incorrectly; expected %s spaces, found %s';
+                $data  = [
+                    $expectedIndent,
+                    $braceIndent,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'BreakIndent', $data);
+            }
+        } else {
+            $expectedIndent = ($startColumn - 1);
+            if ($braceIndent !== $expectedIndent) {
+                $error = 'Closing brace indented incorrectly; expected %s spaces, found %s';
+                $data  = [
+                    $expectedIndent,
+                    $braceIndent,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $scopeEnd, 'Indent', $data);
+            }
+        }//end if
+
+        if ($fix === true) {
+            $spaces = str_repeat(' ', $expectedIndent);
+            if ($braceIndent === 0) {
+                $phpcsFile->fixer->addContentBefore($lineStart, $spaces);
+            } else {
+                $phpcsFile->fixer->replaceToken($lineStart, ltrim($tokens[$lineStart]['content']));
+                $phpcsFile->fixer->addContentBefore($lineStart, $spaces);
+            }
+        }
+
+    }//end process()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/core/misc/code_sniffer/Backdrop/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -1,0 +1,1558 @@
+<?php
+/**
+ * \Backdrop\Sniffs\WhiteSpace\ScopeIndentSniff.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+namespace Backdrop\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+use PHP_CodeSniffer\Config;
+
+/**
+ * Largely copied from
+ * \PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff,
+ * modified to make the exact mode working with comments and multi line
+ * statements.
+ *
+ * Checks that control structures are structured correctly, and their content
+ * is indented correctly. This sniff will throw errors if tabs are used
+ * for indentation rather than spaces.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ScopeIndentSniff implements Sniff
+{
+
+    /**
+     * The number of spaces code should be indented.
+     *
+     * @var integer
+     */
+    public $indent = 2;
+
+    /**
+     * Does the indent need to be exactly right?
+     *
+     * If TRUE, indent needs to be exactly $indent spaces. If FALSE,
+     * indent needs to be at least $indent spaces (but can be more).
+     *
+     * @var boolean
+     */
+    public $exact = true;
+
+    /**
+     * Should tabs be used for indenting?
+     *
+     * If TRUE, fixes will be made using tabs instead of spaces.
+     * The size of each tab is important, so it should be specified
+     * using the --tab-width CLI argument.
+     *
+     * @var boolean
+     */
+    public $tabIndent = false;
+
+    /**
+     * The --tab-width CLI value that is being used.
+     *
+     * @var integer
+     */
+    private $tabWidth = null;
+
+    /**
+     * List of tokens not needing to be checked for indentation.
+     *
+     * Useful to allow Sniffs based on this to easily ignore/skip some
+     * tokens from verification. For example, inline HTML sections
+     * or PHP open/close tags can escape from here and have their own
+     * rules elsewhere.
+     *
+     * @var array<int, int|string>
+     */
+    public $ignoreIndentationTokens = [];
+
+    /**
+     * List of tokens not needing to be checked for indentation.
+     *
+     * This is a cached copy of the public version of this var, which
+     * can be set in a ruleset file, and some core ignored tokens.
+     *
+     * @var array<int|string, bool>
+     */
+    private $ignoreIndentation = [];
+
+    /**
+     * Any scope openers that should not cause an indent.
+     *
+     * @var int[]
+     */
+    protected $nonIndentingScopes = [];
+
+    /**
+     * Show debug output for this sniff.
+     *
+     * @var boolean
+     */
+    private $debug = false;
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array<int|string>
+     */
+    public function register()
+    {
+        if (defined('PHP_CODESNIFFER_IN_TESTS') === true) {
+            $this->debug = false;
+        }
+
+        return [T_OPEN_TAG];
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     *
+     * @return void|int
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $debug = Config::getConfigData('scope_indent_debug');
+        if ($debug !== null) {
+            $this->debug = (bool) $debug;
+        }
+
+        if ($this->tabWidth === null) {
+            if (isset($phpcsFile->config->tabWidth) === false || $phpcsFile->config->tabWidth === 0) {
+                // We have no idea how wide tabs are, so assume 4 spaces for fixing.
+                // It shouldn't really matter because indent checks elsewhere in the
+                // standard should fix things up.
+                $this->tabWidth = 4;
+            } else {
+                $this->tabWidth = $phpcsFile->config->tabWidth;
+            }
+        }
+
+        $lastOpenTag     = $stackPtr;
+        $lastCloseTag    = null;
+        $openScopes      = [];
+        $adjustments     = [];
+        $setIndents      = [];
+        $disableExactEnd = 0;
+        $tokenIndent     = 0;
+
+        $tokens  = $phpcsFile->getTokens();
+        $first   = $phpcsFile->findFirstOnLine(T_INLINE_HTML, $stackPtr);
+        $trimmed = ltrim($tokens[$first]['content']);
+        if ($trimmed === '') {
+            $currentIndent = ($tokens[$stackPtr]['column'] - 1);
+        } else {
+            $currentIndent = (strlen($tokens[$first]['content']) - strlen($trimmed));
+        }
+
+        if ($this->debug === true) {
+            $line = $tokens[$stackPtr]['line'];
+            echo "Start with token $stackPtr on line $line with indent $currentIndent".PHP_EOL;
+        }
+
+        if (empty($this->ignoreIndentation) === true) {
+            $this->ignoreIndentation = [T_INLINE_HTML => true];
+            foreach ($this->ignoreIndentationTokens as $token) {
+                if (is_int($token) === false) {
+                    if (defined($token) === false) {
+                        continue;
+                    }
+
+                    $token = constant($token);
+                }
+
+                $this->ignoreIndentation[$token] = true;
+            }
+        }//end if
+
+        $this->exact     = (bool) $this->exact;
+        $this->tabIndent = (bool) $this->tabIndent;
+
+        $checkAnnotations = $phpcsFile->config->annotations;
+
+        for ($i = ($stackPtr + 1); $i < $phpcsFile->numTokens; $i++) {
+            if ($checkAnnotations === true
+                && $tokens[$i]['code'] === T_PHPCS_SET
+                && isset($tokens[$i]['sniffCode']) === true
+                && $tokens[$i]['sniffCode'] === 'Generic.WhiteSpace.ScopeIndent'
+                && $tokens[$i]['sniffProperty'] === 'exact'
+            ) {
+                $value = $tokens[$i]['sniffPropertyValue'];
+                if ($value === 'true') {
+                    $value = true;
+                } else if ($value === 'false') {
+                    $value = false;
+                } else {
+                    $value = (bool) $value;
+                }
+
+                $this->exact = $value;
+
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    if ($this->exact === true) {
+                        $value = 'true';
+                    } else {
+                        $value = 'false';
+                    }
+
+                    echo "* token $i on line $line set exact flag to $value *".PHP_EOL;
+                }
+            }//end if
+
+            $checkToken  = null;
+            $checkIndent = null;
+
+            /*
+                Don't check indents exactly between parenthesis or arrays as they
+                tend to have custom rules, such as with multi-line function calls
+                and control structure conditions.
+            */
+
+            $exact = $this->exact;
+
+            if ($tokens[$i]['code'] === T_OPEN_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_closer']) === true
+            ) {
+                $disableExactEnd = max($disableExactEnd, $tokens[$i]['parenthesis_closer']);
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    $type = $tokens[$disableExactEnd]['type'];
+                    echo "Opening parenthesis found on line $line".PHP_EOL;
+                    echo "\t=> disabling exact indent checking until $disableExactEnd ($type)".PHP_EOL;
+                }
+            }
+
+            if ($exact === true && $i < $disableExactEnd) {
+                $exact = false;
+            }
+
+            // Detect line changes and figure out where the indent is.
+            if ($tokens[$i]['column'] === 1) {
+                $trimmed = ltrim($tokens[$i]['content']);
+                if ($trimmed === '') {
+                    if (isset($tokens[($i + 1)]) === true
+                        && $tokens[$i]['line'] === $tokens[($i + 1)]['line']
+                    ) {
+                        $checkToken  = ($i + 1);
+                        $tokenIndent = ($tokens[($i + 1)]['column'] - 1);
+                    }
+                } else {
+                    $checkToken  = $i;
+                    $tokenIndent = (strlen($tokens[$i]['content']) - strlen($trimmed));
+                }
+            }
+
+            // Closing parenthesis should just be indented to at least
+            // the same level as where they were opened (but can be more).
+            if (($checkToken !== null
+                && $tokens[$checkToken]['code'] === T_CLOSE_PARENTHESIS
+                && isset($tokens[$checkToken]['parenthesis_opener']) === true)
+                || ($tokens[$i]['code'] === T_CLOSE_PARENTHESIS
+                && isset($tokens[$i]['parenthesis_opener']) === true)
+            ) {
+                if ($checkToken !== null) {
+                    $parenCloser = $checkToken;
+                } else {
+                    $parenCloser = $i;
+                }
+
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    echo "Closing parenthesis found on line $line".PHP_EOL;
+                }
+
+                $parenOpener = $tokens[$parenCloser]['parenthesis_opener'];
+                if ($tokens[$parenCloser]['line'] !== $tokens[$parenOpener]['line']) {
+                    $parens = 0;
+                    if (isset($tokens[$parenCloser]['nested_parenthesis']) === true
+                        && empty($tokens[$parenCloser]['nested_parenthesis']) === false
+                    ) {
+                        $parens = $tokens[$parenCloser]['nested_parenthesis'];
+                        end($parens);
+                        $parens = key($parens);
+                        if ($this->debug === true) {
+                            $line = $tokens[$parens]['line'];
+                            echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
+                        }
+                    }
+
+                    $condition = 0;
+                    if (isset($tokens[$parenCloser]['conditions']) === true
+                        && empty($tokens[$parenCloser]['conditions']) === false
+                        && (isset($tokens[$parenCloser]['parenthesis_owner']) === false
+                        || $parens > 0)
+                    ) {
+                        $condition = $tokens[$parenCloser]['conditions'];
+                        end($condition);
+                        $condition = key($condition);
+                        if ($this->debug === true) {
+                            $line = $tokens[$condition]['line'];
+                            $type = $tokens[$condition]['type'];
+                            echo "\t* token is inside condition $condition ($type) on line $line *".PHP_EOL;
+                        }
+                    }
+
+                    if ($parens > $condition) {
+                        if ($this->debug === true) {
+                            echo "\t* using parenthesis *".PHP_EOL;
+                        }
+
+                        $parenOpener = $parens;
+                        $condition   = 0;
+                    } else if ($condition > 0) {
+                        if ($this->debug === true) {
+                            echo "\t* using condition *".PHP_EOL;
+                        }
+
+                        $parenOpener = $condition;
+                        $parens      = 0;
+                    }
+
+                    $exact = false;
+
+                    $lastOpenTagConditions = array_keys($tokens[$lastOpenTag]['conditions']);
+                    $lastOpenTagCondition  = array_pop($lastOpenTagConditions);
+
+                    if ($condition > 0 && $lastOpenTagCondition === $condition) {
+                        if ($this->debug === true) {
+                            echo "\t* open tag is inside condition; using open tag *".PHP_EOL;
+                        }
+
+                        $checkIndent = ($tokens[$lastOpenTag]['column'] - 1);
+                        if (isset($adjustments[$condition]) === true) {
+                            $checkIndent += $adjustments[$condition];
+                        }
+
+                        $currentIndent = $checkIndent;
+
+                        if ($this->debug === true) {
+                            $type = $tokens[$lastOpenTag]['type'];
+                            echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $lastOpenTag ($type)".PHP_EOL;
+                        }
+                    } else if ($condition > 0
+                        && isset($tokens[$condition]['scope_opener']) === true
+                        && isset($setIndents[$tokens[$condition]['scope_opener']]) === true
+                    ) {
+                        $checkIndent = $setIndents[$tokens[$condition]['scope_opener']];
+                        if (isset($adjustments[$condition]) === true) {
+                            $checkIndent += $adjustments[$condition];
+                        }
+
+                        $currentIndent = $checkIndent;
+
+                        if ($this->debug === true) {
+                            $type = $tokens[$condition]['type'];
+                            echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $condition ($type)".PHP_EOL;
+                        }
+                    } else {
+                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $parenOpener, true);
+
+                        $checkIndent = ($tokens[$first]['column'] - 1);
+                        if (isset($adjustments[$first]) === true) {
+                            $checkIndent += $adjustments[$first];
+                        }
+
+                        if ($this->debug === true) {
+                            $line = $tokens[$first]['line'];
+                            $type = $tokens[$first]['type'];
+                            echo "\t* first token on line $line is $first ($type) *".PHP_EOL;
+                        }
+
+                        if ($first === $tokens[$parenCloser]['parenthesis_opener']
+                            && $tokens[($first - 1)]['line'] === $tokens[$first]['line']
+                        ) {
+                            // This is unlikely to be the start of the statement, so look
+                            // back further to find it.
+                            $first--;
+                            if ($this->debug === true) {
+                                $line = $tokens[$first]['line'];
+                                $type = $tokens[$first]['type'];
+                                echo "\t* first token is the parenthesis opener *".PHP_EOL;
+                                echo "\t* amended first token is $first ($type) on line $line *".PHP_EOL;
+                            }
+                        }
+
+                        $prev = $phpcsFile->findStartOfStatement($first, T_COMMA);
+                        if ($prev !== $first) {
+                            // This is not the start of the statement.
+                            if ($this->debug === true) {
+                                $line = $tokens[$prev]['line'];
+                                $type = $tokens[$prev]['type'];
+                                echo "\t* previous is $type on line $line *".PHP_EOL;
+                            }
+
+                            $first = $phpcsFile->findFirstOnLine([T_WHITESPACE, T_INLINE_HTML], $prev, true);
+                            if ($first !== false) {
+                                $prev  = $phpcsFile->findStartOfStatement($first, T_COMMA);
+                                $first = $phpcsFile->findFirstOnLine([T_WHITESPACE, T_INLINE_HTML], $prev, true);
+                            } else {
+                                $first = $prev;
+                            }
+
+                            if ($this->debug === true) {
+                                $line = $tokens[$first]['line'];
+                                $type = $tokens[$first]['type'];
+                                echo "\t* amended first token is $first ($type) on line $line *".PHP_EOL;
+                            }
+                        }//end if
+
+                        if (isset($tokens[$first]['scope_closer']) === true
+                            && $tokens[$first]['scope_closer'] === $first
+                        ) {
+                            if ($this->debug === true) {
+                                echo "\t* first token is a scope closer *".PHP_EOL;
+                            }
+
+                            if (isset($tokens[$first]['scope_condition']) === true) {
+                                $scopeCloser = $first;
+                                $first       = $phpcsFile->findFirstOnLine(T_WHITESPACE, $tokens[$scopeCloser]['scope_condition'], true);
+
+                                $currentIndent = ($tokens[$first]['column'] - 1);
+                                if (isset($adjustments[$first]) === true) {
+                                    $currentIndent += $adjustments[$first];
+                                }
+
+                                // Make sure it is divisible by our expected indent.
+                                if ($tokens[$tokens[$scopeCloser]['scope_condition']]['code'] !== T_CLOSURE) {
+                                    $currentIndent = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                                }
+
+                                $setIndents[$first] = $currentIndent;
+
+                                if ($this->debug === true) {
+                                    $type = $tokens[$first]['type'];
+                                    echo "\t=> indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                                }
+                            }//end if
+                        } else {
+                            // Don't force current indent to be divisible because there could be custom
+                            // rules in place between parenthesis, such as with arrays.
+                            $currentIndent = ($tokens[$first]['column'] - 1);
+                            if (isset($adjustments[$first]) === true) {
+                                $currentIndent += $adjustments[$first];
+                            }
+
+                            $setIndents[$first] = $currentIndent;
+
+                            if ($this->debug === true) {
+                                $type = $tokens[$first]['type'];
+                                echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                            }
+                        }//end if
+                    }//end if
+                } else if ($this->debug === true) {
+                    echo "\t * ignoring single-line definition *".PHP_EOL;
+                }//end if
+            }//end if
+
+            // Closing short array bracket should just be indented to at least
+            // the same level as where it was opened (but can be more).
+            if ($tokens[$i]['code'] === T_CLOSE_SHORT_ARRAY
+                || ($checkToken !== null
+                && $tokens[$checkToken]['code'] === T_CLOSE_SHORT_ARRAY)
+            ) {
+                if ($checkToken !== null) {
+                    $arrayCloser = $checkToken;
+                } else {
+                    $arrayCloser = $i;
+                }
+
+                if ($this->debug === true) {
+                    $line = $tokens[$arrayCloser]['line'];
+                    echo "Closing short array bracket found on line $line".PHP_EOL;
+                }
+
+                $arrayOpener = $tokens[$arrayCloser]['bracket_opener'];
+                if ($tokens[$arrayCloser]['line'] !== $tokens[$arrayOpener]['line']) {
+                    $first       = $phpcsFile->findFirstOnLine(T_WHITESPACE, $arrayOpener, true);
+                    $checkIndent = ($tokens[$first]['column'] - 1);
+                    if (isset($adjustments[$first]) === true) {
+                        $checkIndent += $adjustments[$first];
+                    }
+
+                    $exact = false;
+
+                    if ($this->debug === true) {
+                        $line = $tokens[$first]['line'];
+                        $type = $tokens[$first]['type'];
+                        echo "\t* first token on line $line is $first ($type) *".PHP_EOL;
+                    }
+
+                    if ($first === $tokens[$arrayCloser]['bracket_opener']) {
+                        // This is unlikely to be the start of the statement, so look
+                        // back further to find it.
+                        $first--;
+                    }
+
+                    $prev = $phpcsFile->findStartOfStatement($first, [T_COMMA, T_DOUBLE_ARROW]);
+                    if ($prev !== $first) {
+                        // This is not the start of the statement.
+                        if ($this->debug === true) {
+                            $line = $tokens[$prev]['line'];
+                            $type = $tokens[$prev]['type'];
+                            echo "\t* previous is $type on line $line *".PHP_EOL;
+                        }
+
+                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                        $prev  = $phpcsFile->findStartOfStatement($first, [T_COMMA, T_DOUBLE_ARROW]);
+                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                        if ($this->debug === true) {
+                            $line = $tokens[$first]['line'];
+                            $type = $tokens[$first]['type'];
+                            echo "\t* amended first token is $first ($type) on line $line *".PHP_EOL;
+                        }
+                    } else if ($tokens[$first]['code'] === T_WHITESPACE) {
+                        $first = $phpcsFile->findNext(T_WHITESPACE, ($first + 1), null, true);
+                    }
+
+                    if (isset($tokens[$first]['scope_closer']) === true
+                        && $tokens[$first]['scope_closer'] === $first
+                    ) {
+                        // The first token is a scope closer and would have already
+                        // been processed and set the indent level correctly, so
+                        // don't adjust it again.
+                        if ($this->debug === true) {
+                            echo "\t* first token is a scope closer; ignoring closing short array bracket *".PHP_EOL;
+                        }
+
+                        if (isset($setIndents[$first]) === true) {
+                            $currentIndent = $setIndents[$first];
+                            if ($this->debug === true) {
+                                echo "\t=> indent reset to $currentIndent".PHP_EOL;
+                            }
+                        }
+                    } else {
+                        // Don't force current indent to be divisible because there could be custom
+                        // rules in place for arrays.
+                        $currentIndent = ($tokens[$first]['column'] - 1);
+                        if (isset($adjustments[$first]) === true) {
+                            $currentIndent += $adjustments[$first];
+                        }
+
+                        $setIndents[$first] = $currentIndent;
+
+                        if ($this->debug === true) {
+                            $type = $tokens[$first]['type'];
+                            echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                        }
+                    }//end if
+                } else if ($this->debug === true) {
+                    echo "\t * ignoring single-line definition *".PHP_EOL;
+                }//end if
+            }//end if
+
+            // Adjust lines within scopes while auto-fixing.
+            if ($checkToken !== null
+                && $exact === false
+                && (empty($tokens[$checkToken]['conditions']) === false
+                || (isset($tokens[$checkToken]['scope_opener']) === true
+                && $tokens[$checkToken]['scope_opener'] === $checkToken))
+            ) {
+                if (empty($tokens[$checkToken]['conditions']) === false) {
+                    $condition = $tokens[$checkToken]['conditions'];
+                    end($condition);
+                    $condition = key($condition);
+                } else {
+                    $condition = $tokens[$checkToken]['scope_condition'];
+                }
+
+                $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $condition, true);
+
+                if (isset($adjustments[$first]) === true
+                    && (($adjustments[$first] < 0 && $tokenIndent > $currentIndent)
+                    || ($adjustments[$first] > 0 && $tokenIndent < $currentIndent))
+                ) {
+                    $length = ($tokenIndent + $adjustments[$first]);
+
+                    // When fixing, we're going to adjust the indent of this line
+                    // here automatically, so use this new padding value when
+                    // comparing the expected padding to the actual padding.
+                    if ($phpcsFile->fixer->enabled === true) {
+                        $tokenIndent = $length;
+                        $this->adjustIndent($phpcsFile, $checkToken, $length, $adjustments[$first]);
+                    }
+
+                    if ($this->debug === true) {
+                        $line = $tokens[$checkToken]['line'];
+                        $type = $tokens[$checkToken]['type'];
+                        echo "Indent adjusted to $length for $type on line $line".PHP_EOL;
+                    }
+
+                    $adjustments[$checkToken] = $adjustments[$first];
+
+                    if ($this->debug === true) {
+                        $line = $tokens[$checkToken]['line'];
+                        $type = $tokens[$checkToken]['type'];
+                        echo "\t=> add adjustment of ".$adjustments[$checkToken]." for token $checkToken ($type) on line $line".PHP_EOL;
+                    }
+                }//end if
+            }//end if
+
+            // Scope closers reset the required indent to the same level as the opening condition.
+            if (($checkToken !== null
+                && isset($openScopes[$checkToken]) === true
+                || (isset($tokens[$checkToken]['scope_condition']) === true
+                && isset($tokens[$checkToken]['scope_closer']) === true
+                && $tokens[$checkToken]['scope_closer'] === $checkToken
+                && $tokens[$checkToken]['line'] !== $tokens[$tokens[$checkToken]['scope_opener']]['line']))
+                || ($checkToken === null
+                && isset($openScopes[$i]) === true)
+            ) {
+                if ($this->debug === true) {
+                    if ($checkToken === null) {
+                        $type = $tokens[$tokens[$i]['scope_condition']]['type'];
+                        $line = $tokens[$i]['line'];
+                    } else {
+                        $type = $tokens[$tokens[$checkToken]['scope_condition']]['type'];
+                        $line = $tokens[$checkToken]['line'];
+                    }
+
+                    echo "Close scope ($type) on line $line".PHP_EOL;
+                }
+
+                $scopeCloser = $checkToken;
+                if ($scopeCloser === null) {
+                    $scopeCloser = $i;
+                }
+
+                $conditionToken = array_pop($openScopes);
+                if ($this->debug === true) {
+                    $line = $tokens[$conditionToken]['line'];
+                    $type = $tokens[$conditionToken]['type'];
+                    echo "\t=> removed open scope $conditionToken ($type) on line $line".PHP_EOL;
+                }
+
+                if (isset($tokens[$scopeCloser]['scope_condition']) === true) {
+                    $first = $phpcsFile->findFirstOnLine([T_WHITESPACE, T_INLINE_HTML], $tokens[$scopeCloser]['scope_condition'], true);
+                    if ($this->debug === true) {
+                        $line = $tokens[$first]['line'];
+                        $type = $tokens[$first]['type'];
+                        echo "\t* first token is $first ($type) on line $line *".PHP_EOL;
+                    }
+
+                    while ($tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
+                        && $tokens[($first - 1)]['code'] === T_CONSTANT_ENCAPSED_STRING
+                    ) {
+                        $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, ($first - 1), true);
+                        if ($this->debug === true) {
+                            $line = $tokens[$first]['line'];
+                            $type = $tokens[$first]['type'];
+                            echo "\t* found multi-line string; amended first token is $first ($type) on line $line *".PHP_EOL;
+                        }
+                    }
+
+                    $currentIndent = ($tokens[$first]['column'] - 1);
+                    if (isset($adjustments[$first]) === true) {
+                        $currentIndent += $adjustments[$first];
+                    }
+
+                    $setIndents[$scopeCloser] = $currentIndent;
+
+                    if ($this->debug === true) {
+                        $type = $tokens[$scopeCloser]['type'];
+                        echo "\t=> indent set to $currentIndent by token $scopeCloser ($type)".PHP_EOL;
+                    }
+
+                    // We only check the indent of scope closers if they are
+                    // curly braces because other constructs tend to have different rules.
+                    if ($tokens[$scopeCloser]['code'] === T_CLOSE_CURLY_BRACKET) {
+                        $exact = true;
+                    } else {
+                        $checkToken = null;
+                    }
+                }//end if
+            }//end if
+
+            // Handle scope for JS object notation.
+            if ($phpcsFile->tokenizerType === 'JS'
+                && (($checkToken !== null
+                && $tokens[$checkToken]['code'] === T_CLOSE_OBJECT
+                && $tokens[$checkToken]['line'] !== $tokens[$tokens[$checkToken]['bracket_opener']]['line'])
+                || ($checkToken === null
+                && $tokens[$i]['code'] === T_CLOSE_OBJECT
+                && $tokens[$i]['line'] !== $tokens[$tokens[$i]['bracket_opener']]['line']))
+            ) {
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    echo "Close JS object on line $line".PHP_EOL;
+                }
+
+                $scopeCloser = $checkToken;
+                if ($scopeCloser === null) {
+                    $scopeCloser = $i;
+                } else {
+                    $conditionToken = array_pop($openScopes);
+                    if ($this->debug === true) {
+                        $line = $tokens[$conditionToken]['line'];
+                        $type = $tokens[$conditionToken]['type'];
+                        echo "\t=> removed open scope $conditionToken ($type) on line $line".PHP_EOL;
+                    }
+                }
+
+                $parens = 0;
+                if (isset($tokens[$scopeCloser]['nested_parenthesis']) === true
+                    && empty($tokens[$scopeCloser]['nested_parenthesis']) === false
+                ) {
+                    $parens = $tokens[$scopeCloser]['nested_parenthesis'];
+                    end($parens);
+                    $parens = key($parens);
+                    if ($this->debug === true) {
+                        $line = $tokens[$parens]['line'];
+                        echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
+                    }
+                }
+
+                $condition = 0;
+                if (isset($tokens[$scopeCloser]['conditions']) === true
+                    && empty($tokens[$scopeCloser]['conditions']) === false
+                ) {
+                    $condition = $tokens[$scopeCloser]['conditions'];
+                    end($condition);
+                    $condition = key($condition);
+                    if ($this->debug === true) {
+                        $line = $tokens[$condition]['line'];
+                        $type = $tokens[$condition]['type'];
+                        echo "\t* token is inside condition $condition ($type) on line $line *".PHP_EOL;
+                    }
+                }
+
+                if ($parens > $condition) {
+                    if ($this->debug === true) {
+                        echo "\t* using parenthesis *".PHP_EOL;
+                    }
+
+                    $first     = $phpcsFile->findFirstOnLine(T_WHITESPACE, $parens, true);
+                    $condition = 0;
+                } else if ($condition > 0) {
+                    if ($this->debug === true) {
+                        echo "\t* using condition *".PHP_EOL;
+                    }
+
+                    $first  = $phpcsFile->findFirstOnLine(T_WHITESPACE, $condition, true);
+                    $parens = 0;
+                } else {
+                    if ($this->debug === true) {
+                        $line = $tokens[$tokens[$scopeCloser]['bracket_opener']]['line'];
+                        echo "\t* token is not in parenthesis or condition; using opener on line $line *".PHP_EOL;
+                    }
+
+                    $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $tokens[$scopeCloser]['bracket_opener'], true);
+                }//end if
+
+                $currentIndent = ($tokens[$first]['column'] - 1);
+                if (isset($adjustments[$first]) === true) {
+                    $currentIndent += $adjustments[$first];
+                }
+
+                if ($parens > 0 || $condition > 0) {
+                    $checkIndent = ($tokens[$first]['column'] - 1);
+                    if (isset($adjustments[$first]) === true) {
+                        $checkIndent += $adjustments[$first];
+                    }
+
+                    if ($condition > 0) {
+                        $checkIndent   += $this->indent;
+                        $currentIndent += $this->indent;
+                        $exact          = true;
+                    }
+                } else {
+                    $checkIndent = $currentIndent;
+                }
+
+                // Make sure it is divisible by our expected indent.
+                $currentIndent      = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                $checkIndent        = (int) (ceil($checkIndent / $this->indent) * $this->indent);
+                $setIndents[$first] = $currentIndent;
+
+                if ($this->debug === true) {
+                    $type = $tokens[$first]['type'];
+                    echo "\t=> checking indent of $checkIndent; main indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                }
+            }//end if
+
+            if ($checkToken !== null
+                && isset(Tokens::$scopeOpeners[$tokens[$checkToken]['code']]) === true
+                && in_array($tokens[$checkToken]['code'], $this->nonIndentingScopes, true) === false
+                && isset($tokens[$checkToken]['scope_opener']) === true
+            ) {
+                $exact = true;
+
+                $lastOpener = null;
+                if (empty($openScopes) === false) {
+                    end($openScopes);
+                    $lastOpener = current($openScopes);
+                }
+
+                // A scope opener that shares a closer with another token (like multiple
+                // CASEs using the same BREAK) needs to reduce the indent level so its
+                // indent is checked correctly. It will then increase the indent again
+                // (as all openers do) after being checked.
+                if ($lastOpener !== null
+                    && isset($tokens[$lastOpener]['scope_closer']) === true
+                    && $tokens[$lastOpener]['level'] === $tokens[$checkToken]['level']
+                    && $tokens[$lastOpener]['scope_closer'] === $tokens[$checkToken]['scope_closer']
+                ) {
+                    $currentIndent          -= $this->indent;
+                    $setIndents[$lastOpener] = $currentIndent;
+                    if ($this->debug === true) {
+                        $line = $tokens[$i]['line'];
+                        $type = $tokens[$lastOpener]['type'];
+                        echo "Shared closer found on line $line".PHP_EOL;
+                        echo "\t=> indent set to $currentIndent by token $lastOpener ($type)".PHP_EOL;
+                    }
+                }
+
+                if ($tokens[$checkToken]['code'] === T_CLOSURE
+                    && $tokenIndent > $currentIndent
+                ) {
+                    // The opener is indented more than needed, which is fine.
+                    // But just check that it is divisible by our expected indent.
+                    $checkIndent = (int) (ceil($tokenIndent / $this->indent) * $this->indent);
+                    $exact       = false;
+
+                    if ($this->debug === true) {
+                        $line = $tokens[$i]['line'];
+                        echo "Closure found on line $line".PHP_EOL;
+                        echo "\t=> checking indent of $checkIndent; main indent remains at $currentIndent".PHP_EOL;
+                    }
+                }
+            }//end if
+
+            // Method prefix indentation has to be exact or else it will break
+            // the rest of the function declaration, and potentially future ones.
+            if ($checkToken !== null
+                && isset(Tokens::$methodPrefixes[$tokens[$checkToken]['code']]) === true
+                && $tokens[($checkToken + 1)]['code'] !== T_DOUBLE_COLON
+            ) {
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($checkToken + 1), null, true);
+                if ($next === false || $tokens[$next]['code'] !== T_CLOSURE) {
+                    if ($this->debug === true) {
+                        $line = $tokens[$checkToken]['line'];
+                        $type = $tokens[$checkToken]['type'];
+                        echo "\t* method prefix ($type) found on line $line; indent set to exact *".PHP_EOL;
+                    }
+
+                    $exact = true;
+                }
+            }
+
+            // JS property indentation has to be exact or else if will break
+            // things like function and object indentation.
+            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_PROPERTY) {
+                $exact = true;
+            }
+
+            // Open PHP tags needs to be indented to exact column positions
+            // so they don't cause problems with indent checks for the code
+            // within them, but they don't need to line up with the current indent
+            // in most cases.
+            if ($checkToken !== null
+                && ($tokens[$checkToken]['code'] === T_OPEN_TAG
+                || $tokens[$checkToken]['code'] === T_OPEN_TAG_WITH_ECHO)
+            ) {
+                $checkIndent = ($tokens[$checkToken]['column'] - 1);
+
+                // If we are re-opening a block that was closed in the same
+                // scope as us, then reset the indent back to what the scope opener
+                // set instead of using whatever indent this open tag has set.
+                if (empty($tokens[$checkToken]['conditions']) === false) {
+                    $close = $phpcsFile->findPrevious(T_CLOSE_TAG, ($checkToken - 1));
+                    if ($close !== false
+                        && $tokens[$checkToken]['conditions'] === $tokens[$close]['conditions']
+                    ) {
+                        $conditions    = array_keys($tokens[$checkToken]['conditions']);
+                        $lastCondition = array_pop($conditions);
+                        $lastOpener    = $tokens[$lastCondition]['scope_opener'];
+                        $lastCloser    = $tokens[$lastCondition]['scope_closer'];
+                        if ($tokens[$lastCloser]['line'] !== $tokens[$checkToken]['line']
+                            && isset($setIndents[$lastOpener]) === true
+                        ) {
+                            $checkIndent = $setIndents[$lastOpener];
+                        }
+                    }
+                }
+
+                $checkIndent = (int) (ceil($checkIndent / $this->indent) * $this->indent);
+            }//end if
+
+            // Close tags needs to be indented to exact column positions.
+            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_CLOSE_TAG) {
+                $exact       = true;
+                $checkIndent = $currentIndent;
+                $checkIndent = (int) (ceil($checkIndent / $this->indent) * $this->indent);
+            }
+
+            // Special case for ELSE statements that are not on the same
+            // line as the previous IF statements closing brace. They still need
+            // to have the same indent or it will break code after the block.
+            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_ELSE) {
+                $exact = true;
+            }
+
+            // Don't perform strict checking on chained method calls since they
+            // are often covered by custom rules.
+            if ($checkToken !== null
+                && $tokens[$checkToken]['code'] === T_OBJECT_OPERATOR
+                && $exact === true
+            ) {
+                $exact = false;
+            }
+
+            if ($checkIndent === null) {
+                $checkIndent = $currentIndent;
+            }
+
+            // If the line starts with "->" we assume this is an indented chained
+            // method invocation, so we add one level of indentation.
+            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_OBJECT_OPERATOR) {
+                $exact        = true;
+                $checkIndent += $this->indent;
+            }
+
+            // Comments starting with a star have an extra whitespace.
+            if ($checkToken !== null && $tokens[$checkToken]['code'] === T_COMMENT) {
+                $content = trim($tokens[$checkToken]['content']);
+                if ($content[0] === '*') {
+                    $checkIndent += 1;
+                }
+            }
+
+            /*
+                The indent of the line is checked by the following IF block.
+
+                Up until now, we've just been figuring out what the indent
+                of this line should be.
+
+                After this IF block, we adjust the indent again for
+                the checking of future lines
+            */
+
+            if ($checkToken !== null
+                && isset($this->ignoreIndentation[$tokens[$checkToken]['code']]) === false
+                && (($tokenIndent !== $checkIndent && $exact === true)
+                || ($tokenIndent < $checkIndent && $exact === false))
+            ) {
+                if ($tokenIndent > $checkIndent) {
+                    // Ignore multi line statements.
+                    $before = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($checkToken - 1), null, true);
+                    if ($before !== false && in_array(
+                        $tokens[$before]['code'],
+                        [
+                            T_SEMICOLON,
+                            T_CLOSE_CURLY_BRACKET,
+                            T_OPEN_CURLY_BRACKET,
+                            T_COLON,
+                            T_OPEN_TAG,
+                        ]
+                    ) === false
+                    ) {
+                        continue;
+                    }
+                }
+
+                // Skip array closing indentation errors, this is handled by the
+                // ArraySniff.
+                if (($tokens[$checkToken]['code'] === T_CLOSE_PARENTHESIS
+                    && isset($tokens[$checkToken]['parenthesis_owner']) === true
+                    && $tokens[$tokens[$checkToken]['parenthesis_owner']]['code'] === T_ARRAY)
+                    || $tokens[$checkToken]['code'] === T_CLOSE_SHORT_ARRAY
+                ) {
+                    continue;
+                }
+
+                $type  = 'IncorrectExact';
+                $error = 'Line indented incorrectly; expected ';
+                if ($exact === false) {
+                    $error .= 'at least ';
+                    $type   = 'Incorrect';
+                }
+
+                if ($this->tabIndent === true) {
+                    $error .= '%s tabs, found %s';
+                    $data   = [
+                        floor($checkIndent / $this->tabWidth),
+                        floor($tokenIndent / $this->tabWidth),
+                    ];
+                } else {
+                    $error .= '%s spaces, found %s';
+                    $data   = [
+                        $checkIndent,
+                        $tokenIndent,
+                    ];
+                }
+
+                if ($this->debug === true) {
+                    $line    = $tokens[$checkToken]['line'];
+                    $message = vsprintf($error, $data);
+                    echo "[Line $line] $message".PHP_EOL;
+                }
+
+                // Assume the change would be applied and continue
+                // checking indents under this assumption. This gives more
+                // technically accurate error messages.
+                $adjustments[$checkToken] = ($checkIndent - $tokenIndent);
+
+                $fix = $phpcsFile->addFixableError($error, $checkToken, $type, $data);
+                if ($fix === true || $this->debug === true) {
+                    $accepted = $this->adjustIndent($phpcsFile, $checkToken, $checkIndent, ($checkIndent - $tokenIndent));
+
+                    if ($accepted === true && $this->debug === true) {
+                        $line = $tokens[$checkToken]['line'];
+                        $type = $tokens[$checkToken]['type'];
+                        echo "\t=> add adjustment of ".$adjustments[$checkToken]." for token $checkToken ($type) on line $line".PHP_EOL;
+                    }
+                }
+            }//end if
+
+            if ($checkToken !== null) {
+                $i = $checkToken;
+            }
+
+            // Don't check indents exactly between arrays as they tend to have custom rules.
+            if ($tokens[$i]['code'] === T_OPEN_SHORT_ARRAY) {
+                $disableExactEnd = max($disableExactEnd, $tokens[$i]['bracket_closer']);
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    $type = $tokens[$disableExactEnd]['type'];
+                    echo "Opening short array bracket found on line $line".PHP_EOL;
+                    if ($disableExactEnd === $tokens[$i]['bracket_closer']) {
+                        echo "\t=> disabling exact indent checking until $disableExactEnd ($type)".PHP_EOL;
+                    } else {
+                        echo "\t=> continuing to disable exact indent checking until $disableExactEnd ($type)".PHP_EOL;
+                    }
+                }
+            }
+
+            // Completely skip here/now docs as the indent is a part of the
+            // content itself.
+            if ($tokens[$i]['code'] === T_START_HEREDOC
+                || $tokens[$i]['code'] === T_START_NOWDOC
+            ) {
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    $type = $tokens[$disableExactEnd]['type'];
+                    echo "Here/nowdoc found on line $line".PHP_EOL;
+                }
+
+                $i    = $phpcsFile->findNext([T_END_HEREDOC, T_END_NOWDOC], ($i + 1));
+                $next = $phpcsFile->findNext(Tokens::$emptyTokens, ($i + 1), null, true);
+                if ($tokens[$next]['code'] === T_COMMA) {
+                    $i = $next;
+                }
+
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    $type = $tokens[$i]['type'];
+                    echo "\t* skipping to token $i ($type) on line $line *".PHP_EOL;
+                }
+
+                continue;
+            }//end if
+
+            // Completely skip multi-line strings as the indent is a part of the
+            // content itself.
+            if ($tokens[$i]['code'] === T_CONSTANT_ENCAPSED_STRING
+                || $tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING
+            ) {
+                $i = $phpcsFile->findNext($tokens[$i]['code'], ($i + 1), null, true);
+                $i--;
+                continue;
+            }
+
+            // Completely skip doc comments as they tend to have complex
+            // indentation rules.
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                $i = $tokens[$i]['comment_closer'];
+                continue;
+            }
+
+            // Open tags reset the indent level.
+            if ($tokens[$i]['code'] === T_OPEN_TAG
+                || $tokens[$i]['code'] === T_OPEN_TAG_WITH_ECHO
+            ) {
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    echo "Open PHP tag found on line $line".PHP_EOL;
+                }
+
+                if ($checkToken === null) {
+                    $first         = $phpcsFile->findFirstOnLine(T_WHITESPACE, $i, true);
+                    $currentIndent = (strlen($tokens[$first]['content']) - strlen(ltrim($tokens[$first]['content'])));
+                } else {
+                    $currentIndent = ($tokens[$i]['column'] - 1);
+                }
+
+                $lastOpenTag = $i;
+
+                if (isset($adjustments[$i]) === true) {
+                    $currentIndent += $adjustments[$i];
+                }
+
+                // Make sure it is divisible by our expected indent.
+                $currentIndent  = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                $setIndents[$i] = $currentIndent;
+
+                if ($this->debug === true) {
+                    $type = $tokens[$i]['type'];
+                    echo "\t=> indent set to $currentIndent by token $i ($type)".PHP_EOL;
+                }
+
+                continue;
+            }//end if
+
+            // Close tags reset the indent level, unless they are closing a tag
+            // opened on the same line.
+            if ($tokens[$i]['code'] === T_CLOSE_TAG) {
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    echo "Close PHP tag found on line $line".PHP_EOL;
+                }
+
+                if ($tokens[$lastOpenTag]['line'] !== $tokens[$i]['line']) {
+                    $currentIndent = ($tokens[$i]['column'] - 1);
+                    $lastCloseTag  = $i;
+                } else {
+                    if ($lastCloseTag === null) {
+                        $currentIndent = 0;
+                    } else {
+                        $currentIndent = ($tokens[$lastCloseTag]['column'] - 1);
+                    }
+                }
+
+                if (isset($adjustments[$i]) === true) {
+                    $currentIndent += $adjustments[$i];
+                }
+
+                // Make sure it is divisible by our expected indent.
+                $currentIndent  = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                $setIndents[$i] = $currentIndent;
+
+                if ($this->debug === true) {
+                    $type = $tokens[$i]['type'];
+                    echo "\t=> indent set to $currentIndent by token $i ($type)".PHP_EOL;
+                }
+
+                continue;
+            }//end if
+
+            // Anon classes and functions set the indent based on their own indent level.
+            if ($tokens[$i]['code'] === T_CLOSURE || $tokens[$i]['code'] === T_ANON_CLASS) {
+                $closer = $tokens[$i]['scope_closer'];
+                if ($tokens[$i]['line'] === $tokens[$closer]['line']) {
+                    if ($this->debug === true) {
+                        $type = str_replace('_', ' ', strtolower(substr($tokens[$i]['type'], 2)));
+                        $line = $tokens[$i]['line'];
+                        echo "* ignoring single-line $type on line $line".PHP_EOL;
+                    }
+
+                    $i = $closer;
+                    continue;
+                }
+
+                if ($this->debug === true) {
+                    $type = str_replace('_', ' ', strtolower(substr($tokens[$i]['type'], 2)));
+                    $line = $tokens[$i]['line'];
+                    echo "Open $type on line $line".PHP_EOL;
+                }
+
+                $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $i, true);
+                if ($this->debug === true) {
+                    $line = $tokens[$first]['line'];
+                    $type = $tokens[$first]['type'];
+                    echo "\t* first token is $first ($type) on line $line *".PHP_EOL;
+                }
+
+                while ($tokens[$first]['code'] === T_CONSTANT_ENCAPSED_STRING
+                    && $tokens[($first - 1)]['code'] === T_CONSTANT_ENCAPSED_STRING
+                ) {
+                    $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, ($first - 1), true);
+                    if ($this->debug === true) {
+                        $line = $tokens[$first]['line'];
+                        $type = $tokens[$first]['type'];
+                        echo "\t* found multi-line string; amended first token is $first ($type) on line $line *".PHP_EOL;
+                    }
+                }
+
+                $currentIndent = (($tokens[$first]['column'] - 1) + $this->indent);
+                $openScopes[$tokens[$i]['scope_closer']] = $tokens[$i]['scope_condition'];
+                if ($this->debug === true) {
+                    $closerToken    = $tokens[$i]['scope_closer'];
+                    $closerLine     = $tokens[$closerToken]['line'];
+                    $closerType     = $tokens[$closerToken]['type'];
+                    $conditionToken = $tokens[$i]['scope_condition'];
+                    $conditionLine  = $tokens[$conditionToken]['line'];
+                    $conditionType  = $tokens[$conditionToken]['type'];
+                    echo "\t=> added open scope $closerToken ($closerType) on line $closerLine, pointing to condition $conditionToken ($conditionType) on line $conditionLine".PHP_EOL;
+                }
+
+                if (isset($adjustments[$first]) === true) {
+                    $currentIndent += $adjustments[$first];
+                }
+
+                // Make sure it is divisible by our expected indent.
+                $currentIndent = (int) (floor($currentIndent / $this->indent) * $this->indent);
+                $i = $tokens[$i]['scope_opener'];
+                $setIndents[$i] = $currentIndent;
+
+                if ($this->debug === true) {
+                    $type = $tokens[$i]['type'];
+                    echo "\t=> indent set to $currentIndent by token $i ($type)".PHP_EOL;
+                }
+
+                continue;
+            }//end if
+
+            // Scope openers increase the indent level.
+            if (isset($tokens[$i]['scope_condition']) === true
+                && isset($tokens[$i]['scope_opener']) === true
+                && $tokens[$i]['scope_opener'] === $i
+            ) {
+                $closer = $tokens[$i]['scope_closer'];
+                if ($tokens[$i]['line'] === $tokens[$closer]['line']) {
+                    if ($this->debug === true) {
+                        $line = $tokens[$i]['line'];
+                        $type = $tokens[$i]['type'];
+                        echo "* ignoring single-line $type on line $line".PHP_EOL;
+                    }
+
+                    $i = $closer;
+                    continue;
+                }
+
+                $condition = $tokens[$tokens[$i]['scope_condition']]['code'];
+                if (isset(Tokens::$scopeOpeners[$condition]) === true
+                    && in_array($condition, $this->nonIndentingScopes, true) === false
+                ) {
+                    if ($this->debug === true) {
+                        $line = $tokens[$i]['line'];
+                        $type = $tokens[$tokens[$i]['scope_condition']]['type'];
+                        echo "Open scope ($type) on line $line".PHP_EOL;
+                    }
+
+                    $currentIndent += $this->indent;
+                    $setIndents[$i] = $currentIndent;
+                    $openScopes[$tokens[$i]['scope_closer']] = $tokens[$i]['scope_condition'];
+                    if ($this->debug === true) {
+                        $closerToken    = $tokens[$i]['scope_closer'];
+                        $closerLine     = $tokens[$closerToken]['line'];
+                        $closerType     = $tokens[$closerToken]['type'];
+                        $conditionToken = $tokens[$i]['scope_condition'];
+                        $conditionLine  = $tokens[$conditionToken]['line'];
+                        $conditionType  = $tokens[$conditionToken]['type'];
+                        echo "\t=> added open scope $closerToken ($closerType) on line $closerLine, pointing to condition $conditionToken ($conditionType) on line $conditionLine".PHP_EOL;
+                    }
+
+                    if ($this->debug === true) {
+                        $type = $tokens[$i]['type'];
+                        echo "\t=> indent set to $currentIndent by token $i ($type)".PHP_EOL;
+                    }
+
+                    continue;
+                }//end if
+            }//end if
+
+            // JS objects set the indent level.
+            if ($phpcsFile->tokenizerType === 'JS'
+                && $tokens[$i]['code'] === T_OBJECT
+            ) {
+                $closer = $tokens[$i]['bracket_closer'];
+                if ($tokens[$i]['line'] === $tokens[$closer]['line']) {
+                    if ($this->debug === true) {
+                        $line = $tokens[$i]['line'];
+                        echo "* ignoring single-line JS object on line $line".PHP_EOL;
+                    }
+
+                    $i = $closer;
+                    continue;
+                }
+
+                if ($this->debug === true) {
+                    $line = $tokens[$i]['line'];
+                    echo "Open JS object on line $line".PHP_EOL;
+                }
+
+                $first         = $phpcsFile->findFirstOnLine(T_WHITESPACE, $i, true);
+                $currentIndent = (($tokens[$first]['column'] - 1) + $this->indent);
+                if (isset($adjustments[$first]) === true) {
+                    $currentIndent += $adjustments[$first];
+                }
+
+                // Make sure it is divisible by our expected indent.
+                $currentIndent      = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                $setIndents[$first] = $currentIndent;
+
+                if ($this->debug === true) {
+                    $type = $tokens[$first]['type'];
+                    echo "\t=> indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                }
+
+                continue;
+            }//end if
+
+            // Closing an anon class or function.
+            if (isset($tokens[$i]['scope_condition']) === true
+                && $tokens[$i]['scope_closer'] === $i
+                && ($tokens[$tokens[$i]['scope_condition']]['code'] === T_CLOSURE
+                || $tokens[$tokens[$i]['scope_condition']]['code'] === T_ANON_CLASS)
+            ) {
+                if ($this->debug === true) {
+                    $type = str_replace('_', ' ', strtolower(substr($tokens[$tokens[$i]['scope_condition']]['type'], 2)));
+                    $line = $tokens[$i]['line'];
+                    echo "Close $type on line $line".PHP_EOL;
+                }
+
+                $prev = false;
+
+                $object = 0;
+                if ($phpcsFile->tokenizerType === 'JS') {
+                    $conditions = $tokens[$i]['conditions'];
+                    krsort($conditions, SORT_NUMERIC);
+                    foreach ($conditions as $token => $condition) {
+                        if ($condition === T_OBJECT) {
+                            $object = $token;
+                            break;
+                        }
+                    }
+
+                    if ($this->debug === true && $object !== 0) {
+                        $line = $tokens[$object]['line'];
+                        echo "\t* token is inside JS object $object on line $line *".PHP_EOL;
+                    }
+                }
+
+                $parens = 0;
+                if (isset($tokens[$i]['nested_parenthesis']) === true
+                    && empty($tokens[$i]['nested_parenthesis']) === false
+                ) {
+                    $parens = $tokens[$i]['nested_parenthesis'];
+                    end($parens);
+                    $parens = key($parens);
+                    if ($this->debug === true) {
+                        $line = $tokens[$parens]['line'];
+                        echo "\t* token has nested parenthesis $parens on line $line *".PHP_EOL;
+                    }
+                }
+
+                $condition = 0;
+                if (isset($tokens[$i]['conditions']) === true
+                    && empty($tokens[$i]['conditions']) === false
+                ) {
+                    $condition = $tokens[$i]['conditions'];
+                    end($condition);
+                    $condition = key($condition);
+                    if ($this->debug === true) {
+                        $line = $tokens[$condition]['line'];
+                        $type = $tokens[$condition]['type'];
+                        echo "\t* token is inside condition $condition ($type) on line $line *".PHP_EOL;
+                    }
+                }
+
+                if ($parens > $object && $parens > $condition) {
+                    if ($this->debug === true) {
+                        echo "\t* using parenthesis *".PHP_EOL;
+                    }
+
+                    $prev      = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($parens - 1), null, true);
+                    $object    = 0;
+                    $condition = 0;
+                } else if ($object > 0 && $object >= $condition) {
+                    if ($this->debug === true) {
+                        echo "\t* using object *".PHP_EOL;
+                    }
+
+                    $prev      = $object;
+                    $parens    = 0;
+                    $condition = 0;
+                } else if ($condition > 0) {
+                    if ($this->debug === true) {
+                        echo "\t* using condition *".PHP_EOL;
+                    }
+
+                    $prev   = $condition;
+                    $object = 0;
+                    $parens = 0;
+                }//end if
+
+                if ($prev === false) {
+                    $prev = $phpcsFile->findPrevious([T_EQUAL, T_RETURN], ($tokens[$i]['scope_condition'] - 1), null, false, null, true);
+                    if ($prev === false) {
+                        $prev = $i;
+                        if ($this->debug === true) {
+                            echo "\t* could not find a previous T_EQUAL or T_RETURN token; will use current token *".PHP_EOL;
+                        }
+                    }
+                }
+
+                if ($this->debug === true) {
+                    $line = $tokens[$prev]['line'];
+                    $type = $tokens[$prev]['type'];
+                    echo "\t* previous token is $type on line $line *".PHP_EOL;
+                }
+
+                $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                if ($this->debug === true) {
+                    $line = $tokens[$first]['line'];
+                    $type = $tokens[$first]['type'];
+                    echo "\t* first token on line $line is $first ($type) *".PHP_EOL;
+                }
+
+                $prev = $phpcsFile->findStartOfStatement($first);
+                if ($prev !== $first) {
+                    // This is not the start of the statement.
+                    if ($this->debug === true) {
+                        $line = $tokens[$prev]['line'];
+                        $type = $tokens[$prev]['type'];
+                        echo "\t* amended previous is $type on line $line *".PHP_EOL;
+                    }
+
+                    $first = $phpcsFile->findFirstOnLine(T_WHITESPACE, $prev, true);
+                    if ($this->debug === true) {
+                        $line = $tokens[$first]['line'];
+                        $type = $tokens[$first]['type'];
+                        echo "\t* amended first token is $first ($type) on line $line *".PHP_EOL;
+                    }
+                }
+
+                $currentIndent = ($tokens[$first]['column'] - 1);
+                if ($object > 0 || $condition > 0) {
+                    $currentIndent += $this->indent;
+                }
+
+                if (isset($tokens[$first]['scope_closer']) === true
+                    && $tokens[$first]['scope_closer'] === $first
+                ) {
+                    if ($this->debug === true) {
+                        echo "\t* first token is a scope closer *".PHP_EOL;
+                    }
+
+                    if ($condition === 0 || $tokens[$condition]['scope_opener'] < $first) {
+                        $currentIndent = $setIndents[$first];
+                    } else if ($this->debug === true) {
+                        echo "\t* ignoring scope closer *".PHP_EOL;
+                    }
+                }
+
+                // Make sure it is divisible by our expected indent.
+                $currentIndent      = (int) (ceil($currentIndent / $this->indent) * $this->indent);
+                $setIndents[$first] = $currentIndent;
+
+                if ($this->debug === true) {
+                    $type = $tokens[$first]['type'];
+                    echo "\t=> indent set to $currentIndent by token $first ($type)".PHP_EOL;
+                }
+            }//end if
+        }//end for
+
+        // Don't process the rest of the file.
+        return $phpcsFile->numTokens;
+
+    }//end process()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile All the tokens found in the document.
+     * @param int                         $stackPtr  The position of the current token
+     *                                               in the stack passed in $tokens.
+     * @param int                         $length    The length of the new indent.
+     * @param int                         $change    The difference in length between
+     *                                               the old and new indent.
+     *
+     * @return bool
+     */
+    protected function adjustIndent(File $phpcsFile, $stackPtr, $length, $change)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // We don't adjust indents outside of PHP.
+        if ($tokens[$stackPtr]['code'] === T_INLINE_HTML) {
+            return false;
+        }
+
+        $padding = '';
+        if ($length > 0) {
+            if ($this->tabIndent === true) {
+                $numTabs = (int) floor($length / $this->tabWidth);
+                if ($numTabs > 0) {
+                    $numSpaces = ($length - ($numTabs * $this->tabWidth));
+                    $padding   = str_repeat("\t", $numTabs).str_repeat(' ', $numSpaces);
+                }
+            } else {
+                $padding = str_repeat(' ', $length);
+            }
+        }
+
+        if ($tokens[$stackPtr]['column'] === 1) {
+            $trimmed  = ltrim($tokens[$stackPtr]['content']);
+            $accepted = $phpcsFile->fixer->replaceToken($stackPtr, $padding.$trimmed);
+        } else {
+            // Easier to just replace the entire indent.
+            $accepted = $phpcsFile->fixer->replaceToken(($stackPtr - 1), $padding);
+        }
+
+        if ($accepted === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+            // We adjusted the start of a comment, so adjust the rest of it
+            // as well so the alignment remains correct.
+            for ($x = ($stackPtr + 1); $x < $tokens[$stackPtr]['comment_closer']; $x++) {
+                if ($tokens[$x]['column'] !== 1) {
+                    continue;
+                }
+
+                $length = 0;
+                if ($tokens[$x]['code'] === T_DOC_COMMENT_WHITESPACE) {
+                    $length = $tokens[$x]['length'];
+                }
+
+                $padding = ($length + $change);
+                if ($padding > 0) {
+                    if ($this->tabIndent === true) {
+                        $numTabs   = (int) floor($padding / $this->tabWidth);
+                        $numSpaces = ($padding - ($numTabs * $this->tabWidth));
+                        $padding   = str_repeat("\t", $numTabs).str_repeat(' ', $numSpaces);
+                    } else {
+                        $padding = str_repeat(' ', $padding);
+                    }
+                } else {
+                    $padding = '';
+                }
+
+                $phpcsFile->fixer->replaceToken($x, $padding);
+                if ($this->debug === true) {
+                    $length = strlen($padding);
+                    $line   = $tokens[$x]['line'];
+                    $type   = $tokens[$x]['type'];
+                    echo "\t=> Indent adjusted to $length for $type on line $line".PHP_EOL;
+                }
+            }//end for
+        }//end if
+
+        return true;
+
+    }//end adjustIndent()
+
+
+}//end class

--- a/core/misc/code_sniffer/Backdrop/coder_unique_autoload_phpcs_bug_2751.php
+++ b/core/misc/code_sniffer/Backdrop/coder_unique_autoload_phpcs_bug_2751.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Includes classes which are not detected by PHP_CodeSniffer's autoloader.
+ *
+ * This file has a weird name on purpose because of https://github.com/squizlabs/PHP_CodeSniffer/pull/2751
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ * @see      https://github.com/squizlabs/PHP_CodeSniffer/issues/1469
+ */
+
+// Abstract base classes are not discovered by the autoloader.
+#require_once 'Sniffs/Semantics/FunctionCall.php';
+#require_once 'Sniffs/Semantics/FunctionDefinition.php';

--- a/core/misc/code_sniffer/Backdrop/ruleset.xml
+++ b/core/misc/code_sniffer/Backdrop/ruleset.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0"?>
+<!-- See http://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php -->
+<ruleset name="Backdrop">
+ <description>Backdrop coding standard</description>
+ <!-- All Backdrop code files must be UTF-8 encoded and we treat them as such. -->
+ <arg name="encoding" value="utf-8"/>
+
+ <autoload>./coder_unique_autoload_phpcs_bug_2751.php</autoload>
+
+ <rule ref="Internal.NoCodeFound">
+  <!-- Empty files are fine, might be used for testing. -->
+  <exclude-pattern>*</exclude-pattern>
+ </rule>
+
+ <rule ref="Backdrop.Commenting.FileComment">
+  <!-- Do not run this sniff on txt files. -->
+  <exclude-pattern>*.txt</exclude-pattern>
+ </rule>
+ <rule ref="Backdrop.Commenting.FileComment.SpacingAfterComment">
+  <!-- Do not run this sniff on template files. -->
+  <exclude-pattern>*.tpl.php</exclude-pattern>
+ </rule>
+ <rule ref="Backdrop.ControlStructures.ControlSignature">
+  <!-- Do not run this sniff on template files. -->
+  <exclude-pattern>*.tpl.php</exclude-pattern>
+ </rule>
+
+ <!-- Silence method name underscore warning which is covered already in
+   Backdrop.NamingConventions.ValidFunctionName.ScopeNotCamelCaps. -->
+ <rule ref="Backdrop.Methods.MethodDeclaration.Underscore">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="Backdrop.WhiteSpace.ScopeIndent">
+  <!-- Do not run this sniff on template files, as the indentation might follow
+  the HTML -->
+  <exclude-pattern>*.tpl.php</exclude-pattern>
+ </rule>
+
+ <rule ref="Generic.CodeAnalysis.UselessOverridingMethod" />
+ <rule ref="Generic.Files.ByteOrderMark" />
+ <rule ref="Generic.Formatting.DisallowMultipleStatements" />
+ <rule ref="Generic.Formatting.SpaceAfterCast" />
+
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
+  <properties>
+   <property name="checkClosures" value="true"/>
+  </properties>
+ </rule>
+
+ <rule ref="Generic.NamingConventions.ConstructorName" />
+ <rule ref="Generic.NamingConventions.UpperCaseConstantName" />
+ <rule ref="Generic.PHP.DeprecatedFunctions" />
+ <rule ref="Generic.PHP.DisallowShortOpenTag" />
+ <rule ref="Generic.PHP.LowerCaseKeyword" />
+ <rule ref="Generic.PHP.UpperCaseConstant" />
+ <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
+
+ <!-- Use Unix newlines -->
+ <rule ref="Generic.Files.LineEndings">
+  <properties>
+   <property name="eolChar" value="\n"/>
+  </properties>
+ </rule>
+
+ <rule ref="MySource.Debug.DebugCode" />
+ <rule ref="PEAR.Files.IncludingFile" />
+ <!-- Disable some error messages that we do not want. -->
+ <rule ref="PEAR.Files.IncludingFile.UseIncludeOnce">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Files.IncludingFile.UseInclude">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Files.IncludingFile.UseRequire">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="PEAR.Functions.FunctionCallSignature"/>
+ <!-- Disable some error messages that we already cover. -->
+ <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket">
+  <severity>0</severity>
+ </rule>
+ <!-- Disable some error messages that we do not want. -->
+ <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.EmptyLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Functions.FunctionCallSignature.OpeningIndent">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="PEAR.Functions.ValidDefaultValue" />
+
+ <rule ref="PSR2.Namespaces.NamespaceDeclaration" />
+ <rule ref="PSR2.Namespaces.UseDeclaration" />
+
+ <rule ref="Squiz.Arrays.ArrayDeclaration" />
+ <!-- Disable some error messages that we do not want. -->
+ <rule ref="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.FirstValueNoNewline">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.NoComma">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.NotLowerCase">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNotAligned">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNoNewline">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="Squiz.Arrays.ArrayBracketSpacing" />
+
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration" />
+ <!-- Disable some error messages that we already cover. -->
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForLoopDeclaration" />
+ <!-- Disable some error messages that we already cover. -->
+ <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterOpen">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingBeforeClose">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration" />
+ <!-- Disable some error messages that we do not want. -->
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.BreakIndent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.CaseIndent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.CloseBraceAlign">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.DefaultIndent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.DefaultNoBreak">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.EmptyCase">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.EmptyDefault">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.MissingDefault">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.SpacingAfterCase">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.SpacingAfterDefaultBreak">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.SwitchDeclaration.SpacingBeforeBreak">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="Squiz.CSS.ClassDefinitionClosingBraceSpace" />
+ <rule ref="Squiz.CSS.ClassDefinitionClosingBraceSpace.SpacingAfterClose">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.CSS.ClassDefinitionOpeningBraceSpace" />
+ <rule ref="Squiz.CSS.ClassDefinitionOpeningBraceSpace.AfterNesting">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.CSS.ColonSpacing" />
+ <rule ref="Squiz.CSS.DisallowMultipleStyleDefinitions" />
+ <rule ref="Squiz.CSS.EmptyClassDefinition" />
+ <rule ref="Squiz.CSS.EmptyStyleDefinition" />
+ <rule ref="Squiz.CSS.Indentation">
+  <properties>
+   <property name="indent" value="2"/>
+  </properties>
+ </rule>
+ <rule ref="Squiz.CSS.MissingColon" />
+ <rule ref="Squiz.CSS.SemicolonSpacing" />
+
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+  <properties>
+   <property name="equalsSpacing" value="1"/>
+  </properties>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration" />
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace">
+  <severity>0</severity>
+ </rule>
+ <!-- Standard yet to be finalized on this (https://www.drupal.org/node/1539712). -->
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.FirstParamSpacing">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.Indent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.CloseBracketLine">
+  <severity>0</severity>
+ </rule>
+
+ <rule ref="Squiz.PHP.LowercasePHPFunctions" />
+ <rule ref="Squiz.PHP.NonExecutableCode" />
+ <rule ref="Squiz.Strings.ConcatenationSpacing">
+  <properties>
+   <property name="spacing" value="1"/>
+   <property name="ignoreNewlines" value="true"/>
+  </properties>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.FunctionSpacing">
+  <properties>
+   <property name="spacing" value="1"/>
+  </properties>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
+ <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+  <properties>
+   <property name="ignoreNewlines" value="true"/>
+  </properties>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />
+ <rule ref="Squiz.WhiteSpace.SemicolonSpacing" />
+ <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace" />
+
+ <rule ref="Zend.Files.ClosingTag">
+  <!-- Do not run this sniff on template files. -->
+  <exclude-pattern>*.tpl.php</exclude-pattern>
+ </rule>
+
+ <!-- Ignore various version control directories. -->
+ <exclude-pattern>*/\.git/*</exclude-pattern>
+ <exclude-pattern>*/\.svn/*</exclude-pattern>
+ <exclude-pattern>*/\.hg/*</exclude-pattern>
+ <exclude-pattern>*/\.bzr/*</exclude-pattern>
+</ruleset>

--- a/core/modules/views/plugins/views_plugin_style.inc
+++ b/core/modules/views/plugins/views_plugin_style.inc
@@ -26,31 +26,34 @@
 class views_plugin_style extends views_plugin {
   /**
    * Store all available tokens row rows.
+   *
+   * @var array
    */
-  var $row_tokens = array();
+  public $row_tokens = array();
 
   /**
-   * Contains the row plugin, if it's initialized
-   * and the style itself supports it.
+   * Contains the row plugin, if it's initialized and the style supports it.
    *
    * @var views_plugin_row
    */
-  var $row_plugin;
+  public $row_plugin;
 
   /**
    * Initialize a style plugin.
    *
-   * @param $view
-   * @param $display
-   * @param $options
+   * @param view $view
+   *   The view.
+   * @param views_display $display
+   *   The display on which this style is bieing applied.
+   * @param array $options
    *   The style options might come externally as the style can be sourced
    *   from at least two locations. If it's not included, look on the display.
    */
-  function init(&$view, &$display, $options = NULL) {
+  public function init(view &$view, views_display &$display, array $options = NULL) {
     $this->view = &$view;
     $this->display = &$display;
 
-    // Overlay incoming options on top of defaults
+    // Overlay incoming options on top of defaults.
     $this->unpack_options($this->options, isset($options) ? $options : $display->handler->get_option('style_options'));
 
     if ($this->uses_row_plugin() && $display->handler->get_option('row_plugin')) {
@@ -66,7 +69,10 @@ class views_plugin_style extends views_plugin {
     );
   }
 
-  function destroy() {
+  /**
+   * {@inheritdoc}
+   */
+  public function destroy() {
     parent::destroy();
 
     if (isset($this->row_plugin)) {
@@ -77,23 +83,21 @@ class views_plugin_style extends views_plugin {
   /**
    * Return TRUE if this style also uses a row plugin.
    */
-  function uses_row_plugin() {
+  public function uses_row_plugin() {
     return !empty($this->definition['uses row plugin']);
   }
 
   /**
    * Return TRUE if this style also uses a row plugin.
    */
-  function uses_row_class() {
+  public function uses_row_class() {
     return !empty($this->definition['uses row class']);
   }
 
   /**
-   * Return TRUE if this style also uses fields.
-   *
-   * @return bool
+   * Determines whether this style plugin uses fields.
    */
-  function uses_fields() {
+  public function uses_fields() {
     // If we use a row plugin, ask the row plugin. Chances are, we don't
     // care, it does.
     $row_uses_fields = FALSE;
@@ -105,11 +109,11 @@ class views_plugin_style extends views_plugin {
   }
 
   /**
-   * Return TRUE if this style uses tokens.
+   * Determines if this style uses tokens.
    *
    * Used to ensure we don't fetch tokens when not needed for performance.
    */
-  function uses_tokens() {
+  public function uses_tokens() {
     if ($this->uses_row_class()) {
       $class = $this->options['row_class'];
       if (strpos($class, '[') !== FALSE || strpos($class, '!') !== FALSE || strpos($class, '%') !== FALSE) {
@@ -121,7 +125,7 @@ class views_plugin_style extends views_plugin {
   /**
    * Return the token replaced row class for the specified row.
    */
-  function get_row_class($row_index) {
+  public function get_row_class($row_index) {
     if ($this->uses_row_class() && $this->options['row_class']) {
 
       $has_tokens = FALSE;
@@ -147,7 +151,7 @@ class views_plugin_style extends views_plugin {
   /**
    * Take a value and apply token replacement logic to it.
    */
-  function tokenize_value($value, $row_index) {
+  public function tokenize_value($value, $row_index) {
     if (strpos($value, '[') !== FALSE || strpos($value, '!') !== FALSE || strpos($value, '%') !== FALSE) {
       $fake_item = array(
         'alter_text' => TRUE,
@@ -169,13 +173,16 @@ class views_plugin_style extends views_plugin {
   }
 
   /**
-   * Should the output of the style plugin be rendered even if it's a empty view.
+   * Print the output of the style plugin even if it's an empty view.
    */
-  function even_empty() {
+  public function even_empty() {
     return !empty($this->definition['even empty']);
   }
 
-  function option_definition() {
+  /**
+   * {@inheritdoc}
+   */
+  public function option_definition() {
     $options = parent::option_definition();
     $options['grouping'] = array('default' => array());
     if ($this->uses_row_class()) {
@@ -188,12 +195,15 @@ class views_plugin_style extends views_plugin {
     return $options;
   }
 
-  function options_form(&$form, &$form_state) {
+  /**
+   * {@inheritdoc}
+   */
+  public function options_form(&$form, &$form_state) {
     parent::options_form($form, $form_state);
     // Only fields-based views can handle grouping. Style plugins can also
     // exclude themselves from being groupable by setting their "use grouping"
     // definition key to FALSE.
-    // @TODO: Document "uses grouping" in docs.php when docs.php is written.
+    // @todo Document "uses grouping" in docs.php when docs.php is written.
     if ($this->uses_fields() && $this->definition['uses grouping']) {
       $options = array('' => t('- None -'));
       $field_labels = $this->display->handler->get_field_labels(TRUE);
@@ -285,7 +295,10 @@ class views_plugin_style extends views_plugin {
     }
   }
 
-  function options_validate(&$form, &$form_state) {
+  /**
+   * {@inheritdoc}
+   */
+  public function options_validate(&$form, &$form_state) {
     // Don't run validation on style plugins without the grouping setting.
     if (isset($form_state['values']['style_options']['grouping'])) {
       // Don't save grouping if no field is specified.
@@ -298,25 +311,31 @@ class views_plugin_style extends views_plugin {
   }
 
   /**
+   * Overrides the default sorting behavior.
+   *
    * Called by the view builder to see if this style handler wants to
    * interfere with the sorts. If so it should build; if it returns
    * any non-TRUE value, normal sorting will NOT be added to the query.
    */
-  function build_sort() { return TRUE; }
+  public function build_sort() {
+    return TRUE;
+  }
 
   /**
+   * Adds additional sorts after the view is built.
+   *
    * Called by the view builder to let the style build a second set of
    * sorts that will come after any other sorts in the view.
    */
-  function build_sort_post() { }
+  public function build_sort_post() {}
 
   /**
    * Allow the style to do stuff before each row is rendered.
    *
-   * @param $result
+   * @param array $result
    *   The full array of results from the query.
    */
-  function pre_render($result) {
+  public function pre_render(array $result) {
     if (!empty($this->row_plugin)) {
       $this->row_plugin->pre_render($result);
     }
@@ -325,7 +344,7 @@ class views_plugin_style extends views_plugin {
   /**
    * Render the display in this style.
    */
-  function render() {
+  public function render() {
     if ($this->uses_row_plugin() && empty($this->row_plugin)) {
       debug('views_plugin_style_default: Missing row plugin');
       return;
@@ -347,15 +366,15 @@ class views_plugin_style extends views_plugin {
    * Plugins may override this method if they wish some other way of handling
    * grouping.
    *
-   * @param $sets
+   * @param array $sets
    *   Array containing the grouping sets to render.
-   * @param $level
+   * @param int $level
    *   Integer indicating the hierarchical level of the grouping.
    *
    * @return string
    *   Rendered output of given grouping sets.
    */
-  function render_grouping_sets($sets, $level = 0) {
+  public function render_grouping_sets(array $sets, $level = 0) {
     $output = '';
     foreach ($sets as $set) {
       $row = reset($set['rows']);
@@ -367,7 +386,8 @@ class views_plugin_style extends views_plugin {
             'grouping' => $this->options['grouping'][$level],
             'grouping_level' => $level,
             'rows' => $set['rows'],
-            'title' => $set['group'])
+            'title' => $set['group'],
+          )
         );
       }
       // Render as a record set.
@@ -385,7 +405,8 @@ class views_plugin_style extends views_plugin {
             'options' => $this->options,
             'grouping_level' => $level,
             'rows' => $set['rows'],
-            'title' => $set['group'])
+            'title' => $set['group'],
+          )
         );
       }
     }
@@ -396,18 +417,19 @@ class views_plugin_style extends views_plugin {
   /**
    * Group records as needed for rendering.
    *
-   * @param $records
+   * @param array $records
    *   An array of records from the view to group.
-   * @param $groupings
+   * @param array $groupings
    *   An array of grouping instructions on which fields to group. If empty, the
    *   result set will be given a single group with an empty string as a label.
-   * @param $group_rendered
+   * @param bool $group_rendered
    *   Boolean value whether to use the rendered or the raw field value for
    *   grouping. If set to NULL the return is structured as before
    *   Views 7.x-3.0-rc2. After Views 7.x-3.0 this boolean is only used if
    *   $groupings is an old-style string or if the rendered option is missing
    *   for a grouping instruction.
-   * @return
+   *
+   * @return array
    *   The grouped record set.
    *   A nested set structure is generated if multiple grouping fields are used.
    *
@@ -432,7 +454,7 @@ class views_plugin_style extends views_plugin {
    *   )
    *   @endcode
    */
-  function render_grouping($records, $groupings = array(), $group_rendered = NULL) {
+  public function render_grouping(array $records, array $groupings = array(), $group_rendered = NULL) {
     // This is for backward compatibility, when $groupings was a string
     // containing the ID of a single field.
     if (is_string($groupings)) {
@@ -440,7 +462,7 @@ class views_plugin_style extends views_plugin {
       $groupings = array(array('field' => $groupings, 'rendered' => $rendered));
     }
 
-    // Make sure fields are rendered
+    // Make sure fields are rendered.
     $this->render_fields($this->view->result);
     $sets = array();
     if ($groupings) {
@@ -485,10 +507,10 @@ class views_plugin_style extends views_plugin {
             $set[$grouping]['rows'] = array();
           }
 
-          // Move the set reference into the row set of the group we just determined.
+          // Move the set reference into the row set of the group.
           $set = &$set[$grouping]['rows'];
         }
-        // Add the row to the hierarchically positioned row set we just determined.
+        // Add the row to the hierarchically positioned row set.
         $set[$index] = $row;
       }
     }
@@ -502,7 +524,7 @@ class views_plugin_style extends views_plugin {
 
     // If this parameter isn't explicitly set, modify the output to be fully
     // backward compatible to code before Views 7.x-3.0-rc2.
-    // @TODO Remove this as soon as possible (e.g. October 2020).
+    // @todo Remove this as soon as possible (e.g. October 2020).
     if ($group_rendered === NULL) {
       $old_style_sets = array();
       foreach ($sets as $group) {
@@ -517,10 +539,10 @@ class views_plugin_style extends views_plugin {
   /**
    * Render all of the fields for a given style and store them on the object.
    *
-   * @param $result
+   * @param array $result
    *   The result array from $view->result.
    */
-  function render_fields($result) {
+  public function render_fields(array $result) {
     if (!$this->uses_fields()) {
       return;
     }
@@ -551,12 +573,12 @@ class views_plugin_style extends views_plugin {
   /**
    * Get a rendered field.
    *
-   * @param $index
+   * @param int $index
    *   The index count of the row.
-   * @param $field
-   *    The id of the field.
+   * @param string $field
+   *   The id of the field.
    */
-  function get_field($index, $field) {
+  public function get_field($index, $field) {
     if (!isset($this->rendered_fields)) {
       $this->render_fields($this->view->result);
     }
@@ -567,21 +589,24 @@ class views_plugin_style extends views_plugin {
   }
 
   /**
-  * Get the raw field value.
-  *
-  * @param $index
-  *   The index count of the row.
-  * @param $field
-  *    The id of the field.
-  */
-  function get_field_value($index, $field) {
+   * Get the raw field value.
+   *
+   * @param int $index
+   *   The index count of the row.
+   * @param string $field
+   *   The id of the field.
+   */
+  public function get_field_value($index, $field) {
     $this->view->row_index = $index;
     $value = $this->view->field[$field]->get_value($this->view->result[$index]);
     unset($this->view->row_index);
     return $value;
   }
 
-  function validate() {
+  /**
+   * {@inheritdoc}
+   */
+  public function validate() {
     $errors = parent::validate();
 
     if ($this->uses_row_plugin()) {
@@ -599,12 +624,16 @@ class views_plugin_style extends views_plugin {
     return $errors;
   }
 
-  function query() {
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
     parent::query();
     if (isset($this->row_plugin)) {
       $this->row_plugin->query();
     }
   }
+
 }
 
 /**

--- a/core/modules/views/plugins/views_plugin_style.inc
+++ b/core/modules/views/plugins/views_plugin_style.inc
@@ -2,6 +2,8 @@
 /**
  * @file
  * Definition of views_plugin_style.
+ *
+ * phpcs:disable Backdrop.NamingConventions
  */
 
 /**


### PR DESCRIPTION
Work in progress on PHPCS coding standards.

This PR is not ready because it currently bundles all the PHPCS files into core. We want to pull all the standards from https://github.com/backdrop-contrib/coder_review module, but we're working on updating the standards in that contrib project.

This does demonstrate getting it working with GitHub Actions however. It only runs on the changed files per Pull Request.