### PR TITLE
Issue #5305: Fix views exposed filter checkbox value handling

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['5.3', '8.0']
+        php-versions: ['5.3', '7.4']
         fraction: ['1/3', '2/3', '3/3']
         database-versions: ['mariadb-10.3']
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['5.3', '7.4']
+        php-versions: ['5.3', '8.0']
         fraction: ['1/3', '2/3', '3/3']
         database-versions: ['mariadb-10.3']
 

--- a/core/modules/views/handlers/views_handler_filter.inc
+++ b/core/modules/views/handlers/views_handler_filter.inc
@@ -1297,7 +1297,7 @@ class views_handler_filter extends views_handler {
         }
 
         if ($this->operator != 'empty' && $this->operator != 'not empty') {
-          if ($value == 'All' || $value === array()) {
+          if ($value === 'All' || $value === array() || $value === 0) {
             return FALSE;
           }
         }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5305: Fix views exposed filter checkbox value handling

Don't expect all checks on PHP 8 to pass - this is just another baby-step.

<s>Todo: revert the temporary switch to php 8.0 in GHA.</s> (done)