### PR TITLE
Issue #5473. Allow node_node_access to handle null in $node argument

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2698,6 +2698,10 @@ function node_access($op, $node, $account = NULL) {
  * @return string
  */
 function node_node_access($node, $op, $account) {
+  if (!isset($node) && user_access('administer nodes', $account)) {
+    return NODE_ACCESS_ALLOW;
+  } 
+
   $type = is_string($node) ? $node : $node->type;
 
   if (in_array($type, node_permissions_get_configured_types())) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5473