### PR TITLE
Issue #3025335: [PHP 7.3] Cannot change session id when session is active

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -2297,6 +2297,17 @@ function drupal_session_regenerate() {
 }
 
 /**
+ * Regenerates an existing session.
+ *
+ * @deprecated since 1.18.3
+ * @see _backdrop_session_regenerate_existing()
+ */
+function _drupal_session_regenerate_existing() {
+  watchdog_deprecated_function('drupal', __FUNCTION__);
+  return _backdrop_session_regenerate_existing();
+}
+
+/**
  * Ends a specific user's session(s).
  *
  * @deprecated since 1.0.0

--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -2297,17 +2297,6 @@ function drupal_session_regenerate() {
 }
 
 /**
- * Regenerates an existing session.
- *
- * @deprecated since 1.18.3
- * @see _backdrop_session_regenerate_existing()
- */
-function _drupal_session_regenerate_existing() {
-  watchdog_deprecated_function('drupal', __FUNCTION__);
-  return _backdrop_session_regenerate_existing();
-}
-
-/**
  * Ends a specific user's session(s).
  *
  * @deprecated since 1.0.0

--- a/core/includes/session.inc
+++ b/core/includes/session.inc
@@ -376,13 +376,11 @@ function backdrop_session_regenerate() {
 
   if (backdrop_session_started()) {
     $old_session_id = session_id();
-    // PHP 7.3 requires closing the session before setting a new session ID.
-    $original_session_saving = backdrop_save_session();
-    backdrop_save_session(FALSE);
-    session_write_close();
-    backdrop_session_started(FALSE);
+    _backdrop_session_regenerate_existing();
   }
-  session_id(backdrop_random_key());
+  else {
+    session_id(backdrop_random_key());
+  }
 
   if (isset($old_session_id)) {
     // Preserve and restore user object, as starting session will reset it.
@@ -426,6 +424,26 @@ function backdrop_session_regenerate() {
   }
   date_default_timezone_set(backdrop_get_user_timezone());
   return TRUE;
+}
+
+/**
+ * Regenerates an existing session.
+ */
+function _backdrop_session_regenerate_existing() {
+  global $user;
+  // Preserve existing settings for the saving of sessions.
+  $original_save_session_status = backdrop_save_session();
+  // Turn off saving of sessions.
+  backdrop_save_session(FALSE);
+  session_write_close();
+  backdrop_session_started(FALSE);
+  // Preserve the user object, as starting a new session will reset it.
+  $original_user = $user;
+  session_id(backdrop_random_key());
+  backdrop_session_start();
+  $user = $original_user;
+  // Restore the original settings for the saving of sessions.
+  backdrop_save_session($original_save_session_status);
 }
 
 /**

--- a/core/includes/session.inc
+++ b/core/includes/session.inc
@@ -383,10 +383,6 @@ function backdrop_session_regenerate() {
   }
 
   if (isset($old_session_id)) {
-    // Preserve and restore user object, as starting session will reset it.
-    $original_user = $user;
-    backdrop_session_start();
-    $user = $original_user;
     $params = session_get_cookie_params();
     $expire = $params['lifetime'] ? REQUEST_TIME + $params['lifetime'] : 0;
     setcookie(session_name(), session_id(), $expire, $params['path'], $params['domain'], $params['secure'], $params['httponly']);

--- a/core/includes/session.inc
+++ b/core/includes/session.inc
@@ -387,7 +387,6 @@ function backdrop_session_regenerate() {
     $original_user = $user;
     backdrop_session_start();
     $user = $original_user;
-    backdrop_save_session($original_session_saving);
     $params = session_get_cookie_params();
     $expire = $params['lifetime'] ? REQUEST_TIME + $params['lifetime'] : 0;
     setcookie(session_name(), session_id(), $expire, $params['path'], $params['domain'], $params['secure'], $params['httponly']);

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -413,6 +413,10 @@ class UserValidationTestCase extends BackdropUnitTestCase {
 class UserLoginTestCase extends UserLoginTestBase {
   protected $profile = 'testing';
 
+  function setUp() {
+    parent::setUp('user_session_test');
+  }
+
   /**
    * Test that login credentials work (or not) in different login modes.
    */
@@ -552,6 +556,17 @@ class UserLoginTestCase extends UserLoginTestBase {
     // Load the stored user, which should have a different password hash now.
     $account = user_load($account->uid, TRUE);
     $this->assertIdentical(_password_get_count_log2($account->pass), BACKDROP_HASH_COUNT + 1);
+  }
+
+  /**
+   * Test logging in when an anon session already exists.
+   */
+  function testLoginWithAnonSession() {
+    // Visit the callback to generate a session for this anon user.
+    $this->backdropGet('user_session_test_anon_session');
+    // Now login.
+    $account = $this->backdropCreateUser(array());
+    $this->backdropLogin($account);
   }
 
   /**

--- a/core/modules/user/tests/user_session_test/user_session_test.info
+++ b/core/modules/user/tests/user_session_test/user_session_test.info
@@ -1,0 +1,7 @@
+name = "User module session tests"
+description = "Support module for user session testing."
+package = Testing
+version = BACKDROP_VERSION
+type = module
+backdrop = 1.x
+hidden = TRUE

--- a/core/modules/user/tests/user_session_test/user_session_test.module
+++ b/core/modules/user/tests/user_session_test/user_session_test.module
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @file
+ * Dummy module implementing a page callback to create an anonymous session.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function user_session_test_menu() {
+  $items = array();
+  $items['user_session_test_anon_session'] = array(
+    'page callback' => 'user_session_test_anon_session',
+    'access callback' => TRUE,
+  );
+  return $items;
+}
+
+/**
+ * Page callback.
+ *
+ * Creates an anonymous user session.
+ */
+function user_session_test_anon_session() {
+  $data = 'This dummy data will be stored in a user session.';
+  $_SESSION[__FUNCTION__] = $data;
+  return $data;
+}


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/5042

See:
- https://www.drupal.org/i/3025335
- https://git.drupalcode.org/project/drupal/-/commit/44fecf2115fd8d6b2864d7d9abb1fb595f39c7ea