### PR TITLE
Issue #5037: Trying to sort NULL array in field_ui_widget_type_options

### DIFF
--- a/core/modules/field_ui/field_ui.admin.inc
+++ b/core/modules/field_ui/field_ui.admin.inc
@@ -1514,7 +1514,7 @@ function field_ui_widget_type_options($field_type = NULL, $by_label = FALSE) {
           $options[$widget_field_type][$name] = $widget_type['label'];
         }
       }
-      if (!empty($options)) {
+      if (isset($options[$widget_field_type])) {
         asort($options[$widget_field_type]);
       }
     }

--- a/core/modules/field_ui/field_ui.admin.inc
+++ b/core/modules/field_ui/field_ui.admin.inc
@@ -1514,7 +1514,9 @@ function field_ui_widget_type_options($field_type = NULL, $by_label = FALSE) {
           $options[$widget_field_type][$name] = $widget_type['label'];
         }
       }
-      asort($options[$widget_field_type]);
+      if (!empty($options)) {
+        asort($options[$widget_field_type]);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5037

Make sure the array is not empty before trying to sort it.