### PR TITLE
Issue #4965: Toggle link for responsive tables never shows

### DIFF
--- a/core/misc/tableresponsive.js
+++ b/core/misc/tableresponsive.js
@@ -35,9 +35,9 @@ function TableResponsive (table) {
   // traversed only once to find them.
   this.$headers = this.$table.find('th');
   // Add a link before the table for users to show or hide weight columns.
-  this.$link = $('<a href="#" class="tableresponsive-toggle"></a>')
+  this.$link = $('<a href="#" class="tableresponsive-toggle">' + this.showText + '</a>')
     .attr({
-      'title': Backdrop.t('Show table cells that were hidden to make the table fit within a small screen.')
+      'title': Backdrop.t('Toogle visibility of table cells, that were hidden to make the table fit within a small screen.')
     })
     .on('click', $.proxy(this, 'eventhandlerToggleColumns'));
 

--- a/core/misc/tableresponsive.js
+++ b/core/misc/tableresponsive.js
@@ -37,7 +37,7 @@ function TableResponsive (table) {
   // Add a link before the table for users to show or hide weight columns.
   this.$link = $('<a href="#" class="tableresponsive-toggle">' + this.showText + '</a>')
     .attr({
-      'title': Backdrop.t('Toogle visibility of table cells, that were hidden to make the table fit within a small screen.')
+      'title': Backdrop.t('Toggle visibility of table cells, that were hidden to make the table fit within a small screen.')
     })
     .on('click', $.proxy(this, 'eventhandlerToggleColumns'));
 

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -632,6 +632,11 @@ tr.selected td {
     display: none;
   }
 }
+@media screen and (min-width: 721px) {
+  .tableresponsive-toggle-columns {
+    display: none;
+  }
+}
 
 /**
  * Fieldsets.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4965

The link shows when it has a text set initially.