### PR TITLE
Issue #5146: Config import should list all invalid configs (v2)

### DIFF
--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -44,16 +44,16 @@ function _config_sync_validate(&$context) {
     $context['sandbox']['current_index'] = 0;
   }
 
-    $config_files = array_slice($context['results']['pending_changes'], $context['sandbox']['current_index'], $context['sandbox']['batch_size']);
-    foreach ($config_files as $config_file => $config_change_type) {
-        try {
-            config_sync_validate_file($config_file, $config_change_type, $context['results']['all_configs']);
-        }
-        catch (ConfigValidateException $e) {
-            $context['results']['errors'][] = $e->getMessage();
-        }
-        $context['sandbox']['current_index']++;
-    }
+  $config_files = array_slice($context['results']['pending_changes'], $context['sandbox']['current_index'], $context['sandbox']['batch_size']);
+  foreach ($config_files as $config_file => $config_change_type) {
+      try {
+          config_sync_validate_file($config_file, $config_change_type, $context['results']['all_configs']);
+      }
+      catch (ConfigValidateException $e) {
+          $context['results']['errors'][] = $e->getMessage();
+      }
+      $context['sandbox']['current_index']++;
+  }
 
   $context['finished'] = $context['sandbox']['total_size'] ? $context['sandbox']['current_index'] / $context['sandbox']['total_size'] : 1;
 }

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -44,18 +44,16 @@ function _config_sync_validate(&$context) {
     $context['sandbox']['current_index'] = 0;
   }
 
-  $config_files = array_slice($context['results']['pending_changes'], $context['sandbox']['current_index'], $context['sandbox']['batch_size']);
-  try {
+    $config_files = array_slice($context['results']['pending_changes'], $context['sandbox']['current_index'], $context['sandbox']['batch_size']);
     foreach ($config_files as $config_file => $config_change_type) {
-      config_sync_validate_file($config_file, $config_change_type, $context['results']['all_configs']);
-      $context['sandbox']['current_index']++;
+        try {
+            config_sync_validate_file($config_file, $config_change_type, $context['results']['all_configs']);
+        }
+        catch (ConfigValidateException $e) {
+            $context['results']['errors'][] = $e->getMessage();
+        }
+        $context['sandbox']['current_index']++;
     }
-  }
-  catch (ConfigValidateException $e) {
-    $context['results']['errors'][] = $e->getMessage();
-    $context['finished'] = 1;
-    return;
-  }
 
   $context['finished'] = $context['sandbox']['total_size'] ? $context['sandbox']['current_index'] / $context['sandbox']['total_size'] : 1;
 }
@@ -99,12 +97,11 @@ function _config_sync_finished($status, $results, $operations) {
   }
   if (!empty($results['completed_changes'])) {
     backdrop_set_message(t('Configuration sync completed. @files configuration files synced.', array('@files' => count($results['completed_changes']))));
-    if (config_get('system.core', 'config_sync_clear_staging')) {
-      // Clean up the staging directory.
-      $config_dir = config_get_config_directory('staging');
-      $config_storage = new ConfigFileStorage($config_dir);
-      $config_storage->deleteAll();
-    }
+
+    // Clean up the staging directory.
+    $config_dir = config_get_config_directory('staging');
+    $config_storage = new ConfigFileStorage($config_dir);
+    $config_storage->deleteAll();
   }
 
   backdrop_flush_all_caches();

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -97,7 +97,7 @@ function _config_sync_finished($status, $results, $operations) {
   }
   if (!empty($results['completed_changes'])) {
     backdrop_set_message(t('Configuration sync completed. @files configuration files synced.', array('@files' => count($results['completed_changes']))));
-
+    if (config_get('system.core', 'config_sync_clear_staging')) {
     // Clean up the staging directory.
     $config_dir = config_get_config_directory('staging');
     $config_storage = new ConfigFileStorage($config_dir);

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -53,7 +53,7 @@ function _config_sync_validate(&$context) {
     catch (ConfigValidateException $e) {
       $context['results']['errors'][] = $e->getMessage();
     }
-      $context['sandbox']['current_index']++;
+    $context['sandbox']['current_index']++;
   }
 
   $context['finished'] = $context['sandbox']['total_size'] ? $context['sandbox']['current_index'] / $context['sandbox']['total_size'] : 1;

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -47,12 +47,12 @@ function _config_sync_validate(&$context) {
 
   $config_files = array_slice($context['results']['pending_changes'], $context['sandbox']['current_index'], $context['sandbox']['batch_size']);
   foreach ($config_files as $config_file => $config_change_type) {
-      try {
-          config_sync_validate_file($config_file, $config_change_type, $context['results']['all_configs']);
-      }
-      catch (ConfigValidateException $e) {
-          $context['results']['errors'][] = $e->getMessage();
-      }
+    try {
+      config_sync_validate_file($config_file, $config_change_type, $context['results']['all_configs']);
+    }
+    catch (ConfigValidateException $e) {
+      $context['results']['errors'][] = $e->getMessage();
+    }
       $context['sandbox']['current_index']++;
   }
 

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -104,7 +104,6 @@ function _config_sync_finished($status, $results, $operations) {
       $config_storage->deleteAll();
     }
   }
-
   backdrop_flush_all_caches();
   state_del('config_sync');
 }

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -36,6 +36,7 @@ function _config_sync_start($config_statuses, &$context) {
 
 /**
  * Batch API callback. Validate the changes before attempting to sync.
+ * Reports all discovered issues in a message.
  */
 function _config_sync_validate(&$context) {
   if (!isset($context['sandbox']['batch_size'])) {

--- a/core/modules/config/config.sync.inc
+++ b/core/modules/config/config.sync.inc
@@ -98,10 +98,11 @@ function _config_sync_finished($status, $results, $operations) {
   if (!empty($results['completed_changes'])) {
     backdrop_set_message(t('Configuration sync completed. @files configuration files synced.', array('@files' => count($results['completed_changes']))));
     if (config_get('system.core', 'config_sync_clear_staging')) {
-    // Clean up the staging directory.
-    $config_dir = config_get_config_directory('staging');
-    $config_storage = new ConfigFileStorage($config_dir);
-    $config_storage->deleteAll();
+      // Clean up the staging directory.
+      $config_dir = config_get_config_directory('staging');
+      $config_storage = new ConfigFileStorage($config_dir);
+      $config_storage->deleteAll();
+    }
   }
 
   backdrop_flush_all_caches();


### PR DESCRIPTION
This PR changes the behavior of the Configuration Management full import to display a list of all incompatible configs, instead of only listing the first one found. Solution provided by @hosef.

Fixes: https://github.com/backdrop/backdrop-issues/issues/5146

(2nd attempt)