### PR TITLE
Issue #5312: Pass indexed array to context load callback.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['5.3', '7.4']
+        php-versions: ['5.3', '7.4', '8.0']
         fraction: ['1/3', '2/3', '3/3']
         database-versions: ['mariadb-10.3']
 

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -798,7 +798,8 @@ class Layout {
       if (!isset($context->position) && !is_object($context->data)) {
         $context_info = layout_get_context_info($context->plugin);
         if (isset($context_info['load callback'])) {
-          $context_data = call_user_func_array($context_info['load callback'], $context->settings);
+          $load_arguments = array_values($context->settings);
+          $context_data = call_user_func_array($context_info['load callback'], $load_arguments);
           $context->setData($context_data);
         }
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5312.