### PR TITLE
Fixes field name not being shown in 'required' validation for multiple value fields

### DIFF
--- a/core/modules/field/field.form.inc
+++ b/core/modules/field/field.form.inc
@@ -213,14 +213,25 @@ function field_multiple_value_form($field, $instance, $langcode, $items, &$form,
         '#language' => $langcode,
         '#field_parents' => $parents,
         '#columns' => array_keys($field['columns']),
-        // For multiple fields, title and description are handled by the wrapping table.
-        '#title' => $multiple ? '' : $title,
-        '#description' => $multiple ? '' : $description,
+        '#title' => $title,
+        '#description' => $description,
         // Only the first widget should be required.
         '#required' => $delta == 0 && $instance['required'],
         '#delta' => $delta,
         '#weight' => $delta,
       );
+      // For multiple fields, title and description are handled by the wrapping
+      // table.
+      if ($multiple) {
+        if ($delta == 0) {
+          $element['#title'] = t('!title', array('!title' => $title));
+        }
+        else {
+          $element['#title'] = t('!title (value @number)', array('@number' => $delta + 1, '!title' => $title));
+        }
+        $element['#title_display'] = 'invisible';
+        $element['#description'] = '';
+      }
       if ($element = $function($form, $form_state, $field, $instance, $langcode, $items, $delta, $element)) {
         // Input field for the delta (drag-n-drop reordering).
         if ($multiple) {

--- a/core/modules/field/field.form.inc
+++ b/core/modules/field/field.form.inc
@@ -227,7 +227,7 @@ function field_multiple_value_form($field, $instance, $langcode, $items, &$form,
           $element['#title'] = t('!title', array('!title' => $title));
         }
         else {
-          $element['#title'] = t('!title (value @number)', array('@number' => $delta + 1, '!title' => $title));
+          $element['#title'] = t('!title (value @number)', array('!title' => $title, '@number' => $delta + 1));
         }
         $element['#title_display'] = 'invisible';
         $element['#description'] = '';

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -1646,7 +1646,7 @@ class FieldFormTestCase extends FieldTestCase {
   }
 
   /**
-   * Tests the position of the required label.
+   * Tests the position of the "required" symbol and the validation error text.
    */
   public function testFieldFormUnlimitedRequired() {
     $this->field = $this->field_unlimited;
@@ -1655,6 +1655,7 @@ class FieldFormTestCase extends FieldTestCase {
     $this->instance['required'] = TRUE;
     field_create_field($this->field);
     field_create_instance($this->instance);
+    $instance = field_read_instance('test_entity', $this->instance['field_name'], $this->instance['bundle']);
 
     // Display creation form -> 1 widget.
     $this->backdropGet('test-entity/add/test-bundle');
@@ -1664,6 +1665,10 @@ class FieldFormTestCase extends FieldTestCase {
     // the field title and an indication of the delta for a11y.
     $result = $this->xpath("//label[contains(@class, 'element-invisible') and contains(text(), :label)]/abbr/text()", array(':label' => $this->instance['label']));
     $this->assertEqual($result[0], '*', t('Required symbol and field label are visually hidden.'));
+
+    // Click "Add another" button
+    $this->backdropPost(NULL, array(), t('Add another'));
+    $this->assertText(t('@name field is required.', array('@name' => $instance['label'])), t('Validation error for required unlimited field includes the name of the field.'));
   }
 
   /**

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -1646,6 +1646,27 @@ class FieldFormTestCase extends FieldTestCase {
   }
 
   /**
+   * Tests the position of the required label.
+   */
+  public function testFieldFormUnlimitedRequired() {
+    $this->field = $this->field_unlimited;
+    $this->field_name = $this->field['field_name'];
+    $this->instance['field_name'] = $this->field_name;
+    $this->instance['required'] = TRUE;
+    field_create_field($this->field);
+    field_create_instance($this->instance);
+
+    // Display creation form -> 1 widget.
+    $this->backdropGet('test-entity/add/test-bundle');
+    $result = $this->xpath("//label[not(contains(@class, 'element-invisible')) and contains(text(), :label)]/abbr/text()", array(':label' => $this->instance['label']));
+    $this->assertEqual($result[0], '*', t('Required symbol added to field label.'));
+    // Check that the label of the field input is visually hidden and contains
+    // the field title and an indication of the delta for a11y.
+    $result = $this->xpath("//label[contains(@class, 'element-invisible') and contains(text(), :label)]/abbr/text()", array(':label' => $this->instance['label']));
+    $this->assertEqual($result[0], '*', t('Required symbol and field label are visually hidden.'));
+  }
+
+  /**
    * Tests widget handling of multiple required radios.
    */
   function testFieldFormMultivalueWithRequiredRadio() {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5377

This code is taken from a Drupal patch found [here](https://www.drupal.org/files/issues/980144-114.patch)