### PR TITLE
Issue 5415: [DX] Simpletest doesn't handle empty or malformed .tests.info file well

### DIFF
--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -371,7 +371,7 @@ function simpletest_test_get_all() {
         // is loaded. So we'll check and put a more informative error here.
         $class_values = array_values($classes);
         if (empty($classes) || !is_array($class_values[0])) {
-          watchdog('simpletest', 'File %uri contains no testing classes.', array('%uri' => $file->uri), WATCHDOG_WARNING);
+          watchdog('simpletest', 'File %uri contains no testing classes. <a href="https://docs.backdropcms.org/documentation/testing-framework">See the Testing Framework documentation for details.</a>', array('%uri' => $file->uri), WATCHDOG_WARNING);
           continue;
         }
         foreach ($classes as $class => $info) {

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -366,12 +366,12 @@ function simpletest_test_get_all() {
       $groups = array();
       foreach ($files as $file) {
         $classes = backdrop_parse_info_file($file->uri, TRUE);
+        // If the .tests.info file contained no classes, then it puts a slew of
+        // hard-to-diagnose errors into the watchdog log when the testing page
+        // is loaded. So we'll check and put a more informative error here.
         $class_values = array_values($classes);
         if (empty($classes) || !is_array($class_values[0])) {
-          // If the .tests.info file contained no classes, then it puts a slew
-          // of hard-to-diagnose errors into the watchdog log when the testing
-          // page is loaded. So we'll put a more informative error here.
-          watchdog('simpletest', 'There are no testing classes in file %uri', array('%uri' => $file->uri), WATCHDOG_WARNING);
+          watchdog('simpletest', 'File %uri contains no testing classes.', array('%uri' => $file->uri), WATCHDOG_WARNING);
           continue;
         }
         foreach ($classes as $class => $info) {

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -371,7 +371,7 @@ function simpletest_test_get_all() {
         // is loaded. So we'll check and put a more informative error here.
         $class_values = array_values($classes);
         if (empty($classes) || !is_array($class_values[0])) {
-          watchdog('simpletest', 'File %uri contains no testing classes. <a href="https://docs.backdropcms.org/documentation/testing-framework">See the Testing Framework documentation for details.</a>', array('%uri' => $file->uri), WATCHDOG_WARNING);
+          watchdog('simpletest', 'File %uri contains no testing classes.', array('%uri' => $file->uri), WATCHDOG_WARNING, '<a href="https://docs.backdropcms.org/documentation/testing-framework">See the Testing Framework documentation.</a>');
           continue;
         }
         foreach ($classes as $class => $info) {

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -371,7 +371,7 @@ function simpletest_test_get_all() {
         // is loaded. So we'll check and put a more informative error here.
         $class_values = array_values($classes);
         if (empty($classes) || !is_array($class_values[0])) {
-          watchdog('simpletest', 'File %uri contains no testing classes.', array('%uri' => $file->uri), WATCHDOG_WARNING, '<a href="https://docs.backdropcms.org/documentation/testing-framework">See the Testing Framework documentation.</a>');
+          watchdog('simpletest', 'File %uri contains no testing classes.', array('%uri' => $file->uri), WATCHDOG_WARNING, l(t('See the Testing Framework documentation.'), 'https://docs.backdropcms.org/documentation/testing-framework'));
           continue;
         }
         foreach ($classes as $class => $info) {

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -364,28 +364,52 @@ function simpletest_test_get_all() {
     else {
       $files = backdrop_system_listing('/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.tests\.info$/', 'modules', 'name', 0);
       $groups = array();
+      $check_keys = array('name', 'description', 'group', 'file');
       foreach ($files as $file) {
         $classes = backdrop_parse_info_file($file->uri, TRUE);
-        // If the .tests.info file contained no classes, then it puts a slew of
-        // hard-to-diagnose errors into the watchdog log when the testing page
-        // is loaded. So we'll check and put a more informative error here.
-        $class_values = array_values($classes);
-        if (empty($classes) || !is_array($class_values[0])) {
-          watchdog('simpletest', 'File %uri contains no testing classes.', array('%uri' => $file->uri), WATCHDOG_WARNING, l(t('See the Testing Framework documentation.'), 'https://docs.backdropcms.org/documentation/testing-framework'));
-          continue;
+        $error = '';
+        if (empty($classes)) {
+          $error = 'File %uri contains no testing classes.';
         }
-        foreach ($classes as $class => $info) {
-          $info['file path'] = dirname($file->uri);
-          // If this test class requires a non-existing module, skip it.
-          if (!empty($info['dependencies'])) {
-            foreach ($info['dependencies'] as $module) {
-              if (!backdrop_get_filename('module', $module)) {
-                continue 2;
+        else {
+          foreach ($classes as $class => $info) {
+            // If the .tests.info file is malformed, it puts a slew of
+            // hard-to-diagnose errors into the watchdog log when the testing page
+            // is loaded. So we'll check for various malformalities and put a more
+            // informative error.
+            if (!is_array($info) || empty($info)) {
+              $error = format_string('File %uri contains a definition for %class that is not an array of testing class fields.', array('%class' => $class));
+              continue;
+            }
+            else {
+              foreach ($check_keys as $key) {
+                if (!isset($info[$key])) {
+                  $error = format_string('File %uri contains a definition for %class that is missing field %key.', array('%class' => $class, '%key' => $key));
+                  break;
+                }
+              }
+              if (!empty($error)) {
+                continue;
               }
             }
+            if (empty($error)) {
+            // If the format passed, build the rest of the groups information.
+              $info['file path'] = dirname($file->uri);
+              // If this test class requires a non-existing module, skip it.
+              if (!empty($info['dependencies'])) {
+                foreach ($info['dependencies'] as $module) {
+                  if (!backdrop_get_filename('module', $module)) {
+                    continue 2;
+                  }
+                }
+              }
+              $groups[$info['group']][$class] = $info;
+            }
           }
-
-          $groups[$info['group']][$class] = $info;
+        }
+        if (!empty($error)) {
+          watchdog('simpletest', $error, array('%uri' => $file->uri), WATCHDOG_WARNING, l(t('See the Testing Framework documentation.'), 'https://docs.backdropcms.org/documentation/testing-framework'));
+          continue;
         }
       }
 

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -366,6 +366,13 @@ function simpletest_test_get_all() {
       $groups = array();
       foreach ($files as $file) {
         $classes = backdrop_parse_info_file($file->uri, TRUE);
+        if (empty($classes) || !is_array(array_values($classes)[0])) {
+          // If the .tests.info file contained no classes, then it puts a slew
+          // of hard-to-diagnose errors into the watchdog log when the testing
+          // page is loaded. So we'll put a more informative error here.
+          watchdog('simpletest', 'There are no testing classes in file %uri', array('%uri' => $file->uri), WATCHDOG_WARNING);
+          continue;
+        }
         foreach ($classes as $class => $info) {
           $info['file path'] = dirname($file->uri);
           // If this test class requires a non-existing module, skip it.

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -366,7 +366,8 @@ function simpletest_test_get_all() {
       $groups = array();
       foreach ($files as $file) {
         $classes = backdrop_parse_info_file($file->uri, TRUE);
-        if (empty($classes) || !is_array(array_values($classes)[0])) {
+        $class_values = array_values($classes);
+        if (empty($classes) || !is_array($class_values[0])) {
           // If the .tests.info file contained no classes, then it puts a slew
           // of hard-to-diagnose errors into the watchdog log when the testing
           // page is loaded. So we'll put a more informative error here.

--- a/core/modules/simpletest/simpletest.module
+++ b/core/modules/simpletest/simpletest.module
@@ -382,13 +382,15 @@ function simpletest_test_get_all() {
               continue;
             }
             else {
+              $missing_keys = array();
               foreach ($check_keys as $key) {
                 if (!isset($info[$key])) {
-                  $error = format_string('File %uri contains a definition for %class that is missing field %key.', array('%class' => $class, '%key' => $key));
-                  break;
+                  $missing_keys[] = $key;
                 }
               }
-              if (!empty($error)) {
+              if (!empty($missing_keys)) {
+                $keys = implode(', ', $missing_keys);
+                $error = format_plural(count($missing_keys), 'File %uri contains a definition for %class that is missing field %keys.','File %uri contains a definition for %class that is missing fields %keys.', array('%class' => $class, '%keys' => $keys));
                 continue;
               }
             }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5415.