### PR TITLE
Issue #5077: Distinguish layout-created/module-provided/missing-callback paths on the layout listing page

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -9,7 +9,11 @@
 .layout-list .layout-group td:first-child {
   font-weight: bold;
 }
-.layout-list .layout-row td:first-child {
+.layout-list .layout-group td.missing-path,
+ .layout-list .layout-group td.missing-path a {
+   color: #c40d00;
+ }
+ .layout-list .layout-row td:first-child {
   padding-left: 24px;
 }
 .layout-list tr.disabled td {
@@ -46,6 +50,13 @@
 .layout-list .layout-conditions-list ul {
   margin-left: 0;
 }
+
+.layout-list thead .layout-title {
+   padding-left: 71px;
+ }
+ [dir="rtl"] .layout-list thead .layout-title {
+   padding-right: 71px;
+ }
 
 /* Individual layout settings form. */
 .layout-settings-page .form-type-checkboxes,

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -51,12 +51,14 @@
   margin-left: 0;
 }
 
-.layout-list thead .layout-title {
-   padding-left: 71px;
- }
- [dir="rtl"] .layout-list thead .layout-title {
-   padding-right: 71px;
- }
+@media (min-width: 768px) {
+  .layout-list thead .layout-title {
+     padding-left: 71px;
+   }
+   [dir="rtl"] .layout-list thead .layout-title {
+     padding-right: 71px;
+   }
+}
 
 /* Individual layout settings form. */
 .layout-settings-page .form-type-checkboxes,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -191,7 +191,7 @@ function layout_list_page() {
     '#header' => $header,
     '#rows' => $stand_alone_rows,
      '#attributes' => array('class' =>   array('layout-list')),
-     '#empty' => t('No layouts have been created yet.'),
+     '#empty' => t('No layout pages have been created yet.'),
      '#weight' => 1,
    );
    $page['override'] = array(

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2517,20 +2517,25 @@ function layout_delete_form($form, &$form_state, $layout) {
   if ($layout->storage === LAYOUT_STORAGE_NORMAL) {
     $question = t('Delete layout @title?', array('@title' => $layout->title));
 
-    // Check whether this is the last layout for the specified path and it's a
-    // layout-created page.
+    // Check whether this is the last existing layout for the specified path and
+    // it's a layout-created page.
     $path = $layout->getPath();
     $router_item = menu_get_item($path);
-    $is_layout_page = ($router_item['page_callback'] == 'layout_page_callback');
-    if ($is_layout_page) {
-      if (!isset($router_item['map'])) {
-        // This needs to exist but isn't always set by menu_get_item().
-        $router_item['map'] = array();
-      }
-      $deletion_warning = count(layout_load_multiple_by_router_item($router_item)) == 1;
+    if ($router_item == FALSE) {
+      $deletion_warning = FALSE;
     }
     else {
-      $deletion_warning = FALSE;
+      $is_layout_page = ($router_item['page_callback'] == 'layout_page_callback');
+      if ($is_layout_page) {
+        if (!isset($router_item['map'])) {
+          // This needs to exist but isn't always set by menu_get_item().
+          $router_item['map'] = array();
+        }
+        $deletion_warning = count(layout_load_multiple_by_router_item($router_item)) == 1;
+      }
+      else {
+        $deletion_warning = FALSE;
+      }
     }
     if ($deletion_warning) {
       $text = t('Are you sure you want to delete this layout? This will completely remove the page at /%path. Deleting a layout cannot be undone.', array('%path' => $path));

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -204,7 +204,7 @@ function layout_list_page() {
     '#header' => $header,
     '#rows' => $override_rows,
     '#attributes' => array('class' =>   array('layout-list')),
-    '#empty' => t('No layout overridess have been created yet.'),
+    '#empty' => t('No layout overrides have been created yet.'),
     '#weight' => 3,
   );
   return $page;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -204,7 +204,7 @@ function layout_list_page() {
     '#header' => $header,
     '#rows' => $override_rows,
     '#attributes' => array('class' =>   array('layout-list')),
-    '#empty' => t('No layouts have been created yet.'),
+    '#empty' => t('No layout overridess have been created yet.'),
     '#weight' => 3,
   );
   return $page;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2517,11 +2517,22 @@ function layout_delete_form($form, &$form_state, $layout) {
   if ($layout->storage === LAYOUT_STORAGE_NORMAL) {
     $question = t('Delete layout @title?', array('@title' => $layout->title));
 
-    // Check whether this is the last layout for the specified path.
+    // Check whether this is the last layout for the specified path and it's a
+    // layout-created page.
     $path = $layout->getPath();
     $router_item = menu_get_item($path);
     $is_layout_page = $router_item['page_callback'] == 'layout_page_callback';
-    if ($is_layout_page && count(layout_load_multiple_by_router_item($router_item)) == 1) {
+    if ($is_layout_page) {
+      if (!isset($router_item['map'])) {
+        // This needs to exist but isn't always set by menu_get_item().
+        $router_item['map'] = array();
+      }
+      $deletion_warning = count(layout_load_multiple_by_router_item($router_item)) == 1;
+    }
+    else {
+      $deletion_warning = FALSE;
+    }
+    if ($deletion_warning) {
       $text = t('Are you sure you want to delete this layout? This will completely remove the page at /%path. Deleting a layout cannot be undone.', array('%path' => $path));
     }
     else {

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -153,6 +153,7 @@ function layout_list_page() {
   );
 
   $help = '<p>' . t('There are two kinds of <em>Layouts</em>:') . '</p>';
+  $help_items = array();
   $help_items[] = t('<strong>Layout pages</strong> are layouts that create new stand-alone pages on the site.  Without the layouts, these pages would not exist.');
   $help_items[] = t('<strong>Layout overrides</strong> are layouts that override existing pages on the site. Without these layout overrides, these pages would use other layouts. Which one is used will depend on the path and visibility conditions. If no other layouts match, one of the defaults will be used.');
   $help .= theme('item_list', array('items' => $help_items));

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -19,8 +19,9 @@ function layout_list_page() {
   $path_groups_end = array();
   foreach ($layouts as $layout) {
     $path = $layout->getPath();
-     // Move admin layouts to the bottom of the list.
-     if (path_is_admin($path)) {
+     // Move admin layouts to the bottom of the list. Note that default layout
+     // has a NULL path, which path_is_admin() won't like in PHP 8.1.
+     if (is_null($path) || path_is_admin($path)) {
        $path_groups_end[$path][$layout->name] = $layout;
      }
      else {

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -14,13 +14,46 @@ function layout_list_page() {
   $layout_template_info = layout_get_layout_template_info();
 
   // Group layouts by path.
+  $layout_paths = array();
   $path_groups = array();
+  $path_groups_end = array();
   foreach ($layouts as $layout) {
-    $path_groups[$layout->getPath()][$layout->name] = $layout;
+    $path = $layout->getPath();
+     // Move admin layouts to the bottom of the list.
+     if (path_is_admin($path)) {
+       $path_groups_end[$path][$layout->name] = $layout;
+     }
+     else {
+       $path_groups[$path][$layout->name] = $layout;
+     }
+     // Build a list of all layout paths to check callbacks.
+     if ($path) {
+       $layout_paths[] = $path;
+     }
+  }
+
+  // Put admin layouts at the bottom of the list.
+   foreach ($path_groups_end as $path => $name) {
+     foreach ($name as $layout) {
+       $path_groups[$path][$layout->name] = $layout;
+     }
+   }
+
+  if (!empty($layout_paths)) {
+  $page_callbacks = db_query('
+    SELECT path, page_callback
+    FROM {menu_router}
+    WHERE path IN (:paths)
+    ', array(':paths' => $layout_paths))
+    ->fetchAllKeyed();
+  }
+  else {
+    $page_callbacks = array();
   }
 
   // Assemble the rows of the table.
-  $rows = array();
+  $override_rows = array();
+  $stand_alone_rows = array();
   foreach ($path_groups as $path => $group) {
     // Print a row for rearranging a group of layouts.
     $operations = array(
@@ -38,20 +71,38 @@ function layout_list_page() {
       $row[] = '';
     }
     else {
-      $path_link = strpos($path, '%') === FALSE ? l($path, $path) : check_plain($path);
-      $row[] = array('data' => $path_link);
+      if (strpos($path, '%') === FALSE) {
+         $path_link = t('Path: ') . l($path, $path);
+       }
+       else {
+         $path_link = t('System path: ') . check_plain($path);
+       }
+
+       $class = array();
+       if (!$page_callbacks[$path]) {
+         $class[] = 'missing-path';
+         $path_link .= ' <span class="path-parenthetical">(' . t('missing callback') . ')</span>';
+       }
+       $row[] = array('data' => $path_link, 'class' => $class);
       // Empty columns are intentional.
       $row[] = '';
       $row[] = '';
       $row[] = '';
     }
+
     if (count($operations['#links']) !== 0) {
       $row[] = backdrop_render($operations);
     }
     else {
       $row[] = '';
     }
-    $rows[] = array('data' => $row, 'class' => array('layout-group'));
+
+    if (isset($page_callbacks[$path]) && $page_callbacks[$path] == 'layout_page_callback') {
+      $stand_alone_rows[] = array('data' => $row, 'class' => array('layout-group'));
+    }
+    else {
+      $override_rows[] = array('data' => $row, 'class' => array('layout-group'));
+    }
 
     foreach ($group as $layout) {
       $operations = array(
@@ -82,12 +133,18 @@ function layout_list_page() {
       if ($layout->disabled) {
         $class[] = 'disabled';
       }
-      $rows[] = array('data' => $row, 'class' => $class);
+
+      if (isset($page_callbacks[$path]) && $page_callbacks[$path] == 'layout_page_callback') {
+        $stand_alone_rows[] = array('data' => $row, 'class' => $class);
+      }
+      else {
+        $override_rows[] = array('data' => $row, 'class' => $class);
+      }
     }
   }
 
   $header = array(
-    array('data' => t('Path and layout'), 'class' => array('layout-title')),
+    array('data' => t('Layout'), 'class' => array('layout-title')),
     array('data' => t('Template'), 'class' => array('layout-template', 'priority-low')),
     array('data' => t('Visibility conditions'), 'class' => array('layout-conditions', 'priority-low')),
     array('data' => t('Storage state'), 'class' => array('layout-status', 'priority-low')),
@@ -120,15 +177,34 @@ function layout_list_page() {
     '#attributes' => array(
       'class' => array('description'),
     ),
+    '#weight' => -1,
   );
-
   $page['#attached']['css'][] = backdrop_get_path('module', 'layout') . '/css/layout.admin.css';
-  $page['table'] = array(
+  $page['stand_alone'] = array(
+    '#type' => 'help',
+    '#markup' => '<h2>' . t('Layout pages') . '</h2>' . t('These layouts will create new stand-alone pages on the site. Without the layouts, these pages would not exist.'),
+    '#weight' => 0,
+  );
+  $page['stand_alone_table'] = array(
     '#theme' => 'table',
     '#header' => $header,
-    '#rows' => $rows,
+    '#rows' => $stand_alone_rows,
+     '#attributes' => array('class' =>   array('layout-list')),
+     '#empty' => t('No layouts have been created yet.'),
+     '#weight' => 1,
+   );
+   $page['override'] = array(
+    '#type' => 'help',
+    '#markup' => '<h2>' . t('Layout overrides') . '</h2>' . t('These layouts will override existing pages on the site. Without the layouts, these pages would use other layouts.'),
+    '#weight' => 2,
+   );
+   $page['override_table'] = array(
+    '#theme' => 'table',
+    '#header' => $header,
+    '#rows' => $override_rows,
     '#attributes' => array('class' =>   array('layout-list')),
     '#empty' => t('No layouts have been created yet.'),
+    '#weight' => 3,
   );
   return $page;
 }
@@ -2440,7 +2516,17 @@ function layout_delete_form($form, &$form_state, $layout) {
 
   if ($layout->storage === LAYOUT_STORAGE_NORMAL) {
     $question = t('Delete layout @title?', array('@title' => $layout->title));
-    $text = t('Are you sure you want to delete this layout? Deleting a layout cannot be undone.');
+
+    // Check whether this is the last layout for the specified path.
+    $path = $layout->getPath();
+    $router_item = menu_get_item($path);
+    $is_layout_page = $router_item['page_callback'] == 'layout_page_callback';
+    if ($is_layout_page && count(layout_load_multiple_by_router_item($router_item)) == 1) {
+      $text = t('Are you sure you want to delete this layout? This will completely remove the page at /%path. Deleting a layout cannot be undone.', array('%path' => $path));
+    }
+    else {
+      $text = t('Are you sure you want to delete this layout? Deleting a layout cannot be undone.');
+    }
     $button_text = t('Delete layout');
   }
   else {

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2521,7 +2521,7 @@ function layout_delete_form($form, &$form_state, $layout) {
     // layout-created page.
     $path = $layout->getPath();
     $router_item = menu_get_item($path);
-    $is_layout_page = $router_item['page_callback'] == 'layout_page_callback';
+    $is_layout_page = ($router_item['page_callback'] == 'layout_page_callback');
     if ($is_layout_page) {
       if (!isset($router_item['map'])) {
         // This needs to exist but isn't always set by menu_get_item().

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -196,7 +196,7 @@ function layout_list_page() {
    );
    $page['override'] = array(
     '#type' => 'help',
-    '#markup' => '<h2>' . t('Layout overrides') . '</h2>' . t('These layouts will override existing pages on the site. Without the layouts, these pages would use other layouts.'),
+    '#markup' => '<h2>' . t('Layout overrides') . '</h2>' . t('These layouts will override existing pages on the site. Without these layout overrides, these pages would use other layouts.'),
     '#weight' => 2,
    );
    $page['override_table'] = array(

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -2517,33 +2517,7 @@ function layout_delete_form($form, &$form_state, $layout) {
 
   if ($layout->storage === LAYOUT_STORAGE_NORMAL) {
     $question = t('Delete layout @title?', array('@title' => $layout->title));
-
-    // Check whether this is the last existing layout for the specified path and
-    // it's a layout-created page.
-    $path = $layout->getPath();
-    $router_item = menu_get_item($path);
-    if ($router_item == FALSE) {
-      $deletion_warning = FALSE;
-    }
-    else {
-      $is_layout_page = ($router_item['page_callback'] == 'layout_page_callback');
-      if ($is_layout_page) {
-        if (!isset($router_item['map'])) {
-          // This needs to exist but isn't always set by menu_get_item().
-          $router_item['map'] = array();
-        }
-        $deletion_warning = count(layout_load_multiple_by_router_item($router_item)) == 1;
-      }
-      else {
-        $deletion_warning = FALSE;
-      }
-    }
-    if ($deletion_warning) {
-      $text = t('Are you sure you want to delete this layout? This will completely remove the page at /%path. Deleting a layout cannot be undone.', array('%path' => $path));
-    }
-    else {
-      $text = t('Are you sure you want to delete this layout? Deleting a layout cannot be undone.');
-    }
+    $text = t('Are you sure you want to delete this layout? Deleting a layout cannot be undone.');
     $button_text = t('Delete layout');
   }
   else {

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -152,7 +152,11 @@ function layout_list_page() {
     array('data' => t('Operations'), 'class' => array('layout-operations')),
   );
 
-  $help = '<p>' . t('As a page is rendered, a <em>Layout</em> is selected as follows.') . '</p>';
+  $help = '<p>' . t('There are two kinds of <em>Layouts</em>:') . '</p>';
+  $help_items[] = t('<strong>Layout pages</strong> are layouts that create new stand-alone pages on the site.  Without the layouts, these pages would not exist.');
+  $help_items[] = t('<strong>Layout overrides</strong> are layouts that override existing pages on the site. Without these layout overrides, these pages would use other layouts. Which one is used will depend on the path and visibility conditions. If no other layouts match, one of the defaults will be used.');
+  $help .= theme('item_list', array('items' => $help_items));
+  $help .= '<p>' . t('As a page is rendered, a <em>Layout</em> is selected as follows.') . '</p>';
   $help_items = array();
   $help_items[] = array(
     'data' => t('The <em>Path</em> for the page is compared to those in the alphabetical list here, and <em>Visibility conditions</em> are evaluated.'),
@@ -183,7 +187,7 @@ function layout_list_page() {
   $page['#attached']['css'][] = backdrop_get_path('module', 'layout') . '/css/layout.admin.css';
   $page['stand_alone'] = array(
     '#type' => 'help',
-    '#markup' => '<h2>' . t('Layout pages') . '</h2>' . t('These layouts will create new stand-alone pages on the site. Without the layouts, these pages would not exist.'),
+    '#markup' => '<h2>' . t('Layout pages') . '</h2>' . t('These layouts will create new stand-alone pages on the site.'),
     '#weight' => 0,
   );
   $page['stand_alone_table'] = array(
@@ -196,7 +200,7 @@ function layout_list_page() {
    );
    $page['override'] = array(
     '#type' => 'help',
-    '#markup' => '<h2>' . t('Layout overrides') . '</h2>' . t('These layouts will override existing pages on the site. Without these layout overrides, these pages would use other layouts.'),
+    '#markup' => '<h2>' . t('Layout overrides') . '</h2>' . t('These layouts will override existing pages on the site.'),
     '#weight' => 2,
    );
    $page['override_table'] = array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5077.

This is a rebase of https://github.com/backdrop/backdrop/pull/3864.