### PR TITLE
Issue #5094: Provide a pass-through of the PDO prepare method.

### DIFF
--- a/core/includes/database/database.inc
+++ b/core/includes/database/database.inc
@@ -480,6 +480,25 @@ abstract class DatabaseConnection {
   }
 
   /**
+   * Provides a pass-through to the PDO prepare method.
+   *
+   * In adding support for PHP 8, the Backdrop DatabaseConnection no longer
+   * directly extends the PHP PDO object directly. A side-effect is that calls
+   * directly to the PDO object no longer worked. This provides a pass-through
+   * to this method specifically for compatibility with previous versions of
+   * Backdrop. See https://github.com/backdrop/backdrop-issues/issues/5094.
+   *
+   * @param $query
+   *
+   * @return bool|PDOStatement
+   *
+   * @since 1.19.2
+   */
+  public function prepare($query) {
+    return $this->pdo->prepare($query);
+  }
+
+  /**
    * Prepares a query string and returns the prepared statement.
    *
    * This method caches prepared statements, reusing them when

--- a/core/includes/database/database.inc
+++ b/core/includes/database/database.inc
@@ -484,7 +484,7 @@ abstract class DatabaseConnection {
    *
    * In adding support for PHP 8, the Backdrop DatabaseConnection no longer
    * directly extends the PHP PDO object. A side-effect is that calls
-   * directly to the PDO object no longer worked. This provides a pass-through
+   * to PDO methods no longer worked. This provides a pass-through
    * to this method specifically for compatibility with previous versions of
    * Backdrop. See https://github.com/backdrop/backdrop-issues/issues/5094.
    *

--- a/core/includes/database/database.inc
+++ b/core/includes/database/database.inc
@@ -483,7 +483,7 @@ abstract class DatabaseConnection {
    * Provides a pass-through to the PDO prepare method.
    *
    * In adding support for PHP 8, the Backdrop DatabaseConnection no longer
-   * directly extends the PHP PDO object directly. A side-effect is that calls
+   * directly extends the PHP PDO object. A side-effect is that calls
    * directly to the PDO object no longer worked. This provides a pass-through
    * to this method specifically for compatibility with previous versions of
    * Backdrop. See https://github.com/backdrop/backdrop-issues/issues/5094.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5094.

This provides a wrapper around the PDO::prepare() method so that it is available for Backup and Migrate. It does not restore complete compatibility with the previous behavior of Backdrop prior to 1.19.0, but it fixes the specific problem with Backup and Migrate module in https://github.com/backdrop/backdrop-issues/issues/5094