### PR TITLE
Issue #4971: Firefox 86+ and fieldsets

### DIFF
--- a/core/modules/system/css/system.theme.css
+++ b/core/modules/system/css/system.theme.css
@@ -12,13 +12,6 @@ fieldset {
   margin-bottom: 1em;
   padding: 0.5em;
 }
-@-moz-document url-prefix() {
-  /* Firefox fix, see stackoverflow.com/questions/17408815 */
-  fieldset {
-    display: table-cell;
-    vertical-align: top;
-  }
-}
 form {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4971

Removes old css workaround.