### PR TITLE
Issue #2171113: Settings returned via ajax are not run through hook_js_alter()

### DIFF
--- a/core/includes/ajax.inc
+++ b/core/includes/ajax.inc
@@ -292,6 +292,7 @@ function ajax_render($commands = array()) {
 
   // Now add a command to merge changes and additions to Backdrop.settings.
   $scripts = backdrop_add_js();
+  backdrop_alter('js', $scripts);
   if (!empty($scripts['settings'])) {
     $settings = $scripts['settings'];
     array_unshift($commands, ajax_command_settings(backdrop_array_merge_deep_array($settings['data']), TRUE));


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5042

See:
- https://www.drupal.org/i/2171113
- https://git.drupalcode.org/project/drupal/commit/4d080b6fc0771e4222743e047c05c92ecc6b8b9d