### PR TITLE
Issue #4055: Link module: Allow '0' as the link title

### DIFF
--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -563,7 +563,7 @@ function _link_sanitize(array &$item, $delta, array $field, $instance, $entity) 
     $title = filter_xss($title, array('b', 'br', 'code', 'em', 'i', 'img', 'span', 'strong', 'sub', 'sup', 'tt', 'u'));
     $item['html'] = TRUE;
   }
-  $item['title'] = empty($title) ? $item['display_url'] : $title;
+  $item['title'] = empty($title) && $title !== '0' ? $item['display_url'] : $title;
 
   if (!isset($item['attributes'])) {
     $item['attributes'] = array();


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4055

This is the respective of [0771f0e](https://git.drupalcode.org/project/link/commit/0771f0e) | [Issue #2140087: Allow '0' as the link title](http://drupal.org/node/2140087)