### PR TITLE
Issue #5215: Fix filter_dialog test syntax on older php versions

### DIFF
--- a/core/modules/filter/tests/filter_dialog.test
+++ b/core/modules/filter/tests/filter_dialog.test
@@ -22,7 +22,7 @@ class FilterEditorLinkValidateTestCase extends BackdropWebTestCase {
       'ckeditor',
       'filter_formtest',
       'language',
-      'locale',
+      'locale'
     );
 
     // Add a language and set it as default.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5215