### PR TITLE
Issue #5288: Prevent PHP warning on date formats during upgrade from D7.

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3908,8 +3908,10 @@ function system_get_date_formats($date_format_name = NULL) {
   $date_formats = &backdrop_static(__FUNCTION__, array());
   if (empty($date_formats)) {
     $date_formats = config_get('system.date', 'formats');
-    foreach ($date_formats as $name => $format) {
-      $date_formats[$name]['name'] = $name;
+    if (is_array($date_formats)) {
+      foreach ($date_formats as $name => $format) {
+        $date_formats[$name]['name'] = $name;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5288