### PR TITLE
Issue 5017: Superfluous static declaration in layout_get_path_layout_…

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1152,11 +1152,12 @@ function layout_get_all_configs($type) {
  */
 function layout_get_path_layout_names($path) {
   $path_map = &backdrop_static(__FUNCTION__, array());
-
-  $configs = layout_get_all_configs('layout');
-  foreach ($configs as $layout_name => $config) {
-    if (isset($config['path'])) {
-      $path_map[$config['path']][] = $layout_name;
+  if (empty($path_map)) {
+    $configs = layout_get_all_configs('layout');
+    foreach ($configs as $layout_name => $config) {
+      if (isset($config['path'])) {
+        $path_map[$config['path']][] = $layout_name;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes [Issue 5017](https://github.com/backdrop/backdrop-issues/issues/5017).

$path_map was a backdrop_static() variable, but its static nature wasn’t made use of. This change ensures that it’s only filled once per page request.