### PR TITLE
Issue 5142: Add missing & to calls to backdrop_static().

### DIFF
--- a/core/modules/field/field.info.inc
+++ b/core/modules/field/field.info.inc
@@ -670,7 +670,7 @@ function field_info_bundles($entity_type = NULL) {
  */
 function field_info_field_map() {
   // Read from the "static" cache.
-  $field_info_cache = backdrop_static(__FUNCTION__, array());
+  $field_info_cache = &backdrop_static(__FUNCTION__, array());
 
   if (!empty($field_info_cache)) {
     return $field_info_cache;

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -2083,7 +2083,7 @@ function file_get_download_token($file) {
  * @see file_file_predelete()
  */
 function file_get_file_references(File $file, $field = NULL, $age = FIELD_LOAD_REVISION, $field_type = 'file', $check_access = TRUE) {
-  $references = backdrop_static(__FUNCTION__, array());
+  $references = &backdrop_static(__FUNCTION__, array());
   $fields = isset($field) ? array($field['field_name'] => $field) : field_info_fields();
 
   foreach ($fields as $field_name => $file_field) {

--- a/core/modules/redirect/redirect.module
+++ b/core/modules/redirect/redirect.module
@@ -223,7 +223,7 @@ function redirect_set_current_redirect($redirect) {
  *   The redirect object (if any) for the current page. FALSE if not found.
  */
 function redirect_get_current_redirect() {
-  $redirect = backdrop_static('redirect_set_current_redirect', NULL);
+  $redirect = &backdrop_static('redirect_set_current_redirect', NULL);
 
   if (!isset($redirect)) {
     $redirect = redirect_load_by_source(current_path(), $GLOBALS['language']->langcode, backdrop_get_query_parameters());

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -2782,6 +2782,10 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
     $this->backdropPost('admin/config/regional/date-time/formats/add', $edit, t('Add format'));
     $this->assertText(t('Date format updated.'));
 
+    // Reset the statically cached date formats so that these calls to
+    // format_date() will pick up the newly created date formats from config.
+    backdrop_static_reset('system_get_date_formats');
+
     $timestamp = strtotime('2007-03-10T00:00:00+00:00');
     $this->assertIdentical(format_date($timestamp, 'example_style', '', 'America/Los_Angeles'), '9 Mar 07', 'Test format_date() using an admin-defined date type.');
     $this->assertIdentical(format_date($timestamp, 'example_style_uppercase', '', 'America/Los_Angeles'), '9 Mar 2007', 'Test format_date() using an admin-defined date type with different case.');

--- a/core/modules/simpletest/tests/module.test
+++ b/core/modules/simpletest/tests/module.test
@@ -103,7 +103,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
 
     module_load_include('inc', 'module_test', 'module_test.file');
     $modules = module_implements('test_hook');
-    $static = backdrop_static('module_implements');
+    $static = &backdrop_static('module_implements');
     $this->assertTrue(in_array('module_test', $modules), 'Hook found.');
     $this->assertEqual($static['test_hook']['module_test'], 'file', 'Include file detected.');
   }

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3885,7 +3885,7 @@ function system_run_automated_cron() {
  *   string.
  */
 function system_get_date_formats($date_format_name = NULL) {
-  $date_formats = backdrop_static(__FUNCTION__, array());
+  $date_formats = &backdrop_static(__FUNCTION__, array());
   if (empty($date_formats)) {
     $date_formats = config_get('system.date', 'formats');
     foreach ($date_formats as $name => $format) {

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -1139,7 +1139,7 @@ function taxonomy_term_load_multiple($tids = array(), $conditions = array()) {
  *  An array of vocabulary objects, indexed by machine name.
  */
 function taxonomy_vocabulary_load_multiple($machine_names = array()) {
-  $static = backdrop_static(__FUNCTION__, array(
+  $static = &backdrop_static(__FUNCTION__, array(
     'vocabularies' => array(),
     'machine_names' => NULL,
   ));


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5142.

Add missing & to several calls to `backdrop_static()`. This doesn't include a change needed in `path.module`, which should be addressed by the PR connected to https://github.com/backdrop/backdrop-issues/issues/5137.