### PR TITLE
Issue #5290 PHP7.4 and empty entity_keys for taxonomy term result in notices

### DIFF
--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -351,8 +351,8 @@ function entity_extract_ids($entity_type, $entity) {
 
   // Objects being created might not have id/vid yet.
   if (!empty($info['entity keys'])) {
-  $id = isset($entity->{$info['entity keys']['id']}) ? $entity->{$info['entity keys']['id']} : NULL;
-  $vid = ($info['entity keys']['revision'] && isset($entity->{$info['entity keys']['revision']})) ? $entity->{$info['entity keys']['revision']} : NULL;
+    $id = isset($entity->{$info['entity keys']['id']}) ? $entity->{$info['entity keys']['id']} : NULL;
+    $vid = ($info['entity keys']['revision'] && isset($entity->{$info['entity keys']['revision']})) ? $entity->{$info['entity keys']['revision']} : NULL;
   }
   else {
     $id = NULL;

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -350,8 +350,14 @@ function entity_extract_ids($entity_type, $entity) {
   $info = entity_get_info($entity_type);
 
   // Objects being created might not have id/vid yet.
+  if (!empty($info['entity keys'])) {
   $id = isset($entity->{$info['entity keys']['id']}) ? $entity->{$info['entity keys']['id']} : NULL;
   $vid = ($info['entity keys']['revision'] && isset($entity->{$info['entity keys']['revision']})) ? $entity->{$info['entity keys']['revision']} : NULL;
+  }
+  else {
+    $id = NULL;
+    $vid = NULL;
+  }
 
   if (!empty($info['entity keys']['bundle'])) {
     // Explicitly fail for malformed entities missing the bundle property.


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/5290

Proposed fix from Drupal issue: https://www.drupal.org/project/drupal/issues/3166668