### PR TITLE
Issue #5054: Remove hidden (sub)modules from the installer 'Enable' page

### DIFF
--- a/core/modules/installer/installer.pages.inc
+++ b/core/modules/installer/installer.pages.inc
@@ -654,7 +654,7 @@ function installer_browser_installation_enable_form($form, &$form_state, $projec
         if (!isset($module->info['project']) || !isset($modules[$project['name']]->info['project']) || !empty($module->info['hidden'])) {
           continue;
         }
-        // The "type" key is required, skip over any (sub)module not specifying
+        // The "type" key is required. Skip over any (sub)module not specifying
         // it in its .info file.
         if (!isset($module->info['type'])) {
           continue;
@@ -697,7 +697,9 @@ function installer_browser_installation_enable_form($form, &$form_state, $projec
           }
         }
         // Build the list of options, but only include (sub)modules that are not
-        // hidden.
+        // hidden. This check also helps with the rare case where the main
+        // module within a project needs to be hidden, and submodules enabled
+        // instead. See https://github.com/backdrop/backdrop-issues/issues/5054.
         if (empty($modules[$project['name']]->info['hidden'])) {
           if ($dependency_check) {
             $options[$project['name']] = array(

--- a/core/modules/installer/installer.pages.inc
+++ b/core/modules/installer/installer.pages.inc
@@ -654,7 +654,8 @@ function installer_browser_installation_enable_form($form, &$form_state, $projec
         if (!isset($module->info['project']) || !isset($modules[$project['name']]->info['project']) || !empty($module->info['hidden'])) {
           continue;
         }
-        // The type key is required, skip over the violating module.
+        // The "type" key is required, skip over any (sub)module not specifying
+        // it in its .info file.
         if (!isset($module->info['type'])) {
           continue;
         }
@@ -695,19 +696,23 @@ function installer_browser_installation_enable_form($form, &$form_state, $projec
             $dependencies[] = $dependency_name . ' (<span class="admin-missing">' . t('missing') . '</span>)';
           }
         }
-        if ($dependency_check) {
-          $options[$project['name']] = array(
-            array('data' => $modules[$project['name']]->info['name']),
-            array('data' => $modules[$project['name']]->info['version']),
-            array('data' => implode(', ', $dependencies)),
-          );
-        }
-        else {
-          $missing[$project['name']] = array(
-            array('data' => $modules[$project['name']]->info['name']),
-            array('data' => $modules[$project['name']]->info['version']),
-            array('data' => implode(', ', $dependencies)),
-          );
+        // Build the list of options, but only include (sub)modules that are not
+        // hidden.
+        if (empty($modules[$project['name']]->info['hidden'])) {
+          if ($dependency_check) {
+            $options[$project['name']] = array(
+              array('data' => $modules[$project['name']]->info['name']),
+              array('data' => $modules[$project['name']]->info['version']),
+              array('data' => implode(', ', $dependencies)),
+            );
+          }
+          else {
+            $missing[$project['name']] = array(
+              array('data' => $modules[$project['name']]->info['name']),
+              array('data' => $modules[$project['name']]->info['version']),
+              array('data' => implode(', ', $dependencies)),
+            );
+          }
         }
       }
       else {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5054

Note: the initial commit message has a typo: `intaller` (missing an `s`).