### PR TITLE
Issue #5077: Add formatting to paths on layout listing page (alt)

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -5,6 +5,13 @@
 .layout-list .layout-group td:first-child {
   font-weight: bold;
 }
+.layout-list .layout-group td.missing-path,
+.layout-list .layout-group td.missing-path a {
+  color: red;
+}
+.layout-list .layout-group td .path-parenthetical {
+  font-weight: normal;
+}
 .layout-list .layout-row td:first-child {
   padding-left: 24px;
 }

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -7,7 +7,7 @@
 }
 .layout-list .layout-group td.missing-path,
 .layout-list .layout-group td.missing-path a {
-  color: #ff1100;
+  color: #c40d00;
 }
 .layout-list .layout-group td .path-parenthetical {
   font-weight: normal;

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -7,7 +7,7 @@
 }
 .layout-list .layout-group td.missing-path,
 .layout-list .layout-group td.missing-path a {
-  color: red;
+  color: #ff1100;
 }
 .layout-list .layout-group td .path-parenthetical {
   font-weight: normal;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -29,7 +29,7 @@ function layout_list_page() {
     $row = array();
     // Default layouts have a null path.
     if ($path === '') {
-      $row[] = array('data' => t('Default layouts') . ' ' . '<span class="path-parenthetical">' . t('(used on all paths without a specific layout)') . '</span>');
+      $row[] = array('data' => t('Default layouts') . ' <span class="path-parenthetical">(' . t('used on all paths without a specific layout') . ')</span>');
       // Empty columns are intentional so that they may be hidden with
       // priority-low class on the $header array.
       $row[] = '';
@@ -46,14 +46,14 @@ function layout_list_page() {
         ->fetchField();
       if (!$page_callback) {
         $cell['class'] = 'missing-path';
-        $path_link .= ' ' . '<span class="path-parenthetical">' .t('(no callback)'). '</span>';
+        $path_link .= ' <span class="path-parenthetical">(' .t('no callback'). ')</span>';
       }
       elseif ($page_callback == 'layout_page_callback') {
         $cell['class'] = 'layout-page';
       }
       else {
         $cell['class'] = 'module-page';
-        $path_link .= ' ' . '<span class="path-parenthetical">' .t('(module-provided)'). '</span>';
+        $path_link .= ' <span class="path-parenthetical">(' .t('module-provided'). ')</span>';
       }
       $cell['data'] = $path_link;
       $row[] = $cell;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -29,7 +29,7 @@ function layout_list_page() {
     $row = array();
     // Default layouts have a null path.
     if ($path === '') {
-      $row[] = array('data' => t('Default layouts (used on all paths without a specific layout)'));
+      $row[] = array('data' => t('Default layouts') . ' ' . '<span class="path-parenthetical">' . t('(used on all paths without a specific layout)') . '</span>');
       // Empty columns are intentional so that they may be hidden with
       // priority-low class on the $header array.
       $row[] = '';
@@ -37,7 +37,26 @@ function layout_list_page() {
     }
     else {
       $path_link = strpos($path, '%') === FALSE ? l($path, $path) : check_plain($path);
-      $row[] = array('data' => $path_link);
+      $cell = array();
+      $page_callback = db_query('
+        SELECT page_callback
+        FROM {menu_router}
+        WHERE path = :path
+        ', array(':path' => $path))
+        ->fetchField();
+      if (!$page_callback) {
+        $cell['class'] = 'missing-path';
+        $path_link .= ' ' . '<span class="path-parenthetical">' .t('(no callback)'). '</span>';
+      }
+      elseif ($page_callback == 'layout_page_callback') {
+        $cell['class'] = 'layout-page';
+      }
+      else {
+        $cell['class'] = 'module-page';
+        $path_link .= ' ' . '<span class="path-parenthetical">' .t('(module-provided)'). '</span>';
+      }
+      $cell['data'] = $path_link;
+      $row[] = $cell;
       // Empty columns are intentional.
       $row[] = '';
       $row[] = '';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5077.

An alternate approach from PR https://github.com/backdrop/backdrop/pull/3617 to adding formatting to distinguish module-provided from layout-provided paths, also paths whose menu router is missing.