### PR TITLE
Issue #4055: Link module: Broken description text when used through Form API

### DIFF
--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -847,10 +847,17 @@ function link_field_process($element, $form_state, $complete_form) {
       $title_label = t('Title');
     }
 
+    // Default value.
+    $title_maxlength = 128;
+    if (!empty($settings['title_maxlength'])) {
+      $title_maxlength = $settings['title_maxlength'];
+    }
+
     $element['title'] = array(
       '#type' => 'textfield',
-      '#maxlength' => $settings['title_maxlength'],
+      '#maxlength' => $title_maxlength,
       '#title' => $title_label,
+      '#description' => t('The link title is limited to @maxlength characters maximum.', array('@maxlength' => $title_maxlength)),
       '#required' => ($settings['title'] == 'required' && (($element['#delta'] == 0 && $element['#required']) || !empty($element['#value']['url']))) ? TRUE : FALSE,
       '#default_value' => isset($element['#value']['title']) ? $element['#value']['title'] : NULL,
     );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4055

This is the respective of [69a4b1c](https://git.drupalcode.org/project/link/commit/69a4b1c) | [Issue #2566443: Broken description text when used through Form API](http://drupal.org/node/2566443)