### PR TITLE
issue #5520: tabledrag.js fix to deal with older jQuery versions

### DIFF
--- a/core/misc/tabledrag.js
+++ b/core/misc/tabledrag.js
@@ -633,6 +633,12 @@ Backdrop.tableDrag.prototype.pointerCoords = function (event) {
     return { x: event.pageX, y: event.pageY };
   }
 
+  // If pageX and pageY are defined in the event.originalEvent, use them instead
+  // of clientX and clientY to avoid potentially faulty pointer position calculations 
+  if (event.originalEvent.pageX || event.originalEvent.pageY) {
+    return { x: event.originalEvent.pageX, y: event.originalEvent.pageY };
+  }
+
   return {
     x: clientX + document.body.scrollLeft - document.body.clientLeft,
     y: clientY + document.body.scrollTop  - document.body.clientTop


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5520

----

This code fixes drag & drop tabledrag.js functionality for older versions of jQuery, an issue I originally opened here: 

https://github.com/backdrop/backdrop-issues/issues/5520

There is existing fallback code that attempts to run pointer position calculations based on clientX / clientY, but in at least jQuery 1.9.1 and perhaps other old versions the calculations attempting to derive pointer position in the document from pointer position in the viewport fail - meanwhile pageX and pageY (pointer position in the document) are available in event.originalEvent.

This code doesn't break the existing fallback, just adds a check for pageX and pageY in the originalEvent. 