### PR TITLE
Issue #3008: handle docroots that are symlinks

### DIFF
--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -168,8 +168,15 @@ abstract class FileTransfer {
    */
   protected final function checkPath($path) {
     $chroot_jail = $this->chroot . $this->jail;
-    $real_jail = backdrop_realpath($chroot_jail);
     $chroot_path = $this->chroot . $path;
+    $full_path = backdrop_realpath(substr($chroot_path, 0, strlen($chroot_jail)));
+    $full_path = $this->fixRemotePath($full_path, FALSE);
+    if ($chroot_jail === $full_path) {
+      // simple test case passes
+      return;
+    }
+    // try handling symbolic links
+    $real_jail = backdrop_realpath($chroot_jail);
     $existing_path = $chroot_path;
     while ($existing_path && !file_exists($existing_path)) {
       $existing_path = dirname($existing_path);

--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -167,10 +167,16 @@ abstract class FileTransfer {
    *
    */
   protected final function checkPath($path) {
-    $full_jail = $this->chroot . $this->jail;
-    $full_path = backdrop_realpath(substr($this->chroot . $path, 0, strlen($full_jail)));
-    $full_path = $this->fixRemotePath($full_path, FALSE);
-    if ($full_jail !== $full_path) {
+    $chroot_jail = $this->chroot . $this->jail;
+    $real_jail = backdrop_realpath($chroot_jail);
+    $chroot_path = $this->chroot . $path;
+    $existing_path = $chroot_path;
+    while ($existing_path && !file_exists($existing_path)) {
+      $existing_path = dirname($existing_path);
+    }
+    $real_path = backdrop_realpath($existing_path);
+    $fixed_path = $this->fixRemotePath($real_path, FALSE);
+    if (strpos($fixed_path, $real_jail) !== 0) {
       throw new FileTransferException('@directory is outside of the @jail', NULL, array('@directory' => $path, '@jail' => $this->jail));
     }
   }

--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -180,9 +180,6 @@ abstract class FileTransfer {
     $front_path = array_shift($parts);
     while ($parts) {
       $front_path .= '/' . array_shift($parts);
-      if (!file_exists($front_path)) {
-        break;
-      }
       $real_path = backdrop_realpath($front_path);
       $fixed_path = $this->fixRemotePath($real_path, FALSE);
       if (strpos($fixed_path, $chroot_jail) === 0) {

--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -181,10 +181,10 @@ abstract class FileTransfer {
     while ($parts) {
       $front_path .= '/' . array_shift($parts);
       if (is_link($front_path)) {
-        $real_path = backdrop_realpath($front_path);
+        $real_path = realpath($front_path);
         $fixed_path = $this->fixRemotePath($real_path, FALSE);
         if (strpos($fixed_path, $chroot_jail) === 0) {
-          // the path goes through a symlink that is inside the jail - pass
+          // the path starts with a symlink that is equal to or inside the jail - pass
           return;
         }
       }

--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -169,23 +169,30 @@ abstract class FileTransfer {
   protected final function checkPath($path) {
     $chroot_jail = $this->chroot . $this->jail;
     $chroot_path = $this->chroot . $path;
-    $full_path = backdrop_realpath(substr($chroot_path, 0, strlen($chroot_jail)));
-    $full_path = $this->fixRemotePath($full_path, FALSE);
-    if ($chroot_jail === $full_path) {
-      // simple test case passes
+    $fixed_path = $this->fixRemotePath($chroot_path, FALSE);
+    if (strpos($fixed_path, $chroot_jail) === 0) {
+      // simplest case - path begins with jail - pass
       return;
     }
-    // try handling symbolic links
-    $real_jail = backdrop_realpath($chroot_jail);
-    $existing_path = $chroot_path;
-    while ($existing_path && !file_exists($existing_path)) {
-      $existing_path = dirname($existing_path);
+    // look for a symlink
+    $parts = explode('/', $chroot_path);
+    // an empty string is the first entry
+    $front_path = array_shift($parts);
+    while ($parts) {
+      $front_path .= '/' . array_shift($parts);
+      if (is_link($front_path)) {
+        $real_path = backdrop_realpath($front_path);
+        $fixed_path = $this->fixRemotePath($real_path, FALSE);
+        if (strpos($fixed_path, $chroot_jail) === 0) {
+          // the path goes through a symlink that is inside the jail - pass
+          return;
+        }
+      }
+      if (!file_exists($front_path)) {
+        break;
+      }
     }
-    $real_path = backdrop_realpath($existing_path);
-    $fixed_path = $this->fixRemotePath($real_path, FALSE);
-    if (strpos($fixed_path, $real_jail) !== 0) {
-      throw new FileTransferException('@directory is outside of the @jail', NULL, array('@directory' => $path, '@jail' => $this->jail));
-    }
+    throw new FileTransferException('@directory is outside of the @jail', NULL, array('@directory' => $path, '@jail' => $this->jail));
   }
 
   /**

--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -180,16 +180,14 @@ abstract class FileTransfer {
     $front_path = array_shift($parts);
     while ($parts) {
       $front_path .= '/' . array_shift($parts);
-      if (is_link($front_path)) {
-        $real_path = realpath($front_path);
-        $fixed_path = $this->fixRemotePath($real_path, FALSE);
-        if (strpos($fixed_path, $chroot_jail) === 0) {
-          // the path starts with a symlink that is equal to or inside the jail - pass
-          return;
-        }
-      }
       if (!file_exists($front_path)) {
         break;
+      }
+      $real_path = backdrop_realpath($front_path);
+      $fixed_path = $this->fixRemotePath($real_path, FALSE);
+      if (strpos($fixed_path, $chroot_jail) === 0) {
+        // the path starts with a symlink that is equal to or inside the jail - pass
+        return;
       }
     }
     throw new FileTransferException('@directory is outside of the @jail', NULL, array('@directory' => $path, '@jail' => $this->jail));

--- a/core/misc/zen-ci/init_test.sh
+++ b/core/misc/zen-ci/init_test.sh
@@ -7,23 +7,14 @@
 # https://github.com/backdrop-ops/backdropcms.org/tree/master/www/modules/custom/borg_qa
 ##
 
-#set site path
+# Set site path variable.
 SITEPATH="$HOME/www"
 
-# Go to domain directory.
-cd $SITEPATH
+# Remove the old site path.
+rm -rf $SITEPATH
 
-# Link Backdrop files
-ln -s $GITLC_DEPLOY_DIR/* ./
-ln -s $GITLC_DEPLOY_DIR/.htaccess ./
-
-# Unlink settings.php and copy instead.
-rm -f settings.php
-cp $GITLC_DEPLOY_DIR/settings.php ./
-
-# Unlink files and copy instead.
-rm -f files
-cp -r $GITLC_DEPLOY_DIR/files ./
+# Link to the git checkout.
+ln -s $GITLC_DEPLOY_DIR $SITEPATH
 
 # Install Backdrop.
 php $SITEPATH/core/scripts/install.sh  --db-url=mysql://test:@localhost/test --root=/home/test/www


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#3008 - update FileTransfer::checkPath() to check real filesystem paths when normal path checking fails. Usually encountered when the web server is serving from a document root that is a symlink.