### PR TITLE
Fix ‘every_page_weight’

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3521,6 +3521,11 @@ function backdrop_get_css($css = NULL, $skip_alter = FALSE) {
     backdrop_alter('css', $css);
   }
 
+  // Fix 'every_page_weight' in case it is missing.
+  foreach ($css as $key => &$item) {
+    $item['every_page_weight'] = $item['every_page_weight'] ?? $item['every_page'] ? -1 : 1;
+  }
+
   // Sort CSS items, so that they appear in the correct order.
   backdrop_sort($css, array('group', 'every_page_weight', 'weight'));
 
@@ -4735,6 +4740,11 @@ function backdrop_get_js($scope = 'header', $javascript = NULL, $skip_alter = FA
     if ($item['scope'] == $scope) {
       $items[$key] = $item;
     }
+  }
+
+  // Fix 'every_page_weight' in case it is missing.
+  foreach ($items as $key => &$item) {
+    $item['every_page_weight'] = $item['every_page_weight'] ?? $item['every_page'] ? -1 : 1;
   }
 
   // Sort the JavaScript so that it appears in the correct order.

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3523,7 +3523,9 @@ function backdrop_get_css($css = NULL, $skip_alter = FALSE) {
 
   // Fix 'every_page_weight' in case it is missing.
   foreach ($css as $key => &$item) {
-    $item['every_page_weight'] = $item['every_page_weight'] ?? $item['every_page'] ? -1 : 1;
+    if (!isset($item['every_page_weight'])) {
+      $item['every_page_weight'] = $item['every_page'] ? -1 : 1;
+    }
   }
 
   // Sort CSS items, so that they appear in the correct order.
@@ -4744,7 +4746,9 @@ function backdrop_get_js($scope = 'header', $javascript = NULL, $skip_alter = FA
 
   // Fix 'every_page_weight' in case it is missing.
   foreach ($items as $key => &$item) {
-    $item['every_page_weight'] = $item['every_page_weight'] ?? $item['every_page'] ? -1 : 1;
+    if (!isset($item['every_page_weight'])) {
+      $item['every_page_weight'] = $item['every_page'] ? -1 : 1;
+    }
   }
 
   // Sort the JavaScript so that it appears in the correct order.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4942

Set the value of ‘every_page_weight’ if it is missing when getting css or js so that loading order is correct.