### PR TITLE
Issue-4677 Remove Search is not casesensitive text

### DIFF
--- a/core/modules/locale/locale.pages.inc
+++ b/core/modules/locale/locale.pages.inc
@@ -175,7 +175,7 @@ function locale_translation_filters() {
 
   $filters['string'] = array(
     'title' => t('String contains'),
-    'description' => t('Leave blank to show all strings. The search is case sensitive.'),
+    'description' => t('Leave blank to show all strings.'),
   );
 
   $filters['language'] = array(


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#4677
The help text in "String contains" field in "User interface translation" says that search is case-sensitive when the search is case-insensitive. 
Fix: Removed the help text that says search is case-sensitive.