### PR TITLE
Issue #4217 : Config import excludes last file for archive import fixed

### DIFF
--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -1433,7 +1433,7 @@ class ConfigFileStorage implements ConfigStorageInterface {
       // Only extract JSON files, ignoring anything else in the archive.
       $file_list = preg_grep('/.json$/', $archiver->listContents());
       if ($file_list) {
-        $archiver->extract($this->directory, $file_list);
+        $archiver->extract($this->directory, array_values($file_list));
       }
     }
     catch (\Exception $e) {


### PR DESCRIPTION
preg_grep filtered only json file to import from archive but its not reindexed when iterating. So i have fixed this using array_values to reindex the file list array. 

Fixes backdrop/backdrop-issues#4217