### PR TITLE
Issue #5447: Report accurate MariaDB versions (3 digits)

### DIFF
--- a/core/modules/telemetry/telemetry.telemetry.inc
+++ b/core/modules/telemetry/telemetry.telemetry.inc
@@ -9,13 +9,13 @@
  */
 function telemetry_telemetry_info() {
   $info['php_version'] = array(
-    'label' => t('PHP Version'),
-    'description' => t('The current version of PHP running on your server.'),
+    'label' => t('PHP version'),
+    'description' => t('The version of PHP running on your server.'),
     'project' => 'backdrop',
   );
   $info['mysql_version'] = array(
-    'label' => t('MySQL Version'),
-    'description' => t('The version number of your database (either MySQL or MariaDB).'),
+    'label' => t('Database version'),
+    'description' => t('The version of your database server (either MySQL or MariaDB).'),
     'project' => 'backdrop',
   );
   $info['server_os'] = array(
@@ -34,7 +34,31 @@ function telemetry_telemetry_data($key) {
     case 'php_version':
       return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
     case 'mysql_version':
-      return Database::getConnection()->databaseType() === 'mysql' ? Database::getConnection()->version() : NULL;
+      $version = Database::getConnection()->databaseType() === 'mysql' ? Database::getConnection()->version() : NULL;
+      // Backdrop core only supports MySQL and MariaDB. MariaDB version strings
+      // tend to have 2 versions, one for the equivalent MySQL version + another
+      // for the actual MariaDB version. For example, in 5.5.5-10.5.11-MariaDB
+      // 5.5.5 would denote the MySQL equivalency, and 10.5.11 would be the
+      // actual MariaDB version.
+      // Grab all strings within the version that are a sequence of numbers and
+      // dots.
+      preg_match_all('/[\d\.]+/', $version, $versions);
+      // Only one version number detencted. Report that.
+      if (count($versions[0]) == 1) {
+        $version = $versions[0][0];
+      }
+      // Multiple versions detected within the version string.
+      else {
+        // Some variations of the MariaDB version string contain the version
+        // number more than once. For example:
+        // 5.5.5-10.5.11-MariaDB-1:10.5.11+maria~focal-log
+        $versions = array_unique($versions[0]);
+        // Sort versions in reverse (descending) order.
+        rsort($versions, SORT_NATURAL);
+        // Get the greatest version (or the only version).
+        $version = $versions[0];
+      }
+      return $version;
     case 'server_os':
       return PHP_OS;
   }

--- a/core/modules/telemetry/telemetry.telemetry.inc
+++ b/core/modules/telemetry/telemetry.telemetry.inc
@@ -43,7 +43,7 @@ function telemetry_telemetry_data($key) {
       // Grab all strings within the version that are a sequence of numbers and
       // dots.
       preg_match_all('/[\d\.]+/', $version, $versions);
-      // Only one version number detencted. Report that.
+      // Only one version number detected. Report that.
       if (count($versions[0]) == 1) {
         $version = $versions[0][0];
       }
@@ -51,7 +51,7 @@ function telemetry_telemetry_data($key) {
       else {
         // Some variations of the MariaDB version string contain the version
         // number more than once. For example:
-        // 5.5.5-10.5.11-MariaDB-1:10.5.11+maria~focal-log
+        // 5.5.5-10.5.11-MariaDB-1:10.5.11+maria~focal-log.
         $versions = array_unique($versions[0]);
         // Sort versions in reverse (descending) order.
         rsort($versions, SORT_NATURAL);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5447

Reports accurate 3-digit versions, and leaves the trimming/aggregation to whatever the setting for the `mysql_version` value is set in the `project_telemetry` module in b.org for Backdrop core:

![image](https://user-images.githubusercontent.com/2423362/149042834-26315641-6ad1-4ea5-b839-35839ec9c32b.png)

The above would previously be reported as `5.5.5-10.3.27-MariaDB`, which would result in `5.5.5` in the telemetry stats on b.org