### PR TITLE
Changed links to show underline on hover

### DIFF
--- a/core/themes/basis/css/base.css
+++ b/core/themes/basis/css/base.css
@@ -253,3 +253,7 @@ details summary:focus:not(:focus-visible) {
   display: table;
   clear: both;
 }
+
+a:hover {
+    text-decoration: underline;	
+}


### PR DESCRIPTION
Fixed issue [#4670](https://github.com/backdrop/backdrop-issues/issues/4670)