### PR TITLE
Issue #5571: Prevent PHP notice when views has no grouping set.

### DIFF
--- a/core/modules/views/includes/handlers.inc
+++ b/core/modules/views/includes/handlers.inc
@@ -789,8 +789,11 @@ class views_many_to_one_helper {
           if (isset($join)) {
             $join->type = 'LEFT';
             // INNER joins are slightly faster; use them when we know it's safe.
-            $group = isset($this->handler->options['group']) ? $this->handler->options['group'] : FALSE;
-            $group_type = $this->handler->query->where[$group]['type'];
+            $group = FALSE;
+            if (isset($this->handler->options['group'])) {
+              $group =  $this->handler->options['group'];
+              $group_type = $this->handler->query->where[$group]['type'];
+            }
             $plugin_id = isset($this->handler->options['plugin_id']) ? $this->handler->options['plugin_id'] : FALSE;
             // @todo Figure out why taxonomy_index_tid is being special-cased here.
             // See: https://github.com/backdrop/backdrop-issues/issues/5225


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5571