### PR TITLE
Issue #5126: Support loose page cache matches based on date only.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1742,9 +1742,17 @@ function backdrop_serve_page_from_cache(stdClass $cache) {
   $if_modified_since = isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ? strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) : FALSE;
   $if_none_match = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? stripslashes($_SERVER['HTTP_IF_NONE_MATCH']) : FALSE;
 
+  // Handle an exact match based on Etag.
   if ($if_modified_since && $if_none_match
       && $if_none_match == $etag // etag must match
       && $if_modified_since == $cache->created) {  // if-modified-since must match
+    header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
+    backdrop_send_headers($default_headers);
+    return;
+  }
+
+  // Handle a loose match based on date only, if no Etag was provided.
+  if ($if_modified_since && !$if_none_match && $if_modified_since <= $cache->created) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
     backdrop_send_headers($default_headers);
     return;

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -1742,17 +1742,16 @@ function backdrop_serve_page_from_cache(stdClass $cache) {
   $if_modified_since = isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) ? strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) : FALSE;
   $if_none_match = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? stripslashes($_SERVER['HTTP_IF_NONE_MATCH']) : FALSE;
 
-  // Handle an exact match based on Etag.
-  if ($if_modified_since && $if_none_match
-      && $if_none_match == $etag // etag must match
-      && $if_modified_since == $cache->created) {  // if-modified-since must match
+  // Handle an exact match based on Etag. The If-None-Match header takes full
+  // precedence over If-Modified-Since header.
+  if ($if_none_match == $etag) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
     backdrop_send_headers($default_headers);
     return;
   }
 
   // Handle a loose match based on date only, if no Etag was provided.
-  if ($if_modified_since && !$if_none_match && $if_modified_since <= $cache->created) {
+  if (!$if_none_match && $if_modified_since && $if_modified_since >= $cache->created) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
     backdrop_send_headers($default_headers);
     return;

--- a/core/modules/simpletest/tests/bootstrap.test
+++ b/core/modules/simpletest/tests/bootstrap.test
@@ -129,24 +129,22 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
     $etag = $this->backdropGetHeader('ETag');
     $last_modified = $this->backdropGetHeader('Last-Modified');
 
+    // Match a cache based on Etag only.
+    $this->backdropGet($test_path, array(), array('If-None-Match: ' . $etag));
+    $this->assertResponse(304, 'Conditional request with Etag only returned 304 Not Modified.');
+
+    // Include both Etag and Date, even though the date is ignored.
+    // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
     $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . $last_modified, 'If-None-Match: ' . $etag));
-    $this->assertResponse(304, 'Conditional request returned 304 Not Modified.');
+    $this->assertResponse(304, 'Conditional request with Etag and unnecessary If-Modified-Since returned 304 Not Modified.');
 
-    $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC822, strtotime($last_modified)), 'If-None-Match: ' . $etag));
-    $this->assertResponse(304, 'Conditional request with obsolete If-Modified-Since date returned 304 Not Modified.');
-
-    $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC850, strtotime($last_modified)), 'If-None-Match: ' . $etag));
-    $this->assertResponse(304, 'Conditional request with obsolete If-Modified-Since date returned 304 Not Modified.');
-
+    // Match a cache based on date only.
     $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . $last_modified));
     $this->assertResponse(304, 'Conditional request without If-None-Match returned 304 Not Modified.');
 
-    $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC1123, strtotime($last_modified) + 1)));
-    $this->assertResponse(200, 'Conditional request with new a If-Modified-Since date newer than Last-Modified returned 200 OK.');
-    $this->assertEqual($this->backdropGetHeader('X-Backdrop-Cache'), 'HIT', 'Page was cached.');
-
-    $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC1123, strtotime($last_modified) + 1), 'If-None-Match: ' . $etag));
-    $this->assertResponse(200, 'Conditional request with new a If-Modified-Since date newer than Last-Modified (and an If-None-Match) returned 200 OK.');
+    // Try a conditional request that is too stale to get a cached copy.
+    $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC1123, strtotime($last_modified) - 1)));
+    $this->assertResponse(200, 'Conditional request with new a If-Modified-Since date older than Last-Modified returned 200 OK.');
     $this->assertEqual($this->backdropGetHeader('X-Backdrop-Cache'), 'HIT', 'Page was cached.');
 
     $user = $this->backdropCreateUser();

--- a/core/modules/simpletest/tests/bootstrap.test
+++ b/core/modules/simpletest/tests/bootstrap.test
@@ -139,11 +139,14 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
     $this->assertResponse(304, 'Conditional request with obsolete If-Modified-Since date returned 304 Not Modified.');
 
     $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . $last_modified));
-    $this->assertResponse(200, 'Conditional request without If-None-Match returned 200 OK.');
+    $this->assertResponse(304, 'Conditional request without If-None-Match returned 304 Not Modified.');
+
+    $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC1123, strtotime($last_modified) + 1)));
+    $this->assertResponse(200, 'Conditional request with new a If-Modified-Since date newer than Last-Modified returned 200 OK.');
     $this->assertEqual($this->backdropGetHeader('X-Backdrop-Cache'), 'HIT', 'Page was cached.');
 
     $this->backdropGet($test_path, array(), array('If-Modified-Since: ' . gmdate(DATE_RFC1123, strtotime($last_modified) + 1), 'If-None-Match: ' . $etag));
-    $this->assertResponse(200, 'Conditional request with new a If-Modified-Since date newer than Last-Modified returned 200 OK.');
+    $this->assertResponse(200, 'Conditional request with new a If-Modified-Since date newer than Last-Modified (and an If-None-Match) returned 200 OK.');
     $this->assertEqual($this->backdropGetHeader('X-Backdrop-Cache'), 'HIT', 'Page was cached.');
 
     $user = $this->backdropCreateUser();


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5126