### PR TITLE
Issue 5627. Use BlockBroken for unavailable fields

### DIFF
--- a/core/modules/layout/includes/block.class.inc
+++ b/core/modules/layout/includes/block.class.inc
@@ -195,7 +195,7 @@ class Block extends LayoutHandler {
     // If this is a child block, merge in its child-specific data.
     if ($this->childDelta) {
       $children_blocks = $this->getChildren();
-      $block_info = array_merge($block_info, $children_blocks[$this->childDelta]);
+      $block_info = isset($children_blocks) ? array_merge($block_info, $children_blocks[$this->childDelta]) : NULL;
     }
 
     return $block_info;

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1728,7 +1728,8 @@ function layout_get_handler_name($plugin_type, $plugin_name) {
   // Block "plugins" for Layouts are wrappers around the generic block system.
   $broken_class = NULL;
   if ($plugin_type === 'block') {
-    list($module, $delta) = explode(':', $plugin_name);
+    $parts = explode(':', $plugin_name);
+    list($module, $delta) = $parts;
     $info = layout_get_block_info($module, $delta);
     if ($info) {
       if (isset($info['class'])) {
@@ -1737,8 +1738,8 @@ function layout_get_handler_name($plugin_type, $plugin_name) {
       else {
         $class_name = 'BlockLegacy';
       }
-      if ($delta == 'field_block') {
-        list( , , $field_name) = explode(':', $plugin_name);
+      if ($delta == 'field_block' && isset($parts[2])) {
+        $field_name = $parts[2];
         if (empty(field_get_block_list()[$field_name])) {
           $class_name = 'BlockBroken';
         }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1740,7 +1740,8 @@ function layout_get_handler_name($plugin_type, $plugin_name) {
       }
       if ($delta == 'field_block' && isset($parts[2])) {
         $field_name = $parts[2];
-        if (empty(field_get_block_list()[$field_name])) {
+        $available_fields = field_get_block_list();
+        if (empty($available_fields()[$field_name])) {
           $class_name = 'BlockBroken';
         }
       }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1737,6 +1737,12 @@ function layout_get_handler_name($plugin_type, $plugin_name) {
       else {
         $class_name = 'BlockLegacy';
       }
+      if ($delta == 'field_block') {
+        list( , , $field_name) = explode(':', $plugin_name);
+        if (empty(field_get_block_list()[$field_name])) {
+          $class_name = 'BlockBroken';
+        }
+      }
     }
     else {
       $class_name = 'BlockBroken';

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1741,7 +1741,7 @@ function layout_get_handler_name($plugin_type, $plugin_name) {
       if ($delta == 'field_block' && isset($parts[2])) {
         $field_name = $parts[2];
         $available_fields = field_get_block_list();
-        if (empty($available_fields()[$field_name])) {
+        if (empty($available_fields[$field_name])) {
           $class_name = 'BlockBroken';
         }
       }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1738,6 +1738,8 @@ function layout_get_handler_name($plugin_type, $plugin_name) {
       else {
         $class_name = 'BlockLegacy';
       }
+      // Field blocks use the field name as the third part of the plugin name.
+      // If the field no longer exists, return a broken block.
       if ($delta == 'field_block' && isset($parts[2])) {
         $field_name = $parts[2];
         $available_fields = field_get_block_list();

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2528,3 +2528,10 @@ function _layout_clean_custom_css($classes = array()) {
 
   return '';
 }
+
+/**
+ * Implements hook_field_delete_instance().
+ */
+function layout_field_delete_instance($instance) {
+  cache('layout_path')->flush();
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5627

This approach catches the issue early on, when deciding what class to use to create the Field Block. Additionally, this also catches a warning generated when creating the layout context for rendering.
