### PR TITLE
Adds chained tokens for date fields

### DIFF
--- a/core/modules/date/date.tokens.inc
+++ b/core/modules/date/date.tokens.inc
@@ -119,11 +119,11 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
         if (empty($chained_token)) {
           $chained_token = array('date:medium' => $original);
         } 
-        $replacements += token_generate('date-field-value', $chained_token,array('item' => $field_items[$delta]), $options);
+        $replacements += token_generate('date-field-value', $chained_token,array('date-field-value' => $field_items[$delta]), $options);
 
       } else {
         // If no delta is specified, send the first item of the field
-        $replacements += token_generate('date-field-value', array($token => $original), array('item' => $field_items[0]), $options);
+        $replacements += token_generate('date-field-value', array($token => $original), array('date-field-value' => $field_items[0]), $options);
       }
     }
   }
@@ -131,8 +131,8 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
   // Process date field item. The token at this point is in the format 
   // "[date||end-date]:[format]", where format is 'long', 'medium', etc. 
   // or 'custom'.
-  elseif (($type == 'date-field-value') && !empty($data['item'])) {
-    $item = $data['item'];
+  elseif (($type == 'date-field-value') && !empty($data['date-field-value'])) {
+    $item = $data['date-field-value'];
 
     // Create tokens for the field's "Date" or "Start date".
     if (($date_tokens = token_find_with_prefix($tokens, 'date')) && !empty($item['value'])) {

--- a/core/modules/date/date.tokens.inc
+++ b/core/modules/date/date.tokens.inc
@@ -83,7 +83,7 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
   $language_code = isset($options['language']) ? $options['language']->langcode : NULL;
 
   // Process date fields attached to entities.
-  if (isset($data[$type]) && !empty($data[$type]) && is_a($data[$type], 'Entity')) {
+  if (!empty($data[$type]) && is_a($data[$type], 'Entity')) {
     $entity = $data[$type];
     $entity_type = $entity->entityType();
     $entity_info = entity_get_info($entity_type); 
@@ -115,14 +115,14 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
         $delta = $explode[0];
         $chained_token = token_find_with_prefix(array($token => $original), $delta);
 
-        // If there is no arguments after delta, send date:medium as default
+        // If there is no arguments after delta, send date:medium as default.
         if (empty($chained_token)) {
           $chained_token = array('date:medium' => $original);
         } 
         $replacements += token_generate('date-field-value', $chained_token,array('date-field-value' => $field_items[$delta]), $options);
 
       } else {
-        // If no delta is specified, send the first item of the field
+        // If no delta is specified, send the first item of the field.
         $replacements += token_generate('date-field-value', array($token => $original), array('date-field-value' => $field_items[0]), $options);
       }
     }

--- a/core/modules/date/date.tokens.inc
+++ b/core/modules/date/date.tokens.inc
@@ -53,7 +53,8 @@ function date_token_info_alter(&$info) {
         }
   
         $info['tokens'][$token_type][$field_name] = array(
-          // Note that label and description have already been sanitized by _field_token_info().
+          // Note that label and description have already been
+          // sanitized by _field_token_info().
           'name' => $field['label'],
           'description' => $field['description'],
           'module' => 'date',
@@ -62,7 +63,7 @@ function date_token_info_alter(&$info) {
 
         if ($field_info[$field_name]['cardinality'] != 1) {
           $info['tokens'][$token_type][$field_name]['dynamic'] = TRUE;
-          $info['tokens'][$token_type][$field_name]['description'] .= t(' Replace the ? with the delta for multi-value fields.');
+          $info['tokens'][$token_type][$field_name]['description'] .= ' ' . t('Replace the ? with the delta for multi-value fields.');
         }
 
         if (empty($field_info[$field_name]['settings']['todate'])) {
@@ -81,7 +82,7 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
   $replacements = array();
   $language_code = isset($options['language']) ? $options['language']->langcode : NULL;
 
-  // Process date fields attached to entities
+  // Process date fields attached to entities.
   if (isset($data[$type]) && !empty($data[$type]) && is_a($data[$type], 'Entity')) {
     $entity = $data[$type];
     $entity_type = $entity->entityType();
@@ -104,7 +105,7 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
     }
   } 
   
-  // Process the chain after the field name
+  // Process the chain after the field name.
   elseif (($type == 'date-field') && !empty($data[$type])) {
     $field_items = $data[$type];
     foreach ($tokens as $token => $original) {
@@ -127,8 +128,9 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
     }
   }
     
-  // Process date field item. The token at this point is in the format "[date||end-date]:[format]" 
-  // where format is 'long', 'medium' etc or 'custom'
+  // Process date field item. The token at this point is in the format 
+  // "[date||end-date]:[format]", where format is 'long', 'medium', etc. 
+  // or 'custom'.
   elseif (($type == 'date-field-value') && !empty($data['item'])) {
     $item = $data['item'];
 
@@ -158,7 +160,8 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
       $replacements += token_generate('date', $date_tokens, array('date' => $timestamp), $options);
     }
 
-    // Handle token chains that do not contain 'date' or 'end-date'. Defaults to "starting date"
+    // Handle token chains that do not contain 'date' or 'end-date'. 
+    // Defaults to "starting date".
     $short_tokens = array();
     foreach ($tokens as $token => $original) {
       if (strpos($token, 'date') === FALSE && strpos($token, 'end-date') === FALSE && !empty($item['value'])) {

--- a/core/modules/date/date.tokens.inc
+++ b/core/modules/date/date.tokens.inc
@@ -7,7 +7,7 @@
 /**
  * Implements hook_token_info().
  */
-function date_token_info() {  
+function date_token_info() {
   // All date types can share the same date value type.
   $info['types']['date-field-value'] = array(
     'name' => t('Date field values'),
@@ -21,7 +21,6 @@ function date_token_info() {
     'name' => t('Date'),
     'description' => t('The date value.'),
     'type' => 'date',
-
   );
   $info['tokens']['date-field-value']['to-date'] = array(
     'name' => t('End Date'),
@@ -63,7 +62,7 @@ function date_token_info_alter(&$info) {
 
         if ($field_info[$field_name]['cardinality'] != 1) {
           $info['tokens'][$token_type][$field_name]['dynamic'] = TRUE;
-          $info['tokens'][$token_type][$field_name]['description'] .= ' Replace the ? with the delta for multi-value fields.';
+          $info['tokens'][$token_type][$field_name]['description'] .= t(' Replace the ? with the delta for multi-value fields.');
         }
 
         if (empty($field_info[$field_name]['settings']['todate'])) {

--- a/core/modules/date/date.tokens.inc
+++ b/core/modules/date/date.tokens.inc
@@ -7,14 +7,7 @@
 /**
  * Implements hook_token_info().
  */
-function date_token_info() {
-  // Type for date fields
-  $info['types']['date-field'] = array(
-    'name' => t('Date fields'),
-    'description' => t('Tokens related to date fields.'),
-    'needs-date' => 'date-field',
-  );
-  
+function date_token_info() {  
   // All date types can share the same date value type.
   $info['types']['date-field-value'] = array(
     'name' => t('Date field values'),

--- a/core/modules/date/date.tokens.inc
+++ b/core/modules/date/date.tokens.inc
@@ -8,6 +8,13 @@
  * Implements hook_token_info().
  */
 function date_token_info() {
+  // Type for date fields
+  $info['types']['date-field'] = array(
+    'name' => t('Date fields'),
+    'description' => t('Tokens related to date fields.'),
+    'needs-date' => 'date-field',
+  );
+  
   // All date types can share the same date value type.
   $info['types']['date-field-value'] = array(
     'name' => t('Date field values'),
@@ -15,11 +22,13 @@ function date_token_info() {
     'needs-data' => 'date-field-value',
     'field-value' => TRUE,
   );
+
   // Provide two tokens: 'date' (the date or start-date), and 'end-date'.
   $info['tokens']['date-field-value']['date'] = array(
     'name' => t('Date'),
     'description' => t('The date value.'),
     'type' => 'date',
+
   );
   $info['tokens']['date-field-value']['to-date'] = array(
     'name' => t('End Date'),
@@ -31,16 +40,107 @@ function date_token_info() {
 }
 
 /**
+ * Implements hook_token_info_alter().
+ */
+function date_token_info_alter(&$info) {
+  // Attach date field tokens to their respective entity tokens.
+  $field_info = field_info_fields();
+  $fields = _field_token_info();
+
+  foreach ($fields as $field_name => $field) {
+    if (in_array($field_info[$field_name]['type'], array('date', 'datetime', 'datestamp'))) {
+      foreach (array_keys($field['bundles']) as $token_type) {
+        // If a token already exists for this field, then don't add it.
+        if (isset($info['tokens'][$token_type][$field_name])) {
+          continue;
+        }
+  
+        // Ensure token type for this entity already exists. 
+        if (!isset($info['types'][$token_type]) || !isset($info['tokens'][$token_type])) {
+          continue;
+        }
+  
+        $info['tokens'][$token_type][$field_name] = array(
+          // Note that label and description have already been sanitized by _field_token_info().
+          'name' => $field['label'],
+          'description' => $field['description'],
+          'module' => 'date',
+          'type' => 'date-field-value',
+        );
+
+        if ($field_info[$field_name]['cardinality'] != 1) {
+          $info['tokens'][$token_type][$field_name]['dynamic'] = TRUE;
+          $info['tokens'][$token_type][$field_name]['description'] .= ' Replace the ? with the delta for multi-value fields.';
+        }
+
+        if (empty($field_info[$field_name]['settings']['todate'])) {
+          $info['tokens'][$token_type][$field_name]['type'] = 'date';
+        }
+      }
+    }
+  }
+}
+
+
+/**
  * Implements hook_tokens().
  */
 function date_tokens($type, $tokens, array $data = array(), array $options = array()) {
   $replacements = array();
   $language_code = isset($options['language']) ? $options['language']->langcode : NULL;
 
-  if (($type == 'date-field-value') && !empty($data['item'])) {
+  // Process date fields attached to entities
+  if (isset($data[$type]) && !empty($data[$type]) && is_a($data[$type], 'Entity')) {
+    $entity = $data[$type];
+    $entity_type = $entity->entityType();
+    $entity_info = entity_get_info($entity_type); 
+
+    if (isset($entity_info['fieldable']) && $entity_info['fieldable']) {
+      $fields = field_info_field_map();
+
+      // Check to see which fields are supported.
+      foreach ($fields as $field_name => $field) {
+        if (in_array($field['type'], array('date', 'datetime', 'datestamp'))) {
+          $date_field_tokens = token_find_with_prefix($tokens, $field_name);
+
+          $field_items = field_get_items($entity_type, $entity, $field_name);
+          if ($date_field_tokens && $field_items) {
+            $replacements += token_generate('date-field', $date_field_tokens, array('date-field' => $field_items), $options);
+          }
+        }
+      }
+    }
+  } 
+  
+  // Process the chain after the field name
+  elseif (($type == 'date-field') && !empty($data[$type])) {
+    $field_items = $data[$type];
+    foreach ($tokens as $token => $original) {
+      $explode = explode(':', $token);
+
+      if (is_numeric($explode[0]) && !empty($field_items[$explode[0]])) {
+        $delta = $explode[0];
+        $chained_token = token_find_with_prefix(array($token => $original), $delta);
+
+        // If there is no arguments after delta, send date:medium as default
+        if (empty($chained_token)) {
+          $chained_token = array('date:medium' => $original);
+        } 
+        $replacements += token_generate('date-field-value', $chained_token,array('item' => $field_items[$delta]), $options);
+
+      } else {
+        // If no delta is specified, send the first item of the field
+        $replacements += token_generate('date-field-value', array($token => $original), array('item' => $field_items[0]), $options);
+      }
+    }
+  }
+    
+  // Process date field item. The token at this point is in the format "[date||end-date]:[format]" 
+  // where format is 'long', 'medium' etc or 'custom'
+  elseif (($type == 'date-field-value') && !empty($data['item'])) {
     $item = $data['item'];
 
-    // Create tokens for the field "Date" or "Start date".
+    // Create tokens for the field's "Date" or "Start date".
     if (($date_tokens = token_find_with_prefix($tokens, 'date')) && !empty($item['value'])) {
       // Load the Start date and convert to a unix timestamp.
       $date = new BackdropDateTime($item['value'], $item['timezone_db'], date_type_format($item['date_type']));
@@ -53,7 +153,7 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
       $replacements += token_generate('date', $date_tokens, array('date' => $timestamp), $options);
     }
 
-    // Create tokens for the field "End date".
+    // Create tokens for the field's "End date".
     if (($date_tokens = token_find_with_prefix($tokens, 'end-date')) && !empty($item['value2'])) {
       // Load the to date and convert to a unix timestamp.
       $date = new BackdropDateTime($item['value2'], $item['timezone_db'], date_type_format($item['date_type']));
@@ -64,6 +164,22 @@ function date_tokens($type, $tokens, array $data = array(), array $options = arr
       // Generate the token replacements, using the date token type provided
       // by system.module.
       $replacements += token_generate('date', $date_tokens, array('date' => $timestamp), $options);
+    }
+
+    // Handle token chains that do not contain 'date' or 'end-date'. Defaults to "starting date"
+    $short_tokens = array();
+    foreach ($tokens as $token => $original) {
+      if (strpos($token, 'date') === FALSE && strpos($token, 'end-date') === FALSE && !empty($item['value'])) {
+        $short_tokens = array_merge($short_tokens, array($token => $original));
+      }
+    }
+    if (!empty($short_tokens)) {
+      $date = new BackdropDateTime($item['value'], $item['timezone_db'], date_type_format($item['date_type']));
+      if (!empty($date) && $item['timezone_db'] != $item['timezone']) {
+        date_timezone_set($date, timezone_open($item['timezone']));
+      }
+      $timestamp = !empty($date) ? date_format_date($date, 'custom', 'U') : '';
+      $replacements += token_generate('date', $short_tokens, array('date' => $timestamp), $options);
     }
   }
 

--- a/core/modules/date/tests/date.tests.info
+++ b/core/modules/date/tests/date.tests.info
@@ -10,6 +10,12 @@ description = Test date field settings and Start/End date interaction.
 group = Date
 file = date_field.test
 
+[DateFieldTokenTestCase]
+name = Date Field Token
+description = Test the date field token replacements.
+group = Date
+file = date_field.test
+
 [DateTimezoneTestCase]
 name = Date Timezone & Granularity
 description = Test combinations of date field timezone handling and granularity.

--- a/core/modules/date/tests/date_field.test
+++ b/core/modules/date/tests/date_field.test
@@ -349,3 +349,75 @@ class DateFieldTestCase extends DateFieldBasic {
     $this->assertText($should_be, "Found the correct date for a $field_type field using the $widget_type widget displayed using the long date format.");
   }
 }
+
+
+class DateFieldTokenTestCase extends DateFieldBasic {
+  public function testDateFieldToken() {
+    $timestamp = REQUEST_TIME;
+    $timestamp_end = $timestamp + 7200; // Two hours later.
+    $timestamp2 = 692955971;
+    $timestamp2_end = 819186371;
+
+    $this->createDateField(array(
+      'field_name' => 'field_date_single',
+      'widget_type' => 'date_text',
+      'increment' => 1,
+    ));
+    $this->createMultiDateField(array(
+      'field_name' => 'field_date_multiple',
+      'widget_type' => 'date_text',
+      'increment' => 1,
+      'todate' => 'required',
+      'cardinality' => 2,
+    ));
+
+    // Create a dummy node.
+    $edit = array();
+    $edit['title'] = $this->randomName(8);
+    $edit['field_date_single[und][0][value][date]'] = format_date($timestamp, 'custom', 'm/d/Y - h:ia','UTC');
+
+    $edit['field_date_multiple[und][0][value][date]'] = format_date($timestamp, 'custom', 'm/d/Y - h:ia','UTC');
+    $edit['field_date_multiple[und][0][value2][date]'] = format_date($timestamp_end, 'custom', 'm/d/Y - h:ia','UTC');
+
+    $edit['field_date_multiple[und][1][value][date]'] = format_date($timestamp2, 'custom', 'm/d/Y - h:ia','UTC');
+    $edit['field_date_multiple[und][1][value2][date]'] = format_date($timestamp2_end, 'custom', 'm/d/Y - h:ia','UTC');
+
+    $this->backdropPost('node/add/story', $edit, t('Save'));
+    $node = $this->backdropGetNodeByTitle($edit['title']);  
+    
+    $tokens = array(
+      'field_date_single:long' => format_date($timestamp, 'long'),
+      'field_date_single:medium' => format_date($timestamp, 'medium'),
+      'field_date_single:short' => format_date($timestamp, 'short'),
+      'field_date_single:date:short' => format_date($timestamp, 'short'),
+      'field_date_single:0:date:short' => format_date($timestamp, 'short'),
+      'field_date_single:custom:Y-m-d' => format_date($timestamp, 'custom', 'Y-m-d'),
+      'field_date_single:2:short' => NULL,
+
+      'field_date_multiple:date:short' => format_date($timestamp, 'short'), // Defaults to delta = 0.
+      'field_date_multiple:0:date:long' => format_date($timestamp, 'long'),
+      'field_date_multiple:0:end-date:medium' => format_date($timestamp_end, 'medium'),
+      'field_date_multiple:1:end-date:custom:l, F j, Y' => format_date($timestamp2_end, 'custom', 'l, F j, Y'),
+      'field_date_multiple:2:date:long' => NULL,
+    );
+
+    $input = $this->mapTokenNames('node', array_keys($tokens));
+    $replacements = token_generate('node', $input, array('node' => $node));
+    foreach ($tokens as $name => $expected) {
+      $token = $input[$name];
+      if (!isset($expected)) {
+        $this->assertTrue(!isset($values[$token]), t("Token value for @token was not generated.", array('@token' => $token)));
+      } else {
+        $this->assertIdentical($replacements[$token], $expected, t("Token value for @token was '@actual', expected value '@expected'.", array('@token' => $token, '@actual' => $replacements[$token], '@expected' => $expected)));
+      }
+    }
+  }
+
+  function mapTokenNames($type, array $tokens = array()) {
+    $return = array();
+    foreach ($tokens as $token) {
+      $return[$token] = "[$type:$token]";
+    }
+    return $return;
+  }
+}

--- a/core/modules/date/tests/date_field.test
+++ b/core/modules/date/tests/date_field.test
@@ -350,8 +350,11 @@ class DateFieldTestCase extends DateFieldBasic {
   }
 }
 
-
 class DateFieldTokenTestCase extends DateFieldBasic {
+
+  /**
+   * Tests that date field tokens functions properly.
+   */
   public function testDateFieldToken() {
     $timestamp = REQUEST_TIME;
     $timestamp_end = $timestamp + 7200; // Two hours later.
@@ -384,7 +387,8 @@ class DateFieldTokenTestCase extends DateFieldBasic {
 
     $this->backdropPost('node/add/story', $edit, t('Save'));
     $node = $this->backdropGetNodeByTitle($edit['title']);  
-    
+
+    // Ceate several tokens.
     $tokens = array(
       'field_date_single:long' => format_date($timestamp, 'long'),
       'field_date_single:medium' => format_date($timestamp, 'medium'),
@@ -413,6 +417,9 @@ class DateFieldTokenTestCase extends DateFieldBasic {
     }
   }
 
+  /**
+   * Helper function that creates a properly formatted token map. 
+   */
   function mapTokenNames($type, array $tokens = array()) {
     $return = array();
     foreach ($tokens as $token) {

--- a/core/modules/date/tests/date_field.test
+++ b/core/modules/date/tests/date_field.test
@@ -353,7 +353,7 @@ class DateFieldTestCase extends DateFieldBasic {
 class DateFieldTokenTestCase extends DateFieldBasic {
 
   /**
-   * Tests that date field tokens functions properly.
+   * Tests that date field tokens function properly.
    */
   public function testDateFieldToken() {
     $timestamp = REQUEST_TIME;

--- a/core/modules/field/field.tokens.inc
+++ b/core/modules/field/field.tokens.inc
@@ -123,7 +123,7 @@ function _field_token_info($field_name = NULL) {
 
   $cache = cache('token');
 
-  if (!isset($fields)) {
+  if (!isset($info)) {
     if ($cached = $cache->get('field:info')) {
       $info = $cached->data;
     }


### PR DESCRIPTION
Fixes [#2069](https://github.com/backdrop/backdrop-issues/issues/2069)

Any suggestions on where to add automated tests? 

## Important notes
To test these changes I suggest you **disable the contrib Entity Tokens**. Entity Tokens (which I started maintaining very recently) is known for causing issues with the token tree and with some token replacements. 

You may want to enable the contrib module [Token Help](https://backdropcms.org/project/token_help) to see the new tokens. 

## Description of the additions:
1. `[node:field_date]` will run its course normally, fulfilled by `field_tokens()`. These PRs do not affect unchained field token replacements in any way. As usual, unchained field tokens will use the Tokens display mode to theme the output
2. Chained date field tokens will be fulfilled by the new features in `date.tokens()` as follows:

### Single value fields
`[node:field_date_single:date:medium]` will output  the date formatted in `medium` date format. Any other core or custom format machine name may be used.

Notice also that the term `date` can be left out if so desired, as in `[node:field_date_single:medium]`, which results in the same output as the above. The term `date` is used to indicate starting date in fields that contain a starting and an end date.

`custom` is also accepted, followed by a custom php date format, as in `[node:field_date_single:date:custom:F j, Y, g:i a]` resulting in "December 3, 2021, 5:27 pm".

### Multi-value field
As in: `[node:field_date_multiple:0:date:medium]`. Notice that the delta is specified in the pattern. You may leave the delta out, and the first field item will be output. You may also leave `date` out.  

Same behavior with date formats as above.

### Fields with end dates
As in: `[node:field_date_single_with_end_date:end-date:long]` will output the **end date** in long format. 

And: `[node:field_date_multiple_with_end_date:1:end-date:long]` will output the end date of the **second field item** (delta == 1) in long format. 


## How to test
1. Add the following date fields to any content type (you may use any date type, like ISO or Unix stamp)
   - field_date_single (single value, no end date)
   - field_date_multiple (multi-value, no end dates)
   - field_date_single_with_end_date (single value, end date)
   - field_date_multiple_with_end_date (multi-value, end dates)
2. Create a node and enter data into these fields
3. Enable Devel and test a bunch of token replacements, for example:

```php
$node = node_load(3);
$texts = array(
  '[node:field_date_single:long]',
  '[node:field_date_multiple:0:date:short]',
  '[node:field_date_multiple_with_end_date:1:end-date:custom:Y-m-d]',  
);

foreach ($texts as $t) {
  dpm(token_replace($t, array('node' => $node)), $t);
}
```
Please test and let me know if any issues or concerns. Any help writing automated tests will be appreciated  😉 
