### PR TITLE
Issue #4055: Link module: Tokens replaced on "Static title" when "Allow user-entered tokens" not enabled

### DIFF
--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -548,7 +548,7 @@ function _link_sanitize(array &$item, $delta, array $field, $instance, $entity) 
   }
 
   // Replace title tokens.
-  if ($title && ($instance['settings']['title'] == 'value' || $instance['settings']['enable_tokens'])) {
+  if ($title && $instance['settings']['enable_tokens']) {
     $text_tokens = token_scan($title);
     if (!empty($text_tokens)) {
       // Load the entity if necessary for entities in views.
@@ -560,7 +560,24 @@ function _link_sanitize(array &$item, $delta, array $field, $instance, $entity) 
       }
       $title = token_replace($title, array($entity_token_type => $entity_loaded));
     }
-    $title = filter_xss($title, array('b', 'br', 'code', 'em', 'i', 'img', 'span', 'strong', 'sub', 'sup', 'tt', 'u'));
+  }
+
+  if ($title && ($instance['settings']['title'] == 'value' || $instance['settings']['enable_tokens'])) {
+    $title = filter_xss($title, array(
+      'b',
+      'br',
+      'code',
+      'em',
+      'i',
+      'img',
+      'span',
+      'strong',
+      'sub',
+      'sup',
+      'tt',
+      'u',
+    ));
+
     $item['html'] = TRUE;
   }
   $item['title'] = empty($title) ? $item['display_url'] : $title;

--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -577,7 +577,6 @@ function _link_sanitize(array &$item, $delta, array $field, $instance, $entity) 
       'tt',
       'u',
     ));
-
     $item['html'] = TRUE;
   }
   $item['title'] = empty($title) ? $item['display_url'] : $title;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4055

This is the respective of [f32d59b](https://git.drupalcode.org/project/link/commit/f32d59b) | [Issue #2693731: Tokens replaced on "Static title" when "Allow user-entered tokens" not enabled](http://drupal.org/node/2693731)