### PR TITLE
Issue #4864: bring back textgroup

### DIFF
--- a/core/includes/gettext.inc
+++ b/core/includes/gettext.inc
@@ -25,11 +25,14 @@
  * @param $mode
  *   Should existing translations be replaced LOCALE_IMPORT_KEEP or
  *   LOCALE_IMPORT_OVERWRITE.
+ * @param $group
+ *   Text group to import PO file into (eg. 'default' for interface
+ *   translations).
  *
  * @return bool
  *   TRUE if the import was successful, FALSE otherwise.
  */
-function _locale_import_po($file, $langcode, $mode) {
+function _locale_import_po($file, $langcode, $mode, $group = NULL) {
   // Check if we have the language already in the database.
   if (!language_load($langcode)) {
     backdrop_set_message(t('The language selected for import is not supported.'), 'error');
@@ -37,7 +40,7 @@ function _locale_import_po($file, $langcode, $mode) {
   }
 
   // Get strings from file (returns on failure after a partial import, or on success)
-  $status = _locale_import_read_po('db-store', $file, $mode, $langcode);
+  $status = _locale_import_read_po('db-store', $file, $mode, $langcode, $group);
   if ($status === FALSE) {
     // Error messages are set in _locale_import_read_po().
     return FALSE;
@@ -84,11 +87,14 @@ function _locale_import_po($file, $langcode, $mode) {
  *   LOCALE_IMPORT_OVERWRITE.
  * @param string $langcode
  *   Language code.
+ * @param $group
+ *   Text group to import PO file into (eg. 'default' for interface
+ *   translations).
  *
  * @return NULL|FALSE
  *   NULL return value on success. FALSE upon failure.
  */
-function _locale_import_read_po($op, $file, $mode = NULL, $langcode = NULL) {
+function _locale_import_read_po($op, $file, $mode = NULL, $langcode = NULL, $group = 'default') {
 
   // The file will get closed by PHP on returning from this function.
   $fd = fopen($file->uri, 'rb');
@@ -145,7 +151,7 @@ function _locale_import_read_po($op, $file, $mode = NULL, $langcode = NULL) {
       }
       elseif (($context == 'MSGSTR') || ($context == 'MSGSTR_ARR')) {
         // We are currently in string token, close it out.
-        _locale_import_one_string($op, $current, $mode, $langcode, $file);
+        _locale_import_one_string($op, $current, $mode, $langcode, $file, $group);
 
         // Start a new entry for the comment.
         $current         = array();
@@ -189,7 +195,7 @@ function _locale_import_read_po($op, $file, $mode = NULL, $langcode = NULL) {
 
       if (($context == 'MSGSTR') || ($context == 'MSGSTR_ARR')) {
         // We are currently in a message string, close it out.
-        _locale_import_one_string($op, $current, $mode, $langcode, $file);
+        _locale_import_one_string($op, $current, $mode, $langcode, $file, $group);
 
         // Start a new context for the id.
         $current = array();
@@ -219,7 +225,7 @@ function _locale_import_read_po($op, $file, $mode = NULL, $langcode = NULL) {
 
       if (($context == 'MSGSTR') || ($context == 'MSGSTR_ARR')) {
         // We are currently in a message, start a new one.
-        _locale_import_one_string($op, $current, $mode, $langcode, $file);
+        _locale_import_one_string($op, $current, $mode, $langcode, $file, $group);
         $current = array();
       }
       elseif (!empty($current['msgctxt'])) {
@@ -333,7 +339,7 @@ function _locale_import_read_po($op, $file, $mode = NULL, $langcode = NULL) {
 
   // End of PO file, closed out the last entry.
   if (($context == 'MSGSTR') || ($context == 'MSGSTR_ARR')) {
-    _locale_import_one_string($op, $current, $mode, $langcode, $file);
+    _locale_import_one_string($op, $current, $mode, $langcode, $file, $group);
   }
   elseif ($context != 'COMMENT') {
     _locale_import_message('The translation file %filename ended unexpectedly at line %line.', $file, $lineno);
@@ -376,12 +382,15 @@ function _locale_import_message($message, $file, $lineno = NULL) {
  * @param stdClass $file
  *   Object representation of file being imported, only required when op is
  *   'db-store'.
+ * @param $group
+ *   Text group to import PO file into (eg. 'default' for interface
+ *   translations).
  *
  * @return NULL|array
  *   If the operation is a "report" operation, an array is returned with
  *   information about currently stored strings. Other operations return NULL.
  */
-function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode = NULL, $file = NULL) {
+function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode = NULL, $file = NULL, $group = 'default') {
   $report = &backdrop_static(__FUNCTION__, array('additions' => 0, 'updates' => 0, 'deletes' => 0, 'skips' => 0));
   $header_done = &backdrop_static(__FUNCTION__ . ':header_done', FALSE);
   $strings = &backdrop_static(__FUNCTION__ . ':strings', array());
@@ -441,7 +450,7 @@ function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode =
             if ($key == 0) {
               $plid = 0;
             }
-            $plid = _locale_import_one_string_db($report, $langcode, isset($value['msgctxt']) ? $value['msgctxt'] : '', $english[$key], $trans, $comments, $mode, $plid, $key);
+            $plid = _locale_import_one_string_db($report, $lang, isset($value['msgctxt']) ? $value['msgctxt'] : '', $english[$key], $trans, $group, $comments, $mode, $plid, $key);
           }
         }
 
@@ -449,7 +458,7 @@ function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode =
           // A simple string to import.
           $english = $value['msgid'];
           $translation = $value['msgstr'];
-          _locale_import_one_string_db($report, $langcode, isset($value['msgctxt']) ? $value['msgctxt'] : '', $english, $translation, $comments, $mode);
+          _locale_import_one_string_db($report, $langcode, isset($value['msgctxt']) ? $value['msgctxt'] : '', $english, $translation, $group, $comments, $mode);
         }
       }
   } // end of db-store operation
@@ -471,6 +480,8 @@ function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode =
  *   Source string.
  * @param $translation
  *   Translation to language specified in $langcode.
+ * @param $textgroup
+ *   Name of textgroup to store translation in.
  * @param $location
  *   Location value to save with source string.
  * @param $mode
@@ -483,12 +494,14 @@ function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode =
  * @return
  *   The string ID of the existing string modified or the new string added.
  */
-function _locale_import_one_string_db(&$report, $langcode, $context, $source, $translation, $location, $mode, $plid = 0, $plural = 0) {
-  $lid = db_query("SELECT lid FROM {locales_source} WHERE source = :source AND context = :context", array(':source' => $source, ':context' => $context))->fetchField();
+function _locale_import_one_string_db(&$report, $langcode, $context, $source, $translation, $textgroup, $location, $mode, $plid = 0, $plural = 0) {
+  $lid = db_query("SELECT lid FROM {locales_source} WHERE source = :source AND context = :context AND textgroup = :textgroup", array(':source' => $source, ':context' => $context, ':textgroup' => $textgroup))->fetchField();
 
   if (!empty($translation)) {
     // Skip this string unless it passes a check for dangerous code.
-    if (!locale_string_is_safe($translation)) {
+    // Text groups other than default still can contain HTML tags
+    // (i.e. translatable blocks).
+    if ($textgroup == "default" && !locale_string_is_safe($translation)) {
       watchdog('locale', 'Import of string "%string" was skipped because of disallowed or malformed HTML.', array('%string' => $translation), WATCHDOG_ERROR);
       $report['skips']++;
       $lid = 0;
@@ -540,6 +553,7 @@ function _locale_import_one_string_db(&$report, $langcode, $context, $source, $t
           'location' => $location,
           'source' => $source,
           'context' => (string) $context,
+          'textgroup' => $textgroup,
         ))
         ->execute();
 
@@ -883,16 +897,19 @@ function _locale_import_parse_quoted($string) {
  * @param stdClass $language
  *   Language object to generate the output for, or NULL if generating
  *   translation template.
+ * @param $group
+ *   Text group to export PO file from (eg. 'default' for interface
+ *   translations).
  *
  * @return array
  *   An array of translated strings that can be used to generate an export.
  */
-function _locale_export_get_strings($language = NULL) {
+function _locale_export_get_strings($language = NULL, $group = 'default') {
   if (isset($language)) {
-    $result = db_query("SELECT s.lid, s.source, s.context, s.location, t.translation, t.plid, t.plural FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language ORDER BY t.plid, t.plural", array(':language' => $language->langcode));
+    $result = db_query("SELECT s.lid, s.source, s.context, s.location, t.translation, t.plid, t.plural FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.textgroup = :textgroup ORDER BY t.plid, t.plural", array(':language' => $language->langcode, ':textgroup' => $group));
   }
   else {
-    $result = db_query("SELECT s.lid, s.source, s.context, s.location, t.plid, t.plural FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid ORDER BY t.plid, t.plural");
+    $result = db_query("SELECT s.lid, s.source, s.context, s.location, t.plid, t.plural FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid WHERE s.textgroup = :textgroup ORDER BY t.plid, t.plural", array(':textgroup' => $group));
   }
   $strings = array();
   foreach ($result as $child) {

--- a/core/includes/gettext.inc
+++ b/core/includes/gettext.inc
@@ -450,7 +450,7 @@ function _locale_import_one_string($op, $value = NULL, $mode = NULL, $langcode =
             if ($key == 0) {
               $plid = 0;
             }
-            $plid = _locale_import_one_string_db($report, $lang, isset($value['msgctxt']) ? $value['msgctxt'] : '', $english[$key], $trans, $group, $comments, $mode, $plid, $key);
+            $plid = _locale_import_one_string_db($report, $langcode, isset($value['msgctxt']) ? $value['msgctxt'] : '', $english[$key], $trans, $group, $comments, $mode, $plid, $key);
           }
         }
 

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -771,7 +771,7 @@ function _locale_rebuild_js($langcode = NULL) {
 
   // Construct the array for JavaScript translations.
   // Only add strings with a translation to the translations array.
-  $result = db_query("SELECT s.lid, s.source, t.translation FROM {locales_source} s INNER JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.location LIKE '%.js%' AND s.textgroup = :textgroup", array(':language' => $language->langcode, ':textgroup' => 'default'));
+  $result = db_query("SELECT s.lid, s.source, s.context, t.translation FROM {locales_source} s INNER JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.location LIKE '%.js%' AND s.textgroup = :textgroup", array(':language' => $language->langcode, ':textgroup' => 'default'));
 
   $translations = array();
   foreach ($result as $data) {

--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -681,7 +681,7 @@ function _locale_parse_js_file($filepath) {
     $string =  implode('', preg_split('~(?<!\\\\)[\'"]\s*\+\s*[\'"]~s', substr($match['string'], 1, -1)));
     $context = implode('', preg_split('~(?<!\\\\)[\'"]\s*\+\s*[\'"]~s', substr($match['context'], 1, -1)));
 
-    $source = db_query("SELECT lid, location FROM {locales_source} WHERE source = :source AND context = :context", array(':source' => $string, ':context' => $context))->fetchObject();
+    $source = db_query("SELECT lid, location FROM {locales_source} WHERE source = :source AND context = :context AND textgroup = 'default'", array(':source' => $string, ':context' => $context))->fetchObject();
     if ($source) {
       // We already have this source string and now have to add the location
       // to the location column, if this file is not yet present in there.
@@ -707,6 +707,7 @@ function _locale_parse_js_file($filepath) {
           'location'  => $filepath,
           'source'    => $string,
           'context'   => $context,
+          'textgroup' => 'default',
         ))
         ->execute();
     }
@@ -770,7 +771,7 @@ function _locale_rebuild_js($langcode = NULL) {
 
   // Construct the array for JavaScript translations.
   // Only add strings with a translation to the translations array.
-  $result = db_query("SELECT s.lid, s.source, s.context, t.translation FROM {locales_source} s INNER JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.location LIKE '%.js%'", array(':language' => $language->langcode));
+  $result = db_query("SELECT s.lid, s.source, t.translation FROM {locales_source} s INNER JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.location LIKE '%.js%' AND s.textgroup = :textgroup", array(':language' => $language->langcode, ':textgroup' => 'default'));
 
   $translations = array();
   foreach ($result as $data) {

--- a/core/modules/locale/locale.api.php
+++ b/core/modules/locale/locale.api.php
@@ -10,6 +10,19 @@
  * @{
  */
 
+/**
+ * Allows modules to define their own text groups that can be translated.
+ *
+ * @param $op
+ *   Type of operation. Currently, only supports 'groups'.
+ */
+function hook_locale($op = 'groups') {
+  switch ($op) {
+    case 'groups':
+      return array('custom' => t('Custom'));
+  }
+}
+
  /**
  * React to a language about to be added or updated in the system.
  *

--- a/core/modules/locale/locale.bulk.inc
+++ b/core/modules/locale/locale.bulk.inc
@@ -54,6 +54,12 @@ function locale_translate_import_form($form, &$form_state) {
     '#default_value' => $default,
     '#description' => t('Choose the language you want to add strings into. If you choose a language which is not yet set up, it will be added.'),
   );
+  $form['import']['group'] = array('#type' => 'radios',
+    '#title' => t('Text group'),
+    '#default_value' => 'default',
+    '#options' => module_invoke_all('locale', 'groups'),
+    '#description' => t('Imported translations will be added to this text group.'),
+  );
   $form['import']['mode'] = array('#type' => 'radios',
     '#title' => t('Mode'),
     '#default_value' => LOCALE_IMPORT_KEEP,
@@ -90,7 +96,7 @@ function locale_translate_import_form_submit($form, &$form_state) {
     }
 
     // Now import strings into the language
-    if ($return = _locale_import_po($file, $langcode, $form_state['values']['mode']) == FALSE) {
+    if ($return = _locale_import_po($file, $langcode, $form_state['values']['mode'], $form_state['values']['group']) == FALSE) {
       $variables = array('%filename' => $file->filename);
       backdrop_set_message(t('The translation import of %filename failed.', $variables), 'error');
       watchdog('locale', 'The translation import of %filename failed.', $variables, WATCHDOG_ERROR);
@@ -146,6 +152,11 @@ function locale_translate_export_po_form($form, &$form_state, $names) {
     '#options' => $names,
     '#description' => t('Select the language to export in Gettext Portable Object (<em>.po</em>) format.'),
   );
+  $form['group'] = array('#type' => 'radios',
+    '#title' => t('Text group'),
+    '#default_value' => 'default',
+    '#options' => module_invoke_all('locale', 'groups'),
+  );
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array('#type' => 'submit', '#value' => t('Export'));
   return $form;
@@ -159,6 +170,11 @@ function locale_translate_export_pot_form() {
   $form['export_title'] = array('#type' => 'item',
     '#title' => t('Export template'),
     '#description' => t('Generate a Gettext Portable Object Template (<em>.pot</em>) file with all strings from the Backdrop locale database.'),
+  );
+  $form['group'] = array('#type' => 'radios',
+    '#title' => t('Text group'),
+    '#default_value' => 'default',
+    '#options' => module_invoke_all('locale', 'groups'),
   );
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array('#type' => 'submit', '#value' => t('Export'));
@@ -177,7 +193,7 @@ function locale_translate_export_po_form_submit($form, &$form_state) {
     $languages = language_list();
     $language = $languages[$form_state['values']['langcode']];
   }
-  _locale_export_po($language, _locale_export_po_generate($language, _locale_export_get_strings($language)));
+  _locale_export_po($language, _locale_export_po_generate($language, _locale_export_get_strings($language, $form_state['values']['group'])));
 }
 
 /**

--- a/core/modules/locale/locale.install
+++ b/core/modules/locale/locale.install
@@ -219,23 +219,12 @@ function locale_update_dependencies() {
  */
 
 /**
- * Drop textgroup support.
- *
- * Update assumes i18n migrated this data before the update happened. Core
- * never used textgroups for anything, so it is not our job to find place
- * for the data elsewhere.
+ * Update removed.
  */
 function locale_update_1000() {
-  $subquery = db_select('locales_source', 'ls')
-    ->fields('ls', array('lid'))
-    ->condition('ls.textgroup', 'default', '<>');
-  db_delete('locales_target')
-    ->condition('lid', $subquery, 'IN')
-    ->execute();
-  db_delete('locales_source')
-    ->condition('textgroup', 'default', '<>')
-    ->execute();
-  db_drop_field('locales_source', 'textgroup');
+// Previously this was "Drop textgroup support." But locale_update_1006() adds
+// textgroup back in to provide backwards-compatibility for i18n and other
+// modules.
 }
 
 /**
@@ -389,7 +378,9 @@ function locale_update_1005() {
  * Add textgroup to locales_source.
  */
 function locale_update_1006() {
-  if (db_field_exists('locale_source', 'textgroup')) {
+  // Textgroup was previously removed in locale_update_1001() but reverting
+  // that change here.
+  if (db_field_exists('locales_source', 'textgroup')) {
     return;
   }
 
@@ -400,9 +391,9 @@ function locale_update_1006() {
     'default' => 'default',
     'description' => 'A module defined group of translations, see hook_locale().',
   );
-  db_add_field('locale_source', 'textgroup', $schema);
+  db_add_field('locales_source', 'textgroup', $schema);
 
-  db_update('locale_source')
+  db_update('locales_source')
   ->fields(array(
     'textgroup' => 'default',
   ))

--- a/core/modules/locale/locale.install
+++ b/core/modules/locale/locale.install
@@ -112,6 +112,13 @@ function locale_schema() {
         'size' => 'big',
         'description' => 'Backdrop path in case of online discovered translations or file path in case of imported strings.',
       ),
+      'textgroup' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => 'default',
+        'description' => 'A module defined group of translations, see hook_locale().',
+      ),
       'source' => array(
         'type' => 'text',
         'not null' => TRUE,
@@ -376,6 +383,30 @@ function locale_update_1005() {
       'description' => 'Translation string value in this language.',
     )
   );
+}
+
+/**
+ * Add textgroup to locales_source.
+ */
+function locale_update_1006() {
+  if (db_field_exists('locale_source', 'textgroup')) {
+    return;
+  }
+
+  $schema = array(
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => TRUE,
+    'default' => 'default',
+    'description' => 'A module defined group of translations, see hook_locale().',
+  );
+  db_add_field('locale_source', 'textgroup', $schema);
+
+  db_update('locale_source')
+  ->fields(array(
+    'textgroup' => 'default',
+  ))
+  ->execute();
 }
 
 /**

--- a/core/modules/locale/locale.install
+++ b/core/modules/locale/locale.install
@@ -219,12 +219,16 @@ function locale_update_dependencies() {
  */
 
 /**
- * Update removed.
+ * Drop textgroup support.
+ *
+ * Update assumes i18n migrated this data before the update happened. Core
+ * never used textgroups for anything, so it is not our job to find place
+ * for the data elsewhere.
  */
 function locale_update_1000() {
-// Previously this was "Drop textgroup support." But locale_update_1006() adds
-// textgroup back in to provide backwards-compatibility for i18n and other
-// modules.
+  // Update removed. See https://github.com/backdrop/backdrop-issues/issues/4864.
+  // locale_update_1006() adds textgroup back in to provide backwards
+  // compatibility for i18n and other modules.
 }
 
 /**
@@ -380,6 +384,7 @@ function locale_update_1005() {
 function locale_update_1006() {
   // Textgroup was previously removed in locale_update_1001() but reverting
   // that change here.
+  // See https://github.com/backdrop/backdrop-issues/issues/4864.
   if (db_field_exists('locales_source', 'textgroup')) {
     return;
   }

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -161,6 +161,16 @@ function locale_config_info() {
 }
 
 /**
+ * Implements hook_locale().
+ */
+function locale_locale($op = 'groups') {
+  switch ($op) {
+    case 'groups':
+      return array('default' => t('Built-in interface'));
+  }
+}
+
+/**
  * Form builder callback to display language selection widget.
  *
  * @ingroup forms
@@ -564,7 +574,7 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
         // We only store short strings used in current version, to improve
         // performance and consume less memory.
         try {
-          $result = db_query("SELECT s.source, s.context, t.translation, t.language FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.version = :version AND LENGTH(s.source) < :length", array(
+          $result = db_query("SELECT s.source, s.context, t.translation, t.language FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.textgroup = 'default' AND s.version = :version AND LENGTH(s.source) < :length", array(
             ':language' => $langcode,
             ':version' => BACKDROP_VERSION,
             ':length' => config_get('locale.settings', 'cache_length'),
@@ -590,10 +600,11 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
   if (!isset($locale_t[$langcode][$context][$string])) {
     // We do not have this translation cached, so get it from the DB.
     try {
-      $translation = db_query("SELECT s.lid, t.translation, s.version FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.source = :source AND s.context = :context", array(
+      $translation = db_query("SELECT s.lid, t.translation, s.version FROM {locales_source} s LEFT JOIN {locales_target} t ON s.lid = t.lid AND t.language = :language WHERE s.source = :source AND s.context = :context AND s.textgroup = 'default'", array(
         ':language' => $langcode,
         ':source' => $string,
         ':context' => (string) $context,
+        'textgroup' => 'default',
       ))->fetchObject();
     }
     // In the event the table does not exist (such as when uninstalling the

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -633,6 +633,7 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
       db_merge('locales_source')
         ->insertFields(array(
           'location' => request_uri(),
+          'textgroup' => 'default',
           'version' => BACKDROP_VERSION,
         ))
         ->key(array(

--- a/core/modules/locale/locale.module
+++ b/core/modules/locale/locale.module
@@ -604,7 +604,6 @@ function locale($string = NULL, $context = NULL, $langcode = NULL) {
         ':language' => $langcode,
         ':source' => $string,
         ':context' => (string) $context,
-        'textgroup' => 'default',
       ))->fetchObject();
     }
     // In the event the table does not exist (such as when uninstalling the

--- a/core/modules/locale/locale.pages.inc
+++ b/core/modules/locale/locale.pages.inc
@@ -339,10 +339,9 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
   // list. The source language is English for built-in strings and the default
   // language for other strings.
   $languages = language_list();
-  $default = language_default();
-  // We don't need the default language value, that value is in $source.
-  $omit = $source->textgroup == 'default' ? 'en' : $default->langcode;
-  unset($languages[($omit)]);
+  if (!locale_translate_english()) {
+    unset($languages['en']);
+  }
   $form['translations'] = array('#tree' => TRUE);
   // Approximate the number of rows to use in the default textarea.
   $rows = min(ceil(str_word_count($source->source) / 12), 10);
@@ -356,7 +355,7 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
   }
 
   // Fetch translations and fill in default values in the form.
-  $result = db_query("SELECT DISTINCT translation, language FROM {locales_target} WHERE lid = :lid AND language <> :omit", array(':lid' => $lid, ':omit' => $omit));
+  $result = db_query("SELECT DISTINCT translation, language FROM {locales_target} WHERE lid = :lid", array(':lid' => $lid));
   foreach ($result as $translation) {
     $form['translations'][$translation->language]['#default_value'] = $translation->translation;
   }

--- a/core/modules/locale/locale.pages.inc
+++ b/core/modules/locale/locale.pages.inc
@@ -27,6 +27,7 @@ function _locale_translate_seek() {
   if (!($query = _locale_translate_seek_query())) {
     $query = array(
       'translation' => 'all',
+      'group' => 'all',
       'language' => 'all',
       'string' => '',
     );
@@ -43,7 +44,12 @@ function _locale_translate_seek() {
     $sql_query->leftJoin('locales_target', 't', 't.lid = s.lid');
   }
 
-  $sql_query->fields('s', array('source', 'location', 'context', 'lid'));
+  // Add a condition on the text group.
+  if (!empty($query['group']) && $query['group'] != 'all') {
+    $sql_query->condition('s.textgroup', $query['group']);
+  }
+
+  $sql_query->fields('s', array('source', 'location', 'context', 'lid', 'textgroup'));
   $sql_query->fields('t', array('translation', 'language'));
 
   // Compute LIKE section.
@@ -74,12 +80,14 @@ function _locale_translate_seek() {
   $sql_query = $sql_query->extend('PagerDefault')->limit(50);
   $locales = $sql_query->execute();
 
-  $header = array(t('String'), t('Context'), ($limit_language) ? t('Language') : t('Languages'), array('data' => t('Operations'), 'colspan' => '2'));
+  $groups = module_invoke_all('locale', 'groups');
+  $header = array(t('Text group'), t('String'), t('Context'), ($limit_language) ? t('Language') : t('Languages'), array('data' => t('Operations'), 'colspan' => '2'));
 
   $strings = array();
   foreach ($locales as $locale) {
     if (!isset($strings[$locale->lid])) {
       $strings[$locale->lid] = array(
+        'group' => $locale->textgroup,
         'languages' => array(),
         'location' => $locale->location,
         'source' => $locale->source,
@@ -107,6 +115,7 @@ function _locale_translate_seek() {
       'class' => array('nowrap'),
     );
     $rows[] = array(
+      $groups[$string['group']],
       array('data' => check_plain(truncate_utf8($string['source'], 150, FALSE, TRUE)) . '<br /><small>' . $string['location'] . '</small>'),
       $string['context'],
       array('data' => _locale_translate_language_list($string, $limit_language), 'align' => 'center'),
@@ -150,7 +159,7 @@ function _locale_translate_seek_query() {
   $query = &backdrop_static(__FUNCTION__);
   if (!isset($query)) {
     $query = array();
-    $fields = array('string', 'language', 'translation');
+    $fields = array('string', 'language', 'translation', 'group');
     foreach ($fields as $field) {
       if (isset($_SESSION['locale_translation_filter'][$field])) {
         $query[$field] = $_SESSION['locale_translation_filter'][$field];
@@ -186,6 +195,12 @@ function locale_translation_filters() {
   $filters['translation'] = array(
     'title' => t('Search in'),
     'options' => array('all' => t('Both translated and untranslated strings'), 'translated' => t('Only translated strings'), 'untranslated' => t('Only untranslated strings')),
+  );
+
+  $groups = module_invoke_all('locale', 'groups');
+  $filters['group'] = array(
+    'title' => t('Limit search to'),
+    'options' => array_merge(array('all' => t('All text groups')), $groups),
   );
 
   return $filters;
@@ -253,7 +268,7 @@ function locale_translation_filter_form() {
  * Validate result from locale translation filter form.
  */
 function locale_translation_filter_form_validate($form, &$form_state) {
-  if ($form_state['values']['op'] == t('Filter') && empty($form_state['values']['language'])) {
+  if ($form_state['values']['op'] == t('Filter') && empty($form_state['values']['language']) && empty($form_state['values']['group'])) {
     form_set_error('type', t('You must select something to filter by.'));
   }
 }
@@ -288,7 +303,7 @@ function locale_translation_filter_form_submit($form, &$form_state) {
  */
 function locale_translate_edit_form($form, &$form_state, $lid) {
   // Fetch source string, if possible.
-  $source = db_query('SELECT source, context, location FROM {locales_source} WHERE lid = :lid', array(':lid' => $lid))->fetchObject();
+  $source = db_query('SELECT source, context, textgroup, location FROM {locales_source} WHERE lid = :lid', array(':lid' => $lid))->fetchObject();
   if (!$source) {
     backdrop_set_message(t('String not found.'), 'error');
     backdrop_goto('admin/config/regional/translate/translate');
@@ -311,6 +326,10 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
     '#type'  => 'value',
     '#value' => $lid
   );
+  $form['textgroup'] = array(
+    '#type'  => 'value',
+    '#value' => $source->textgroup,
+  );
   $form['location'] = array(
     '#type'  => 'value',
     '#value' => $source->location
@@ -320,9 +339,10 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
   // list. The source language is English for built-in strings and the default
   // language for other strings.
   $languages = language_list();
-  if (!locale_translate_english()) {
-    unset($languages['en']);
-  }
+  $default = language_default();
+  // We don't need the default language value, that value is in $source.
+  $omit = $source->textgroup == 'default' ? 'en' : $default->langcode;
+  unset($languages[($omit)]);
   $form['translations'] = array('#tree' => TRUE);
   // Approximate the number of rows to use in the default textarea.
   $rows = min(ceil(str_word_count($source->source) / 12), 10);
@@ -336,7 +356,7 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
   }
 
   // Fetch translations and fill in default values in the form.
-  $result = db_query("SELECT DISTINCT translation, language FROM {locales_target} WHERE lid = :lid", array(':lid' => $lid));
+  $result = db_query("SELECT DISTINCT translation, language FROM {locales_target} WHERE lid = :lid AND language <> :omit", array(':lid' => $lid, ':omit' => $omit));
   foreach ($result as $translation) {
     $form['translations'][$translation->language]['#default_value'] = $translation->translation;
   }
@@ -352,8 +372,10 @@ function locale_translate_edit_form($form, &$form_state, $lid) {
 function locale_translate_edit_form_validate($form, &$form_state) {
   require_once BACKDROP_ROOT . '/core/includes/locale.inc';
 
+  // Locale string check is needed for default textgroup only.
+  $safe_check_needed = $form_state['values']['textgroup'] == 'default';
   foreach ($form_state['values']['translations'] as $key => $value) {
-    if (!locale_string_is_safe($value)) {
+    if ($safe_check_needed && !locale_string_is_safe($value)) {
       form_set_error('translations', t('The submitted string contains disallowed HTML: %string', array('%string' => $value)));
       watchdog('locale', 'Attempted submission of a translation string with disallowed HTML: %string', array('%string' => $value), WATCHDOG_WARNING);
     }

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -218,6 +218,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $name,
       'language' => 'all',
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     // assertText() seems to remove the input field where $name always could be
@@ -308,6 +309,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $name,
       'language' => 'all',
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     // Assume this is the only result, given the random name.
@@ -357,7 +359,9 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
     // table and translate it.
     $query = db_select('locales_source', 'l');
     $query->addExpression('min(l.lid)', 'lid');
-    $result = $query->condition('l.location', '%.js%', 'LIKE')->execute();
+    $result = $query->condition('l.location', '%.js%', 'LIKE')
+      ->condition('l.textgroup', 'default')
+      ->execute();
     $url = 'admin/config/regional/translate/edit/' . $result->fetchObject()->lid;
     $edit = array('translations['. $langcode .']' => $this->randomName());
     $this->backdropPost($url, $edit, t('Save translations'));
@@ -418,6 +422,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $name,
       'language' => 'all',
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     // Find the edit path.
@@ -478,6 +483,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $name,
       'language' => 'all',
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     // assertText() seems to remove the input field where $name always could be
@@ -562,6 +568,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $translation,
       'language' => $langcode,
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     $this->assertNoText(t('No strings available.'), 'Search found the translation.');
@@ -571,6 +578,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $translation,
       'language' => LANGUAGE_SYSTEM,
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     $this->assertText(t('No strings available.'), "Search didn't find the translation.");
@@ -581,6 +589,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
       'string' => $unavailable_string,
       'language' => 'all',
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     $this->assertText(t('No strings available.'), "Search didn't find the invalid string.");
@@ -794,7 +803,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
     $this->assertEqual($this->getUrl(), url('admin/config/regional/translate', array('absolute' => TRUE)), 'Correct page redirection.');
 
 
-    // Try importing a .po file with invalid tags.
+    // Try importing a .po file with invalid tags in the default text group.
     $this->importPoFile($this->getBadPoFile(), array(
       'langcode' => 'fr',
     ));
@@ -805,11 +814,21 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
     $this->assertRaw($skip_message, 'Unsafe strings were skipped.');
 
 
-    // Try importing a .po file which doesn't exist.
+    // Try importing a .po file with invalid tags in a non default text group.
+    $this->importPoFile($this->getBadPoFile(), array(
+      'langcode' => 'fr',
+      'group' => 'custom',
+    ));
+
+    // The import should have created 3 strings.
+    $this->assertRaw(t('The translation was successfully imported. There are %number newly created translated strings, %update strings were updated and %delete strings were removed.', array('%number' => 3, '%update' => 0, '%delete' => 0)), t('The translation file was successfully imported.'));
+
+
     $name = $this->randomName(16);
     $this->backdropPost('admin/config/regional/translate/import', array(
       'langcode' => 'fr',
       'files[file]' => $name,
+      'group' => 'custom',
     ), t('Import'));
     $this->assertEqual($this->getUrl(), url('admin/config/regional/translate/import', array('absolute' => TRUE)), 'Correct page redirection.');
     $this->assertText(t('File to import not found.'), 'File to import not found message.');
@@ -829,6 +848,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
       'string' => 'Montag',
       'language' => 'fr',
       'translation' => 'translated',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     $this->assertText(t('No strings available.'), 'String not overwritten by imported string.');
@@ -851,6 +871,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
       'string' => 'Montag',
       'language' => 'fr',
       'translation' => 'translated',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     $this->assertNoText(t('No strings available.'), 'String overwritten by imported string.');
@@ -886,6 +907,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
       'string' => 'lundi',
       'language' => $langcode,
       'translation' => 'translated',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     $this->assertNoText(t('No strings available.'), 'String successfully imported.');
@@ -932,6 +954,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
       'string' => $str,
       'language' => 'all',
       'translation' => 'all',
+      'group' => 'all',
     );
     $this->backdropPost('admin/config/regional/translate/translate', $search, t('Filter'));
     // assertText() seems to remove the input field where $str always could be
@@ -1250,8 +1273,9 @@ class LocaleUninstallFunctionalTest extends BackdropWebTestCase {
     $user = $this->backdropCreateUser(array('translate interface', 'access administration pages'));
     $this->backdropLogin($user);
     $this->backdropGet('admin/config/regional/translate/translate');
-    $string = db_query('SELECT min(lid) AS lid FROM {locales_source} WHERE location LIKE :location', array(
+    $string = db_query('SELECT min(lid) AS lid FROM {locales_source} WHERE location LIKE :location AND textgroup = :textgroup', array(
       ':location' => '%.js%',
+      ':textgroup' => 'default',
     ))->fetchObject();
     $edit = array('translations[fr]' => 'french translation');
     $this->backdropPost('admin/config/regional/translate/edit/' . $string->lid, $edit, t('Save translations'));

--- a/core/modules/locale/tests/locale_test/locale_test.module
+++ b/core/modules/locale/tests/locale_test/locale_test.module
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Implements hook_locale().
+ */
+function locale_test_locale($op = 'groups') {
+  switch ($op) {
+    case 'groups':
+      return array('custom' => t('Custom'));
+  }
+}
+
+/**
  * Implements hook_boot().
  *
  * For testing domain language negotiation, we fake it by setting


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4864

Adapts the reverse of this patch: https://www.drupal.org/files/issues/remove-textgroups-for-good-4.patch which removed textgroup (see https://www.drupal.org/project/drupal/issues/1188430). 