### PR TITLE
Issue #4055: Link module: Add TLD starting with a dot to the list of invalid ones.

### DIFF
--- a/core/modules/link/tests/link.validate.test
+++ b/core/modules/link/tests/link.validate.test
@@ -234,12 +234,13 @@ class LinkValidateUnitTest extends BackdropUnitTestCase {
   function testInvalidExternalLinks() {
     $links = array(
       'http://www.ex ample.com/',
+      'http://.www.example.com/', // Bad TLD.
       'http://@www.example.com/',
       'http://username:@www.example.com/',
-      'http://25.0.0/', // Bad ip!
+      'http://25.0.0/', // Bad ip.
       'http://4827.0.0.2/',
       '//www.example.com/',
-      'http://www.-fudge.com/', // Domains can't have sections starting with a dash.
+      'http://www.-example.com/', // Domains can't have sections starting with a dash.
     );
     foreach ($links as $link) {
       $valid = link_validate_url($link);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4055

This was the only change applicable to Backdrop from [232dc95](https://git.drupalcode.org/project/link/commit/232dc95) | [Issue #2299657: Allow any TLD because site admins can never keep up with ICANN](http://drupal.org/node/2299657)

See see https://github.com/backdrop/backdrop-issues/issues/4055#issuecomment-786952558 for the rest of the cahnges.