### PR TITLE
Issue #5236: Print test errors inline with other results. 

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Run tests
         run: |
           echo Running fraction ${{ matrix.fraction }} with PHP ${{ matrix.php-versions }}
-          core/scripts/run-tests.sh --force --cache --verbose --color --directory=core --split=${{ matrix.fraction }} --concurrency 7
+          # Pipe stderr to stdout so that GitHub Actions displays errors inline
+          # with the rest of the results, otherwise it prints them afterwards.
+          core/scripts/run-tests.sh --force --cache --verbose --color --directory=core --split=${{ matrix.fraction }} --concurrency 7 2>&1
 
       - name: System status
         if: ${{ always() }}

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2151,9 +2151,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
    * Test adding, renaming and deleting roles.
    */
   function testRoleAdministration() {
-    // Cause intentional failures.
-    // @todo Remove.
-    //$this->backdropLogin($this->admin_user);
+    $this->backdropLogin($this->admin_user);
 
     // Test adding a role.
     $role_name = '123';

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -2151,7 +2151,9 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
    * Test adding, renaming and deleting roles.
    */
   function testRoleAdministration() {
-    $this->backdropLogin($this->admin_user);
+    // Cause intentional failures.
+    // @todo Remove.
+    //$this->backdropLogin($this->admin_user);
 
     // Test adding a role.
     $role_name = '123';

--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -131,7 +131,8 @@ if ($args['clean']) {
   echo "\nEnvironment cleaned.\n";
 
   // Get the status messages and print them.
-  $messages = array_pop(backdrop_get_messages('status'));
+  $message_array = backdrop_get_messages('status');
+  $messages = array_pop($message_array);
   foreach ($messages as $text) {
     echo " - " . $text . "\n";
   }
@@ -141,7 +142,8 @@ if ($args['clean']) {
   echo "\nProfile cache tables cleaned.\n";
 
   // Get the status messages and print them.
-  $messages = array_pop(backdrop_get_messages('status'));
+  $message_array = backdrop_get_messages('status');
+  $messages = array_pop($message_array);
   foreach ($messages as $text) {
     echo " - " . $text . "\n";
   }
@@ -151,7 +153,8 @@ if ($args['clean']) {
   echo "\nProfile cache folders cleaned.\n";
 
   // Get the status messages and print them.
-  $messages = array_pop(backdrop_get_messages('status'));
+  $message_array = backdrop_get_messages('status');
+  $messages = array_pop($message_array);
   foreach ($messages as $text) {
     echo " - " . $text . "\n";
   }
@@ -919,7 +922,7 @@ function simpletest_script_reporter_display_results() {
           $test_class = $result->test_class;
 
           // Print table header.
-          echo "Status    Group      Filename          Line Function                            \n";
+          echo "Status    Group      Filename          Line    Function                            \n";
           echo "------------------------------------------------------------------------------------------------------------------------\n";
         }
 
@@ -936,10 +939,17 @@ function simpletest_script_reporter_display_results() {
  *   The result object to format.
  */
 function simpletest_script_format_result($result) {
-  global $results_map, $color;
+  global $results_map;
+
+  // @todo Remove this unless we want it.
+  // Only print the function name, the class is redundant with the heading.
+  // list($class, $function) = explode('->', $result->function);
+  // if (!isset($function)) {
+  //   $function = $class;
+  // }
 
   $summary = sprintf(
-    "%-9.9s %-10.10s %-17.17s %4.4s %-75.75s\n",
+    "%-9.9s %-10.10s %-17.17s %-7.7s %-72.72s\n",
     $results_map[$result->status],
     $result->message_group,
     basename($result->file),

--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -786,14 +786,14 @@ function simpletest_script_write_summary($summary_file) {
         $test_class = $result->test_class;
       }
 
-      if ($count < 10 ) {
+      if ($count < 10) {
         $summary .= " - `" . $result->status . "` " . trim(strip_tags($result->message)) . ' **' . basename($result->file) . '**:' . $result->line . "\n";
       }
       $count++;
     }
   }
 
-  if ($count > 10){
+  if ($count > 10) {
     $summary .= "\nResult limited to first 10 items. More details are available from the full log.\n";
   }
 

--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -940,12 +940,8 @@ function simpletest_script_reporter_display_results() {
 function simpletest_script_format_result($result) {
   global $results_map;
 
-  // @todo Remove this unless we want it.
   // Only print the function name, the class is redundant with the heading.
-  // list($class, $function) = explode('->', $result->function);
-  // if (!isset($function)) {
-  //   $function = $class;
-  // }
+  list($class, $function) = explode('->', $result->function, 2);
 
   $summary = sprintf(
     "%-9.9s %-10.10s %-17.17s %-7.7s %-72.72s\n",
@@ -953,7 +949,7 @@ function simpletest_script_format_result($result) {
     $result->message_group,
     basename($result->file),
     $result->line,
-    $result->function
+    $function
   );
 
   simpletest_script_print($summary, $result->status);

--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -635,7 +635,6 @@ function simpletest_script_get_test_list() {
     }
     elseif ($args['directory']) {
       // Extract test case class names from specified directory.
-      $files = array();
       if ($args['directory'][0] === '/') {
         $directory = $args['directory'];
       }
@@ -721,7 +720,7 @@ function simpletest_script_get_test_list() {
  * Initialize the reporter.
  */
 function simpletest_script_reporter_init() {
-  global $args, $all_tests, $test_list, $results_map;
+  global $args, $test_list, $results_map;
 
   $results_map = array(
     'pass' => 'Pass',
@@ -769,7 +768,7 @@ function simpletest_script_reporter_init() {
  *   The path to a file to which the summary will be written.
  */
 function simpletest_script_write_summary($summary_file) {
-  global $test_list, $args, $test_id, $results_map;
+  global $test_id, $results_map;
 
   $summary = '';
   $results = db_query("SELECT * FROM {simpletest} WHERE test_id = :test_id AND (status = 'exception' OR status = 'fail') ORDER BY test_class, message_id", array(':test_id' => $test_id));

--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -328,7 +328,8 @@ EOF;
 /**
  * Parse execution argument and ensure that all are valid.
  *
- * @return The list of arguments.
+ * @return array
+ *   The list of arguments.
  */
 function simpletest_script_parse_args() {
   // Set default values.
@@ -603,7 +604,8 @@ function simpletest_script_command($test_id, $test_class) {
  *
  * Will print error and exit if no valid tests were found.
  *
- * @return List of tests.
+ * @return array
+ *   List of tests.
  */
 function simpletest_script_get_test_list() {
   global $args, $all_tests, $groups;
@@ -782,14 +784,14 @@ function simpletest_script_write_summary($summary_file) {
         $test_class = $result->test_class;
       }
 
-      if($count < 10 ){
+      if ($count < 10 ) {
         $summary .= " - `" . $result->status . "` " . trim(strip_tags($result->message)) . ' **' . basename($result->file) . '**:' . $result->line . "\n";
       }
       $count++;
     }
   }
 
-  if($count > 10 ){
+  if ($count > 10){
     $summary .= "\nResult limited to first 10 items. More details are available from the full log.\n";
   }
 
@@ -918,7 +920,7 @@ function simpletest_script_reporter_display_results() {
 
           // Print table header.
           echo "Status    Group      Filename          Line Function                            \n";
-          echo "--------------------------------------------------------------------------------\n";
+          echo "------------------------------------------------------------------------------------------------------------------------\n";
         }
 
         simpletest_script_format_result($result);
@@ -928,20 +930,26 @@ function simpletest_script_reporter_display_results() {
 }
 
 /**
- * Format the result so that it fits within the default 80 character
- * terminal size.
+ * Format the result so that it fits within a 120 character terminal size.
  *
- * @param $result The result object to format.
+ * @param $result
+ *   The result object to format.
  */
 function simpletest_script_format_result($result) {
   global $results_map, $color;
 
-  $summary = sprintf("%-9.9s %-10.10s %-17.17s %4.4s %-35.35s\n",
-    $results_map[$result->status], $result->message_group, basename($result->file), $result->line, $result->function);
+  $summary = sprintf(
+    "%-9.9s %-10.10s %-17.17s %4.4s %-75.75s\n",
+    $results_map[$result->status],
+    $result->message_group,
+    basename($result->file),
+    $result->line,
+    $result->function
+  );
 
   simpletest_script_print($summary, $result->status);
 
-  $lines = explode("\n", wordwrap(trim(strip_tags(decode_entities($result->message))), 76));
+  $lines = explode("\n", wordwrap(trim(strip_tags(decode_entities($result->message))), 116));
   foreach ($lines as $line) {
     echo "    $line\n";
   }
@@ -951,7 +959,8 @@ function simpletest_script_format_result($result) {
  * Print error message prefixed with "ERROR: " and displayed in fail color
  * if color output is enabled.
  *
- * @param $message The message to print.
+ * @param $message
+ *   The message to print.
  */
 function simpletest_script_print_error($message) {
   simpletest_script_print("ERROR: $message\n", 'fail');
@@ -961,8 +970,10 @@ function simpletest_script_print_error($message) {
  * Print a message to the console, if color is enabled then the specified
  * color code will be used.
  *
- * @param $message The message to print.
- * @param $status One of the following:
+ * @param $message
+ *   The message to print.
+ * @param $status
+ *   One of the following:
  *   - pass
  *   - debug
  *   - exception
@@ -986,8 +997,10 @@ function simpletest_script_print($message, $status) {
 /**
  * Get the color code associated with the specified status.
  *
- * @param $status The status string to get code for.
- * @return Color code.
+ * @param $status
+ *   The status string to get code for.
+ * @return int
+ *   Color code.
  */
 function simpletest_script_color_code($status) {
   switch ($status) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5236

* Wraps lines at 120 characters instead of 80 characters
* Pipes stderr to stdout so that errors are displayed inline instead of after the results
* Fixes to docblock formatting in run-tests.sh