### PR TITLE
Issue #4862: Attempt to fix random failures in batch operations.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -6003,6 +6003,9 @@ function _backdrop_bootstrap_full() {
     // specific file directory.
     ini_set('log_errors', 1);
     ini_set('error_log', 'public://error.log');
+
+    // Disable garbage collection inside of test runs.
+    gc_disable();
   }
 
   // Initialize $_GET['q'] prior to invoking hook_init().


### PR DESCRIPTION
A different approach at trying to fix some of our random test failures.

This tries something similar to https://www.drupal.org/project/drupal/issues/2828559, which discovered a weird issue with random failures caused by PHP's Garbage Collection occurring when running update.php. This may be similar to our problem with tests that use Batch API (like PathPatternBulkUpdateTestCase) failing intermittently.

Relates to https://github.com/backdrop/backdrop-issues/issues/4862