### PR TITLE
Issue #5437: return all nodes on node_load_multiple() without args

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -872,7 +872,7 @@ function node_invoke($node, $hook, $a2 = NULL, $a3 = NULL, $a4 = NULL) {
  * @see entity_load()
  * @see EntityFieldQuery
  */
-function node_load_multiple($nids = array(), $conditions = array(), $reset = FALSE) {
+function node_load_multiple($nids = FALSE, $conditions = array(), $reset = FALSE) {
   return entity_load('node', $nids, $conditions, $reset);
 }
 


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#5437

Makes `FALSE` the default value for `$ids` - this matches the arguments, functionality and behavior of entity_load_multiple.