### PR TITLE
Issue #4679: Remove unused originalLanguageDefault variable.

### DIFF
--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -1919,9 +1919,6 @@ class BackdropWebTestCase extends BackdropTestCase {
     // Rebuild caches.
     $this->refreshVariables();
 
-    // Reset public files directory.
-    $GLOBALS['conf']['file_public_path'] = $this->originalFileDirectory;
-
     // Reset language.
     $language = $this->originalLanguage;
     $language_url = $this->originalLanguageUrl;

--- a/core/modules/simpletest/backdrop_web_test_case_cache.php
+++ b/core/modules/simpletest/backdrop_web_test_case_cache.php
@@ -155,12 +155,6 @@ class BackdropWebTestCaseCache extends BackdropWebTestCase {
     // Reset public files directory.
     $GLOBALS['conf']['file_public_path'] = $this->originalFileDirectory;
 
-    // Reset language.
-    $language = $this->originalLanguage;
-    if ($this->originalLanguageDefault) {
-      $GLOBALS['conf']['language_default'] = $this->originalLanguageDefault;
-    }
-
     // Close the CURL handler.
     $this->curlClose();
   }

--- a/core/modules/simpletest/backdrop_web_test_case_cache.php
+++ b/core/modules/simpletest/backdrop_web_test_case_cache.php
@@ -152,9 +152,6 @@ class BackdropWebTestCaseCache extends BackdropWebTestCase {
     // Rebuild caches.
     $this->refreshVariables();
 
-    // Reset public files directory.
-    $GLOBALS['conf']['file_public_path'] = $this->originalFileDirectory;
-
     // Close the CURL handler.
     $this->curlClose();
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4679