### PR TITLE
Issue 5501: NULL layout paths (e.g., Default layout) cause problems in PHP 8.1

### DIFF
--- a/core/includes/path.inc
+++ b/core/includes/path.inc
@@ -312,7 +312,7 @@ function backdrop_match_path($path, $patterns) {
     $patterns_quoted = preg_quote($patterns, '/');
     $regexps[$patterns] = '/^(' . preg_replace($to_replace, $replacements, $patterns_quoted) . ')$/';
   }
-  return (bool)preg_match($regexps[$patterns], $path);
+  return (bool) preg_match($regexps[$patterns], (string) $path);
 }
 
 /**

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3435,7 +3435,7 @@ class LayoutPathTest extends BackdropWebTestCase {
   }
 
   /**
-   * Test that the correct renderer is used
+   * Test that null paths (in default layouts) don't cause problems.
    */
   function testLayoutPath() {
     $layouts = layout_load_multiple_by_path('');
@@ -3444,9 +3444,9 @@ class LayoutPathTest extends BackdropWebTestCase {
     $this->assertTrue(is_null($path), 'Default layout path is NULL.');
 
     backdrop_static_reset('path_is_admin');
-    $result = path_is_admin($path); // This should throw a deprecation warning in PHP 8.1
+    $result = path_is_admin($path);
     $this->assertFalse($result, 'Default layout is not an admin path.');
 
-    backdrop_match_path($path, "foo\nbar"); // This should throw a deprecation warning in PHP 8.1
+    backdrop_match_path($path, "foo\nbar");
   }
 }

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3435,18 +3435,20 @@ class LayoutPathTest extends BackdropWebTestCase {
   }
 
   /**
-   * Test that null paths (in default layouts) don't cause problems.
+   * Tests that null paths (in default layouts) don't cause problems.
    */
   public function testLayoutPath() {
     $layouts = layout_load_multiple_by_path('');
     $default_layout = $layouts['default'];
-    $path = $default_layout->getPath(); // this will be NULL
+    $path = $default_layout->getPath(); // This will be NULL.
     $this->assertNull($path, 'Default layout path is NULL.');
 
+    // Make sure path_is_admin can handle a NULL path.
     backdrop_static_reset('path_is_admin');
     $result = path_is_admin($path);
     $this->assertFalse($result, 'Default layout is not an admin path.');
 
+    // Make sure backdrop_match_path can handle a NULL path.
     backdrop_match_path($path, "foo\nbar");
   }
 }

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3422,8 +3422,8 @@ class LayoutPathTest extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
-    parent::setUp(array('layout', 'layout_test'));
+  public function setUp() {
+    parent::setUp(array('layout_test'));
 
     // Create and login admin user.
     $this->admin_user = $this->backdropCreateUser(array(
@@ -3443,12 +3443,12 @@ class LayoutPathTest extends BackdropWebTestCase {
     $path = $default_layout->getPath(); // This will be NULL.
     $this->assertNull($path, 'Default layout path is NULL.');
 
-    // Make sure path_is_admin can handle a NULL path.
+    // Make sure path_is_admin() can handle a NULL path.
     backdrop_static_reset('path_is_admin');
     $result = path_is_admin($path);
     $this->assertFalse($result, 'Default layout is not an admin path.');
 
-    // Make sure backdrop_match_path can handle a NULL path.
+    // Make sure backdrop_match_path() can handle a NULL path.
     backdrop_match_path($path, "foo\nbar");
   }
 }

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3437,7 +3437,7 @@ class LayoutPathTest extends BackdropWebTestCase {
   /**
    * Test that null paths (in default layouts) don't cause problems.
    */
-  function testLayoutPath() {
+  public function testLayoutPath() {
     $layouts = layout_load_multiple_by_path('');
     $default_layout = $layouts['default'];
     $path = $default_layout->getPath(); // this will be NULL

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3414,3 +3414,39 @@ class LayoutFlexibleTemplateTest extends BackdropWebTestCase {
   }
 
 }
+
+/**
+ * Tests that default layout paths are handled properly.
+ */
+class LayoutPathTest extends BackdropWebTestCase {
+  protected $profile = 'testing';
+  protected $admin_user;
+
+  function setUp() {
+    parent::setUp(array('layout', 'layout_test'));
+
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access content',
+      'administer layouts',
+      'access user profiles',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
+
+  /**
+   * Test that the correct renderer is used
+   */
+  function testLayoutPath() {
+    $layouts = layout_load_multiple_by_path('');
+    $default_layout = $layouts['default'];
+    $path = $default_layout->getPath(); // this will be NULL
+    $this->assertTrue(is_null($path), 'Default layout path is NULL.');
+
+    backdrop_static_reset('path_is_admin');
+    $result = path_is_admin($path); // This should throw a deprecation warning in PHP 8.1
+    $this->assertFalse($result, 'Default layout is not an admin path.');
+
+    backdrop_match_path($path, "foo\nbar"); // This should throw a deprecation warning in PHP 8.1
+  }
+}

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3441,7 +3441,7 @@ class LayoutPathTest extends BackdropWebTestCase {
     $layouts = layout_load_multiple_by_path('');
     $default_layout = $layouts['default'];
     $path = $default_layout->getPath(); // this will be NULL
-    $this->assertTrue(is_null($path), 'Default layout path is NULL.');
+    $this->assertNull($path, 'Default layout path is NULL.');
 
     backdrop_static_reset('path_is_admin');
     $result = path_is_admin($path);

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -60,6 +60,6 @@ file = layout.test
 
 [LayoutPathTest]
 name = Layout Paths Test
-description = Tests involving layout paths, like the Default Layout.
+description = Tests layout paths, like the Default Layout.
 group = Layout
 file = layout.test

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -57,3 +57,9 @@ name = Layout Flexible Template Test
 description = Tests that flexible layout templates perform correctly.
 group = Layout
 file = layout.test
+
+[LayoutPathTest]
+name = Layout Paths Test
+description = Tests involving layout paths, like the Default Layout.
+group = Layout
+file = layout.test


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5501. 

<strike>(Doesn't really fix, just demonstrates. Using "Fixes" to link it to the issue.)</strike> [Update: now fixes.]