### PR TITLE
Fix main class and add more space

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -431,8 +431,8 @@ ul.secondary li.active a.active {
   /* Make the one column layout margin match other layouts. */
   margin: 0 15px;
 }
-.l-content {
-  margin-bottom: 80px;
+.l-wrapper {
+  padding-bottom: 80px;
 }
 
 /* Administration page listings. */

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -431,8 +431,8 @@ ul.secondary li.active a.active {
   /* Make the one column layout margin match other layouts. */
   margin: 0 15px;
 }
-main {
-  margin-bottom: 20px;
+.l-content {
+  margin-bottom: 80px;
 }
 
 /* Administration page listings. */


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/5600

It looks like there is no `<main>` tag in the mark up on the page, but maybe `.l-content` can work?

Also, I feel like there's too little space at the bottom, which makes it feel claustrophobic, so also adding some more space.