### PR TITLE
In backdrop_http_request(), allow passing data as array

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -925,7 +925,7 @@ function backdrop_access_denied() {
  *   - data: An array or object containing the values for the request body or a
  *     string containing the request body, formatted as
  *     'param=value&param=value&...'.
- *     To generate this, use http_build_query(). Defaults to NULL.
+ *     To generate this, use backdrop_http_build_query(). Defaults to NULL.
  *   - max_redirects: An integer representing how many times a redirect
  *     may be followed. Defaults to 3.
  *   - timeout: A float representing the maximum number of seconds the function
@@ -950,6 +950,8 @@ function backdrop_access_denied() {
  *     HTTP header names are case-insensitive (RFC 2616, section 4.2), so for
  *     easy access the array keys are returned in lower case.
  *   - data: A string containing the response body that was received.
+ *
+ * @see backdrop_http_build_query()
  */
 function backdrop_http_request($url, array $options = array()) {
   // Allow an alternate HTTP client library to replace Backdrop's default
@@ -1092,7 +1094,7 @@ function backdrop_http_request($url, array $options = array()) {
 
   // Convert array or object $options['data'] to query string.
   if (is_array($options['data']) || is_object($options['data'])) {
-    $options['data'] = http_build_query($options['data']);
+    $options['data'] = backdrop_http_build_query($options['data']);
   }
 
   // Only add Content-Length if we actually have any content or if it is a POST

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -922,9 +922,8 @@ function backdrop_access_denied() {
  *   (optional) An array that can have one or more of the following elements:
  *   - headers: An array containing request headers to send as name/value pairs.
  *   - method: A string containing the request method. Defaults to 'GET'.
- *   - data: An array or object containing the values for the request body or a
- *     string containing the request body, formatted as
- *     'param=value&param=value&...'.
+ *   - data: An array containing the values for the request body or a string
+ *     containing the request body, formatted as 'param=value&param=value&...'.
  *     To generate this, use backdrop_http_build_query(). Defaults to NULL.
  *   - max_redirects: An integer representing how many times a redirect
  *     may be followed. Defaults to 3.
@@ -1092,8 +1091,8 @@ function backdrop_http_request($url, array $options = array()) {
     $path .= '?' . $uri['query'];
   }
 
-  // Convert array or object $options['data'] to query string.
-  if (is_array($options['data']) || is_object($options['data'])) {
+  // Convert array $options['data'] to a query string.
+  if (is_array($options['data'])) {
     $options['data'] = backdrop_http_build_query($options['data']);
   }
 

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -922,9 +922,10 @@ function backdrop_access_denied() {
  *   (optional) An array that can have one or more of the following elements:
  *   - headers: An array containing request headers to send as name/value pairs.
  *   - method: A string containing the request method. Defaults to 'GET'.
- *   - data: A string containing the request body, formatted as
- *     'param=value&param=value&...'; to generate this, use http_build_query().
- *     Defaults to NULL.
+ *   - data: An array or object containing the values for the request body or a
+ *     string containing the request body, formatted as
+ *     'param=value&param=value&...'.
+ *     To generate this, use http_build_query(). Defaults to NULL.
  *   - max_redirects: An integer representing how many times a redirect
  *     may be followed. Defaults to 3.
  *   - timeout: A float representing the maximum number of seconds the function
@@ -1087,6 +1088,11 @@ function backdrop_http_request($url, array $options = array()) {
   $path = isset($uri['path']) ? $uri['path'] : '/';
   if (isset($uri['query'])) {
     $path .= '?' . $uri['query'];
+  }
+
+  // Convert array or object $options['data'] to query string.
+  if (is_array($options['data']) || is_object($options['data'])) {
+    $options['data'] = http_build_query($options['data']);
   }
 
   // Only add Content-Length if we actually have any content or if it is a POST

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -951,6 +951,8 @@ function backdrop_access_denied() {
  *   - data: A string containing the response body that was received.
  *
  * @see backdrop_http_build_query()
+ *
+ * @since 1.18.4 The $options['data'] key may now be passed as an array.
  */
 function backdrop_http_request($url, array $options = array()) {
   // Allow an alternate HTTP client library to replace Backdrop's default

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1034,8 +1034,8 @@ class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
 
     // Fetch page, and check that the data parameter works with both array and
     // string.
-    $data_array = array($this->randomName() => $this->randomName());
-    $data_string = http_build_query($data_array);
+    $data_array = array($this->randomName() => $this->randomString() . ' "\'');
+    $data_string = backdrop_http_build_query($data_array);
     $result = backdrop_http_request(url('node', array('absolute' => TRUE)), array('data' => $data_array));
     $this->assertEqual($result->code, 200, 'Fetched page successfully.');
     $this->assertTrue(substr($result->request, -strlen($data_string)) === $data_string, 'Request ends with URL-encoded data when drupal_http_request() is called using an array.');

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1032,9 +1032,16 @@ class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
     $this->assertEqual($unable_to_parse->code, -1001, 'Returned with "-1001" error code.');
     $this->assertEqual($unable_to_parse->error, 'unable to parse URL', 'Returned with "unable to parse URL" error message.');
 
-    // Fetch page.
-    $result = backdrop_http_request(url('node', array('absolute' => TRUE)));
+    // Fetch page, and check that the data parameter works with both array and
+    // string.
+    $data_array = array($this->randomName() => $this->randomName());
+    $data_string = http_build_query($data_array);
+    $result = backdrop_http_request(url('node', array('absolute' => TRUE)), array('data' => $data_array));
     $this->assertEqual($result->code, 200, 'Fetched page successfully.');
+    $this->assertTrue(substr($result->request, -strlen($data_string)) === $data_string, 'Request ends with URL-encoded data when drupal_http_request() is called using an array.');
+    $result = backdrop_http_request(url('node', array('absolute' => TRUE)), array('data' => $data_string));
+    $this->assertTrue(substr($result->request, -strlen($data_string)) === $data_string, 'Request ends with URL-encoded data when drupal_http_request() is called using a string.');
+
     $this->backdropSetContent($result->data);
     $this->assertTitle(t('Home | @site-name', array('@site-name' => config_get_translated('system.core', 'site_name'))), 'Site title matches.');
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5042

See:
- https://www.drupal.org/project/drupal/issues/2814031
- https://www.drupal.org/node/3098661 (change record)
- https://git.drupalcode.org/project/drupal/-/commit/23ae731d0fb44fec4146964d5c8895f786ff6e19

PR also includes changes from:
- https://www.drupal.org/node/3059391 (follow-up from #2814031)
- https://git.drupalcode.org/project/drupal/commit/ff3c4ca5bf2f41a877b8ce8c8f27cd48f55c85b4

PR also includes changes from:
- https://www.drupal.org/node/3098664 (follow-up from #3059391)
- https://git.drupalcode.org/project/drupal/commit/cd372205fc666fad8c96e40d8480654ffb57d78a