### PR TITLE
Issue #1739: Entity view() documentation follow-ups.

### DIFF
--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -132,6 +132,7 @@ interface EntityInterface {
    *   (optional) A language code to use for rendering. Defaults to the global
    *   content language of the current request.
    *
+   * @since 1.21.0 Method added.
    */
   public function buildContent($view_mode = 'full', $langcode = NULL);
 
@@ -150,6 +151,8 @@ interface EntityInterface {
    *
    * @return
    *   A render array of the entity.
+   *
+   * @since 1.21.0 Method added.
    */
   public function view($view_mode = 'full', $langcode = NULL, $page = NULL);
 

--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -313,6 +313,8 @@ abstract class Entity extends stdClass implements EntityInterface {
 
   /**
    * Implements EntityInterface::buildContent().
+   *
+   * @since 1.21.0 Method added.
    */
   public function buildContent($view_mode = 'full', $langcode = NULL) {
     return entity_get_controller($this->entityType())->buildContent($this, $view_mode, $langcode);
@@ -320,6 +322,8 @@ abstract class Entity extends stdClass implements EntityInterface {
 
   /**
    * Implements EntityInterface::view().
+   *
+   * @since 1.21.0 Method added.
    */
   public function view($view_mode = 'full', $langcode = NULL, $page = NULL) {
     $view = entity_get_controller($this->entityType())->view(array($this->id() => $this), $view_mode, $langcode, $page);

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -67,6 +67,8 @@ interface EntityControllerInterface {
    *
    * @return
    *   The renderable array.
+   *
+   * @since 1.21.0 Method added.
    */
   public function buildContent(EntityInterface $entity, $view_mode = 'full', $langcode = NULL);
 
@@ -87,6 +89,8 @@ interface EntityControllerInterface {
    *
    * @return array
    *   The renderable array, keyed by entity type and entity ID.
+   *
+   * @since 1.21.0 Method added.
    */
   public function view($entities, $view_mode = 'full', $langcode = NULL, $page = NULL);
 }
@@ -572,6 +576,8 @@ class DefaultEntityController implements EntityControllerInterface {
 
   /**
    * Implements EntityControllerInterface::buildContent().
+   *
+   * @since 1.21.0 Method added.
    */
   public function buildContent(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
     global $language_content;
@@ -604,6 +610,8 @@ class DefaultEntityController implements EntityControllerInterface {
 
   /**
    * Implements EntityControllerInterface::view().
+   *
+   * @since 1.21.0 Method added.
    */
   public function view($entities, $view_mode = 'full', $langcode = NULL, $page = NULL) {
     global $language_content;

--- a/core/modules/entity/entity.module
+++ b/core/modules/entity/entity.module
@@ -214,15 +214,17 @@ function entity_access($op, $entity_type, EntityInterface $entity = NULL, User $
  * The content built for the entity will vary depending on the $view_mode
  * parameter.
  *
- * @param Entity $entity
+ * @param EntityInterface $entity
  *   An entity object.
  * @param string $view_mode
  *   A view mode as used by this entity type, e.g. 'full', 'teaser'...
  * @param string $langcode
  *   (optional) A language code to use for rendering. Defaults to the global
  *   content language of the current request.
+ *
+ * @since 1.21.0 Function added.
  */
-function entity_build_content(EntityInterface $entity = NULL, $view_mode = 'full', $langcode = NULL) {
+function entity_build_content(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
   $info = entity_get_info($entity->entityType());
   if (in_array('EntityControllerInterface', class_implements($info['controller class']))) {
     entity_get_controller($entity->entityType())->buildContent($entity, $view_mode, $langcode);
@@ -240,9 +242,11 @@ function entity_build_content(EntityInterface $entity = NULL, $view_mode = 'full
  *   (optional) A language code to use for rendering. Defaults to the global
  *   content language of the current request.
  *
- * @return
+ * @return array|FALSE
  *   The renderable array. If there is no information on how to view an entity,
  *   FALSE is returned.
+ *
+ * @since 1.21.0 Function added.
  */
 function entity_view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
   $entity_type = $entity->entityType();
@@ -276,9 +280,11 @@ function entity_view(EntityInterface $entity, $view_mode = 'full', $langcode = N
  *   If unset, the page mode will be enabled if the current path is the URI
  *   of the entity, as returned by entity_uri().
  *
- * @return
+ * @return array|FALSE
  *   The renderable array, keyed by the entity type and by entity ID. If
  *   there is no information on how to view an entity, FALSE is returned.
+ *
+ * @since 1.21.0 Function added.
  */
 function entity_view_multiple($entity_type, $entities, $view_mode = 'full', $langcode = NULL, $page = NULL) {
   $info = entity_get_info($entity_type);


### PR DESCRIPTION
Small follow-ups for https://github.com/backdrop/backdrop-issues/issues/1739 that add `@since` lines and update a few docblock parameters and return values.