### PR TITLE
Issue  #4939: Fix typo in file.file.inc file description.

### DIFF
--- a/core/modules/file/file.file.inc
+++ b/core/modules/file/file.file.inc
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * File hooks implemented by the Fil module.
+ * File hooks implemented by the File module.
  */
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4939