### PR TITLE
Issue #2902430: [PHP 7.1] A non-numeric value encountered in theme_pager()

### DIFF
--- a/core/includes/pager.inc
+++ b/core/includes/pager.inc
@@ -159,7 +159,7 @@ function theme_pager($variables) {
   $tags = $variables['tags'];
   $element = $variables['element'];
   $parameters = $variables['parameters'];
-  $quantity = (int) $variables['quantity'];
+  $quantity = empty($variables['quantity']) ? 0 : (int) $variables['quantity'];
   global $pager_page_array, $pager_total;
 
   // Return if there is no pager to be rendered.

--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -484,6 +484,40 @@ abstract class BackdropTestCase {
   }
 
   /**
+   * Asserts that an element has a given class.
+   *
+   * @param SimpleXMLElement $element
+   *   The element to test.
+   * @param string $class
+   *   The class to assert.
+   * @param string $message
+   *   (optional) A verbose message to output.
+   */
+  protected function assertClass(SimpleXMLElement $element, $class, $message = NULL) {
+    if (!isset($message)) {
+      $message = "Class .$class found.";
+    }
+    $this->assertTrue(strpos($element['class'], $class) !== FALSE, $message);
+  }
+
+  /**
+   * Asserts that an element does not have a given class.
+   *
+   * @param SimpleXMLElement $element
+   *   The element to test.
+   * @param string $class
+   *   The class to assert.
+   * @param string $message
+   *   (optional) A verbose message to output.
+   */
+  protected function assertNoClass(SimpleXMLElement $element, $class, $message = NULL) {
+    if (!isset($message)) {
+      $message = "Class .$class not found.";
+    }
+    $this->assertTrue(strpos($element['class'], $class) === FALSE, $message);
+  }
+
+  /**
    * Fire an assertion that is always positive.
    *
    * @param $message

--- a/core/modules/simpletest/tests/pager.test
+++ b/core/modules/simpletest/tests/pager.test
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @file
+ * Tests for pager functionality.
+ */
+
+/**
+ * Tests pager functionality.
+ */
+class PagerFunctionalWebTestCase extends BackdropWebTestCase {
+  protected $profile = 'testing';
+
+  function setUp() {
+    parent::setUp(array('dblog'));
+
+    // Insert 300 log messages.
+    for ($i = 0; $i < 300; $i++) {
+      watchdog('pager_test', $this->randomString(), NULL, WATCHDOG_DEBUG);
+    }
+
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access site reports',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
+
+  /**
+   * Tests markup and CSS classes of pager links.
+   */
+  function testActiveClass() {
+    // Verify first page.
+    $this->backdropGet('admin/reports/dblog');
+    $current_page = 0;
+    $this->assertPagerItems($current_page);
+
+    // Verify any page but first/last.
+    $current_page++;
+    $this->backdropGet('admin/reports/dblog', array('query' => array('page' => $current_page)));
+    $this->assertPagerItems($current_page);
+
+    // Verify last page.
+    $elements = $this->xpath('//li[contains(@class, :class)]/a', array(':class' => 'pager-last'));
+    preg_match('@page=(\d+)@', $elements[0]['href'], $matches);
+    $current_page = (int) $matches[1];
+    $this->backdropGet($GLOBALS['base_root'] . $elements[0]['href'], array('external' => TRUE));
+    $this->assertPagerItems($current_page);
+  }
+
+  /**
+   * Tests theme_pager() when an empty quantity is passed.
+   */
+  public function testThemePagerQuantityNotSet() {
+    $variables = array(
+      'element' => 0,
+      'parameters' => array(),
+      'quantity' => '',
+      'tags' => '',
+    );
+    pager_default_initialize(100, 10);
+    $rendered_output = theme_pager($variables);
+    $this->assertNotIdentical(stripos($rendered_output, 'next'), FALSE);
+    $this->assertNotIdentical(stripos($rendered_output, 'last'), FALSE);
+  }
+
+  /**
+   * Asserts pager items and links.
+   *
+   * @param int $current_page
+   *   The current pager page the internal browser is on.
+   */
+  protected function assertPagerItems($current_page) {
+    $elements = $this->xpath('//ul[@class=:class]/li', array(':class' => 'pager'));
+    $this->assertTrue(!empty($elements), 'Pager found.');
+
+    // Make current page 1-based.
+    $current_page++;
+
+    // Extract first/previous and next/last items.
+    // first/previous only exist, if the current page is not the first.
+    if ($current_page > 1) {
+      $first = array_shift($elements);
+      $previous = array_shift($elements);
+    }
+    // next/last always exist, unless the current page is the last.
+    if ($current_page != count($elements)) {
+      $last = array_pop($elements);
+      $next = array_pop($elements);
+    }
+
+    // Verify items and links to pages.
+    foreach ($elements as $page => $element) {
+      // Make item/page index 1-based.
+      $page++;
+      if ($current_page == $page) {
+        $this->assertClass($element, 'pager-current', 'Item for current page has .pager-current class.');
+        $this->assertFalse(isset($element->a), 'Item for current page has no link.');
+      }
+      else {
+        $this->assertNoClass($element, 'pager-current', "Item for page $page has no .pager-current class.");
+        $this->assertClass($element, 'pager-item', "Item for page $page has .pager-item class.");
+        $this->assertTrue($element->a, "Link to page $page found.");
+        $this->assertNoClass($element->a, 'active', "Link to page $page is not active.");
+      }
+      unset($elements[--$page]);
+    }
+    // Verify that no other items remain untested.
+    $this->assertTrue(empty($elements), 'All expected items found.');
+
+    // Verify first/previous and next/last items and links.
+    if (isset($first)) {
+      $this->assertClass($first, 'pager-first', 'Item for first page has .pager-first class.');
+      $this->assertTrue($first->a, 'Link to first page found.');
+      $this->assertNoClass($first->a, 'active', 'Link to first page is not active.');
+    }
+    if (isset($previous)) {
+      $this->assertClass($previous, 'pager-previous', 'Item for first page has .pager-previous class.');
+      $this->assertTrue($previous->a, 'Link to previous page found.');
+      $this->assertNoClass($previous->a, 'active', 'Link to previous page is not active.');
+    }
+    if (isset($next)) {
+      $this->assertClass($next, 'pager-next', 'Item for next page has .pager-next class.');
+      $this->assertTrue($next->a, 'Link to next page found.');
+      $this->assertNoClass($next->a, 'active', 'Link to next page is not active.');
+    }
+    if (isset($last)) {
+      $this->assertClass($last, 'pager-last', 'Item for last page has .pager-last class.');
+      $this->assertTrue($last->a, 'Link to last page found.');
+      $this->assertNoClass($last->a, 'active', 'Link to last page is not active.');
+    }
+  }
+}

--- a/core/modules/simpletest/tests/simpletest.tests.info
+++ b/core/modules/simpletest/tests/simpletest.tests.info
@@ -1108,6 +1108,12 @@ description = Tests the hook_module_implements_alter.
 group = Module
 file = module.test
 
+[PagerFunctionalWebTestCase]
+name = Pager functionality
+description = Tests pager functionality.
+group = Pager
+file = pager.test
+
 [PasswordHashingTest]
 name = Password hashing
 description = Password hashing unit tests.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5042

See:
- http://drupal.org/node/2902430
- https://cgit.drupalcode.org/drupal/commit/?id=63473379cda3b1d0b08bff61017d13376ae19342

It turns out that we were missing the entire `pager.test` file in Backdrop (how come?), so I've added it in this PR.

One key difference with the D7 code is that I've moved the `assertClass()` and `assertNoClass()` assertions to `backdrop_web_test_case.php` instead, so that all tests can start using them, and benefit.

Questions:
- Is moving those assertions a good thing as I thought, or not and should be put back in `pager.test`?
- Should we call these assertions `assertCssClass` and `assertNoCssClass` instead, or keep as is for D7 backwards compatibility?
- Should we also add `assertCssId` and `assertNoCssId` assertions?

--- 

Replaced by https://github.com/backdrop/backdrop/pull/3624