### PR TITLE
Issue #5447: Report db type and version (2 digits)

### DIFF
--- a/core/modules/telemetry/telemetry.telemetry.inc
+++ b/core/modules/telemetry/telemetry.telemetry.inc
@@ -9,13 +9,13 @@
  */
 function telemetry_telemetry_info() {
   $info['php_version'] = array(
-    'label' => t('PHP Version'),
-    'description' => t('The current version of PHP running on your server.'),
+    'label' => t('PHP version'),
+    'description' => t('The version of PHP running on your server.'),
     'project' => 'backdrop',
   );
   $info['mysql_version'] = array(
-    'label' => t('MySQL Version'),
-    'description' => t('The version number of your database (either MySQL or MariaDB).'),
+    'label' => t('Database version'),
+    'description' => t('The version of your database server (either MySQL or MariaDB).'),
     'project' => 'backdrop',
   );
   $info['server_os'] = array(
@@ -34,7 +34,37 @@ function telemetry_telemetry_data($key) {
     case 'php_version':
       return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
     case 'mysql_version':
-      return Database::getConnection()->databaseType() === 'mysql' ? Database::getConnection()->version() : NULL;
+      $version = Database::getConnection()->databaseType() === 'mysql' ? Database::getConnection()->version() : NULL;
+      // Backdrop core only supports MySQL and MariaDB. If there is no "maria"
+      // in the version string, assume it is MySQL.
+      $type = strpos(strtolower($version), 'maria') !== FALSE ? 'MariaDB' : 'MySQL';
+      // MariaDB version strings tend to have 2 versions, one for the equivalent
+      // MySQL version + another for the actual MariaDB version. For example, in
+      // 5.5.5-10.5.11-MariaDB:
+      // - 5.5.5 would denote the MySQL equivalency
+      // - 10.5.11 would be the actual MariaDB version.
+      // Grab all strings within the version that are a sequence of numbers and
+      // dots.
+      preg_match_all('/[\d\.]+/', $version, $versions);
+      if (count($versions[0]) == 1) {
+        $version = $versions[0][0];
+      }
+      else {
+        // Some variations of the MariaDB version string contain the version
+        // number more than once. For example:
+        // 5.5.5-10.5.11-MariaDB-1:10.5.11+maria~focal-log.
+        $versions = array_unique($versions[0]);
+        // Sort versions in reverse (descending) order.
+        rsort($versions, SORT_NATURAL);
+        // Get the greatest version (or the only version).
+        $version = $versions[0];
+      }
+      // Trim the version number to only major + minor, otherwise we'd flood the
+      // table with dozens of bug fix versions.
+      $version = explode(".", $version);
+      $version = array_slice($version, 0, 2);
+      $version = implode('.', $version);
+      return $type . ' v' . $version;
     case 'server_os':
       return PHP_OS;
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5447

Reports db type and version, so the version number decimals/accuracy cannot be handled by the current trimming/aggregation options provided by the `project_telemetry` module. That's why the reported value is trimmed down to only 2 digits in `core/modules/telemetry/telemetry.telemetry.inc` (before it gets sent to b.org).

![image](https://user-images.githubusercontent.com/2423362/149046313-6766b166-6522-4fe1-bdf4-00473f5ec1d9.png)

The above would previously be reported as `5.5.5-10.3.27-MariaDB`, which would result in `5.5.5` in the telemetry stats on b.org