### PR TITLE
Issue #5472: Patch from Silkscreen - update SQL SELECT to work with MySQL and PostgreSQL.

### DIFF
--- a/core/modules/menu/menu.install
+++ b/core/modules/menu/menu.install
@@ -144,7 +144,7 @@ function menu_update_1006() {
   // duplicates.
   $query = 'SELECT MIN(mlid) as min_mlid, link_path, menu_name, plid, depth FROM {menu_links}';
   // Paths appearing more than once, limited to "system" entries.
-  $query .= " WHERE module = 'system' GROUP BY link_path HAVING count(link_path) > 1";
+  $query .= " WHERE module = 'system' GROUP BY link_path, menu_name, plid, depth HAVING count(link_path) > 1";
   $candidates = db_query($query)->fetchAllAssoc('link_path');
 
   // Sites updating from versions before 1.21.0 won't have duplicates.


### PR DESCRIPTION
Add the other columns from the SELECT to the GROUP BY clause to prevent an issue with PostgreSQL.

This is a patch added to Silkscreen CMS and submitted upstream to Backdrop to help reduce drift between the two projects.