### PR TITLE
Issue 5591. Revert the order of hooks and postSave

### DIFF
--- a/core/modules/node/node.entity.inc
+++ b/core/modules/node/node.entity.inc
@@ -496,7 +496,12 @@ class NodeStorageController extends EntityDatabaseStorageController {
       $this->resetCache($op == 'update' ? array($entity->{$this->idKey}): array());
 
       $this->invokeHook($op, $entity);
-      $this->postSave($entity);
+  
+      // Update the node access table for this node, but only if it is the
+      // active revision.
+      if ($entity->isActiveRevision()) {
+        node_access_acquire_grants($entity);
+      }
 
       // Ignore slave server temporarily.
       db_ignore_slave();
@@ -653,20 +658,6 @@ class NodeStorageController extends EntityDatabaseStorageController {
       if (!isset($node->revision_uid)) {
         $node->revision_uid = $GLOBALS['user']->uid;
       }
-    }
-  }
-
-  /**
-   * Overrides EntityDatabaseStorageController::postSave().
-   *
-   * @param Node $node
-   *   The node object that has just been saved.
-   */
-  function postSave(EntityInterface $node, $update = TRUE) {
-    // Update the node access table for this node, but only if it is the
-    // active revision. 
-    if ($node->isActiveRevision()) {
-      node_access_acquire_grants($node, $update);
     }
   }
 

--- a/core/modules/node/node.entity.inc
+++ b/core/modules/node/node.entity.inc
@@ -496,7 +496,7 @@ class NodeStorageController extends EntityDatabaseStorageController {
       $this->resetCache($op == 'update' ? array($entity->{$this->idKey}): array());
 
       $this->invokeHook($op, $entity);
-      $this->postSave($entity, $op == 'update');
+      $this->postSave($entity);
 
       // Ignore slave server temporarily.
       db_ignore_slave();
@@ -662,10 +662,9 @@ class NodeStorageController extends EntityDatabaseStorageController {
    * @param Node $node
    *   The node object that has just been saved.
    */
-  function postSave(EntityInterface $node, $update) {
+  function postSave(EntityInterface $node, $update = TRUE) {
     // Update the node access table for this node, but only if it is the
-    // active revision. There's no need to delete existing records if the node
-    // is new.
+    // active revision. 
     if ($node->isActiveRevision()) {
       node_access_acquire_grants($node, $update);
     }

--- a/core/modules/node/node.entity.inc
+++ b/core/modules/node/node.entity.inc
@@ -495,8 +495,8 @@ class NodeStorageController extends EntityDatabaseStorageController {
       // Reset general caches, but keep caches specific to certain entities.
       $this->resetCache($op == 'update' ? array($entity->{$this->idKey}): array());
 
-      $this->postSave($entity, $op == 'update');
       $this->invokeHook($op, $entity);
+      $this->postSave($entity, $op == 'update');
 
       // Ignore slave server temporarily.
       db_ignore_slave();


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5591

This PR makes the calls to `hook_node_update`, `hook_entity_update`,  `hook_node_insert` and `hook_entity_insert` happen before the `postSave()` method is called. `postSave()` is used to update the `node_access` table.

Important to note: this PR restores the order of invocation found in D7. This order is especially important for modules like Organic Groups, that expects hook_node_update and hook_node_insert to be run BEFORE creating access grants for those saved nodes.  In the case of Organic Groups, the module creates "membership" relationships among group and content nodes before updating the `node_access` table.