### PR TITLE
Issue #5046: Prevent multiple data rebuild runs on module listing

### DIFF
--- a/core/modules/update/update.compare.inc
+++ b/core/modules/update/update.compare.inc
@@ -824,7 +824,6 @@ function update_project_cache($cid) {
   // update status of the site to avoid presenting stale information.
   $q = $_GET['q'];
   $paths = array(
-    'admin/modules',
     'admin/modules/update',
     'admin/appearance',
     'admin/appearance/update',


### PR DESCRIPTION
POC fo fix https://github.com/backdrop/backdrop-issues/issues/5046

It prevents multiple runs of the rather expensive function system_rebuild_module_data() on the module listing page form.

On "admin/modules" the cache refresh, which should prevent stale data, is already handled by the system module.