### PR TITLE
Issue #3992: Provide warning that PHP versions prior to 5.6 will be dropped soon.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -75,12 +75,13 @@ function system_requirements($phase) {
   }
 
   // Minimum recommended PHP version can be incremented when deprecating older
-  // versions of PHP but while they are still supported.
+  // versions of PHP but while they are still supported. This does not throw
+  // a warning or error on updates to keep upgrade tests compatible.
   $minimum_recommended_version = '5.6.0';
   $minimum_warning = $t('Your PHP installation is too old. Backdrop requires at least PHP %version.', array('%version' => $minimum_recommended_version));
   if (version_compare($phpversion, $minimum_recommended_version) < 0) {
     $requirements['php']['description'] = $minimum_warning . ' ' . l(t('Read about the minimum version increase'), 'https://backdropcms.org/news/backdrop-cms-drops-support-for-php-versions-prior-to-56') . '.';
-    $requirements['php']['severity'] = $phase === 'runtime' ? REQUIREMENT_ERROR : REQUIREMENT_WARNING;
+    $requirements['php']['severity'] = $phase === 'runtime' ? REQUIREMENT_ERROR : REQUIREMENT_INFO;
   }
 
   // If PHP does not meet the bare minimum, remaining checks are unnecessary.

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -74,10 +74,19 @@ function system_requirements($phase) {
     );
   }
 
+  // Minimum recommended PHP version can be incremented when deprecating older
+  // versions of PHP but while they are still supported.
+  $minimum_recommended_version = '5.6.0';
+  $minimum_warning = $t('Your PHP installation is too old. Backdrop requires at least PHP %version.', array('%version' => $minimum_recommended_version));
+  if (version_compare($phpversion, $minimum_recommended_version) < 0) {
+    $requirements['php']['description'] = $minimum_warning . ' ' . l(t('Read about the minimum version increase'), 'https://backdropcms.org/news/backdrop-cms-drops-support-for-php-versions-prior-to-56') . '.';
+    $requirements['php']['severity'] = $phase === 'runtime' ? REQUIREMENT_ERROR : REQUIREMENT_WARNING;
+  }
+
+  // If PHP does not meet the bare minimum, remaining checks are unnecessary.
   if (version_compare($phpversion, BACKDROP_MINIMUM_PHP) < 0) {
-    $requirements['php']['description'] = $t('Your PHP installation is too old. Backdrop requires at least PHP %version.', array('%version' => BACKDROP_MINIMUM_PHP));
+    $requirements['php']['description'] = $minimum_warning;
     $requirements['php']['severity'] = REQUIREMENT_ERROR;
-    // If PHP is old, it's not safe to continue with the requirements check.
     return $requirements;
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3992