### PR TITLE
Issue #4904: PDOException when uninstalling comment module

### DIFF
--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -66,9 +66,6 @@ function comment_uninstall() {
   if (db_field_exists('node', 'comment_close_override')) {
     db_drop_field('node', 'comment_close_override');
   }
-  // Reset the cached information about entity types.
-  backdrop_static_reset('entity_get_info');
-  cache()->deletePrefix('entity_info:');
 
   // Remove default, un-modified view.
   $config = config('views.view.comments_recent');

--- a/core/modules/comment/comment.install
+++ b/core/modules/comment/comment.install
@@ -66,6 +66,9 @@ function comment_uninstall() {
   if (db_field_exists('node', 'comment_close_override')) {
     db_drop_field('node', 'comment_close_override');
   }
+  // Reset the cached information about entity types.
+  backdrop_static_reset('entity_get_info');
+  cache()->deletePrefix('entity_info:');
 
   // Remove default, un-modified view.
   $config = config('views.view.comments_recent');

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -19,6 +19,15 @@ function entity_modules_disabled() {
 }
 
 /**
+ * Implements hook_modules_uninstalled().
+ */
+function entity_modules_uninstalled($modules) {
+  // It is important that the entity info cache gets flushed last to prevent
+  // fatal errors with outdated entity information.
+  backdrop_register_shutdown_function('entity_info_cache_clear');
+}
+
+/**
  * Implements hook_flush_caches().
  */
 function entity_flush_caches() {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4904

Prevent fatal error by flushing the cached information about entity types.