### PR TITLE
Fixed: Escape all dots used in RewriteCond/RewriteRule within .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -113,9 +113,9 @@ DirectoryIndex index.php index.html index.htm
   # RewriteBase /
 
   # Redirect common PHP files to their new locations.
-  RewriteCond %{REQUEST_URI} ^(.*)?/(update.php) [OR]
-  RewriteCond %{REQUEST_URI} ^(.*)?/(install.php) [OR]
-  RewriteCond %{REQUEST_URI} ^(.*)?/(cron.php)
+  RewriteCond %{REQUEST_URI} ^(.*)?/(update\.php) [OR]
+  RewriteCond %{REQUEST_URI} ^(.*)?/(install\.php) [OR]
+  RewriteCond %{REQUEST_URI} ^(.*)?/(cron\.php)
   RewriteCond %{REQUEST_URI} !core
   RewriteRule ^ %1/core/%2 [L,QSA,R=301]
 


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/5555

Changes done: Escape dots in RewriteCond/RewriteRule in .htaccess
-  Line 116
- Line 117
- Line 118