### PR TITLE
Issue #3008: Fix module updates if docroot is a symlink

### DIFF
--- a/core/includes/filetransfer/filetransfer.inc
+++ b/core/includes/filetransfer/filetransfer.inc
@@ -167,6 +167,10 @@ abstract class FileTransfer {
    *
    */
   protected final function checkPath($path) {
+    // Resolve symbolic link in given path, if the root directory is a symlink.
+    if (is_link(BACKDROP_ROOT)) {
+      $path = realpath($path);
+    }
     $full_jail = $this->chroot . $this->jail;
     $full_path = backdrop_realpath(substr($this->chroot . $path, 0, strlen($full_jail)));
     $full_path = $this->fixRemotePath($full_path, FALSE);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3008

Alternate approach with less impact, more specific to the problem when BACKDROP_ROOT is a symlink.

Why resolving the path in advance?
Because otherwise the substring length of the concatenated path, which is passed to backdrop_realpath() ends up wrong, and backdrop_realpath returns FALSE.

Example:
```
$path = '/var/www/bdroptesting/html/modules/devel';// The unresolved path, "html" is a symlink.
$full_jail = '/var/www/bdroptesting/html_real';// The length of the resolved base path differs in this case and could be something totally different anyway.
...
...substr($this->chroot . $path, 0, strlen($full_jail)) // '/var/www/bdroptesting/html/modu' -> Obviously wrong, can never get resolved by backdrop_realpath.
```

Note that this PR is only still open for discussion, personally I don't recommend that approach anymore.