### PR TITLE
Issue #4571: Allow messages to be dismissable.

### DIFF
--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1751,9 +1751,15 @@ function theme_datetime($variables) {
  *     of that type.
  */
 function theme_status_messages($variables) {
+  $config = config('system.core');
   $display = $variables['display'];
   $message_types = (empty($variables['messages']))? backdrop_get_messages($display) : $variables['messages'];
   $output = '';
+
+  // Add the 'Dismiss' library.
+  if ($config->get('messages_dismissable')) {
+    backdrop_add_library('system', 'backdrop.dismiss');
+  }
 
   $status_heading = array(
     'status' => t('Status message'),
@@ -1776,6 +1782,9 @@ function theme_status_messages($variables) {
     }
     else {
       $output .= reset($messages) . "\n";
+    }
+    if ($config->get('messages_dismissable')) {
+      $output .= '<a href="#" class="dismiss" title="' . t('Dismiss') . '"><span class="element-invisible">' . t('Dismiss') . '</span></a>' . "\n";
     }
     $output .= "</div>\n";
   }

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1777,7 +1777,7 @@ function theme_status_messages($variables) {
     else {
       $output .= reset($messages) . "\n";
     }
-    if (config_get('system.core', 'messages_dismissible');) {
+    if (config_get('system.core', 'messages_dismissible')) {
       // Add the 'Dismiss' library and place a 'Dismiss' link on messages.
       backdrop_add_library('system', 'backdrop.dismiss');
       $output .= '<a href="#" class="dismiss" title="' . t('Dismiss') . '"><span class="element-invisible">' . t('Dismiss') . '</span></a>' . "\n";

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1751,15 +1751,9 @@ function theme_datetime($variables) {
  *     of that type.
  */
 function theme_status_messages($variables) {
-  $config = config('system.core');
   $display = $variables['display'];
   $message_types = (empty($variables['messages']))? backdrop_get_messages($display) : $variables['messages'];
   $output = '';
-
-  // Add the 'Dismiss' library.
-  if ($config->get('messages_dismissable')) {
-    backdrop_add_library('system', 'backdrop.dismiss');
-  }
 
   $status_heading = array(
     'status' => t('Status message'),
@@ -1783,7 +1777,9 @@ function theme_status_messages($variables) {
     else {
       $output .= reset($messages) . "\n";
     }
-    if ($config->get('messages_dismissable')) {
+    if (config_get('system.core', 'messages_dismissible');) {
+      // Add the 'Dismiss' library and place a 'Dismiss' link on messages.
+      backdrop_add_library('system', 'backdrop.dismiss');
       $output .= '<a href="#" class="dismiss" title="' . t('Dismiss') . '"><span class="element-invisible">' . t('Dismiss') . '</span></a>' . "\n";
     }
     $output .= "</div>\n";

--- a/core/misc/dismiss.js
+++ b/core/misc/dismiss.js
@@ -1,0 +1,24 @@
+(function ($) {
+
+"use strict";
+
+/**
+ * Add buttons to messages to allow users to dismiss them.
+ */
+Backdrop.behaviors.dismiss = {
+  attach: function (context, settings) {
+
+    $('.messages a.dismiss').click(function(event) {
+      event.preventDefault();
+
+      $(this).parent().fadeOut('fast', function() {
+        if ($('.l-messages').children(':visible').size() == 0) {
+          $('.l-messages').hide();
+        }
+      });
+    });
+
+  }
+};
+
+})(jQuery);

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -49,6 +49,7 @@
     "maintenance_page_maximum_age": 10,
     "maintenance_theme": null,
     "menu_route_handler": null,
+    "messages_dismissable": 0,
     "node_admin_theme": "",
     "page_cache_maximum_age": 300,
     "page_cache_background_fetch": 1,

--- a/core/modules/system/config/system.core.json
+++ b/core/modules/system/config/system.core.json
@@ -49,7 +49,7 @@
     "maintenance_page_maximum_age": 10,
     "maintenance_theme": null,
     "menu_route_handler": null,
-    "messages_dismissable": 0,
+    "messages_dismissible": 1,
     "node_admin_theme": "",
     "page_cache_maximum_age": 300,
     "page_cache_background_fetch": 1,

--- a/core/modules/system/css/messages.theme.css
+++ b/core/modules/system/css/messages.theme.css
@@ -124,3 +124,34 @@ div.messages.info:before {
   background-image: linear-gradient(transparent, transparent), url(../../../misc/message-info.svg);
 }
 
+/* Dismiss buttons */
+.messages .dismiss {
+  display: block;
+  height: 15px;
+  position: absolute;
+  right: 5px; /* LTR */
+  top: 5px;
+  width: 15px;
+}
+.messages .dismiss:before,
+.messages .dismiss:after {
+  background: #999;
+  content: '';
+  display: block;
+  height: 2px;
+  margin-top: 6px;
+  width: 15px;
+}
+.messages .dismiss:before {
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}
+.messages .dismiss:after {
+  margin-top: -2px;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+[dir="rtl"] .messages .dismiss {
+  left: 5px;
+  right: auto;
+}

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1617,6 +1617,28 @@ function system_run_cron_submit($form, &$form_state) {
 }
 
 /**
+ * Form builder; Messages form.
+ *
+ * @ingroup forms
+ */
+function system_message_settings($form, &$form_state) {
+  $form['#config'] = 'system.core';
+
+  $form['messages'] = array(
+    '#title' => t('Message configuration'),
+    '#type' => 'fieldset',
+  );
+  $form['messages']['messages_dismissable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow messages to be dismissed'),
+    '#description' => t('A link will be added to all messages, allowing users to manually dismiss them.'),
+    '#default_value' => config_get('system.core', 'messages_dismissable'),
+  );
+
+  return system_settings_form($form);
+}
+
+/**
  * Form builder; Configure error reporting settings.
  *
  * @ingroup forms

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1617,28 +1617,6 @@ function system_run_cron_submit($form, &$form_state) {
 }
 
 /**
- * Form builder; Messages form.
- *
- * @ingroup forms
- */
-function system_message_settings($form, &$form_state) {
-  $form['#config'] = 'system.core';
-
-  $form['messages'] = array(
-    '#title' => t('Message configuration'),
-    '#type' => 'fieldset',
-  );
-  $form['messages']['messages_dismissable'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Allow messages to be dismissed'),
-    '#description' => t('A link will be added to all messages, allowing users to manually dismiss them.'),
-    '#default_value' => config_get('system.core', 'messages_dismissable'),
-  );
-
-  return system_settings_form($form);
-}
-
-/**
  * Form builder; Configure error reporting settings.
  *
  * @ingroup forms

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3194,11 +3194,11 @@ function system_update_1075() {
 }
 
 /*
- * Add default values for message settings.
+ * Add default values for dismissible message settings.
  */
 function system_update_1076() {
   $config = config('system.core');
-  $config->set('messages_dismissible', 0);
+  $config->set('messages_dismissible', 1);
   $config->save();
 }
 

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3181,7 +3181,7 @@ function system_update_1074() {
  * This will make it so that the Google Federated Learning of Cohorts (FLoC)
  * feature that gathers user data without cookies is blocked by default, unless
  * overridden in settings.php.
- * 
+ *
  * For more information, see the change record at:
  * https://docs.backdropcms.org/change-records/header-added-by-default-to-disable-floc
  */
@@ -3191,6 +3191,15 @@ function system_update_1075() {
   $config->save();
 
   update_variable_del('block_interest_cohort');
+}
+
+/*
+ * Add default values for message settings.
+ */
+function system_update_1076() {
+  $config = config('system.core');
+  $config->set('messages_dismissable', 0);
+  $config->save();
 }
 
 /**

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3198,7 +3198,7 @@ function system_update_1075() {
  */
 function system_update_1076() {
   $config = config('system.core');
-  $config->set('messages_dismissable', 0);
+  $config->set('messages_dismissible', 0);
   $config->save();
 }
 

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -944,6 +944,15 @@ function system_menu() {
     'file' => 'system.admin.inc',
     'weight' => 20,
   );
+  $items['admin/config/system/messages'] = array(
+    'title' => 'Messages',
+    'description' => 'Configure the display of site messages.',
+    'page callback' => 'backdrop_get_form',
+    'page arguments' => array('system_message_settings'),
+    'access arguments' => array('administer site configuration'),
+    'file' => 'system.admin.inc',
+    'weight' => 25,
+  );
 
   // URL handling.
   $items['admin/config/urls'] = array(
@@ -1322,6 +1331,15 @@ function system_library_info() {
     $libraries['backdrop.menus']['css'][$system_module_path . '/css/menu-dropdown.theme.css'] = array('group' => CSS_DEFAULT);
     $libraries['backdrop.menu-toggle']['css'][$system_module_path . '/css/menu-toggle.theme.css'] = array('group' => CSS_DEFAULT);
   }
+
+  // Dismiss buttons.
+  $libraries['backdrop.dismiss'] = array(
+    'title' => 'Dismiss buttons',
+    'version' => BACKDROP_VERSION,
+    'js' => array(
+      'core/misc/dismiss.js' => array('group' => JS_DEFAULT),
+    ),
+  );
 
   // jQuery.
   $libraries['jquery'] = array(

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -944,15 +944,6 @@ function system_menu() {
     'file' => 'system.admin.inc',
     'weight' => 20,
   );
-  $items['admin/config/system/messages'] = array(
-    'title' => 'Messages',
-    'description' => 'Configure the display of site messages.',
-    'page callback' => 'backdrop_get_form',
-    'page arguments' => array('system_message_settings'),
-    'access arguments' => array('administer site configuration'),
-    'file' => 'system.admin.inc',
-    'weight' => 25,
-  );
 
   // URL handling.
   $items['admin/config/urls'] = array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4571

Replaces https://github.com/backdrop/backdrop/pull/3387

I've added a second commit to the PR that:
* removes the UI
* changes the spelling from `dismissable` to `dismissible` 
* Simplifies the changes in `theme.inc` (one `if` instead of two, one call to `config_get()` instead of two)
* and updates the number of the update hook in system module.