### PR TITLE
Issue #5501: NULL layout paths (e.g., Default layout) cause problems in PHP 8.1

### DIFF
--- a/core/includes/path.inc
+++ b/core/includes/path.inc
@@ -312,7 +312,7 @@ function backdrop_match_path($path, $patterns) {
     $patterns_quoted = preg_quote($patterns, '/');
     $regexps[$patterns] = '/^(' . preg_replace($to_replace, $replacements, $patterns_quoted) . ')$/';
   }
-  return (bool)preg_match($regexps[$patterns], $path);
+  return (bool) preg_match($regexps[$patterns], (string) $path);
 }
 
 /**

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3414,3 +3414,39 @@ class LayoutFlexibleTemplateTest extends BackdropWebTestCase {
   }
 
 }
+
+/**
+ * Tests that default layout paths are handled properly.
+ */
+class LayoutPathTest extends BackdropWebTestCase {
+  protected $profile = 'testing';
+  protected $admin_user;
+
+  function setUp() {
+    parent::setUp(array('layout', 'layout_test'));
+
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access content',
+      'administer layouts',
+      'access user profiles',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
+
+  /**
+   * Test that the correct renderer is used
+   */
+  function testLayoutPath() {
+    $layouts = layout_load_multiple_by_path('');
+    $default_layout = $layouts['default'];
+    $path = $default_layout->getPath(); // this will be NULL
+    $this->assertTrue(is_null($path), 'Default layout path is NULL.');
+
+    backdrop_static_reset('path_is_admin');
+    $result = path_is_admin($path); // This should throw a deprecation warning in PHP 8.1
+    $this->assertFalse($result, 'Default layout is not an admin path.');
+
+    backdrop_match_path($path, "foo\nbar"); // This should throw a deprecation warning in PHP 8.1
+  }
+}

--- a/core/modules/layout/tests/layout.tests.info
+++ b/core/modules/layout/tests/layout.tests.info
@@ -57,3 +57,9 @@ name = Layout Flexible Template Test
 description = Tests that flexible layout templates perform correctly.
 group = Layout
 file = layout.test
+
+[LayoutPathTest]
+name = Layout Paths Test
+description = Tests involving layout paths, like the Default Layout.
+group = Layout
+file = layout.test


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5501.

Builds on (and may replace) https://github.com/backdrop/backdrop/pull/3958 which was tests only. This should pass on PHP 8.1 by casting the given `$path` value to a string to handle `NULL` values.