### PR TITLE
Issue - 3795 Disable scheduling options for page

### DIFF
--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -123,7 +123,7 @@ function standard_install() {
       'settings' => array(
         'status_default' => NODE_PUBLISHED,
         'promote_enabled' => FALSE,
-        'node_preview' => TRUE,
+        'node_preview' => FALSE,
         'promote_default' => FALSE,
         'sticky_enabled' => FALSE,
         'sticky_default' => FALSE,


### PR DESCRIPTION
In the standard install profile, the Show option for scheduling setting for Pages should be disabled. (It should remain enabled for Posts)