### PR TITLE
5399 configure layout page compact

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -85,6 +85,34 @@
   margin-left: 0;
 }
 
+/* Inject a little space after the path matches text within the description. */
+#path-matches {
+  margin-bottom: 0.5em;
+}
+
+/* Toggle for the placeholder examples */
+.placeholder-examples-toggle {
+  white-space: nowrap;
+}
+.placeholder-examples-toggle .arrow {
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+  border-right-color: transparent;
+  border-style: solid;
+  border-width: 0.3333em 0.3333em 0;
+  display: inline-block;
+  height: 0;
+  line-height: 0;
+  width: 0;
+  overflow: hidden;
+  margin: 0.15em 0.3333em;
+}
+.placeholder-examples-toggle .arrow.close {
+  border-top-color: transparent;
+  border-bottom-color: #0074bd;
+  border-width: 0 0.3333em 0.3333em;
+}
+
 /* Menu item argument settings. */
 #layout-arguments strong,
 #layout-context-table strong {

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -86,15 +86,18 @@
 }
 
 /* Inject a little space after the path matches text within the description. */
-#path-matches {
+#layout-path-matches {
   margin-bottom: 0.5em;
+}
+.layout-placeholder-examples {
+  margin-top: 0.5em;
 }
 
 /* Toggle for the placeholder examples */
-.placeholder-examples-toggle {
+.layout-placeholder-examples-toggle {
   white-space: nowrap;
 }
-.placeholder-examples-toggle .arrow {
+.layout-placeholder-examples-toggle .arrow {
   border-bottom-color: transparent;
   border-left-color: transparent;
   border-right-color: transparent;
@@ -107,7 +110,7 @@
   overflow: hidden;
   margin: 0.15em 0.3333em;
 }
-.placeholder-examples-toggle .arrow.close {
+.layout-placeholder-examples-toggle .arrow.close {
   border-top-color: transparent;
   border-bottom-color: #0074bd;
   border-width: 0 0.3333em 0.3333em;

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -40,10 +40,10 @@ Backdrop.behaviors.layoutConfigure = {
     function examples_toggle_handler(e) {
       var $examples = $(this).next().toggle();
       if ($examples.is(':visible')) {
-        $(this).text(Backdrop.t('less')).append('<span class="arrow close"></span>');
+        $(this).text(Backdrop.t('Hide examples')).append('<span class="arrow close"></span>');
       }
       else {
-        $(this).text(Backdrop.t('more')).append('<span class="arrow"></span>');
+        $(this).text(Backdrop.t('Show examples')).append('<span class="arrow"></span>');
       }
       e.preventDefault();
       e.stopPropagation();

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -33,6 +33,22 @@ Backdrop.behaviors.layoutList = {
  */
 Backdrop.behaviors.layoutConfigure = {
   attach: function(context) {
+
+    /**
+     * Toggle handler for the placeholder examples.
+     */
+    function examples_toggle_handler(e) {
+      var $examples = $(this).next().toggle();
+      if ($examples.is(':visible')) {
+        $(this).text(Backdrop.t('less')).append('<span class="arrow close"></span>');
+      }
+      else {
+        $(this).text(Backdrop.t('more')).append('<span class="arrow"></span>');
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
     var $form = $('.layout-settings-form').once('layout-settings');
     if ($form.length && Backdrop.ajax) {
       var ajax = Backdrop.ajax['edit-path-update'];
@@ -43,6 +59,10 @@ Backdrop.behaviors.layoutConfigure = {
           ajax.cleanUp(ajax.currentRequests[n]);
         }
         $('input[data-layout-path-update]').triggerHandler('mousedown');
+
+      // (Re)install placeholder examples toggle handler.
+      $('a.placeholder-examples-toggle').click(examples_toggle_handler);
+
       };
       // Update contexts after a slight typing delay.
       var timer = 0;
@@ -51,6 +71,12 @@ Backdrop.behaviors.layoutConfigure = {
         timer = setTimeout(updateContexts, 200);
       });
     }
+
+    // Hide the placeholder examples.
+    $form.find('.placeholder-examples').hide();
+
+    // Handle toggling the placeholder examples.
+   $('a.placeholder-examples-toggle').click(examples_toggle_handler);
 
     // Convert AJAX buttons to links.
     var $linkButtons = $(context).find('.layout-link-button').once('link-button');
@@ -135,7 +161,7 @@ Backdrop.behaviors.layoutDisplayEditor = {
         }
       }
 
-      $('#layout-edit-main').on('keydown', '.layout-editor-block', function(event) { 
+      $('#layout-edit-main').on('keydown', '.layout-editor-block', function(event) {
         var currentDroppable = $(this).closest('.layout-editor-region');
         var currentDroppableId = currentDroppable.attr('id');
         var that = $(this);

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -76,7 +76,7 @@ Backdrop.behaviors.layoutConfigure = {
     $form.find('.placeholder-examples').hide();
 
     // Handle toggling the placeholder examples.
-   $('a.placeholder-examples-toggle').click(examples_toggle_handler);
+    $('a.placeholder-examples-toggle').click(examples_toggle_handler);
 
     // Convert AJAX buttons to links.
     var $linkButtons = $(context).find('.layout-link-button').once('link-button');

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -61,7 +61,7 @@ Backdrop.behaviors.layoutConfigure = {
         $('input[data-layout-path-update]').triggerHandler('mousedown');
 
       // (Re)install placeholder examples toggle handler.
-      $('a.placeholder-examples-toggle').click(examples_toggle_handler);
+      $('a.layout-placeholder-examples-toggle').click(examples_toggle_handler);
 
       };
       // Update contexts after a slight typing delay.
@@ -73,10 +73,10 @@ Backdrop.behaviors.layoutConfigure = {
     }
 
     // Hide the placeholder examples.
-    $form.find('.placeholder-examples').hide();
+    $form.find('.layout-placeholder-examples').hide();
 
     // Handle toggling the placeholder examples.
-    $('a.placeholder-examples-toggle').click(examples_toggle_handler);
+    $('a.layout-placeholder-examples-toggle').click(examples_toggle_handler);
 
     // Convert AJAX buttons to links.
     var $linkButtons = $(context).find('.layout-link-button').once('link-button');

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -743,8 +743,9 @@ function layout_settings_form_validate(&$form, &$form_state) {
 }
 
 /**
- * Submit handler for layout_settings_form() that updates available contexts
- * and information about path matching.
+ * Submit handler for layout_settings_form().
+ *
+ * Updates available contexts and information about path matching.
  */
 function layout_settings_form_path_rebuild($form, &$form_state) {
   $form_state['rebuild'] = TRUE;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -284,7 +284,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   // Path entry field with dynamic information about the entered path and
   // toggleable placeholder examples.
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
-  $is_new = $layout && $layout->is_new;
+  $is_new = isset($layout->is_new) && $layout->is_new;
   $has_placeholder = strpos($path, '%') !== FALSE;
   if (empty($path)) {
     $path_matches_text = t('Please enter a path.');

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -284,6 +284,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   // Path entry field with dynamic information about the entered path and
   // toggleable placeholder examples.
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
+  $is_new = $layout && $layout->is_new;
   $has_placeholder = strpos($path, '%') !== FALSE;
   if (empty($path)) {
     $path_matches_text = t('Please enter a path.');
@@ -305,7 +306,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     }
     else {
       if ($has_placeholder) {
-        if ($layout->is_new) {
+        if ($is_new) {
           $path_matches_text = t('This path will create pages whose paths match this pattern.');
         }
         else {
@@ -313,7 +314,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
         }
       }
       else {
-        if ($layout->is_new) {
+        if ($is_new) {
           $path_matches_text = t('This path will create a page at this path.');
         }
         else {

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -296,10 +296,6 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#default_value' => $layout->getPath(),
     '#required' => TRUE,
     '#access' => !$layout->isDefault(),
-    '#ajax' => array(
-      'callback' => 'layout_path_matches_callback',
-      'wrapper' => 'path-matches',
-    ),
   );
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
   $path_matches = db_query('
@@ -643,13 +639,6 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
 }
 
 /**
- * Callback to return the path matching information.
- */
-function layout_path_matches_callback($form, &$form_state) {
-  return $form['path_matches'];
-}
-
-/**
  * Validates layout_settings_form(), ensuring a valid path.
  */
 function layout_settings_form_validate(&$form, &$form_state) {
@@ -701,19 +690,22 @@ function layout_settings_form_validate(&$form, &$form_state) {
 }
 
 /**
- * Submit handler for layout_settings_form() that updates available contexts.
+ * Submit handler for layout_settings_form() that updates available contexts
+ * and information about path matching.
  */
 function layout_settings_form_path_rebuild($form, &$form_state) {
   $form_state['rebuild'] = TRUE;
 }
 
 /**
- * AJAX handler for layout_settings_form() the returns updated contexts.
+ * AJAX handler for layout_settings_form() the returns updated contexts and
+ * information about path matching.
  */
 function layout_settings_form_path_ajax($form, &$form_state) {
   $commands[] = ajax_command_remove('.l-messages');
   $commands[] = ajax_command_html('#layout-messages', theme('status_messages'));
   $commands[] = ajax_command_html('#layout-contexts', backdrop_render($form['context_wrapper']));
+  $commands[] = ajax_command_html('#path-matches', backdrop_render($form['path_matches']));
   return array(
     '#type' => 'ajax',
     '#commands' => $commands,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -284,7 +284,11 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   // Path entry field with dynamic information about the entered path and
   // toggleable placeholder examples.
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
-  if (!empty($path)) {
+  $has_placeholder = strpos($path, '%') !== FALSE;
+  if (empty($path)) {
+    $path_matches_text = t('Please enter a path.');
+  }
+  else {
     $path_matches = db_query('
       SELECT path, page_callback
       FROM {menu_router}
@@ -292,14 +296,31 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       ', array(':path' => $path))
       ->fetchAllKeyed();
     if (count($path_matches)) {
-      $path_matches_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
+      if ($has_placeholder) {
+        $path_matches_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
+      }
+      else {
+        $path_matches_text = t('This layout will override the default layout for an existing page whose path matches this pattern.');
+      }
     }
     else {
-      $path_matches_text = t('This path will create a page.');
+      if ($has_placeholder) {
+        if ($layout->is_new) {
+          $path_matches_text = t('This path will create pages whose paths match this pattern.');
+        }
+        else {
+          $path_matches_text = t('This path will provide pages whose paths match this pattern.');
+        }
+      }
+      else {
+        if ($layout->is_new) {
+          $path_matches_text = t('This path will create a page at this path.');
+        }
+        else {
+          $path_matches_text = t('This path will provide a page at this path.');
+        }
+      }
     }
-  }
-  else {
-    $path_matches_text = t('Please enter a path.');
   }
   $form['path_matches_text'] = array(
     '#type' => 'value',

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -295,9 +295,36 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#type' => 'textfield',
     '#default_value' => $layout->getPath(),
     '#required' => TRUE,
-    '#description' => '<p>' . t('Use the percent symbol ("%") to indicate a placeholder in the path. Some common examples include:') . '</p>' . $description_list,
     '#access' => !$layout->isDefault(),
+    '#ajax' => array(
+      'callback' => 'layout_path_matches_callback',
+      'wrapper' => 'path-matches',
+    ),
   );
+  $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
+  $path_matches = db_query('
+    SELECT path, page_callback
+    FROM {menu_router}
+    WHERE path = :path
+    ', array(':path' => $path))
+    ->fetchAllKeyed();
+  if (count($path_matches)) {
+    $path_match_text = t('This layout will override the page(s) created by function %page_callback.', array('%page_callback' => $path_matches[$path]));
+  }
+  else {
+    $path_match_text = t('This path will create a layout-provided page.');
+  }
+  $form['path_matches'] = array(
+    '#markup' => $path_match_text,
+    '#prefix' => '<p id="path-matches">',
+    '#suffix' => '</p>',
+  );
+  $form['path_details'] = array(
+    '#type' => 'details',
+    '#summary' => t('Paths and placeholders'),
+    '#details' => '<p>' . t('Use the percent symbol ("%") to indicate a placeholder in the path. Some common examples include:') . '</p>' . $description_list,
+  );
+
   $form['path_update'] = array(
     '#type' => 'submit',
     '#value' => t('Check path'),
@@ -327,7 +354,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#title' => t('Contexts'),
     '#type' => 'item',
     '#id' => 'context-wrapper',
-    '#description' => t('(Optional) Contexts define what blocks are available within this layout. Most placeholders in the path will be associated with a context automatically.'),
+    '#description' => t('Contexts define what blocks are available within this layout. Most placeholders in the path will be associated with a context automatically.'),
     // Current user context is always present.
   );
   $form['context_wrapper']['#access'] = !$layout->isDefault();
@@ -613,6 +640,13 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   }
 
   return $form;
+}
+
+/**
+ * Callback to return the path matching information.
+ */
+function layout_path_matches_callback($form, &$form_state) {
+  return $form['path_matches'];
 }
 
 /**

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -752,8 +752,9 @@ function layout_settings_form_path_rebuild($form, &$form_state) {
 }
 
 /**
- * AJAX handler for layout_settings_form() the returns updated contexts and
- * information about path matching.
+ * AJAX handler for layout_settings_form().
+ *
+ * Returns updated contexts and information about path matching.
  */
 function layout_settings_form_path_ajax($form, &$form_state) {
   $commands[] = ajax_command_remove('.l-messages');

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -320,6 +320,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#type' => 'details',
     '#summary' => t('Paths and placeholders'),
     '#details' => '<p>' . t('Use the percent symbol ("%") to indicate a placeholder in the path. Some common examples include:') . '</p>' . $description_list,
+    '#attributes' => array('class' => array('description')),
   );
 
   $form['path_update'] = array(

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -328,6 +328,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   $form['path_matches_wrapper'] = array(
     '#type' => 'container',
     '#id' => 'path-matches',
+    '#access' => !$layout->isDefault(),
   );
   $form['path_matches_wrapper']['path_matches'] = array(
     '#markup' => $path_match_text,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -314,7 +314,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     'path_matches_text' => array('#markup' => $path_matches_text),
   );
   $path_matches_description = backdrop_render($path_matches);
-  $toggle = ' <a class="placeholder-examples-toggle" href="#">' . t('more') . '<span class="arrow"></span></a>';
+  $toggle = ' <a class="placeholder-examples-toggle" href="#">' . t('Show examples') . '<span class="arrow"></span></a>';
   $description_items = array(
     t('Content: <code>node/%</code>'),
     t('User accounts: <code>user/%</code>'),

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -314,7 +314,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     'path_matches_text' => array('#markup' => $path_matches_text),
   );
   $path_matches_description = backdrop_render($path_matches);
-  $toggle .= ' <a class="placeholder-examples-toggle" href="#">' . t('more') . '<span class="arrow"></span></a>';
+  $toggle = ' <a class="placeholder-examples-toggle" href="#">' . t('more') . '<span class="arrow"></span></a>';
   $description_items = array(
     t('Content: <code>node/%</code>'),
     t('User accounts: <code>user/%</code>'),

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -301,7 +301,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   $form['path_details'] = array(
     '#type' => 'details',
     '#summary' => t('Placeholder examples'),
-    '#details' => '<p>' . t('Some common examples of placeholders include:') . '</p>' . $description_list,
+    '#details' => t('Some common examples of placeholders include:') . $description_list,
     '#attributes' => array('class' => array('description')),
   );
 
@@ -314,7 +314,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       ', array(':path' => $path))
       ->fetchAllKeyed();
     if (count($path_matches)) {
-      $path_match_text = t('This layout will override the default layout for existing page(s) (which are created by %page_callback).', array('%page_callback' => $path_matches[$path]));
+      $path_match_text = t('This layout will override the default layout for existing page(s).');
     }
     else {
       $path_match_text = t('This path will create a page.');
@@ -323,10 +323,13 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   else {
     $path_match_text = '';
   }
-  $form['path_matches'] = array(
+
+  $form['path_matches_wrapper'] = array(
+    '#type' => 'container',
+    '#id' => 'path-matches',
+  );
+  $form['path_matches_wrapper']['path_matches'] = array(
     '#markup' => $path_match_text,
-    '#prefix' => '<p id="path-matches">',
-    '#suffix' => '</p>',
   );
 
   $form['path_update'] = array(
@@ -723,7 +726,7 @@ function layout_settings_form_path_ajax($form, &$form_state) {
   $commands[] = ajax_command_remove('.l-messages');
   $commands[] = ajax_command_html('#layout-messages', theme('status_messages'));
   $commands[] = ajax_command_html('#layout-contexts', backdrop_render($form['context_wrapper']));
-  $commands[] = ajax_command_html('#path-matches', backdrop_render($form['path_matches']));
+  $commands[] = ajax_command_html('#path-matches', backdrop_render($form['path_matches_wrapper']['path_matches']));
   return array(
     '#type' => 'ajax',
     '#commands' => $commands,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -305,7 +305,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     ', array(':path' => $path))
     ->fetchAllKeyed();
   if (count($path_matches)) {
-    $path_match_text = t('This layout will override the page(s) created by function %page_callback.', array('%page_callback' => $path_matches[$path]));
+    $path_match_text = t('This layout will override the default layout for existing page(s) (created by %page_callback).', array('%page_callback' => $path_matches[$path]));
   }
   else {
     $path_match_text = t('This path will create a layout-provided page.');

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -306,17 +306,22 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   );
 
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
-  $path_matches = db_query('
-    SELECT path, page_callback
-    FROM {menu_router}
-    WHERE path = :path
-    ', array(':path' => $path))
-    ->fetchAllKeyed();
-  if (count($path_matches)) {
-    $path_match_text = t('This layout will override the default layout for existing page(s) (which are created by %page_callback).', array('%page_callback' => $path_matches[$path]));
+  if (!empty($path)) {
+    $path_matches = db_query('
+      SELECT path, page_callback
+      FROM {menu_router}
+      WHERE path = :path
+      ', array(':path' => $path))
+      ->fetchAllKeyed();
+    if (count($path_matches)) {
+      $path_match_text = t('This layout will override the default layout for existing page(s) (which are created by %page_callback).', array('%page_callback' => $path_matches[$path]));
+    }
+    else {
+      $path_match_text = t('This path will create a page.');
+    }
   }
   else {
-    $path_match_text = t('This path will create a page.');
+    $path_match_text = '';
   }
   $form['path_matches'] = array(
     '#markup' => $path_match_text,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -303,6 +303,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#summary' => t('Placeholder examples'),
     '#details' => t('Some common examples of placeholders include:') . $description_list,
     '#attributes' => array('class' => array('description')),
+    '#access' => !$layout->isDefault(),
   );
 
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -315,7 +315,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       ', array(':path' => $path))
       ->fetchAllKeyed();
     if (count($path_matches)) {
-      $path_match_text = t('This layout will override the default layout for existing page(s).');
+      $path_match_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
     }
     else {
       $path_match_text = t('This path will create a page.');

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -288,25 +288,8 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#default_value' => $layout->getPath(),
     '#required' => TRUE,
     '#access' => !$layout->isDefault(),
-  );
-
-  $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
-  $path_matches = db_query('
-    SELECT path, page_callback
-    FROM {menu_router}
-    WHERE path = :path
-    ', array(':path' => $path))
-    ->fetchAllKeyed();
-  if (count($path_matches)) {
-    $path_match_text = t('This layout will override the default layout for existing page(s) (created by %page_callback).', array('%page_callback' => $path_matches[$path]));
-  }
-  else {
-    $path_match_text = t('This path will create a layout-provided page.');
-  }
-  $form['path_matches'] = array(
-    '#markup' => $path_match_text,
-    '#prefix' => '<p id="path-matches">',
-    '#suffix' => '</p>',
+    '#description' => t('Use the percent symbol ("%") to indicate a placeholder in the path.'),
+    '#field_suffix' => '<small class="pattern-preview">' . $preview . '</small>',
   );
 
   $description_items = array(
@@ -318,9 +301,28 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   $description_list = theme('item_list', array('items' => $description_items));
   $form['path_details'] = array(
     '#type' => 'details',
-    '#summary' => t('Paths and placeholders'),
-    '#details' => '<p>' . t('Use the percent symbol ("%") to indicate a placeholder in the path. Some common examples include:') . '</p>' . $description_list,
+    '#summary' => t('Placeholder examples'),
+    '#details' => '<p>' . t('Some common examples of placeholders include:') . '</p>' . $description_list,
     '#attributes' => array('class' => array('description')),
+  );
+
+  $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
+  $path_matches = db_query('
+    SELECT path, page_callback
+    FROM {menu_router}
+    WHERE path = :path
+    ', array(':path' => $path))
+    ->fetchAllKeyed();
+  if (count($path_matches)) {
+    $path_match_text = t('This layout will override the default layout for existing page(s) (which are created by %page_callback).', array('%page_callback' => $path_matches[$path]));
+  }
+  else {
+    $path_match_text = t('This path will create a page.');
+  }
+  $form['path_matches'] = array(
+    '#markup' => $path_match_text,
+    '#prefix' => '<p id="path-matches">',
+    '#suffix' => '</p>',
   );
 
   $form['path_update'] = array(
@@ -348,12 +350,11 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   // Get all contexts except those provided by relationships.
   $contexts = $layout->getContexts(LayoutContext::USAGE_TYPE_ALL ^ LayoutContext::USAGE_TYPE_RELATIONSHIP);
   $built_in_contexts = isset($contexts['overrides_path']) ? 2 : 1;
+  $context_description = t('Contexts provide additional information to blocks displayed within the layout. Most placeholders in the path will automatically create context(s).');
   $form['context_wrapper'] = array(
     '#title' => t('Contexts'),
     '#type' => 'item',
     '#id' => 'context-wrapper',
-    '#description' => t('Contexts define what blocks are available within this layout. Most placeholders in the path will be associated with a context automatically.'),
-    // Current user context is always present.
   );
   $form['context_wrapper']['#access'] = !$layout->isDefault();
   $form['context_wrapper']['#prefix'] = '<div id="layout-contexts">';
@@ -362,7 +363,11 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#type' => 'container',
     '#parents' => array('context'),
   );
-
+  $form['context_wrapper']['context']['description'] = array(
+    '#markup' => '',
+    '#prefix' => '<div class="description">',
+    '#suffix' => '</div>',
+  );
   $form['context_wrapper']['context']['links'] = array(
     '#theme' => 'layout_action_links',
   );
@@ -397,7 +402,9 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
         'callback' => 'layout_ajax_form_open_dialog',
       ),
     );
+    $context_description .= ' ' . t('Relationships create contexts from data provided by existing contexts.');
   }
+  $form['context_wrapper']['context']['description']['#markup'] = $context_description;
 
   $all_context_info = _layout_get_all_info('layout_context');
   $context_options = array();
@@ -544,9 +551,13 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   $form['conditions'] = array(
     '#title' => t('Visibility conditions'),
     '#type' => 'item',
-    '#description' => t('Visibility conditions allow this layout to selectively apply to different situations, such as different types of content at the same placeholder path.'),
     '#id' => 'layout-access',
     '#access' => !$layout->isDefault(),
+  );
+  $form['conditions']['description'] = array(
+    '#markup' => t('Visibility conditions allow this layout to selectively apply to different situations, such as different types of content at the same path.'),
+    '#prefix' => '<div class="description">',
+    '#suffix' => '</div>',
   );
   $form['conditions']['links'] = array(
     '#theme' => 'layout_action_links',
@@ -564,6 +575,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       'callback' => 'layout_ajax_form_open_dialog',
     ),
   );
+
   $form['conditions']['active'] = array(
     '#type' => 'container',
     '#theme' => 'layout_conditions',

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -298,10 +298,20 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       ->fetchAllKeyed();
     if (count($path_matches)) {
       if ($has_placeholder) {
-        $path_matches_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
+        if ($is_new) {
+          $path_matches_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
+        }
+        else {
+          $path_matches_text = t('This layout overrides the default layout for existing page(s) whose paths match this pattern.');
+        }
       }
       else {
-        $path_matches_text = t('This layout will override the default layout for an existing page whose path matches this pattern.');
+        if ($is_new) {
+          $path_matches_text = t('This layout will override the default layout for an existing page whose path matches this pattern.');
+        }
+        else {
+          $path_matches_text = t('This layout overrides the default layout for an existing page whose path matches this pattern.');
+        }
       }
     }
     else {
@@ -310,7 +320,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
           $path_matches_text = t('This path will create pages whose paths match this pattern.');
         }
         else {
-          $path_matches_text = t('This path will provide pages whose paths match this pattern.');
+          $path_matches_text = t('This path provides pages whose paths match this pattern.');
         }
       }
       else {
@@ -318,7 +328,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
           $path_matches_text = t('This path will create a page at this path.');
         }
         else {
-          $path_matches_text = t('This path will provide a page at this path.');
+          $path_matches_text = t('This path provides a page at this path.');
         }
       }
     }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -356,6 +356,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   $description_list = '<div class="placeholder-examples">' . t('Some common examples of placeholders include:') . theme('item_list', array('items' => $description_items)) . '</div>';
   $form['path'] = array(
     '#title' => t('Path'),
+    '#field_prefix' => url('', array('absolute' => TRUE)),
     '#type' => 'textfield',
     '#default_value' => $layout->getPath(),
     '#required' => TRUE,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -281,31 +281,8 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     }
   }
 
-  $form['path'] = array(
-    '#title' => t('Path'),
-    '#field_prefix' => url('', array('absolute' => TRUE)),
-    '#type' => 'textfield',
-    '#default_value' => $layout->getPath(),
-    '#required' => TRUE,
-    '#access' => !$layout->isDefault(),
-    '#description' => t('Use the percent symbol ("%") to indicate a placeholder in the path.'),
-  );
-
-  $description_items = array(
-    t('Content: <code>node/%</code>'),
-    t('User accounts: <code>user/%</code>'),
-    t('Taxonomy terms: <code>taxonomy/term/%</code>'),
-    t('Comments: <code>comment/%</code>'),
-  );
-  $description_list = theme('item_list', array('items' => $description_items));
-  $form['path_details'] = array(
-    '#type' => 'details',
-    '#summary' => t('Placeholder examples'),
-    '#details' => t('Some common examples of placeholders include:') . $description_list,
-    '#attributes' => array('class' => array('description')),
-    '#access' => !$layout->isDefault(),
-  );
-
+  // Path entry field with dynamic information about the entered path and
+  // toggleable placeholder examples.
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
   if (!empty($path)) {
     $path_matches = db_query('
@@ -315,23 +292,43 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       ', array(':path' => $path))
       ->fetchAllKeyed();
     if (count($path_matches)) {
-      $path_match_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
+      $path_matches_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
     }
     else {
-      $path_match_text = t('This path will create a page.');
+      $path_matches_text = t('This path will create a page.');
     }
   }
   else {
-    $path_match_text = '';
+    $path_matches_text = t('Please enter a path.');
   }
-
-  $form['path_matches_wrapper'] = array(
-    '#type' => 'container',
-    '#id' => 'path-matches',
-    '#access' => !$layout->isDefault(),
+  $form['path_matches_text'] = array(
+    '#type' => 'value',
+    '#value' => $path_matches_text,
   );
-  $form['path_matches_wrapper']['path_matches'] = array(
-    '#markup' => $path_match_text,
+  $path_matches = array(
+    '#type' => 'container',
+    '#access' => !$layout->isDefault(),
+    '#attributes' => array(
+      'id' => array('path-matches'),
+    ),
+    'path_matches_text' => array('#markup' => $path_matches_text),
+  );
+  $path_matches_description = backdrop_render($path_matches);
+  $toggle .= ' <a class="placeholder-examples-toggle" href="#">' . t('more') . '<span class="arrow"></span></a>';
+  $description_items = array(
+    t('Content: <code>node/%</code>'),
+    t('User accounts: <code>user/%</code>'),
+    t('Taxonomy terms: <code>taxonomy/term/%</code>'),
+    t('Comments: <code>comment/%</code>'),
+  );
+  $description_list = '<div class="placeholder-examples">' . t('Some common examples of placeholders include:') . theme('item_list', array('items' => $description_items)) . '</div>';
+  $form['path'] = array(
+    '#title' => t('Path'),
+    '#type' => 'textfield',
+    '#default_value' => $layout->getPath(),
+    '#required' => TRUE,
+    '#access' => !$layout->isDefault(),
+    '#description' => $path_matches_description . t('Use the percent symbol ("%") to indicate a placeholder in the path.') . $toggle . $description_list,
   );
 
   $form['path_update'] = array(
@@ -727,8 +724,8 @@ function layout_settings_form_path_rebuild($form, &$form_state) {
 function layout_settings_form_path_ajax($form, &$form_state) {
   $commands[] = ajax_command_remove('.l-messages');
   $commands[] = ajax_command_html('#layout-messages', theme('status_messages'));
+  $commands[] = ajax_command_html('#path-matches', $form['path_matches_text']['#value']);
   $commands[] = ajax_command_html('#layout-contexts', backdrop_render($form['context_wrapper']));
-  $commands[] = ajax_command_html('#path-matches', backdrop_render($form['path_matches_wrapper']['path_matches']));
   return array(
     '#type' => 'ajax',
     '#commands' => $commands,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -281,14 +281,6 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     }
   }
 
-  $items = array(
-    t('Content: <code>node/%</code>'),
-    t('User accounts: <code>user/%</code>'),
-    t('Taxonomy terms: <code>taxonomy/term/%</code>'),
-    t('Comments: <code>comment/%</code>'),
-  );
-  $description_list = theme('item_list', array('items' => $items));
-
   $form['path'] = array(
     '#title' => t('Path'),
     '#field_prefix' => url('', array('absolute' => TRUE)),
@@ -297,6 +289,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#required' => TRUE,
     '#access' => !$layout->isDefault(),
   );
+
   $path = isset($form_state['values']['path']) ? $form_state['values']['path'] : $layout->getPath();
   $path_matches = db_query('
     SELECT path, page_callback
@@ -315,6 +308,14 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#prefix' => '<p id="path-matches">',
     '#suffix' => '</p>',
   );
+
+  $description_items = array(
+    t('Content: <code>node/%</code>'),
+    t('User accounts: <code>user/%</code>'),
+    t('Taxonomy terms: <code>taxonomy/term/%</code>'),
+    t('Comments: <code>comment/%</code>'),
+  );
+  $description_list = theme('item_list', array('items' => $description_items));
   $form['path_details'] = array(
     '#type' => 'details',
     '#summary' => t('Paths and placeholders'),

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -289,7 +289,6 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#required' => TRUE,
     '#access' => !$layout->isDefault(),
     '#description' => t('Use the percent symbol ("%") to indicate a placeholder in the path.'),
-    '#field_suffix' => '<small class="pattern-preview">' . $preview . '</small>',
   );
 
   $description_items = array(

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -290,13 +290,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     $path_matches_text = t('Please enter a path.');
   }
   else {
-    $path_matches = db_query('
-      SELECT path, page_callback
-      FROM {menu_router}
-      WHERE path = :path
-      ', array(':path' => $path))
-      ->fetchAllKeyed();
-    if (count($path_matches)) {
+    if (_layout_menu_router_path_exists($path)) {
       if ($has_placeholder) {
         if ($is_new) {
           $path_matches_text = t('This layout will override the default layout for existing page(s) whose paths match this pattern.');
@@ -341,19 +335,19 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#type' => 'container',
     '#access' => !$layout->isDefault(),
     '#attributes' => array(
-      'id' => array('path-matches'),
+      'id' => array('layout-path-matches'),
     ),
     'path_matches_text' => array('#markup' => $path_matches_text),
   );
   $path_matches_description = backdrop_render($path_matches);
-  $toggle = ' <a class="placeholder-examples-toggle" href="#">' . t('Show examples') . '<span class="arrow"></span></a>';
+  $toggle = ' <a class="layout-placeholder-examples-toggle" href="#">' . t('Show examples') . '<span class="arrow"></span></a>';
   $description_items = array(
     t('Content: <code>node/%</code>'),
     t('User accounts: <code>user/%</code>'),
     t('Taxonomy terms: <code>taxonomy/term/%</code>'),
     t('Comments: <code>comment/%</code>'),
   );
-  $description_list = '<div class="placeholder-examples">' . t('Some common examples of placeholders include:') . theme('item_list', array('items' => $description_items)) . '</div>';
+  $description_list = '<div class="layout-placeholder-examples">' . t('Some common examples of placeholders include:') . theme('item_list', array('items' => $description_items)) . '</div>';
   $form['path'] = array(
     '#title' => t('Path'),
     '#field_prefix' => url('', array('absolute' => TRUE)),
@@ -692,6 +686,20 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
 }
 
 /**
+ * Helper function to determine whether a layout path is an existing menu router
+ * path.
+ */
+function _layout_menu_router_path_exists($path) {
+  $path_matches = db_query('
+    SELECT path, page_callback
+    FROM {menu_router}
+    WHERE path = :path
+    ', array(':path' => $path))
+    ->fetchAll();
+  return !empty($path_matches);
+}
+
+/**
  * Validates layout_settings_form(), ensuring a valid path.
  */
 function layout_settings_form_validate(&$form, &$form_state) {
@@ -759,7 +767,7 @@ function layout_settings_form_path_rebuild($form, &$form_state) {
 function layout_settings_form_path_ajax($form, &$form_state) {
   $commands[] = ajax_command_remove('.l-messages');
   $commands[] = ajax_command_html('#layout-messages', theme('status_messages'));
-  $commands[] = ajax_command_html('#path-matches', $form['path_matches_text']['#value']);
+  $commands[] = ajax_command_html('#layout-path-matches', $form['path_matches_text']['#value']);
   $commands[] = ajax_command_html('#layout-contexts', backdrop_render($form['context_wrapper']));
   return array(
     '#type' => 'ajax',

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -809,6 +809,28 @@ details .details-child-wrapper {
 }
 
 /**
+ * Description version of details element.
+ */
+details.description {
+  padding: 6px 15px;
+  border-radius: 0 0 4px 4px;
+  border: 2px solid #EAEAEA;
+  margin: 1em 0;
+  overflow: hidden;
+  background-color: transparent;
+  display: table-cell;
+}
+details.description summary span {
+  color: #000000;
+  font-size: 100%;
+}
+details.description .details-content-wrapper,
+details.description .details-child-wrapper {
+  color: #666;
+  font-size: 0.85em;
+}
+
+/**
  * Views exposed form (matches fieldsets).
  */
 form.views-exposed-form {

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -809,28 +809,6 @@ details .details-child-wrapper {
 }
 
 /**
- * Description version of details element.
- */
-details.description {
-  padding: 6px 15px;
-  border-radius: 0 0 4px 4px;
-  border: 2px solid #EAEAEA;
-  margin: 1em 0;
-  overflow: hidden;
-  background-color: transparent;
-  display: table-cell;
-}
-details.description summary span {
-  color: #000000;
-  font-size: 100%;
-}
-details.description .details-content-wrapper,
-details.description .details-child-wrapper {
-  color: #666;
-  font-size: 0.85em;
-}
-
-/**
  * Views exposed form (matches fieldsets).
  */
 form.views-exposed-form {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5399.

This version provides a more compact presentation of the additional information, putting it all in the description text under the field. <strike>It also leaves off the URL prefix.</strike>