### PR TITLE
BACKDROP-SA-CORE-2021-002 Cross-port from Drupal 7.80

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -1953,7 +1953,13 @@ function _filter_xss_attributes($attr) {
         // Attribute name, href for instance.
         if (preg_match('/^([-a-zA-Z]+)/', $attr, $match)) {
           $attrname = strtolower($match[1]);
-          $skip = ($attrname == 'style' || substr($attrname, 0, 2) == 'on');
+          $skip = (
+            $attrname == 'style' ||
+            substr($attrname, 0, 2) == 'on' ||
+            substr($attrname, 0, 1) == '-' ||
+            // Ignore long attributes to avoid unnecessary processing overhead.
+            strlen($attrname) > 96
+          );
           $working = $mode = 1;
           $attr = preg_replace('/^[-a-zA-Z]+/', '', $attr);
         }


### PR DESCRIPTION
Cross-port PR from Drupal 7.80. Fixes Security Issue https://github.com/backdrop-ops/security/issues/119 (private repository).