### PR TITLE
Issue #726 : Bartik's main menu sub-links design fixes

### DIFF
--- a/core/themes/bartik/css/style.css
+++ b/core/themes/bartik/css/style.css
@@ -705,11 +705,6 @@ ul.menu-tree > li.has-children > a {
   display: inline-block;
 }
 
-
-.menu-tree > li.has-children > ul ul {
-  /*padding-left: 15px;*/
-}
-
 /* ------------------- Main ------------------- */
 
 .l-container {

--- a/core/themes/bartik/css/style.css
+++ b/core/themes/bartik/css/style.css
@@ -679,6 +679,37 @@ ul.tips {
   background: none;
 }
 
+/* --------------- Hierarchical Tree Menu ------------ */
+
+.menu-tree > li > ul {
+  background: rgba(255, 255, 255, 0.8);
+}
+.menu-tree > li.has-children > ul li a,
+.menu-tree > li.has-children > ul li li a {
+  background: transparent;
+  display: block;
+}
+
+.menu-tree > li.has-children > ul li li a {
+  padding-left: 30px;
+}
+.menu-tree > li.has-children > ul li li li a {
+  padding-left: 45px;
+}
+.menu-tree > li.has-children > ul li a.active,
+.menu-tree > li.has-children > ul li li a.active {
+  background: #fff;
+}
+
+ul.menu-tree > li.has-children > a {
+  display: inline-block;
+}
+
+
+.menu-tree > li.has-children > ul ul {
+  /*padding-left: 15px;*/
+}
+
 /* ------------------- Main ------------------- */
 
 .l-container {


### PR DESCRIPTION
Fixes: https://github.com/backdrop/backdrop-issues/issues/726
Fixed the sub-links design of Bartik main menu.

![Hierarchical tree sub menu 1 _ backdrop-fork local](https://user-images.githubusercontent.com/13948360/160766942-352f14d4-fa3d-4c3e-b3d9-c5556c152713.png)
