### PR TITLE
Issue #4500: Automatically clear caches after user admin form submission

### DIFF
--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -291,7 +291,7 @@ function user_admin_settings_submit($form, &$form_state) {
   // Clear the token cache, which also resets token-related static variables.
   token_cache_clear();
 
-  // Clear all other caches because menu items and permissions may have changed.
+  // Clear all other caches, because menu items and permissions may have changed.
   backdrop_flush_all_caches();
 }
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -288,8 +288,11 @@ function user_admin_settings($form, &$form_state) {
  */
 function user_admin_settings_submit($form, &$form_state) {
   system_settings_form_submit($form, $form_state);
-  // Clear the token cache.
+  // Clear the token cache, which also resets token-related static variables.
   token_cache_clear();
+
+  // Clear all other caches because menu items and permissions may have changed.
+  backdrop_flush_all_caches();
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4500.