### PR TITLE
Issue 5018: Node previews, wrong layout

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1224,7 +1224,7 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
     $preview_node = NULL;
     $node_types = node_type_get_types();
     foreach ($node_types as $type) {
-      $preview_path = "node/preview/{$type->type}/%";
+      $preview_path = 'node/preview/' . $type->type . '/%';
       if ($router_item['path'] == $preview_path) {
         $tempstore_id = $router_item['map'][3];
         $preview_node = node_get_node_tempstore($tempstore_id);

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1221,18 +1221,18 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
     // @ todo: This adds very specific code for node previews which too closely
     // couples Node and Layout modules. This needs to be reverted in a future
     // commit.
-    $data = NULL;
+    $preview_node = NULL;
     $node_types = node_type_get_types();
     foreach ($node_types as $type) {
-      $preview_path = 'node/' . $type->type . '/preview';
+      $preview_path = "node/preview/{$type->type}/%";
       if ($router_item['path'] == $preview_path) {
-        $tempstore_id = node_build_tempstore_id($type->type);
-        $data = node_get_node_tempstore($tempstore_id);
+        $tempstore_id = $router_item['map'][3];
+        $preview_node = node_get_node_tempstore($tempstore_id);
         break;
       }
     }
-    if ($data && $node_layouts = layout_load_multiple_by_path('node/%', TRUE)) {
-      $layouts = $node_layouts;
+    if ($preview_node) {
+      $layouts = layout_load_multiple_by_path('node/%', TRUE);
     }
     else {
       $layouts = layout_load_multiple_by_path($router_item['path'], TRUE);
@@ -1244,21 +1244,27 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
       foreach ($contexts as $context) {
         if (isset($context->position)) {
 
-          // Check for an object loaded by the menu router. Use a preview from
-          // Tempstore if on a node preview page.
+          // If on a node preview page use the preview from tempstore.
           // @ todo: This is also specific code for node previews which needs
           // to be reverted in a future commit.
-          if (isset($router_item['map'][$context->position])) {
-            $data = isset($data) ? $data : $router_item['map'][$context->position];
-            $context->setData($data);
+          if ($preview_node) {
+            $context->setData($preview_node);
           }
-
-          // If no context is set, load one using the layout info.
-          if (!is_object($context->data)) {
-            $context_info = layout_get_context_info($context->plugin);
-            if (isset($context_info['load callback'])) {
-              $context_data = call_user_func_array($context_info['load callback'], $router_item['original_map'][$context->position]);
-              $context->setData($context_data);
+          else {
+            if (isset($router_item['map'][$context->position])) {
+              $context_data = $router_item['map'][$context->position];
+              // Check for an object loaded by the menu router.
+              if (is_object($context_data)) {
+                $context->setData($context_data);
+              }
+              else {
+                // If no context is set, load one using the layout info.
+                $context_info = layout_get_context_info($context->plugin);
+                if (isset($context_info['load callback'])) {
+                  $context_data = call_user_func_array($context_info['load callback'], $router_item['original_map'][$context->position]);
+                  $context->setData($context_data);
+                }
+              }
             }
           }
         }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1244,7 +1244,7 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
       foreach ($contexts as $context) {
         if (isset($context->position)) {
 
-          // If on a node preview page use the preview from tempstore.
+          // If on a node preview page, use the preview from tempstore.
           // @ todo: This is also specific code for node previews which needs
           // to be reverted in a future commit.
           if ($preview_node) {

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2288,6 +2288,88 @@ class LayoutSelectionTest extends BackdropWebTestCase {
 }
 
 /**
+ * Tests that the correct layout is used for node previews.
+ */
+class LayoutPreviewTest extends BackdropWebTestCase {
+  protected $profile = 'testing';
+  protected $content_type;
+  protected $admin_user;
+
+  function setUp() {
+    parent::setUp(array('layout'));
+
+    // Enable the test module that contains our test layout in its config.
+    module_enable(array('layout_preview_test'));
+
+    // Create a content type for checking node/edit page layouts.
+    $this->content_type = $this->backdropCreateContentType();
+
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'bypass node access',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
+
+  /**
+   * Tests that the correct layout is used for node add and node edit previews.
+   */
+  function testPages() {
+    // Create a node to test through the admin interface.
+    $this->backdropGet('node/add/' . $this->content_type->type);
+
+    // Fill in its title and body, then select the 'Preview' option.
+    $title = $this->randomName();
+    $body = $this->randomName();
+    $edit = array(
+      'title' => $title,
+      'body[und][0][value]' => $body,
+    );
+    $this->backdropPost(NULL, $edit, t('Preview'));
+
+    // Look for the taylor template (only in our layout).
+    $this->assertText('taylor', 'Layout template "taylor" found.');
+
+    // Look for the heading of the field body block that exists only in our
+    // layout.
+    $this->assertText('Node body field', '"Node body field" found.');
+
+    // Look for the body text, which appears only in that field if the context
+    // was set properly.
+    $this->assertText($body, "\"{$body}\" found.");
+
+    // Create a new node; fill in its title and body, then save.
+    $this->backdropGet('node/add/' . $this->content_type->type);
+    $title = $this->randomName();
+    $body = $this->randomName();
+    $edit = array(
+      'title' => $title,
+      'body[und][0][value]' => $body,
+    );
+    $this->backdropPost(NULL, $edit, t('Save'));
+
+    // Edit the node with a new random body content, then preview.
+    $this->backdropGet('node/1/edit');
+    $body = $this->randomName();
+    $edit = array(
+      'body[und][0][value]' => $body,
+    );
+     $this->backdropPost(NULL, $edit, t('Preview'));
+
+    // Look for the taylor template (only in our layout).
+    $this->assertText('taylor', 'Layout template "taylor" found.');
+
+    // Look for the heading of the field body block that exists only in our
+    // layout.
+    $this->assertText('Node body field', '"Node body field" found.');
+
+    // Look for the body text, which appears only in that field if the context
+    // was set properly.
+    $this->assertText($body, "\"{$body}\" found.");
+  }
+}
+
+/**
  * Tests the BlockTest (custom text) block functionality.
  */
 class LayoutBlockTextTest extends BackdropWebTestCase {

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -28,6 +28,12 @@ description = Tests that the correct layout is used in various situations.
 group = Layout
 file = layout.test
 
+[LayoutPreviewTest]
+name = Layout Preview Test
+description = Tests that the correct layout is used for node previews.
+group = Layout
+file = layout.test
+
 [LayoutUpgradePathTest]
 name = Layout Upgrade Test
 description = Tests the upgrade path from block-based regions to layouts.

--- a/core/modules/layout/tests/layout_preview_test/config/layout.layout.preview_test.json
+++ b/core/modules/layout/tests/layout_preview_test/config/layout.layout.preview_test.json
@@ -1,0 +1,198 @@
+{
+    "_config_name": "layout.layout.preview_test",
+    "path": "node/%",
+    "name": "preview_test",
+    "title": "Custom Node",
+    "description": null,
+    "renderer_name": "standard",
+    "module": null,
+    "weight": 0,
+    "storage": 1,
+    "layout_template": "taylor",
+    "disabled": false,
+    "settings": {
+        "title": "",
+        "title_display": "default",
+        "title_block": null
+    },
+    "positions": {
+        "header": [
+            "e9179a32-542d-4a4b-9800-cfacf56496af",
+            "2ed75bf9-7831-460b-8b03-3c7ed69e7b7d"
+        ],
+        "top": [
+            "13dccc4e-e5b4-4940-8d00-eccf4f04ee31"
+        ],
+        "content": [
+            "be4cc176-c0a5-4688-b02d-454bfd5b9dc3",
+            "76637580-8042-4576-8d00-a2614c90dd95"
+        ],
+        "bottom": [],
+        "footer": [
+            "fae65ea1-6fd7-489e-8200-a4c2addfb380"
+        ],
+        "title": []
+    },
+    "contexts": [],
+    "content": {
+        "e9179a32-542d-4a4b-9800-cfacf56496af": {
+            "plugin": "system:header",
+            "data": {
+                "module": "system",
+                "delta": "header",
+                "settings": {
+                    "title_display": "default",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": {
+                        "menu": "user-menu",
+                        "logo": 1,
+                        "site_name": 1,
+                        "site_slogan": 1
+                    },
+                    "contexts": []
+                },
+                "uuid": "e9179a32-542d-4a4b-9800-cfacf56496af",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "2ed75bf9-7831-460b-8b03-3c7ed69e7b7d": {
+            "plugin": "system:main-menu",
+            "data": {
+                "module": "system",
+                "delta": "main-menu",
+                "settings": {
+                    "title_display": "none",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": {
+                        "style": "dropdown",
+                        "level": 1,
+                        "depth": 0
+                    },
+                    "contexts": []
+                },
+                "uuid": "2ed75bf9-7831-460b-8b03-3c7ed69e7b7d",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "13dccc4e-e5b4-4940-8d00-eccf4f04ee31": {
+            "plugin": "system:breadcrumb",
+            "data": {
+                "module": "system",
+                "delta": "breadcrumb",
+                "settings": {
+                    "title_display": "default",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": []
+                },
+                "uuid": "13dccc4e-e5b4-4940-8d00-eccf4f04ee31",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "be4cc176-c0a5-4688-b02d-454bfd5b9dc3": {
+            "plugin": "layout:custom_block",
+            "data": {
+                "module": "layout",
+                "delta": "custom_block",
+                "settings": {
+                    "title_display": "default",
+                    "title": "Custom Node layout title",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": [],
+                    "content": "<p>This page uses the Custom Node layout.</p>\r\n",
+                    "format": "filtered_html",
+                    "admin_label": "",
+                    "admin_description": ""
+                },
+                "uuid": "be4cc176-c0a5-4688-b02d-454bfd5b9dc3",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "76637580-8042-4576-8d00-a2614c90dd95": {
+            "plugin": "field:field_block:node-body",
+            "data": {
+                "module": "field",
+                "delta": "field_block",
+                "settings": {
+                    "title_display": "custom",
+                    "title": "Node body field",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": [],
+                    "label": "hidden",
+                    "formatter": "text_default",
+                    "formatter_settings": [],
+                    "delta_offset": 0,
+                    "delta_limit": "",
+                    "delta_reversed": 0,
+                    "admin_label": "",
+                    "admin_description": ""
+                },
+                "uuid": "76637580-8042-4576-8d00-a2614c90dd95",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "fae65ea1-6fd7-489e-8200-a4c2addfb380": {
+            "plugin": "system:powered-by",
+            "data": {
+                "module": "system",
+                "delta": "powered-by",
+                "settings": {
+                    "title_display": "default",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": []
+                },
+                "uuid": "fae65ea1-6fd7-489e-8200-a4c2addfb380",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/modules/layout/tests/layout_preview_test/layout_preview_test.info
+++ b/core/modules/layout/tests/layout_preview_test/layout_preview_test.info
@@ -1,0 +1,7 @@
+name = Layout Preview Test
+description = Support module for Layout module tests of node preview pages.
+package = Testing
+version = BACKDROP_VERSION
+type = module
+backdrop = 1.x
+hidden = TRUE

--- a/core/modules/layout/tests/layout_preview_test/layout_preview_test.module
+++ b/core/modules/layout/tests/layout_preview_test/layout_preview_test.module
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @file
+ * Layout preview test module.
+ */
+
+/**
+ * Implements hook_config_info().
+ */
+function layout_preview_test_config_info() {
+  $prefixes['layout.layout.preview_test'] = array(
+    'label' => t('Layout Preview Test layout'),
+    'group' => t('Layouts'),
+  );
+  return $prefixes;
+}


### PR DESCRIPTION
Fixes [#5018](https://github.com/backdrop/backdrop-issues/issues/5018).

If a custom layout is defined for a node path, use that layout for node preview pages.

Current code uses the default layout for preview. This fix will use the correct custom layout if one is defined.

## Testing

### Setup

1. Create a new layout with path `node/%`.
2. Add a custom block to it with some distinctive content so you can tell when it's being applied.

(optional)

3. Add a custom block that uses a context, e.g., "Field: Body (body)". This will let you verify that the context is being properly set.

### Test: create new node

1. Create a new node, e.g., at `node/add/post`.
2. Select 'Preview'.
3. The preview page should show the custom layout and if the block with context was added, the block contents should be shown.

### Test: edit existing node

1. Select the edit page for an existing node, e.g., `node/1/edit`.
2. Select 'Preview'.
3. The preview page should show the custom layout and if the block with context was added, the block contents should be shown.
