### PR TITLE
Issue #4055: Link module: Add default title when title is optional

### DIFF
--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -76,25 +76,36 @@ function link_field_instance_settings_form($field, $instance) {
   );
 
   $title_options = array(
-    'optional' => t('Optional Title'),
-    'required' => t('Required Title'),
-    'value' => t('Static Title'),
-    'none' => t('No Title'),
+    'optional' => t('Optional title'),
+    'required' => t('Required title'),
+    'value' => t('Static title'),
+    'none' => t('No title'),
   );
 
   $form['title'] = array(
     '#type' => 'radios',
-    '#title' => t('Link Title'),
+    '#title' => t('Link title'),
     '#default_value' => $instance['settings']['title'],
     '#options' => $title_options,
     '#description' => t('If the link title is optional or required, a field will be displayed to the end user. If the link title is static, the link will always use the same title.'),
   );
 
+  $static_title_description = array();
+  $static_title_description[] = array(
+    'data' => t('This title will be used:'),
+    'children' => array(
+      t('Always, if the "Static title" option is selected above.'),
+      t('If the "Optional title" option is selected above, and no title is entered when creating content.'),
+    ),
+  );
+  $static_title_description[] = t('The static title value may use tokens of any other entity field as its value.') . $token_link;
+  $static_title_description[] = t('Static and token-based titles may include most inline XHTML tags such as <code>strong</code>, <code>em</code>, <code>img</code>, <code>span</code>, etc.');
+
   $form['title_value'] = array(
     '#type' => 'textfield',
-    '#title' => t('Static title'),
+    '#title' => t('Static or default title'),
     '#default_value' => $instance['settings']['title_value'],
-    '#description' => t('This title will always be used if &quot;Static Title&quot; is selected above. The static title value may use tokens of any other entity field as its value. Static and token-based titles may include most inline XHTML tags such as <em>strong</em>, <em>em</em>, <em>img</em>, <em>span</em>, etc.') . $token_link,
+    '#description' => theme('item_list', array('items' => $static_title_description)),
     '#states' => array(
       'visible' => array(
         ':input[name="instance[settings][title]"]' => array('value' => 'value'),
@@ -540,8 +551,13 @@ function _link_sanitize(array &$item, $delta, array $field, $instance, $entity) 
     }
   }
   // Use the title defined by the user at the widget level.
-  elseif (isset($item['title'])) {
+  elseif (backdrop_strlen(trim($item['title']))) {
     $title = $item['title'];
+  }
+  // If a user-defined title is optional, and a static title has been defined,
+  // use the static title.
+  elseif ($instance['settings']['title'] == 'optional' && drupal_strlen(trim($instance['settings']['title_value']))) {
+    $title = $instance['settings']['title_value'];
   }
   else {
     $title = '';

--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -76,15 +76,15 @@ function link_field_instance_settings_form($field, $instance) {
   );
 
   $title_options = array(
-    'optional' => t('Optional title'),
-    'required' => t('Required title'),
-    'value' => t('Static title'),
-    'none' => t('No title'),
+    'optional' => t('Optional Title'),
+    'required' => t('Required Title'),
+    'value' => t('Static Title'),
+    'none' => t('No Title'),
   );
 
   $form['title'] = array(
     '#type' => 'radios',
-    '#title' => t('Link title'),
+    '#title' => t('Link Title'),
     '#default_value' => $instance['settings']['title'],
     '#options' => $title_options,
     '#description' => t('If the link title is optional or required, a field will be displayed to the end user. If the link title is static, the link will always use the same title.'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4055

This is the respective of [1830a00](https://git.drupalcode.org/project/link/commit/1830a00) | [Issue #1418762: Provide default title when title is optional](http://drupal.org/node/1418762), plus the following:

The help text of that field already included multiple items, so it was getting pretty long. Current Backdrop 1.x: 

![image](https://user-images.githubusercontent.com/2423362/109373174-0351b700-78b6-11eb-96ef-0eb900012531.png)

This PR would add the following line in that help text from Link 7.x, which would make the help text even longer:
![image](https://user-images.githubusercontent.com/2423362/109373150-e917d900-78b5-11eb-9cb6-bb87c6b6150e.png)

Using bullet points instead makes the help text more readable:
![image](https://user-images.githubusercontent.com/2423362/109373200-1fedef00-78b6-11eb-89a2-9f59b2d41640.png)
