### PR TITLE
Issue #5325: MySQL on PHP 8 now errors when committing or rolling back when there is no active transaction.

### DIFF
--- a/core/includes/database/mysql/database.inc
+++ b/core/includes/database/mysql/database.inc
@@ -335,7 +335,7 @@ class DatabaseConnection_mysql extends DatabaseConnection {
   /**
    * {@inheritdoc}
    */
-  public function rollback($savepoint_name = 'drupal_transaction') {
+  public function rollback($savepoint_name = 'backdrop_transaction') {
     // MySQL will automatically commit transactions when tables are altered or
     // created (DDL transactions are not supported). Prevent triggering an
     // exception to ensure that the error that has caused the rollback is

--- a/core/includes/database/mysql/database.inc
+++ b/core/includes/database/mysql/database.inc
@@ -282,7 +282,7 @@ class DatabaseConnection_mysql extends DatabaseConnection {
       // If there are no more layers left then we should commit.
       unset($this->transactionLayers[$name]);
       if (empty($this->transactionLayers)) {
-        if (!$this->pdo->commit()) {
+        if (!$this->doCommit()) {
           throw new DatabaseTransactionCommitFailedException();
         }
       }
@@ -305,7 +305,7 @@ class DatabaseConnection_mysql extends DatabaseConnection {
             $this->transactionLayers = array();
             // We also have to explain to PDO that the transaction stack has
             // been cleaned-up.
-            $this->pdo->commit();
+            $this->doCommit();
           }
           else {
             throw $e;
@@ -313,6 +313,53 @@ class DatabaseConnection_mysql extends DatabaseConnection {
         }
       }
     }
+  }
+
+  /**
+   * Do the actual commit, including a workaround for PHP 8 behaviour changes.
+   *
+   * @return bool
+   *   Success or otherwise of the commit.
+   */
+  protected function doCommit() {
+    if ($this->pdo->inTransaction()) {
+      return $this->pdo->commit();
+    }
+    else {
+      // In PHP 8.0 a PDOException is thrown when a commit is attempted with no
+      // transaction active. In previous PHP versions this failed silently.
+      return TRUE;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function rollback($savepoint_name = 'drupal_transaction') {
+    // MySQL will automatically commit transactions when tables are altered or
+    // created (DDL transactions are not supported). Prevent triggering an
+    // exception to ensure that the error that has caused the rollback is
+    // properly reported.
+    if (!$this->pdo->inTransaction()) {
+      // On PHP 7 $this->connection->inTransaction() will return TRUE and
+      // $this->connection->rollback() does not throw an exception; the
+      // following code is unreachable.
+
+      // If \DatabaseConnection::rollback() would throw an
+      // exception then continue to throw an exception.
+      if (!$this->inTransaction()) {
+        throw new DatabaseTransactionNoActiveException();
+      }
+      // A previous rollback to an earlier savepoint may mean that the savepoint
+      // in question has already been accidentally committed.
+      if (!isset($this->transactionLayers[$savepoint_name])) {
+        throw new DatabaseTransactionNoActiveException();
+      }
+
+      trigger_error('Rollback attempted when there is no active transaction. This can cause data integrity issues.', E_USER_WARNING);
+      return;
+    }
+    return parent::rollback($savepoint_name);
   }
 
   public function utf8mb4IsActive() {

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -3531,7 +3531,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
     if (strpos($message, 'Rollback attempted when there is no active transaction.') !== FALSE ) {
       throw new Exception('Rollback attempted when there is no active transaction.');
     }
-    _drupal_error_handler($error_level, $message, $filename, $line);
+    _backdrop_error_handler($error_level, $message, $filename, $line);
   }
 
   /**

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -3504,19 +3504,34 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
       $transaction = db_transaction();
       $this->insertRow('row');
       $this->executeDDLStatement();
-      // Rollback the outer transaction.
+
+      set_error_handler(array($this, 'rollBackWithoutTransactionErrorHandler'));
       try {
+        // Rollback the outer transaction.
         $transaction->rollback();
-        unset($transaction);
-        // @TODO: an exception should be triggered here, but is not, because
-        // "ROLLBACK" fails silently in MySQL if there is no transaction active.
-        // $this->fail(t('Rolling back a transaction containing DDL should fail.'));
+        // @see \DatabaseConnection_mysql::rollback()
+        if (PHP_VERSION_ID >= 80000) {
+          $this->fail('Rolling back a transaction containing DDL should produce a warning.');
+        }
       }
-      catch (DatabaseTransactionNoActiveException $e) {
-        $this->pass('Rolling back a transaction containing DDL should fail.');
+      catch (Exception $e) {
+        $this->assertEqual('Rollback attempted when there is no active transaction.', $e->getMessage());
       }
+      restore_error_handler();
+      unset($transaction);
       $this->assertRowPresent('row');
     }
+  }
+
+  /**
+   * Special handling of "rollback without transaction" errors.
+   */
+  public function rollBackWithoutTransactionErrorHandler($error_level, $message, $filename, $line) {
+    // Throw an exception if this is a "rollback without transaction" error.
+    if (strpos($message, 'Rollback attempted when there is no active transaction.') !== FALSE ) {
+      throw new Exception('Rollback attempted when there is no active transaction.');
+    }
+    _drupal_error_handler($error_level, $message, $filename, $line);
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5325.

Port of [Drupal issue #3204161](https://www.drupal.org/project/drupal/issues/3204161) by mcdruid, alexpott, catch, Charlie ChX Negyesi, mondrake, Mile23, andypost.