### PR TITLE
Issue 5018: Node previews, wrong layout (add tests)

### DIFF
--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2350,7 +2350,7 @@ class LayoutPreviewTest extends BackdropWebTestCase {
 
     // Edit the node with a new random body content, then preview.
     $this->backdropGet('node/1/edit');
-   $body = $this->randomName();
+    $body = $this->randomName();
     $edit = array(
       'body[und][0][value]' => $body,
     );

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2288,6 +2288,84 @@ class LayoutSelectionTest extends BackdropWebTestCase {
 }
 
 /**
+ * Tests that the correct layout is used for node previews.
+ */
+class LayoutPreviewTest extends BackdropWebTestCase {
+  protected $profile = 'testing';
+  protected $content_type;
+  protected $admin_user;
+
+  function setUp() {
+    parent::setUp(array('layout'));
+
+    // Enable the test module that contains our test layout in its config.
+    module_enable(array('layout_preview_test'));
+
+    // Create a content type for checking node/edit page layouts.
+    $this->content_type = $this->backdropCreateContentType();
+
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'bypass node access',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
+
+  /**
+   * Tests that the correct layout is used for node add and node edit previews.
+   */
+  function testPages() {
+    // Create a node to test through the admin interface.
+    $this->backdropGet('node/add/' . $this->content_type->type);
+
+    // Fill in its title and body, then select the 'Preview' option.
+    $title = $this->randomName();
+    $body = $this->randomName();
+    $edit = array(
+      'title' => $title,
+      'body[und][0][value]' => $body,
+    );
+    $this->backdropPost(NULL, $edit, t('Preview'));
+
+    // Look for the taylor template (only in our layout).
+    $this->assertText('taylor', 'Layout template "taylor" found.');
+
+    // Look for the heading of the field body block that exists only in our
+    // layout.
+    $this->assertText('Node body field', '"Node body field" found.');
+
+    // Look for the body text, which appears only in that field if the context
+    // was set properly.
+    $this->assertText($body, "\"{$body}\" found.");
+
+    // Create a new node; fill in its title and body, then save.
+    $this->backdropGet('node/add/' . $this->content_type->type);
+    $title = $this->randomName();
+    $body = $this->randomName();
+    $edit = array(
+      'title' => $title,
+      'body[und][0][value]' => $body,
+    );
+    $this->backdropPost(NULL, $edit, t('Save'));
+
+    // Edit the node, then preview.
+    $this->backdropGet('node/1/edit');
+    $this->backdropPost(NULL, array(), t('Save'));
+
+    // Look for the taylor template (only in our layout).
+    $this->assertText('taylor', 'Layout template "taylor" found.');
+
+    // Look for the heading of the field body block that exists only in our
+    // layout.
+    $this->assertText('Node body field', '"Node body field" found.');
+
+    // Look for the body text, which appears only in that field if the context
+    // was set properly.
+    $this->assertText($body, "\"{$body}\" found.");
+  }
+}
+
+/**
  * Tests the BlockTest (custom text) block functionality.
  */
 class LayoutBlockTextTest extends BackdropWebTestCase {

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2348,9 +2348,13 @@ class LayoutPreviewTest extends BackdropWebTestCase {
     );
     $this->backdropPost(NULL, $edit, t('Save'));
 
-    // Edit the node, then preview.
+    // Edit the node with a new random body content, then preview.
     $this->backdropGet('node/1/edit');
-    $this->backdropPost(NULL, array(), t('Save'));
+   $body = $this->randomName();
+    $edit = array(
+      'body[und][0][value]' => $body,
+    );
+     $this->backdropPost(NULL, $edit, t('Preview'));
 
     // Look for the taylor template (only in our layout).
     $this->assertText('taylor', 'Layout template "taylor" found.');

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -28,6 +28,12 @@ description = Tests that the correct layout is used in various situations.
 group = Layout
 file = layout.test
 
+[LayoutPreviewTest]
+name = Layout Preview Test
+description = Tests that the correct layout is used for node previews.
+group = Layout
+file = layout.test
+
 [LayoutUpgradePathTest]
 name = Layout Upgrade Test
 description = Tests the upgrade path from block-based regions to layouts.
@@ -57,3 +63,8 @@ name = Layout Flexible Template Test
 description = Tests that flexible layout templates perform correctly.
 group = Layout
 file = layout.test
+
+; Added by Backdrop CMS packaging script on 2021-01-27
+project = backdrop
+version = 1.18.1
+timestamp = 1611786026

--- a/core/modules/layout/tests/layout_preview_test/config/layout.layout.preview_test.json
+++ b/core/modules/layout/tests/layout_preview_test/config/layout.layout.preview_test.json
@@ -1,0 +1,198 @@
+{
+    "_config_name": "layout.layout.preview_test",
+    "path": "node/%",
+    "name": "preview_test",
+    "title": "Custom Node",
+    "description": null,
+    "renderer_name": "standard",
+    "module": null,
+    "weight": 0,
+    "storage": 1,
+    "layout_template": "taylor",
+    "disabled": false,
+    "settings": {
+        "title": "",
+        "title_display": "default",
+        "title_block": null
+    },
+    "positions": {
+        "header": [
+            "e9179a32-542d-4a4b-9800-cfacf56496af",
+            "2ed75bf9-7831-460b-8b03-3c7ed69e7b7d"
+        ],
+        "top": [
+            "13dccc4e-e5b4-4940-8d00-eccf4f04ee31"
+        ],
+        "content": [
+            "be4cc176-c0a5-4688-b02d-454bfd5b9dc3",
+            "76637580-8042-4576-8d00-a2614c90dd95"
+        ],
+        "bottom": [],
+        "footer": [
+            "fae65ea1-6fd7-489e-8200-a4c2addfb380"
+        ],
+        "title": []
+    },
+    "contexts": [],
+    "content": {
+        "e9179a32-542d-4a4b-9800-cfacf56496af": {
+            "plugin": "system:header",
+            "data": {
+                "module": "system",
+                "delta": "header",
+                "settings": {
+                    "title_display": "default",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": {
+                        "menu": "user-menu",
+                        "logo": 1,
+                        "site_name": 1,
+                        "site_slogan": 1
+                    },
+                    "contexts": []
+                },
+                "uuid": "e9179a32-542d-4a4b-9800-cfacf56496af",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "2ed75bf9-7831-460b-8b03-3c7ed69e7b7d": {
+            "plugin": "system:main-menu",
+            "data": {
+                "module": "system",
+                "delta": "main-menu",
+                "settings": {
+                    "title_display": "none",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": {
+                        "style": "dropdown",
+                        "level": 1,
+                        "depth": 0
+                    },
+                    "contexts": []
+                },
+                "uuid": "2ed75bf9-7831-460b-8b03-3c7ed69e7b7d",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "13dccc4e-e5b4-4940-8d00-eccf4f04ee31": {
+            "plugin": "system:breadcrumb",
+            "data": {
+                "module": "system",
+                "delta": "breadcrumb",
+                "settings": {
+                    "title_display": "default",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": []
+                },
+                "uuid": "13dccc4e-e5b4-4940-8d00-eccf4f04ee31",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "be4cc176-c0a5-4688-b02d-454bfd5b9dc3": {
+            "plugin": "layout:custom_block",
+            "data": {
+                "module": "layout",
+                "delta": "custom_block",
+                "settings": {
+                    "title_display": "default",
+                    "title": "Custom Node layout title",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": [],
+                    "content": "<p>This page uses the Custom Node layout.</p>\r\n",
+                    "format": "filtered_html",
+                    "admin_label": "",
+                    "admin_description": ""
+                },
+                "uuid": "be4cc176-c0a5-4688-b02d-454bfd5b9dc3",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "76637580-8042-4576-8d00-a2614c90dd95": {
+            "plugin": "field:field_block:node-body",
+            "data": {
+                "module": "field",
+                "delta": "field_block",
+                "settings": {
+                    "title_display": "custom",
+                    "title": "Node body field",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": [],
+                    "label": "hidden",
+                    "formatter": "text_default",
+                    "formatter_settings": [],
+                    "delta_offset": 0,
+                    "delta_limit": "",
+                    "delta_reversed": 0,
+                    "admin_label": "",
+                    "admin_description": ""
+                },
+                "uuid": "76637580-8042-4576-8d00-a2614c90dd95",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        },
+        "fae65ea1-6fd7-489e-8200-a4c2addfb380": {
+            "plugin": "system:powered-by",
+            "data": {
+                "module": "system",
+                "delta": "powered-by",
+                "settings": {
+                    "title_display": "default",
+                    "title": "",
+                    "style": "default",
+                    "block_settings": [],
+                    "contexts": []
+                },
+                "uuid": "fae65ea1-6fd7-489e-8200-a4c2addfb380",
+                "style": {
+                    "plugin": "default",
+                    "data": {
+                        "settings": {
+                            "classes": ""
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/modules/layout/tests/layout_preview_test/layout_preview_test.info
+++ b/core/modules/layout/tests/layout_preview_test/layout_preview_test.info
@@ -1,0 +1,7 @@
+name = Layout Preview Test
+description = Support module for Layout module tests of node preview pages.
+package = Testing
+version = BACKDROP_VERSION
+type = module
+backdrop = 1.x
+hidden = TRUE

--- a/core/modules/layout/tests/layout_preview_test/layout_preview_test.module
+++ b/core/modules/layout/tests/layout_preview_test/layout_preview_test.module
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @file
+ * Layout preview test module.
+ */
+
+/**
+ * Implements hook_config_info().
+ */
+function layout_preview_test_config_info() {
+  $prefixes['layout.layout.preview_test'] = array(
+    'label' => t('Layout Preview Test layout'),
+    'group' => t('Layouts'),
+  );
+  return $prefixes;
+}

--- a/core/modules/layout/tests/layout_test/layout_test.info
+++ b/core/modules/layout/tests/layout_test/layout_test.info
@@ -5,3 +5,8 @@ version = BACKDROP_VERSION
 type = module
 backdrop = 1.x
 hidden = TRUE
+
+; Added by Backdrop CMS packaging script on 2021-01-27
+project = backdrop
+version = 1.18.1
+timestamp = 1611786026


### PR DESCRIPTION
Addresses [Issue 5018](https://github.com/backdrop/backdrop-issues/issues/5018).

Add tests for the proper layout to use on node preview pages.

Current Backdrop core will fail this test for node add page preview (but will pass for node edit preview).

[PR 3574](https://github.com/backdrop/backdrop/pull/3574) will pass it.