### PR TITLE
Issue #5583: Modify .htaccess to allow backdrop to serve .well-known URIs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,7 +3,7 @@
 #
 
 # Protect files and directories from prying eyes.
-<FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\..*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
+<FilesMatch "\.(engine|inc|info|install|make|module|profile|test|po|sh|.*sql|theme|tpl(\.php)?|xtmpl)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig\.save)$">
   <IfModule mod_authz_core.c>
     Require all denied
   </IfModule>


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5583

Modify Backdrop's `.htaccess` file to allow access to files (and therefore Backdrop paths) beginning with `.well-known`. 

This change modifies the `<FilesMatch>` section of Backdrop's `.htaccess` file so that it more closely matches Drupal 7's `.htaccess` file.

**Note:** This change will allow access to files of the form `.well-known*` e.g. if you have a file called `.well-knownMYFILE` in your document root then this change will allow access to it. It might be preferable to change the rule to allow `.well-known/*` but disallow `.well-known*`. However, I wanted to suggest a change which mirrors the Drupal 7 rule, as these regular expressions are getting pretty hairy! 😉