### PR TITLE
Issue #4981: add support for attributes in backdrop_add_css and add test

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3313,6 +3313,32 @@ function backdrop_add_html_head_link($attributes, $header = FALSE) {
 }
 
 /**
+ * Constructs an array of the defaults that are used for styles items.
+ *
+ * @param $data
+ *   (optional) The default data parameter for the style item array.
+ *
+ * @see backdrop_get_css()
+ * @see backdrop_add_css()
+ *
+ * @return array
+ *   An array of key and values.
+*/
+function backdrop_css_defaults($data = NULL) {
+  return array(
+    'type' => 'file',
+    'group' => CSS_DEFAULT,
+    'weight' => 0,
+    'every_page' => FALSE,
+    'media' => 'all',
+    'preprocess' => TRUE,
+    'data' => $data,
+    'browsers' => array(),
+    'attributes' => array(),
+  );
+}
+
+/**
  * Adds a cascading stylesheet to the stylesheet queue.
  *
  * Calling backdrop_static_reset('backdrop_add_css') will clear all cascading
@@ -3410,6 +3436,10 @@ function backdrop_add_html_head_link($attributes, $header = FALSE) {
  *       which backdrop_add_css() happened earlier in the page request.
  *   - 'media': The media type for the stylesheet, e.g., all, print, screen.
  *     Defaults to 'all'.
+ *   - attributes: An associative array of attributes for the <link> tag.
+ *     This may be used to add 'integrity' or custom attributes. Note that
+ *     setting any attributes will disable preprocessing as though the
+ *     'preprocess' option was set to FALSE.
  *   - 'preprocess': If TRUE and CSS aggregation/compression is enabled, the
  *     styles will be aggregated and compressed. Defaults to TRUE.
  *   - 'browsers': An array containing information specifying which browsers
@@ -3440,19 +3470,16 @@ function backdrop_add_css($data = NULL, $options = NULL) {
     $options = array();
   }
 
+  $defaults = backdrop_css_defaults($data);
+  $options += $defaults;
+  $options['attributes'] += $defaults['attributes'];
+
+  // Preprocess can only be set if no attributes are set.
+  $options['preprocess'] = empty($options['attributes']) ? $options['preprocess'] : FALSE;
+
   // Create an array of CSS files for each media type first, since each type needs to be served
   // to the browser differently.
   if (isset($data)) {
-    $options += array(
-      'type' => 'file',
-      'group' => CSS_DEFAULT,
-      'weight' => 0,
-      'every_page' => FALSE,
-      'media' => 'all',
-      'preprocess' => TRUE,
-      'data' => $data,
-      'browsers' => array(),
-    );
     $options['browsers'] += array(
       'IE' => TRUE,
       '!IE' => TRUE,
@@ -3796,6 +3823,9 @@ function backdrop_pre_render_styles($elements) {
 
   // Loop through each group.
   foreach ($elements['#groups'] as $group) {
+    // Ensure the group's attributes setting is an array before attempting to
+    // merge with the element's attributes.
+    $group['attributes'] = isset($group['attributes']) ? $group['attributes'] : array();
     switch ($group['type']) {
       // For file items, there are three possibilites.
       // - The group has been aggregated: in this case, output a LINK tag for
@@ -3813,6 +3843,7 @@ function backdrop_pre_render_styles($elements) {
         // for the aggregate file.
         if (isset($group['data'])) {
           $element = $link_element_defaults;
+          $element['#attributes'] = $group['attributes'] + $element['#attributes'];
           $element['#attributes']['href'] = file_create_url($group['data']);
           $element['#attributes']['media'] = $group['media'];
           $element['#browsers'] = $group['browsers'];
@@ -3853,6 +3884,8 @@ function backdrop_pre_render_styles($elements) {
             // This means that we can use ^ and $ on one line at a time, and not
             // worry about style tags since they'll never match the regex.
             $element['#value'] = "\n" . implode("\n", $import_batch) . "\n";
+            $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
+            $element['#attributes'] = $group['attributes'] + $element['#attributes'];
             $element['#attributes']['media'] = $group['media'];
             $element['#browsers'] = $group['browsers'];
             $elements[] = $element;
@@ -3874,6 +3907,12 @@ function backdrop_pre_render_styles($elements) {
             // The dummy query string needs to be added to the URL to control
             // browser-caching.
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
+
+            // Ensure the item's attributes setting is an array before
+            // attempting to merge with the element's attributes.
+            $item['attributes'] = isset($item['attributes']) ? $item['attributes'] : array();
+            $element['#attributes'] = $item['attributes'] + $element['#attributes'];
+
             $element['#attributes']['href'] = file_create_url($item['data']) . $query_string_separator . $query_string;
             $element['#attributes']['media'] = $item['media'];
             $element['#browsers'] = $group['browsers'];
@@ -3888,6 +3927,8 @@ function backdrop_pre_render_styles($elements) {
         if (isset($group['data'])) {
           $element = $style_element_defaults;
           $element['#value'] = $group['data'];
+          $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
+          $element['#attributes'] = $group['attributes'] + $element['#attributes'];
           $element['#attributes']['media'] = $group['media'];
           $element['#browsers'] = $group['browsers'];
           $elements[] = $element;
@@ -3896,6 +3937,8 @@ function backdrop_pre_render_styles($elements) {
           foreach ($group['items'] as $item) {
             $element = $style_element_defaults;
             $element['#value'] = $item['data'];
+            $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
+            $element['#attributes'] = $group['attributes'] + $element['#attributes'];
             $element['#attributes']['media'] = $item['media'];
             $element['#browsers'] = $group['browsers'];
             $elements[] = $element;
@@ -3906,7 +3949,12 @@ function backdrop_pre_render_styles($elements) {
       // contains the full URL.
       case 'external':
         foreach ($group['items'] as $item) {
+          // Ensure the item's attributes setting is an array before attempting
+          // to merge with the element's attributes.
+          $item['attributes'] = isset($item['attributes']) ? $item['attributes'] : array();
+          $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
           $element = $link_element_defaults;
+          $element['#attributes'] = $item['attributes'] + $element['#attributes'];
           $element['#attributes']['href'] = $item['data'];
           $element['#attributes']['media'] = $item['media'];
           $element['#browsers'] = $group['browsers'];

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3658,11 +3658,11 @@ function backdrop_group_css($css) {
         // Help ensure maximum reuse of aggregate files by only grouping
         // together items that share the same 'group' value and 'every_page'
         // flag. See backdrop_add_css() for details about that.
-        $group_keys = $item['preprocess'] ? array($item['type'], $item['group'], $item['every_page'], $item['media'], $item['browsers']) : FALSE;
+        $group_keys = $item['preprocess'] ? array($item['type'], $item['group'], $item['every_page'], $item['media'], $item['browsers'], $item['attributes']) : FALSE;
         break;
       case 'inline':
         // Always group inline items.
-        $group_keys = array($item['type'], $item['media'], $item['browsers']);
+        $group_keys = array($item['type'], $item['media'], $item['browsers'], $item['attributes']);
         break;
       case 'external':
         // Do not group external items.

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3901,6 +3901,7 @@ function backdrop_pre_render_styles($elements) {
             // The dummy query string needs to be added to the URL to control
             // browser-caching.
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
+            $element['#attributes'] += $item['attributes'];
             $element['#attributes']['href'] = file_create_url($item['data']) . $query_string_separator . $query_string;
             $element['#attributes']['media'] = $item['media'];
             $element['#browsers'] = $group['browsers'];
@@ -3923,6 +3924,7 @@ function backdrop_pre_render_styles($elements) {
           foreach ($group['items'] as $item) {
             $element = $style_element_defaults;
             $element['#value'] = $item['data'];
+            $element['#attributes'] += $item['attributes'];
             $element['#attributes']['media'] = $item['media'];
             $element['#browsers'] = $group['browsers'];
             $elements[] = $element;
@@ -3934,6 +3936,7 @@ function backdrop_pre_render_styles($elements) {
       case 'external':
         foreach ($group['items'] as $item) {
           $element = $link_element_defaults;
+          $element['#attributes'] += $item['attributes'];
           $element['#attributes']['href'] = $item['data'];
           $element['#attributes']['media'] = $item['media'];
           $element['#browsers'] = $group['browsers'];

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3658,11 +3658,11 @@ function backdrop_group_css($css) {
         // Help ensure maximum reuse of aggregate files by only grouping
         // together items that share the same 'group' value and 'every_page'
         // flag. See backdrop_add_css() for details about that.
-        $group_keys = $item['preprocess'] ? array($item['type'], $item['group'], $item['every_page'], $item['media'], $item['browsers'], $item['attributes']) : FALSE;
+        $group_keys = $item['preprocess'] ? array($item['type'], $item['group'], $item['every_page'], $item['media'], $item['browsers']) : FALSE;
         break;
       case 'inline':
         // Always group inline items.
-        $group_keys = array($item['type'], $item['media'], $item['browsers'], $item['attributes']);
+        $group_keys = array($item['type'], $item['media'], $item['browsers']);
         break;
       case 'external':
         // Do not group external items.
@@ -3823,9 +3823,6 @@ function backdrop_pre_render_styles($elements) {
 
   // Loop through each group.
   foreach ($elements['#groups'] as $group) {
-    // Ensure the group's attributes setting is an array before attempting to
-    // merge with the element's attributes.
-    $group['attributes'] = isset($group['attributes']) ? $group['attributes'] : array();
     switch ($group['type']) {
       // For file items, there are three possibilites.
       // - The group has been aggregated: in this case, output a LINK tag for
@@ -3843,7 +3840,6 @@ function backdrop_pre_render_styles($elements) {
         // for the aggregate file.
         if (isset($group['data'])) {
           $element = $link_element_defaults;
-          $element['#attributes'] = $group['attributes'] + $element['#attributes'];
           $element['#attributes']['href'] = file_create_url($group['data']);
           $element['#attributes']['media'] = $group['media'];
           $element['#browsers'] = $group['browsers'];
@@ -3884,8 +3880,6 @@ function backdrop_pre_render_styles($elements) {
             // This means that we can use ^ and $ on one line at a time, and not
             // worry about style tags since they'll never match the regex.
             $element['#value'] = "\n" . implode("\n", $import_batch) . "\n";
-            $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
-            $element['#attributes'] = $group['attributes'] + $element['#attributes'];
             $element['#attributes']['media'] = $group['media'];
             $element['#browsers'] = $group['browsers'];
             $elements[] = $element;
@@ -3907,12 +3901,6 @@ function backdrop_pre_render_styles($elements) {
             // The dummy query string needs to be added to the URL to control
             // browser-caching.
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
-
-            // Ensure the item's attributes setting is an array before
-            // attempting to merge with the element's attributes.
-            $item['attributes'] = isset($item['attributes']) ? $item['attributes'] : array();
-            $element['#attributes'] = $item['attributes'] + $element['#attributes'];
-
             $element['#attributes']['href'] = file_create_url($item['data']) . $query_string_separator . $query_string;
             $element['#attributes']['media'] = $item['media'];
             $element['#browsers'] = $group['browsers'];
@@ -3927,8 +3915,6 @@ function backdrop_pre_render_styles($elements) {
         if (isset($group['data'])) {
           $element = $style_element_defaults;
           $element['#value'] = $group['data'];
-          $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
-          $element['#attributes'] = $group['attributes'] + $element['#attributes'];
           $element['#attributes']['media'] = $group['media'];
           $element['#browsers'] = $group['browsers'];
           $elements[] = $element;
@@ -3937,8 +3923,6 @@ function backdrop_pre_render_styles($elements) {
           foreach ($group['items'] as $item) {
             $element = $style_element_defaults;
             $element['#value'] = $item['data'];
-            $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
-            $element['#attributes'] = $group['attributes'] + $element['#attributes'];
             $element['#attributes']['media'] = $item['media'];
             $element['#browsers'] = $group['browsers'];
             $elements[] = $element;
@@ -3949,12 +3933,7 @@ function backdrop_pre_render_styles($elements) {
       // contains the full URL.
       case 'external':
         foreach ($group['items'] as $item) {
-          // Ensure the item's attributes setting is an array before attempting
-          // to merge with the element's attributes.
-          $item['attributes'] = isset($item['attributes']) ? $item['attributes'] : array();
-          $element['#attributes'] = isset($element['#attributes']) ? $element['#attributes'] : array();
           $element = $link_element_defaults;
-          $element['#attributes'] = $item['attributes'] + $element['#attributes'];
           $element['#attributes']['href'] = $item['data'];
           $element['#attributes']['media'] = $item['media'];
           $element['#browsers'] = $group['browsers'];

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3323,6 +3323,8 @@ function backdrop_add_html_head_link($attributes, $header = FALSE) {
  *
  * @return array
  *   An array of key and values.
+ *
+ * @since 1.19.0 Function added.
 */
 function backdrop_css_defaults($data = NULL) {
   return array(

--- a/core/modules/simpletest/tests/ajax.test
+++ b/core/modules/simpletest/tests/ajax.test
@@ -121,17 +121,7 @@ class AJAXFrameworkTestCase extends AJAXTestCase {
       'css' => backdrop_get_path('module', 'system') . '/css/system.admin.css',
       'js' => backdrop_get_path('module', 'system') . '/js/system.admin.js',
     );
-    // @todo: Add a backdrop_css_defaults() helper function.
-    $expected_css_html = backdrop_get_css(array($expected['css'] => array(
-      'type' => 'file',
-      'group' => CSS_DEFAULT,
-      'weight' => 0,
-      'every_page' => FALSE,
-      'media' => 'all',
-      'preprocess' => TRUE,
-      'data' => $expected['css'],
-      'browsers' => array('IE' => TRUE, '!IE' => TRUE),
-    )), TRUE);
+    $expected_css_html = backdrop_get_css(array($expected['css'] => backdrop_css_defaults($expected['css'])), TRUE);
     $expected_js_html = backdrop_get_js('header', array($expected['js'] => backdrop_js_defaults($expected['js'])), TRUE);
 
     // Get the base page.

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -876,6 +876,41 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   }
 
   /**
+   * Test CSS Styles with attributes rendering.
+   *
+   * @todo make it more like JavaScriptTestCase::testAttributes() {
+   */
+  function testRenderStylesAttributes() {
+    // Disable aggregation.
+    config_set('system.core', 'preprocess_css', 0);
+
+    backdrop_add_css(
+      'misc/print.css',
+      array(
+        'attributes' => array(
+          'foo' => 'bar',
+        ),
+      )
+    );
+
+    // Retrieve the rendered Styles.
+    $css = backdrop_get_css();
+
+    $expected = array(
+      'foo' => 'bar',
+      'media' => 'all',
+    );
+
+    foreach ($expected as $expected_string) {
+      $this->assertNotEqual(
+        strpos($css, $expected_string),
+        FALSE,
+        'Styles with attributes has been properly rendered.'
+      );
+    }
+  }
+
+  /**
    * Tests that the query string remains intact when adding CSS files that have
    * query string parameters.
    */

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -877,37 +877,26 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
 
   /**
    * Test CSS Styles with attributes rendering.
-   *
-   * @todo make it more like JavaScriptTestCase::testAttributes() {
    */
   function testRenderStylesAttributes() {
     // Disable aggregation.
     config_set('system.core', 'preprocess_css', 0);
 
-    backdrop_add_css(
-      'misc/print.css',
-      array(
-        'attributes' => array(
-          'foo' => 'bar',
-        ),
-      )
-    );
-
-    // Retrieve the rendered Styles.
+    // Add internal and external CSS files that add custom attributes, and
+    // check that these attributes appear on the <link> tags.
+    $css_internal = 'core/misc/print.css';
+    $css_external = 'http://example.com/styles.css';
+    backdrop_add_css($css_internal, array('attributes' => array('custom' => 'foo')));
+    backdrop_add_css($css_external, array(
+      'attributes' => array(
+        'custom' => 'foo',
+      ),
+      'type' => 'external',
+    ));
     $css = backdrop_get_css();
-
-    $expected = array(
-      'foo' => 'bar',
-      'media' => 'all',
-    );
-
-    foreach ($expected as $expected_string) {
-      $this->assertNotEqual(
-        strpos($css, $expected_string),
-        FALSE,
-        'Styles with attributes has been properly rendered.'
-      );
-    }
+    $this->backdropSetContent($css);
+    $this->assertTrue($this->xpath('//link[starts-with(@href, "' . file_create_url($css_internal) . '") and @custom="foo"]'), 'Rendered internal CSS with correct custom attribute.');
+    $this->assertTrue($this->xpath('//link[@href="' . $css_external . '" and @custom="foo"]'), 'Rendered external CSS with correct custom attribute.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4981

This is cherry picking from https://www.drupal.org/files/issues/2020-12-14/attached-attributes-1664602-176.patch and leaving out the addition of attributes to backdrop_add_js since we've already added them in https://github.com/backdrop/backdrop-issues/issues/2877.

