### PR TITLE
Issue #3055805: .htaccess file generated by file.inc doesn't cover PHP 7

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -550,7 +550,9 @@ SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
 <IfModule mod_php5.c>
   php_flag engine off
 </IfModule>
-
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
 EOF;
 
   if ($private) {


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/5042

See:
- https://www.drupal.org/i/3055805
- https://git.drupalcode.org/project/drupal/-/commit/c6f73e2754b02321c09c4e770cf852641699135e