### PR TITLE
Issue #4630: smarter cleanup and validating of links in editor dialog

### DIFF
--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -526,9 +526,8 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
  * Clean up the URL for validation.
  *
  * Attempts to create a URL that will pass validation: add a protocol if it
- * looks like a domain but it's missing; create a valid internal multilingual
- * alias; or create a valid, encoded internal alias in case transliteration is
- * disabled.
+ * looks like a domain but it's missing; or create a valid, encoded internal
+ * alias in case transliteration is disabled.
  *
  * @param string $url
  *
@@ -555,13 +554,6 @@ function _filter_cleanup_url($url) {
 
   // Break up the components so we can build up an aliased internal path.
   $url_parts = backdrop_parse_url($url);
-
-  // Lookup valid internal paths if multilingual
-  if (module_exists('locale') && language_multilingual()) {
-    if ($language = _filter_lookup_locale_path($url)) {
-      $url_parts['language'] = $language;
-    }
-  }
 
   return url($url_parts['path'], $url_parts);
 }
@@ -590,10 +582,7 @@ function _filter_create_valid_external_url($url) {
   // an http:// or https://, depending on the site configuration.
   $domain_match = preg_match('/^(([a-z0-9]([a-z0-9\-_]*\.){1,63})([a-z]{2,63}))/i', $url);
   if (!empty($domain_match)) {
-    if (isset($_SERVER['HTTPS']) &&
-    ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1) ||
-    isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
-    $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+    if (backdrop_is_https()) {
       $protocol = 'https://';
     }
     else {
@@ -622,26 +611,6 @@ function _filter_url_has_protocol($url) {
     return TRUE;
   }
   return FALSE;
-}
-
-/**
- * Given a URL, find an alias and matching lanaguage.
- *
- * @param $url
- *   The path to investigate for corresponding aliases.
- *
- * @return object|FALSE
- *   The langcode.
- */
-function _filter_lookup_locale_path($url) {
-  $languages = language_list(TRUE);
-    foreach ($languages as $language) {
-      $alias = backdrop_lookup_path('alias', $url, $language->langcode);
-      if ($alias) {
-        return $language;
-      }
-    }
-  return NULL;
 }
 
 /**

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -491,26 +491,167 @@ function filter_format_editor_dialog_save($form, &$form_state) {
 
 /**
  * Element validation function.
+ *
+ * In addition to validing the URL, it will clean it up if necessary.
  */
 function _filter_format_editor_link_url_validate(&$element, &$form_state) {
   $value = trim($element['#value']);
 
-  // If Link module is available, automatically clean up URL, automatically
-  // adding http:// or a prefixing slash if needed.
-  if (module_exists('link') && $type = link_validate_url($value)) {
-    $value = link_cleanup_url($value);
-    $form_state['values']['type'] = $type;
-    if ($type === LINK_INTERNAL && strpos($value, '/') !== 0) {
-      $value = '/' . $value;
-    }
+  // Allow empty values, since this will not result in a link tag anyway.
+  if ($value === '') {
+    form_set_value($element, $value, $form_state);
+    return;
   }
+
+  // Cleanup the URL so it's more likely to pass validation.
+  $value = _filter_cleanup_url($value);
 
   form_set_value($element, $value, $form_state);
 
+  // If external URL ensure it doesn't have dangerous protocols.
+  $dangerous_protocols = _filter_check_dangerous_protocols($value);
+
   // Unlike #type = 'url' validation, we allow both relative and absolute paths.
-  if ($value !== '' && !valid_url($value, TRUE) && !valid_url($value, FALSE)) {
+  if ($dangerous_protocols || (!valid_url($value, TRUE) && !valid_url($value, FALSE))) {
     form_error($element, t('The URL %url is not valid.', array('%url' => $value)));
   }
+}
+
+/**
+ * Clean up URL for validation.
+ *
+ * Attempts to create a URL that will pass validation: adds a protocol if it's
+ * missing; urlencodes an anchor link; attempts to find the proper multilingual
+ * URL; and urlencodes any internal Backdrop path.
+ *
+ * @param string $url
+ *
+ * @return string
+ *   A cleaned-up URL that is either a properly formatted external URL or an
+ *   internal path.
+ *
+ * @see _filter_format_editor_link_url_validate()
+ */
+function _filter_cleanup_url($url) {
+  // Will add a default protocol if missing on an external url.
+  $url = _filter_create_valid_external_url($url);
+
+  if (_filter_url_is_external($url)) {
+    return $url;
+  }
+
+  // Urlencode an anchor as it's more likely to be typed in with unicode.
+  if (substr($url, 0, 1) == '#' && preg_match('/^(#)([\S]+)$/', $url, $matches)) {
+    return $matches['1'] . backdrop_encode_path($matches['2']);
+  }
+
+  // Break up the components so we can build up an aliased internal path.
+  $url_parts = backdrop_parse_url($url);
+
+  // Lookup valid internal paths if multilingual
+  if (module_exists('locale') && language_multilingual()) {
+    if ($language = _filter_lookup_locale_path($url)) {
+      $url_parts['language'] = $language;
+    }
+  }
+
+  return url($url_parts['path'], $url_parts);
+}
+
+/**
+ * Forms a valid external URL if possible.
+ *
+ * Trims whitespace and automatically adds an http:// to addresses that
+ * appear to be external URLs but have no specified protocol.
+ *
+ * @param string $url
+ *   The URL entered by the user.
+ *
+ * @return string
+ *   The URL with the protocol prepended if needed.
+ *
+ * @see link_cleanup_url().
+ */
+function _filter_create_valid_external_url($url) {
+  $url = trim($url);
+
+  // Check if there is no protocol specified.
+  $protocol_match = preg_match('/^([a-z0-9][a-z0-9\.\-_]*:\/\/)/i', $url);
+  if (empty($protocol_match)) {
+    // But should there be? Add an automatic http:// if it starts with a domain name.
+    $domain_match = preg_match('/^(([a-z0-9]([a-z0-9\-_]*\.){1,63})([a-z]{2,63}))/i', $url);
+    if (!empty($domain_match)) {
+      $url = "http://" . $url;
+    }
+  }
+
+  return $url;
+}
+
+/**
+ * Checks if a URL is external to Backdrop.
+ *
+ * Checks for a protocol as a sign that the URL is external. We want to include
+ * all external URLs even if they have dangerous protocols.
+ *
+ * @param string $url
+ *
+ * @return bool
+ *   TRUE if URL is external.
+ *
+ * @see url_is_external()
+ */
+function _filter_url_is_external($url) {
+  $protocol_match = preg_match('/^([a-z0-9][a-z0-9\.\-_]*:\/\/)/i', $url);
+  if (!empty($protocol_match)) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Given a URL, find an alias and matching lanaguage.
+ *
+ * @param $url
+ *   The path to investigate for corresponding aliases.
+ *
+ * @return object|FALSE
+ *   The langcode.
+ */
+function _filter_lookup_locale_path($url) {
+  $languages = language_list(TRUE);
+    foreach ($languages as $language) {
+      $alias = backdrop_lookup_path('alias', $url, $language->langcode);
+      if ($alias) {
+        return $language;
+      }
+    }
+  return NULL;
+}
+
+/**
+ * Check for dangerous protocols.
+ *
+ * If it has a protocol that doesn't match any of the allowed protocols then
+ * flag it as dangerous.
+ *
+ * @param string $url
+ *
+ * @return bool
+ *   True if any dangerous protocols present.
+ */
+function _filter_check_dangerous_protocols($url) {
+  if (!_filter_url_is_external($url)) {
+    return FALSE;
+  }
+  $protocols = settings_get('filter_allowed_protocols', array('ftp', 'http', 'https', 'irc', 'mailto', 'news', 'nntp', 'rtsp', 'sftp', 'ssh', 'tel', 'telnet', 'webcal'));
+  $protocols = implode(':(?://)?|', $protocols) . ':(?://)?';
+  $pattern = "`(?:$protocols)`";
+  $matches = preg_match($pattern, $url);
+  if ($matches) {
+    return FALSE;
+  }
+  return TRUE;
 }
 
 /**

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -509,8 +509,8 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
   form_set_value($element, $value, $form_state);
 
   // Flag if it has any dangerous protocols.
-  $cleaned_url = backdrop_strip_dangerous_protocols($value);
-  $dangerous_protocols = $cleaned_url !== $value ? TRUE : FALSE;
+  $stripped_url = backdrop_strip_dangerous_protocols($value);
+  $dangerous_protocols = $stripped_url !== $value ? TRUE : FALSE;
 
   // Unlike #type = 'url' validation, we allow both relative and absolute paths.
   if ($dangerous_protocols || (!valid_url($value, TRUE) && !valid_url($value, FALSE))) {
@@ -537,14 +537,10 @@ function _filter_cleanup_url($url) {
   // Will add a default protocol if missing on an external url.
   $url = _filter_create_valid_external_url($url);
 
-  // If it's an external URL we can skip the rest of the clean up.
-  if (_filter_url_is_external($url)) {
+  // If it's an external URL with a protocol we can skip the rest of the
+  // clean up.
+  if (_filter_url_has_protocol($url)) {
     return $url;
-  }
-
-  // Encode an anchor as it might have been typed in with unicode.
-  if (substr($url, 0, 1) == '#' && preg_match('/^(#)([\S]+)$/', $url, $matches)) {
-    return $matches['1'] . backdrop_encode_path($matches['2']);
   }
 
   // Break up the components so we can build up an aliased internal path.
@@ -575,8 +571,8 @@ function _filter_cleanup_url($url) {
  * @see link_cleanup_url().
  */
 function _filter_create_valid_external_url($url) {
-  // Skip if it's already a valid external URL.
-  if (_filter_url_is_external($url)) {
+  // Skip if it's already a valid external URL with a protocol.
+  if (_filter_url_has_protocol($url)) {
     return $url;
   }
 
@@ -591,7 +587,7 @@ function _filter_create_valid_external_url($url) {
 }
 
 /**
- * Checks if a URL is external to Backdrop.
+ * Checks if a URL has a protocol.
  *
  * Checks for a protocol as a sign that the URL is external. We want to include
  * all external URLs even if they have dangerous protocols.
@@ -599,13 +595,13 @@ function _filter_create_valid_external_url($url) {
  * @param string $url
  *
  * @return bool
- *   TRUE if URL is external.
- *
- * @see url_is_external()
+ *   TRUE if URL has protocol.
  */
-function _filter_url_is_external($url) {
-  $protocol_match = preg_match('/^([a-z0-9][a-z0-9\.\-_]*:\/\/)/i', $url);
-  if (!empty($protocol_match)) {
+function _filter_url_has_protocol($url) {
+  $url_parts = parse_url($url);
+
+  // If it has a host and scheme then it has a protocol.
+  if (isset($url_parts['host']) && isset($url_parts['scheme'])) {
     return TRUE;
   }
   return FALSE;

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -553,8 +553,11 @@ function _filter_cleanup_url($url) {
     return $url;
   }
 
-  // Return if it begins with a slash to avoid extra language prefixes
-  // if it's a multilingual site.
+  // Return if it begins with a slash. Avoids issues such as:
+  // - extra language prefixes if it's a multilingual site;
+  // - adding extra prefixes if being re-edited;
+  // - a url getting double-encoded;
+  // - or domains with relative protocols.
   // E.g. /fr/node/1, //domain.tld
   if (substr($url, 0, 1) == '/') {
     return $url;

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -553,6 +553,13 @@ function _filter_cleanup_url($url) {
     return $url;
   }
 
+  // Return if it begins with a slash to avoid extra language prefixes
+  // if it's a multilingual site.
+  // E.g. /fr/node/1, //domain.tld
+  if (substr($url, 0, 1) == '/') {
+    return $url;
+  }
+
   // Break up the components so we can build up an aliased internal path.
   $url_parts = backdrop_parse_url($url);
 

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -492,7 +492,7 @@ function filter_format_editor_dialog_save($form, &$form_state) {
 /**
  * Element validation function.
  *
- * Validate a URL, and clean it up if necessary. Instead of stripping
+ * Clean up a URL and see if it will pass validation. Instead of stripping
  * dangerous protocols we flag them as invalid to make the user aware.
  *
  * @see filter_format_editor_link_form()
@@ -516,7 +516,8 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
   $stripped_url = backdrop_strip_dangerous_protocols($value);
   $dangerous_protocols = $stripped_url !== $value ? TRUE : FALSE;
 
-  // Unlike #type = 'url' validation, we allow both relative and absolute paths.
+  // If it has dangerous protocols the URL is invalid. Or if it isn't either
+  // a valid relative nor a valid absolute path.
   if ($dangerous_protocols || (!valid_url($value, TRUE) && !valid_url($value, FALSE))) {
     form_error($element, t('The URL %url is not valid.', array('%url' => $value)));
   }
@@ -526,8 +527,8 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
  * Clean up the URL for validation.
  *
  * Attempts to create a URL that will pass validation: add a protocol if it
- * looks like a domain but it's missing; or create a valid, encoded internal
- * alias in case transliteration is disabled.
+ * looks like a domain but the protocol is missing; or create a valid, encoded
+ * internal alias.
  *
  * @param string $url
  *
@@ -561,8 +562,8 @@ function _filter_cleanup_url($url) {
 /**
  * Forms a valid external URL if possible.
  *
- * Trims whitespace and automatically adds an http:// to addresses that
- * appear to be external URLs but have no specified protocol.
+ * Automatically adds an http:// to addresses that appear to be external URLs
+ * but have no specified protocol.
  *
  * @param string $url
  *   The URL entered by the user.
@@ -578,17 +579,14 @@ function _filter_create_valid_external_url($url) {
     return $url;
   }
 
-  // If it looks like a domain name but it's missing a protocol Add an
-  // an http:// or https://, depending on the site configuration.
+  // If it looks like a domain name but it's missing a protocol, add a protocol.
+  // The will catch domains like archive.org but will skip a valid external
+  // domains with a relative protocol like //archive.org.
   $domain_match = preg_match('/^(([a-z0-9]([a-z0-9\-_]*\.){1,63})([a-z]{2,63}))/i', $url);
   if (!empty($domain_match)) {
-    if (backdrop_is_https()) {
-      $protocol = 'https://';
-    }
-    else {
-      $protocol = 'http://';
-    }
-    $url = $protocol . $url;
+    // We add a relative protocol since we don't know if the address requires
+    // http or https.
+    $url = '//' . $url;
   }
 
   return $url;

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -543,6 +543,11 @@ function _filter_cleanup_url($url) {
     return $url;
   }
 
+  // Return anchors as is.
+  if (substr($url, 0, 1) == '#') {
+    return $url;
+  }
+
   // Break up the components so we can build up an aliased internal path.
   $url_parts = backdrop_parse_url($url);
 
@@ -598,10 +603,8 @@ function _filter_create_valid_external_url($url) {
  *   TRUE if URL has protocol.
  */
 function _filter_url_has_protocol($url) {
-  $url_parts = parse_url($url);
-
-  // If it has a host and scheme then it has a protocol.
-  if (isset($url_parts['host']) && isset($url_parts['scheme'])) {
+  // If it has a scheme then it has a protocol.
+  if (parse_url($url, PHP_URL_SCHEME)) {
     return TRUE;
   }
   return FALSE;

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -494,6 +494,9 @@ function filter_format_editor_dialog_save($form, &$form_state) {
  *
  * Validate a URL, and clean it up if necessary. Instead of stripping
  * dangerous protocols we flag them as invalid to make the user aware.
+ *
+ * @see filter_format_editor_link_form()
+ * @see filter_format_editor_image_form()
  */
 function _filter_format_editor_link_url_validate(&$element, &$form_state) {
   $value = trim($element['#value']);
@@ -522,9 +525,10 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
 /**
  * Clean up the URL for validation.
  *
- * Attempts to create a URL that will pass validation: add a protocol if it's
- * missing; create a valid internal multilingual URL; or create a valid,
- * encoded internal Backdrop path.
+ * Attempts to create a URL that will pass validation: add a protocol if it
+ * looks like a domain but it's missing; create a valid internal multilingual
+ * alias; or create a valid, encoded internal alias in case transliteration is
+ * disabled.
  *
  * @param string $url
  *
@@ -582,11 +586,20 @@ function _filter_create_valid_external_url($url) {
     return $url;
   }
 
-  // Should there be a protocol? Add an automatic http:// if it starts with a
-  // domain name.
+  // If it looks like a domain name but it's missing a protocol Add an
+  // an http:// or https://, depending on the site configuration.
   $domain_match = preg_match('/^(([a-z0-9]([a-z0-9\-_]*\.){1,63})([a-z]{2,63}))/i', $url);
   if (!empty($domain_match)) {
-    $url = "http://" . $url;
+    if (isset($_SERVER['HTTPS']) &&
+    ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1) ||
+    isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+    $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+      $protocol = 'https://';
+    }
+    else {
+      $protocol = 'http://';
+    }
+    $url = $protocol . $url;
   }
 
   return $url;

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -508,8 +508,9 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
 
   form_set_value($element, $value, $form_state);
 
-  // If external URL ensure it doesn't have dangerous protocols.
-  $dangerous_protocols = _filter_check_dangerous_protocols($value);
+  // Flag if it has any dangerous protocols.
+  $cleaned_url = backdrop_strip_dangerous_protocols($value);
+  $dangerous_protocols = $cleaned_url !== $value ? TRUE : FALSE;
 
   // Unlike #type = 'url' validation, we allow both relative and absolute paths.
   if ($dangerous_protocols || (!valid_url($value, TRUE) && !valid_url($value, FALSE))) {
@@ -536,11 +537,12 @@ function _filter_cleanup_url($url) {
   // Will add a default protocol if missing on an external url.
   $url = _filter_create_valid_external_url($url);
 
+  // If it's an external URL we can skip the rest of the clean up.
   if (_filter_url_is_external($url)) {
     return $url;
   }
 
-  // Urlencode an anchor as it's more likely to be typed in with unicode.
+  // Encode an anchor as it might have been typed in with unicode.
   if (substr($url, 0, 1) == '#' && preg_match('/^(#)([\S]+)$/', $url, $matches)) {
     return $matches['1'] . backdrop_encode_path($matches['2']);
   }
@@ -573,16 +575,16 @@ function _filter_cleanup_url($url) {
  * @see link_cleanup_url().
  */
 function _filter_create_valid_external_url($url) {
-  $url = trim($url);
+  // Skip if it's already a valid external URL.
+  if (_filter_url_is_external($url)) {
+    return $url;
+  }
 
-  // Check if there is no protocol specified.
-  $protocol_match = preg_match('/^([a-z0-9][a-z0-9\.\-_]*:\/\/)/i', $url);
-  if (empty($protocol_match)) {
-    // But should there be? Add an automatic http:// if it starts with a domain name.
-    $domain_match = preg_match('/^(([a-z0-9]([a-z0-9\-_]*\.){1,63})([a-z]{2,63}))/i', $url);
-    if (!empty($domain_match)) {
-      $url = "http://" . $url;
-    }
+  // Should there be a protocol? Add an automatic http:// if it starts with a
+  // domain name.
+  $domain_match = preg_match('/^(([a-z0-9]([a-z0-9\-_]*\.){1,63})([a-z]{2,63}))/i', $url);
+  if (!empty($domain_match)) {
+    $url = "http://" . $url;
   }
 
   return $url;
@@ -627,31 +629,6 @@ function _filter_lookup_locale_path($url) {
       }
     }
   return NULL;
-}
-
-/**
- * Check for dangerous protocols.
- *
- * If it has a protocol that doesn't match any of the allowed protocols then
- * flag it as dangerous.
- *
- * @param string $url
- *
- * @return bool
- *   True if any dangerous protocols present.
- */
-function _filter_check_dangerous_protocols($url) {
-  if (!_filter_url_is_external($url)) {
-    return FALSE;
-  }
-  $protocols = settings_get('filter_allowed_protocols', array('ftp', 'http', 'https', 'irc', 'mailto', 'news', 'nntp', 'rtsp', 'sftp', 'ssh', 'tel', 'telnet', 'webcal'));
-  $protocols = implode(':(?://)?|', $protocols) . ':(?://)?';
-  $pattern = "`(?:$protocols)`";
-  $matches = preg_match($pattern, $url);
-  if ($matches) {
-    return FALSE;
-  }
-  return TRUE;
 }
 
 /**

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -492,7 +492,8 @@ function filter_format_editor_dialog_save($form, &$form_state) {
 /**
  * Element validation function.
  *
- * In addition to validing the URL, it will clean it up if necessary.
+ * Validate a URL, and clean it up if necessary. Instead of stripping
+ * dangerous protocols we flag them as invalid to make the user aware.
  */
 function _filter_format_editor_link_url_validate(&$element, &$form_state) {
   $value = trim($element['#value']);
@@ -503,7 +504,7 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
     return;
   }
 
-  // Cleanup the URL so it's more likely to pass validation.
+  // Clean up the URL so it's more likely to pass validation.
   $value = _filter_cleanup_url($value);
 
   form_set_value($element, $value, $form_state);
@@ -519,11 +520,11 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
 }
 
 /**
- * Clean up URL for validation.
+ * Clean up the URL for validation.
  *
- * Attempts to create a URL that will pass validation: adds a protocol if it's
- * missing; urlencodes an anchor link; attempts to find the proper multilingual
- * URL; and urlencodes any internal Backdrop path.
+ * Attempts to create a URL that will pass validation: add a protocol if it's
+ * missing; create a valid internal multilingual URL; or create a valid,
+ * encoded internal Backdrop path.
  *
  * @param string $url
  *

--- a/core/modules/filter/tests/filter.tests.info
+++ b/core/modules/filter/tests/filter.tests.info
@@ -69,3 +69,9 @@ name = Editor access
 description = Tests access to editors and their associated dialogs.
 group = Filter
 file = filter.test
+
+[FilterEditorLinkValidateTestCase]
+name = Editor link validation
+description = Validate correct handling of URLs inserted via editor link dialog.
+group = Filter
+file = filter_dialog.test

--- a/core/modules/filter/tests/filter_dialog.test
+++ b/core/modules/filter/tests/filter_dialog.test
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @file
+ * Functional tests for the Filter module.
+ */
+
+/**
+ * Test for filter dialog link validation.
+ */
+class FilterEditorLinkValidateTestCase extends BackdropWebTestCase {
+
+  protected $profile = 'testing';
+  protected $editorUser;
+  protected $format;
+
+  /**
+   * Set up testing environment.
+   */
+  public function setUp() {
+    parent::setUp(
+      'filter',
+      'ckeditor',
+      'filter_formtest',
+      'language',
+      'locale',
+    );
+
+    // Add a language and set it as default.
+    $german = (object) array(
+      'langcode' => 'de',
+      'name' => 'German',
+      'direction' => LANGUAGE_LTR,
+    );
+    language_save($german);
+    config_set('system.core', 'language_default', 'de');
+
+    // Create text format using filter default settings.
+    $filter_info = filter_filter_info();
+    $filters = array_fill_keys(array_keys($filter_info), array());
+    $format = (object) array(
+      'format' => 'filter_custom',
+      'name' => 'Filter custom',
+      'filters' => $filters,
+      'editor' => 'ckeditor',
+    );
+    filter_format_save($format);
+    $permission = filter_permission_name($format);
+    $this->format = $format;
+
+    // Create content type.
+    $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
+
+    // Create user and log in.
+    $this->editorUser = $this->backdropCreateUser(array(
+      'access content',
+      'bypass node access',
+      $permission,
+    ));
+    $this->backdropLogin($this->editorUser);
+  }
+
+  /**
+   * Check function _filter_format_editor_link_url_validate().
+   */
+  public function testEditorLinkValidate() {
+    // Create a node and get the nid for the calling path.
+    $node = $this->backdropCreateNode();
+    $calling_path = "node/{$node->nid}/edit";
+    $link_token = filter_editor_dialog_token($this->format, 'link', $this->editorUser, $calling_path);
+    $german = language_load('de');
+    $options = array(
+      'query' => array(
+        'token' => $link_token,
+        'calling_path' => $calling_path,
+      ),
+      'language' => $german,
+    );
+    $this->backdropGet('editor/dialog/link/' . $this->format->format, $options);
+
+    $edit = array(
+      'attributes[text]' => 'The link',
+    );
+    $invalid_urls = array(
+      'javascript://boo',
+      'http://foo>bar.baz',
+      'http://foobar\.baz',
+    );
+    foreach ($invalid_urls as $url) {
+      $edit['attributes[href]'] = $url;
+      $this->backdropPost(NULL, $edit, t('Save'));
+      $this->assertRaw('The URL <em class="placeholder">' . check_plain($url) . '</em> is not valid.', format_string('Invalid URL %url did not pass validation', array(
+        '%url' => $url,
+      )));
+    }
+
+    $valid_urls = array(
+      // Should get altered.
+      'node/1' => '/de/node/1',
+      'ärger-im-büro' => '/de/%C3%A4rger-im-b%C3%BCro',
+      '<front>?page=1#main-content' => '/de?page=1#main-content',
+      '#ärger' => '#%C3%A4rger',
+      // Should stay untouched.
+      '#main-content' => '#main-content',
+      'http://domain.tld:8080/index.php?page=3&foo=bar' => 'http://domain.tld:8080/index.php?page=3&foo=bar',
+      'http://user:pass@domain.tld/path' => 'http://user:pass@domain.tld/path',
+      '//domain.tld' => '//domain.tld',
+      'mailto:boo@example.com' => 'mailto:boo@example.com',
+      'telnet://host.tld' => 'telnet://host.tld',
+    );
+    foreach ($valid_urls as $url => $altered_or_not) {
+      $edit['attributes[href]'] = $url;
+      $this->backdropPost(NULL, $edit, t('Save'));
+      // No form error.
+      $this->assertNoRaw('The URL <em class="placeholder">' . check_plain($url) . '</em> is not valid.', format_string('Valid URL %url passes validation', array(
+        '%url' => $url,
+      )));
+      // The filter_formtest helper module sets the value from $form_state as
+      // message. It would be impossible to validate, what CKEditor inserts via
+      // Javascript.
+      $this->assertRaw('Output href is: ' . check_plain($altered_or_not), format_string('Expected output value @value found', array(
+        '@value' => $altered_or_not,
+      )));
+    }
+  }
+
+}

--- a/core/modules/filter/tests/filter_dialog.test
+++ b/core/modules/filter/tests/filter_dialog.test
@@ -98,7 +98,6 @@ class FilterEditorLinkValidateTestCase extends BackdropWebTestCase {
       'node/1' => '/de/node/1',
       'ärger-im-büro' => '/de/%C3%A4rger-im-b%C3%BCro',
       '<front>?page=1#main-content' => '/de?page=1#main-content',
-      '#ärger' => '#%C3%A4rger',
       // Should stay untouched.
       '#main-content' => '#main-content',
       'http://domain.tld:8080/index.php?page=3&foo=bar' => 'http://domain.tld:8080/index.php?page=3&foo=bar',

--- a/core/modules/filter/tests/filter_dialog.test
+++ b/core/modules/filter/tests/filter_dialog.test
@@ -99,6 +99,7 @@ class FilterEditorLinkValidateTestCase extends BackdropWebTestCase {
       'ärger-im-büro' => '/de/%C3%A4rger-im-b%C3%BCro',
       '<front>?page=1#main-content' => '/de?page=1#main-content',
       // Should stay untouched.
+      '/en/node/1' => '/en/node/1',
       '#main-content' => '#main-content',
       'http://domain.tld:8080/index.php?page=3&foo=bar' => 'http://domain.tld:8080/index.php?page=3&foo=bar',
       'http://user:pass@domain.tld/path' => 'http://user:pass@domain.tld/path',

--- a/core/modules/filter/tests/filter_dialog.test
+++ b/core/modules/filter/tests/filter_dialog.test
@@ -103,6 +103,7 @@ class FilterEditorLinkValidateTestCase extends BackdropWebTestCase {
       '#main-content' => '#main-content',
       'http://domain.tld:8080/index.php?page=3&foo=bar' => 'http://domain.tld:8080/index.php?page=3&foo=bar',
       'http://user:pass@domain.tld/path' => 'http://user:pass@domain.tld/path',
+      '/de/%C3%A4rger-im-b%C3%BCro' => '/de/%C3%A4rger-im-b%C3%BCro',
       '//domain.tld' => '//domain.tld',
       'mailto:boo@example.com' => 'mailto:boo@example.com',
       'telnet://host.tld' => 'telnet://host.tld',

--- a/core/modules/filter/tests/filter_formtest.info
+++ b/core/modules/filter/tests/filter_formtest.info
@@ -1,0 +1,7 @@
+name = 'Filter form test'
+description = 'Helper module to test filter form validation'
+package = Testing
+version = BACKDROP_VERSION
+type = module
+backdrop = 1.x
+hidden = TRUE

--- a/core/modules/filter/tests/filter_formtest.module
+++ b/core/modules/filter/tests/filter_formtest.module
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Helper module for FilterEditorLinkValidateTestCase.
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function filter_formtest_form_filter_format_editor_link_form_alter(&$form, &$form_state, $form_id) {
+  $form['href']['#element_validate'][] = '_filter_formtest_href_element_validate';
+}
+
+/**
+ * Helper function to output potentially altered form values as message.
+ */
+function _filter_formtest_href_element_validate(&$element, &$form_state) {
+  if (isset($form_state['values'])) {
+    $new_value = $form_state['values']['attributes']['href'];
+    $message = format_string('Output href is: @href', array(
+      '@href' => $new_value,
+    ));
+    backdrop_set_message($message, 'info');
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4630

This PR borrows a lot from https://github.com/backdrop/backdrop/pull/3331 by @indigoxela so thank you! It reorganizes things and addresses the same tests.

## Approach

I've taken the approach of separating out the functionality that validates the string (immutable) from the functionality that changes (mutable) the string. And each of those has a flatter logic where we return early if possible. And then a few other small functions to do specific things. These functions are meant to be used only in filter.pages.inc but it would be still good to abstract a function like `link_validate_url()` and use that instead.

## Dangerous protocols

I ended up checking for dangerous protocols in a separate function so it would consider "javascript://boo" as invalid (as the original PR did). However, by default it considers URLs like "telnet://abc" as valid, which I think it fine. The current code passes both of these anyway.

## Multilingual URL

This PR does a bit more by trying to find the right path for a multilingual url. I'm uncertain if it will work across domains however; like where a site has a different domain for each language.

## Regarding URL encoding

It will encode an anchor because it's likely to be typed in by hand. But I've skipped encoding an external URL since someone is likely copying and pasting it from a browser.

I removed checking with `backdrop_encode_path($path) == $path` since this is unreliable. A path can be encoded multiple times and still end up different each time. So instead we try to return early for external URLs and hashes and then the encoding can happen with `url()`.

## External URL checking

Speaking of external URLs, I ended up with a simple function for checking so that it would also catch any protocol, even if dangerous so that it can be flagged later. Is this the best way? I don't know. I do know it's not a great way to check for external URLs. There are two other options: `url_is_external()` and `link_validate_url()`. The latter is the gold standard I think, though that function would be good even for the final validation.