### PR TITLE
Issue #999: Revised - Add a 'Save and add terms' button to the 'Add vocabulary'…

### DIFF
--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -754,7 +754,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
     $vocabulary = $this->addVocabulary();
     $pattern = $vocabulary->machine_name . '/[term:name]/foo';
     $edit = array('path_pattern' =>  $pattern);
-    $this->backdropPost('admin/structure/taxonomy/' . $vocabulary->machine_name . '/configure', $edit, 'Save');
+    $this->backdropPost('admin/structure/taxonomy/' . $vocabulary->machine_name . '/configure', $edit, 'Save vocabulary');
     // Check that the page URL alias pattern is on the pathauto form.
     $this->backdropGet('admin/config/urls/path/patterns');
     $this->assertFieldByName('taxonomy_term_' . $vocabulary->machine_name . '_pattern', $pattern, 'URL alias pattern set with vocabulary settings appears on path config page.');

--- a/core/modules/taxonomy/taxonomy.admin.inc
+++ b/core/modules/taxonomy/taxonomy.admin.inc
@@ -214,7 +214,25 @@ function taxonomy_form_vocabulary($form, &$form_state, TaxonomyVocabulary $vocab
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
-    '#value' => t('Save'),
+    '#value' => t('Save vocabulary'),
+    '#weight' => 2,
+  );
+
+  // Only show 'Save and add terms' button when creating new vocabulary.
+  if ($vocabulary->machine_name == NULL) {
+    $form['actions']['continue'] = array(
+      '#type' => 'submit',
+      '#value' => t('Save and add terms'),
+      '#weight' => 1,
+    );
+  }
+
+  $form['actions']['cancel'] = array(
+    '#type' => 'link',
+    '#title' => t('Cancel'),
+    '#href' => 'admin/structure/taxonomy',
+    '#options' => array('attributes' => array('class' => array('form-cancel'))),
+    '#weight' => 15,
   );
 
   return $form;
@@ -343,7 +361,7 @@ function taxonomy_form_vocabulary_submit($form, &$form_state) {
     case SAVED_NEW:
       backdrop_set_message(t('Created new vocabulary %name.', array('%name' => $vocabulary->name)));
       watchdog('taxonomy', 'Created new vocabulary %name.', array('%name' => $vocabulary->name), WATCHDOG_NOTICE, l(t('configure'), 'admin/structure/taxonomy/' . $vocabulary->machine_name . '/configure'));
-      $form_state['redirect'] = 'admin/structure/taxonomy/' . $vocabulary->machine_name;
+      $form_state['redirect'] = 'admin/structure/taxonomy';
       // Save new permissions
       foreach ($form_state['values']['roles'] as $role_name => $role) {
         $valid_perms = array();
@@ -355,6 +373,10 @@ function taxonomy_form_vocabulary_submit($form, &$form_state) {
           }
         }
         user_role_grant_permissions($role->name, $valid_perms);
+      }
+
+      if ($form_state['triggering_element']['#value'] == t('Save and add terms')) {
+        $form_state['redirect'] = 'admin/structure/taxonomy/' . $vocabulary->machine_name . '/add';
       }
       break;
 
@@ -769,7 +791,7 @@ function taxonomy_form_term($form, &$form_state, TaxonomyTerm $term = NULL, Taxo
   if (!isset($vocabulary) && isset($term->vocabulary)) {
     $vocabulary = taxonomy_vocabulary_load($term->vocabulary);
   }
-  
+
   // During initial form build, add the term entity to the form state for use
   // during form building and processing. During a rebuild, use what is in the
   // form state.
@@ -908,8 +930,9 @@ function taxonomy_form_term($form, &$form_state, TaxonomyTerm $term = NULL, Taxo
   else {
     $path = '<front>';
   }
-  $options = backdrop_parse_url($path);
-  $options['attributes']['class'][] = 'form-cancel';
+
+  $cancel_options = backdrop_parse_url($path);
+  $cancel_options['attributes']['class'][] = 'form-cancel';
 
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
@@ -930,12 +953,11 @@ function taxonomy_form_term($form, &$form_state, TaxonomyTerm $term = NULL, Taxo
   else {
     $form_state['redirect'] = $_GET['q'];
   }
-
   $form['actions']['cancel'] = array(
     '#type' => 'link',
     '#title' => t('Cancel'),
-    '#href' => $options['path'],
-    '#options' => $options,
+    '#href' => $cancel_options['path'],
+    '#options' => $cancel_options,
     '#weight' => 15,
   );
 

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -159,7 +159,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     $edit = array(
       $role_name . '[edit terms in tags]' => TRUE,
     );
-    $this->backdropPost('admin/structure/taxonomy/tags/configure', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/tags/configure', $edit, t('Save vocabulary'));
 
     // Check that the permission changes are saved on the permissions page.
     $this->backdropGet('admin/config/people/permissions');
@@ -1719,7 +1719,7 @@ class TaxonomyLanguageFunctionalTest extends TaxonomyWebTestCase {
     $this->clickLink(t('Configure'));
     $edit = array();
     $edit['language'] = TAXONOMY_LANGUAGE_ENABLED;
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->backdropPost(NULL, $edit, t('Save vocabulary'));
 
     // Check vocabulary settings.
     $this->backdropGet('admin/structure/taxonomy');
@@ -1736,7 +1736,7 @@ class TaxonomyLanguageFunctionalTest extends TaxonomyWebTestCase {
     $this->clickLink(t('Configure'));
     $edit = array();
     $edit['language'] = TAXONOMY_LANGUAGE_ENABLED;
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->backdropPost(NULL, $edit, t('Save vocabulary'));
 
     $terms = array(
       'term1' => $this->randomName(),

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -59,15 +59,28 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     // Visit the main taxonomy administration page.
     $this->backdropGet('admin/structure/taxonomy');
 
-    // Create a new vocabulary.
+    // Create a new vocabulary and then add terms.
     $this->clickLink(t('Add vocabulary'));
     $edit = array();
     $machine_name = backdrop_strtolower($this->randomName());
     $edit['name'] = $this->randomName();
     $edit['description'] = $this->randomName();
     $edit['machine_name'] = $machine_name;
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->backdropPost(NULL, $edit, t('Save and add terms'));
     $this->assertRaw(t('Created new vocabulary %name.', array('%name' => $edit['name'])), 'Vocabulary created successfully.');
+    $this->assertRaw(t('Add term'), 'Redirected to add term form');
+
+    // Create a new vocabulary.
+    $this->backdropGet('admin/structure/taxonomy');
+    $this->clickLink(t('Add vocabulary'));
+    $edit = array();
+    $machine_name = backdrop_strtolower($this->randomName());
+    $edit['name'] = $this->randomName();
+    $edit['description'] = $this->randomName();
+    $edit['machine_name'] = $machine_name;
+    $this->backdropPost(NULL, $edit, t('Save vocabulary'));
+    $this->assertRaw(t('Created new vocabulary %name.', array('%name' => $edit['name'])), 'Vocabulary created successfully.');
+    $this->assertRaw(t('Add vocabulary'), 'Redirected to vocabulary listing page');
 
     // Configure the vocabulary.
     $this->backdropGet('admin/structure/taxonomy');
@@ -75,18 +88,18 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     $this->clickLink(t('Configure'));
     $edit = array();
     $edit['name'] = $this->randomName();
-    $this->backdropPost(NULL, $edit, t('Save'));
+    $this->backdropPost(NULL, $edit, t('Save vocabulary'));
     $this->backdropGet('admin/structure/taxonomy');
     $this->assertText($edit['name'], 'Vocabulary found in the vocabulary overview listing.');
 
     // Try to submit a vocabulary with a duplicate machine name.
     $edit['machine_name'] = $machine_name;
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
     $this->assertText(t('The machine-readable name is already in use. It must be unique.'));
 
     // Try to submit an invalid machine name.
     $edit['machine_name'] = '!&^%';
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
     $this->assertText(t('The machine-readable name must contain only lowercase letters, numbers, and underscores.'));
 
     // Ensure that vocabulary titles are escaped properly.
@@ -94,7 +107,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
     $edit['name'] = 'Don\'t Panic';
     $edit['description'] = $this->randomName();
     $edit['machine_name'] = 'don_t_panic';
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
 
     $site_name = config_get('system.core', 'site_name');
     $this->backdropGet('admin/structure/taxonomy/don_t_panic');
@@ -228,7 +241,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
       'name' => $this->randomName(),
       'machine_name' => $vocabulary_name,
     );
-    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save'));
+    $this->backdropPost('admin/structure/taxonomy/add', $edit, t('Save vocabulary'));
     $this->assertText(t('Created new vocabulary'), 'New vocabulary was created.');
 
     // Check the created vocabulary.
@@ -1839,7 +1852,7 @@ class TaxonomyEFQTestCase extends TaxonomyWebTestCase {
     $result = $result['taxonomy_term'];
     asort($result);
     $this->assertEqual(array_keys($terms), array_keys($result), 'Taxonomy terms were retrieved by EntityFieldQuery.');
- 
+
     $first_result = reset($result);
     $term = _field_create_entity_from_ids($first_result);
     $this->assertEqual($term->tid, $first_result->entity_id, 'Taxonomy term can be created based on the IDs');


### PR DESCRIPTION
Forked previous PR #3669 by @jenlampton to fix a couple of tests. I didn't do much but tests seem to be passing now.

Fixes backdrop/backdrop-issues#999