### PR TITLE
Issue #[5397]: ["Show as Expanded" help text needs revising]

### DIFF
--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -403,7 +403,7 @@ function menu_edit_item($form, &$form_state, $type, $item, $menu) {
     '#type' => 'checkbox',
     '#title' => t('Show as expanded'),
     '#default_value' => $item['expanded'],
-    '#description' => t('When displayed in a 'hierarchial tree' menu style, children of expanded menu links will always be visible.'),
+    '#description' => t("When displayed in a 'hierarchial tree' menu style, children of expanded menu links will always be visible."),
   );
 
   // Generate a list of possible parents (not including this link or descendants).

--- a/core/modules/menu/menu.admin.inc
+++ b/core/modules/menu/menu.admin.inc
@@ -403,7 +403,7 @@ function menu_edit_item($form, &$form_state, $type, $item, $menu) {
     '#type' => 'checkbox',
     '#title' => t('Show as expanded'),
     '#default_value' => $item['expanded'],
-    '#description' => t('If selected and this menu link has children, the menu will always appear expanded.'),
+    '#description' => t('When displayed in a 'hierarchial tree' menu style, children of expanded menu links will always be visible.'),
   );
 
   // Generate a list of possible parents (not including this link or descendants).


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5397
The help text for this issue is revised from "If selected and this menu link has children, the menu will always appear expanded" to "When displayed in a 'hierarchial tree' menu style, children of expanded menu links will always be visible."