### PR TITLE
Issue-3795 Disable scheduling options

### DIFF
--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -122,6 +122,7 @@ function standard_install() {
       'description' => st("Add a page with static content, like the 'About' page."),
       'settings' => array(
         'status_default' => NODE_PUBLISHED,
+        'scheduling_enabled' => FALSE,
         'promote_enabled' => FALSE,
         'node_preview' => TRUE,
         'promote_default' => FALSE,


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#3795
In the standard install profile, the Show option for scheduling setting for Pages should be disabled. (It should remain enabled for Posts)