### PR TITLE
Issue #4834: Remove duplicate selectors in Seven's Vertical Tabs CSS file

### DIFF
--- a/core/themes/seven/css/vertical-tabs.css
+++ b/core/themes/seven/css/vertical-tabs.css
@@ -143,9 +143,6 @@
 }
 .vertical-tab-link:focus,
 .vertical-tab-link:active,
-.vertical-tab-link:hover,
-.vertical-tab-link:focus,
-.vertical-tab-link:active,
 .vertical-tab-link:hover {
   text-decoration: none;
   background: #d5d5d5;


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/4834


This PR is for issue [#4834](https://github.com/backdrop/backdrop-issues/issues/4834)