### PR TITLE
Issue 5203: MIssing update description for system_update_1076()

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3193,7 +3193,7 @@ function system_update_1075() {
   update_variable_del('block_interest_cohort');
 }
 
-/*
+/**
  * Add default values for dismissible message settings.
  */
 function system_update_1076() {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5203.

Missing * in the docblock comment means that the description doesn't show up on update.php. Adding another * restores the description.