### PR TITLE
Issue #5208: Add a 'Save and configure permissions' button to the 'Add role' form

### DIFF
--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2158,9 +2158,8 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
 
     // Ensure both submit buttons exist in the "Add role" form.
     $this->clickLink(t('Add role'));
-    $this->assertResponse(200);
     $this->assertUrl('admin/config/people/roles/add', array(), 'Redirected to correct URL after clicking the "+ Add role" link.');
-    $this->assertTitle(t('Add role'), 'The title on the form is "Add role".');
+    $this->assertTitle(t('Add role'), 'The page title on the form page is "Add role".');
     $this->assertRaw(t('Save and set permissions'), '"Save and set permissions" button found on "Add role" form.');
     $this->assertRaw(t('Save role'), '"Save role" button found on "Add role" form.');
     $this->clickLink(t('Cancel'));
@@ -2178,9 +2177,8 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
 
     // Ensure only one submit button exists in the "Edit role" form.
     $this->clickLink(t('Configure role'));
-    $this->assertResponse(200);
     $this->assertUrl('admin/config/people/roles/configure/' . $role1_name, array(), 'Redirected to correct URL after clicking the "Configure role" operation.');
-    $this->assertTitle(t('Configure role'), 'The title on the form is "Configure role".');
+    $this->assertTitle(t('Configure role'), 'The page title on the form is "Configure role".');
     $this->assertNoRaw(t('Save and set permissions'), '"Save and set permissions" button not found on "Configure role" form.');
     $this->assertRaw(t('Save role'), '"Save role" button found on "Configure role" form.');
     $this->clickLink(t('Cancel'));

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2184,7 +2184,8 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     $this->backdropGet('admin/config/people/roles/configure/' . BACKDROP_AUTHENTICATED_ROLE);
     $this->assertResponse(200, 'Access granted when trying to edit the built-in authenticated role.');
 
-    // Create a default role for site administrators, with all available permissions assigned.
+    // Create a default role for site administrators, with all available
+    // permissions assigned.
     $admin_role = new stdClass();
     $admin_role->name = 'administrator';
     $admin_role->label = st('Administrator');

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2153,29 +2153,67 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
   function testRoleAdministration() {
     $this->backdropLogin($this->admin_user);
 
-    // Test adding a role.
-    $role_name = '123';
-    $edit = array('name' => $role_name, 'label' => $role_name);
+    // Visit the main roles administration page.
+    $this->backdropGet('admin/config/people/roles');
+
+    // Ensure both submit buttons exist in the "Add role" form.
+    $this->clickLink(t('Add role'));
+    $this->assertResponse(200);
+    $this->assertUrl('admin/config/people/roles/add', array(), 'Redirected to correct URL after clicking the "+ Add role" link.');
+    $this->assertTitle(t('Add role'), 'The title on the form is "Add role".');
+    $this->assertRaw(t('Save and set permissions'), '"Save and set permissions" button found on "Add role" form.');
+    $this->assertRaw(t('Save role'), '"Save role" button found on "Add role" form.');
+    $this->clickLink(t('Cancel'));
+    $this->assertRaw(t('Add role'), 'Redirected to the main roles listing page.');
+
+    // Test adding a role using the 'Save role' button.
+    $role1_name = '123';
+    $edit = array('name' => $role1_name, 'label' => $role1_name);
     $this->backdropPost('admin/config/people/roles/add', $edit, t('Save role'));
     $this->assertText(t('The 123 role has been added.'), 'The role has been added.');
+    $this->assertUrl('admin/config/people/roles', array(), 'Redirected to correct URL after clicking the "Save role" button.');
     backdrop_static_reset('user_roles');
-    $role = user_role_load($role_name);
-    $this->assertTrue(is_object($role), 'The role was successfully loaded from config.');
+    $role1 = user_role_load($role1_name);
+    $this->assertTrue(is_object($role1), 'The role was successfully loaded from config.');
+
+    // Ensure only one submit button exists in the "Edit role" form.
+    $this->clickLink(t('Configure role'));
+    $this->assertResponse(200);
+    $this->assertUrl('admin/config/people/roles/configure/' . $role1_name, array(), 'Redirected to correct URL after clicking the "Configure role" operation.');
+    $this->assertTitle(t('Configure role'), 'The title on the form is "Configure role".');
+    $this->assertNoRaw(t('Save and set permissions'), '"Save and set permissions" button not found on "Configure role" form.');
+    $this->assertRaw(t('Save role'), '"Save role" button found on "Configure role" form.');
+    $this->clickLink(t('Cancel'));
+    $this->assertRaw(t('Add role'), 'Redirected to the main roles listing page.');
+
+    // Test adding a role using the 'Save and set permissions' button.
+    $role2_name = '456';
+    $edit = array('name' => $role2_name, 'label' => $role2_name);
+    $this->backdropPost('admin/config/people/roles/add', $edit, t('Save and set permissions'));
+    $this->assertText(t('The 456 role has been added.'), 'The role has been added.');
+    $this->assertUrl('admin/config/people/permissions', array(), 'Redirected to correct URL after clicking the "Save and set permissions" button.');
+    backdrop_static_reset('user_roles');
+    $role2 = user_role_load($role2_name);
+    $this->assertTrue(is_object($role2), 'The role was successfully loaded from config.');
 
     // Try adding a duplicate role.
+    $duplicate_role_warning = t('The machine-readable name is already in use. It must be unique.');
+    $this->backdropPost('admin/config/people/roles/add', $edit, t('Save and set permissions'));
+    $this->assertRaw($duplicate_role_warning, 'Duplicate role warning displayed.');
     $this->backdropPost('admin/config/people/roles/add', $edit, t('Save role'));
-    $this->assertRaw(t('The machine-readable name is already in use. It must be unique.'), 'Duplicate role warning displayed.');
+    $this->assertRaw($duplicate_role_warning, 'Duplicate role warning displayed.');
 
-    // Test renaming a role.
-    $old_label = $role->label;
-    $new_label = '456';
+    // Test renaming an existing role.
+    $old_label = $role1->label;
+    $new_label = '789';
     $edit = array('label' => $new_label);
-    $this->backdropPost("admin/config/people/roles/configure/$role_name", $edit, t('Save role'));
-    $this->assertText(t('The 123 role has been renamed to 456.'), 'The role has been renamed.');
+    $this->backdropPost("admin/config/people/roles/configure/$role1_name", $edit, t('Save role'));
+    $this->assertText(t('The 123 role has been renamed to 789.'), 'The role has been renamed.');
+    $this->assertUrl('admin/config/people/roles', array(), 'Redirected to correct URL after clicking the renaming the role.');
     backdrop_static_reset('user_roles');
-    $role = user_role_load($role_name);
-    $this->assertFalse($role->label === $old_label, 'The role has had its label changed.');
-    $this->assertTrue($role->label === $new_label, 'The role has the new label.');
+    $role = user_role_load($role1_name);
+    $this->assertFalse($role1->label === $old_label, 'The role has had its label changed.');
+    $this->assertTrue($role1->label === $new_label, 'The role has the new label.');
 
     // Make sure that the system-defined roles can still be edited, to adjust
     // their labels.

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2159,7 +2159,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     // Ensure both submit buttons exist in the "Add role" form.
     $this->clickLink(t('Add role'));
     $this->assertUrl('admin/config/people/roles/add', array(), 'Redirected to correct URL after clicking the "+ Add role" link.');
-    $this->assertTitle(t('Add role'), 'The page title on the form page is "Add role".');
+    $this->assertTitle(t('Add role | Backdrop CMS'), 'The page title on the form page is "Add role".');
     $this->assertRaw(t('Save and set permissions'), '"Save and set permissions" button found on "Add role" form.');
     $this->assertRaw(t('Save role'), '"Save role" button found on "Add role" form.');
     $this->clickLink(t('Cancel'));
@@ -2176,9 +2176,9 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     $this->assertTrue(is_object($role1), 'The role was successfully loaded from config.');
 
     // Ensure only one submit button exists in the "Edit role" form.
-    $this->clickLink(t('Configure role'));
+    $this->clickLink(t('Configure role'), 3);
     $this->assertUrl('admin/config/people/roles/configure/' . $role1_name, array(), 'Redirected to correct URL after clicking the "Configure role" operation.');
-    $this->assertTitle(t('Configure role'), 'The page title on the form is "Configure role".');
+    $this->assertTitle(t('Configure role | Backdrop CMS'), 'The page title on the form is "Configure role".');
     $this->assertNoRaw(t('Save and set permissions'), '"Save and set permissions" button not found on "Configure role" form.');
     $this->assertRaw(t('Save role'), '"Save role" button found on "Configure role" form.');
     $this->clickLink(t('Cancel'));
@@ -2209,7 +2209,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
     $this->assertText(t('The 123 role has been renamed to 789.'), 'The role has been renamed.');
     $this->assertUrl('admin/config/people/roles', array(), 'Redirected to correct URL after clicking the renaming the role.');
     backdrop_static_reset('user_roles');
-    $role = user_role_load($role1_name);
+    $role1 = user_role_load($role1_name);
     $this->assertFalse($role1->label === $old_label, 'The role has had its label changed.');
     $this->assertTrue($role1->label === $new_label, 'The role has the new label.');
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -658,25 +658,22 @@ function user_admin_role($form, &$form_state, $role = NULL) {
     '#value' => empty($role->weight) ? 0 : $role->weight,
   );
   $form['actions'] = array('#type' => 'actions');
-  $form['actions']['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Save role'),
-    '#weight' => 2,
-  );
   // Only show the 'Save and set permissions' button when creating a new role.
   if (empty($role)) {
     $form['actions']['continue'] = array(
       '#type' => 'submit',
       '#value' => t('Save and set permissions'),
-      '#weight' => 1,
     );
   }
+  $form['actions']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save role'),
+  );
   $form['actions']['cancel'] = array(
     '#type' => 'link',
     '#href' => 'admin/config/people/roles',
     '#title' => t('Cancel'),
     '#options' => array('attributes' => array('class' => array('form-cancel'))),
-    '#weight' => 15,
   );
 
   return $form;

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -639,7 +639,7 @@ function user_admin_role($form, &$form_state, $role = NULL) {
     '#size' => 30,
     '#required' => TRUE,
     '#maxlength' => 64,
-    '#description' => t('The name for this role. Example: "moderator", "editorial board", "site architect".'),
+    '#description' => t('The name for this role. Example: "Moderator", "Editorial board", "Site architect".'),
   );
   $form['name'] = array(
     '#type' => 'machine_name',
@@ -661,13 +661,24 @@ function user_admin_role($form, &$form_state, $role = NULL) {
   $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save role'),
+    '#weight' => 2,
   );
+  // Only show the 'Save and configure permissions' button when creating a new
+  // role.
+  if (empty($role)) {
+    $form['actions']['continue'] = array(
+      '#type' => 'submit',
+      '#value' => t('Save and configure permissions'),
+      '#weight' => 1,
+    );
+  }
   $form['actions']['cancel'] = array(
     '#type' => 'link',
     '#href' => 'admin/config/people/roles',
     '#title' => t('Cancel'),
+    '#options' => array('attributes' => array('class' => array('form-cancel'))),
+    '#weight' => 15,
   );
-  $form['actions']['cancel']['#options']['attributes']['class'][] = 'form-cancel';
 
   return $form;
 }
@@ -684,6 +695,7 @@ function user_admin_role_submit($form, &$form_state) {
     );
     user_role_save($role);
     backdrop_set_message(t('The %role role has been added.', array('%role' => $role->label)));
+    $redirect = 'admin/config/people/permissions';
   }
   else {
     // Update existing role.
@@ -693,9 +705,10 @@ function user_admin_role_submit($form, &$form_state) {
     user_role_save($role);
     $new_role = $role->label;
     backdrop_set_message(t('The %old_role role has been renamed to %new_role.', array('%old_role' => $old_role, '%new_role' => $new_role)));
+    $redirect = 'admin/config/people/roles';
   }
 
-  $form_state['redirect'] = 'admin/config/people/roles';
+  $form_state['redirect'] = $redirect;
 }
 
 /**

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -683,7 +683,7 @@ function user_admin_role($form, &$form_state, $role = NULL) {
  * Form submit handler for the user_admin_role() form.
  */
 function user_admin_role_submit($form, &$form_state) {
-  //Set the default redirect.
+  // Set the default redirect.
   $redirect = 'admin/config/people/roles';
 
   if (empty($form_state['role'])) {

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -683,6 +683,9 @@ function user_admin_role($form, &$form_state, $role = NULL) {
  * Form submit handler for the user_admin_role() form.
  */
 function user_admin_role_submit($form, &$form_state) {
+  //Set the default redirect.
+  $redirect = 'admin/config/people/roles';
+
   if (empty($form_state['role'])) {
     // Save a new role.
     $role = (object) array(
@@ -691,7 +694,11 @@ function user_admin_role_submit($form, &$form_state) {
     );
     user_role_save($role);
     backdrop_set_message(t('The %role role has been added.', array('%role' => $role->label)));
-    $redirect = 'admin/config/people/permissions';
+    // Determine whether it was the 'Save and set permissions' or the 'Save
+    // role' button that was clicked, and set the form redirect accordingly.
+    if ($form_state['triggering_element']['#id'] == 'edit-continue') {
+      $redirect = 'admin/config/people/permissions';
+    }
   }
   else {
     // Update existing role.
@@ -701,7 +708,6 @@ function user_admin_role_submit($form, &$form_state) {
     user_role_save($role);
     $new_role = $role->label;
     backdrop_set_message(t('The %old_role role has been renamed to %new_role.', array('%old_role' => $old_role, '%new_role' => $new_role)));
-    $redirect = 'admin/config/people/roles';
   }
 
   $form_state['redirect'] = $redirect;

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -663,12 +663,11 @@ function user_admin_role($form, &$form_state, $role = NULL) {
     '#value' => t('Save role'),
     '#weight' => 2,
   );
-  // Only show the 'Save and configure permissions' button when creating a new
-  // role.
+  // Only show the 'Save and set permissions' button when creating a new role.
   if (empty($role)) {
     $form['actions']['continue'] = array(
       '#type' => 'submit',
-      '#value' => t('Save and configure permissions'),
+      '#value' => t('Save and set permissions'),
       '#weight' => 1,
     );
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5208