### PR TITLE
Issue #4718: Use localStorage to store tableDrag.showWeight value

### DIFF
--- a/core/misc/tabledrag.js
+++ b/core/misc/tabledrag.js
@@ -134,7 +134,7 @@ Backdrop.tableDrag = function (table, tableSettings) {
   $(document).on('mousemove pointermove', function (event) { return self.dragRow(event, self); });
   $(document).on('mouseup pointerup', function (event) { return self.dropRow(event, self); });
   // React to localStorage event showing or hiding weight columns.
-  $(window).bind('storage', $.proxy(function (e) {
+  $(window).on('storage', $.proxy(function (e) {
     // Only react to 'Backdrop.tableDrag.showWeight' value change.
     if (e.originalEvent.key === 'Backdrop.tableDrag.showWeight') {
       // This was changed in another window, get the new value for this window.

--- a/core/misc/tabledrag.js
+++ b/core/misc/tabledrag.js
@@ -137,7 +137,7 @@ Backdrop.tableDrag = function (table, tableSettings) {
   $(window).on('storage', function (e) {
     // Only react to 'Backdrop.tableDrag.showWeight' value change.
     if (e.originalEvent.key === 'Backdrop.tableDrag.showWeight') {
-      // This was changed in another window, get the new value for this window.
+      // This was changed in another window. Get the new value for this window.
       showWeight = JSON.parse(e.originalEvent.newValue);
       self.displayColumns(showWeight);
     }

--- a/core/misc/tabledrag.js
+++ b/core/misc/tabledrag.js
@@ -113,10 +113,10 @@ Backdrop.tableDrag = function (table, tableSettings) {
   // Add a link before the table for users to show or hide weight columns.
   $(table).before($('<a href="#" class="tabledrag-toggle-weight"></a>')
     .attr('title', Backdrop.t('Re-order rows by numerical weight instead of dragging.'))
-    .click($.proxy(function (e) {
+    .click(function (e) {
       e.preventDefault();
-      this.toggleColumns();
-    }, this))
+      self.toggleColumns();
+    })
     .wrap('<div class="tabledrag-toggle-weight-wrapper"></div>')
     .parent()
   );
@@ -134,14 +134,14 @@ Backdrop.tableDrag = function (table, tableSettings) {
   $(document).on('mousemove pointermove', function (event) { return self.dragRow(event, self); });
   $(document).on('mouseup pointerup', function (event) { return self.dropRow(event, self); });
   // React to localStorage event showing or hiding weight columns.
-  $(window).on('storage', $.proxy(function (e) {
+  $(window).on('storage', function (e) {
     // Only react to 'Backdrop.tableDrag.showWeight' value change.
     if (e.originalEvent.key === 'Backdrop.tableDrag.showWeight') {
       // This was changed in another window, get the new value for this window.
       showWeight = JSON.parse(e.originalEvent.newValue);
-      this.displayColumns(showWeight);
+      self.displayColumns(showWeight);
     }
-  }, this));
+  });
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4718

Alternative to https://github.com/backdrop/backdrop/pull/3869
Mimics: https://git.drupalcode.org/project/drupal/-/commit/148871a8c914c2db9c28ceac3ebf9763a0e83e7e + follow-up https://git.drupalcode.org/project/drupal/-/commit/96bca83bcc2eb969d1330f84092652bc2615faf8