### PR TITLE
Issue #5043: Fix low contrast for primary tabs in Seven

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -290,7 +290,7 @@ ul.primary li.active a,
   border: none;
   overflow: visible;
   line-height: 1;
-  color: #757575;
+  color: #606060;
   font-weight: normal;
   background-color: #DBDBD9;
   transition:


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5043

This slightly darker color provides a contrast of 4.54 (AA)