### PR TITLE
Issue #5632: Add entity info property to support per-bundle caching.

### DIFF
--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -17,8 +17,9 @@
  * attached).
  *
  * @return
- *   An array whose keys are entity type names and whose values identify
- *   properties of those types that the system needs to know about:
+ *   An array of information about one or more entity types
+ *   Keys are entity type names; values identify properties of those types that
+ *   the system needs to know about:
  *   - label: The human-readable name of the type.
  *   - entity class: A class that the controller will use for instantiating
  *     entities. Must extend the Entity class or implement EntityInterface.
@@ -69,7 +70,7 @@
  *     - bundle: The name of the property that contains the name of the bundle
  *       object.
  *   - bundles: An array describing all bundles for this object type. Keys are
- *     bundles machine names, as found in the objects' 'bundle' property
+ *     bundles' machine names, as found in the objects' 'bundle' property
  *     (defined in the 'entity keys' entry above). This entry can be omitted if
  *     this entity type exposes a single bundle (all entities have the same
  *     collection of fields). The name of this single bundle will be the same as
@@ -88,6 +89,9 @@
  *       - access callback: As in hook_menu(). 'user_access' will be assumed if
  *         no value is provided.
  *       - access arguments: As in hook_menu().
+ *     - no cache: (used by DefaultEntityController) Set to TRUE to disable
+ *         persistent caching of fully loaded entities for this bundle. Has no
+ *         effect if 'entity cache' for the entity is FALSE. Defaults to FALSE.
  *   - view modes: An array describing the display modes for the entity type.
  *     Display modes let entities be displayed differently depending on the
  *     context. For instance, a node can be displayed differently on its own

--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -89,9 +89,9 @@
  *       - access callback: As in hook_menu(). 'user_access' will be assumed if
  *         no value is provided.
  *       - access arguments: As in hook_menu().
- *     - no cache: (used by DefaultEntityController) Set to TRUE to disable
- *         persistent caching of fully loaded entities for this bundle. Has no
- *         effect if 'entity cache' for the entity is FALSE. Defaults to FALSE.
+ *     - bundle cache: (used by DefaultEntityController) Set to FALSE to disable
+ *       persistent caching of fully loaded entities for this bundle. Has no
+ *       effect if 'entity cache' for the entity is FALSE. Defaults to TRUE.
  *   - view modes: An array describing the display modes for the entity type.
  *     Display modes let entities be displayed differently depending on the
  *     context. For instance, a node can be displayed differently on its own

--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -90,8 +90,8 @@
  *         no value is provided.
  *       - access arguments: As in hook_menu().
  *     - bundle cache: (used by DefaultEntityController) Set to FALSE to disable
- *       persistent caching of fully loaded entities for this bundle. Has no
- *       effect if 'entity cache' for the entity is FALSE. Defaults to TRUE.
+ *       persistent caching of fully loaded entities for this bundle. Defaults
+ *       to TRUE. Has no effect if 'entity cache' for the entity is FALSE.
  *   - view modes: An array describing the display modes for the entity type.
  *     Display modes let entities be displayed differently depending on the
  *     context. For instance, a node can be displayed differently on its own

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Entity API controller classes and interface.
@@ -365,7 +364,7 @@ class DefaultEntityController implements EntityControllerInterface {
         $queried_entities_by_id = array_intersect_key($queried_entities, $passed_ids);
         if (!empty($queried_entities_by_id)) {
           foreach ($queried_entities_by_id as $id => $item) {
-            list(, , $bundle_name) = entity_extract_ids($this->entityType, $item);
+            $bundle_name = !empty($item->bundle()) ? $item->bundle() : $this->entityType;
             $bundle_cache = isset($this->entityInfo['bundles'][$bundle_name]['bundle cache']) ? $this->entityInfo['bundles'][$bundle_name]['bundle cache'] : TRUE;
             if ($bundle_cache) {
               cache_set($id, $item, 'cache_entity_' . $this->entityType);

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -365,7 +365,17 @@ class DefaultEntityController implements EntityControllerInterface {
         $queried_entities_by_id = array_intersect_key($queried_entities, $passed_ids);
         if (!empty($queried_entities_by_id)) {
           foreach ($queried_entities_by_id as $id => $item) {
-            cache_set($id, $item, 'cache_entity_' . $this->entityType);
+            if (!empty($this->entityInfo['entity keys']['bundle'])) {
+              $bundle_property = $this->entityInfo['entity keys']['bundle'];
+              $bundle_name = $item->$bundle_property;
+            }
+            else {
+              $bundle_name = $this->entityType;
+            }
+            $no_cache = isset($this->entityInfo['bundles'][$bundle_name]['no cache']) ? $this->entityInfo['bundles'][$bundle_name]['no cache'] : FALSE;
+            if (!$no_cache) {
+              cache_set($id, $item, 'cache_entity_' . $this->entityType);
+            }
           }
         }
       }

--- a/core/modules/entity/entity.controller.inc
+++ b/core/modules/entity/entity.controller.inc
@@ -365,15 +365,9 @@ class DefaultEntityController implements EntityControllerInterface {
         $queried_entities_by_id = array_intersect_key($queried_entities, $passed_ids);
         if (!empty($queried_entities_by_id)) {
           foreach ($queried_entities_by_id as $id => $item) {
-            if (!empty($this->entityInfo['entity keys']['bundle'])) {
-              $bundle_property = $this->entityInfo['entity keys']['bundle'];
-              $bundle_name = $item->$bundle_property;
-            }
-            else {
-              $bundle_name = $this->entityType;
-            }
-            $no_cache = isset($this->entityInfo['bundles'][$bundle_name]['no cache']) ? $this->entityInfo['bundles'][$bundle_name]['no cache'] : FALSE;
-            if (!$no_cache) {
+            list(, , $bundle_name) = entity_extract_ids($this->entityType, $item);
+            $bundle_cache = isset($this->entityInfo['bundles'][$bundle_name]['bundle cache']) ? $this->entityInfo['bundles'][$bundle_name]['bundle cache'] : TRUE;
+            if ($bundle_cache) {
               cache_set($id, $item, 'cache_entity_' . $this->entityType);
             }
           }

--- a/core/modules/entity/tests/entity.test
+++ b/core/modules/entity/tests/entity.test
@@ -60,29 +60,41 @@ class EntityAPITestCase extends BackdropWebTestCase {
    * Tests caching (and not caching) of entities in the Entity API.
    */
   function testCaching() {
+    module_enable(array('entity_caching_test'));
+
     $user1 = $this->backdropCreateUser();
 
-    // Create some test entities of each type.
-    $entity = entity_create('entity_test', array('name' => 'test', 'uid' => $user1->uid));
+    // Create an entity that is cached.
+    $entity = entity_create('test_cacheable', array('name' => 'cache_this', 'uid' => $user1->uid));
     $entity->save();
-    $loaded_entity = entity_load('entity_test', $entity->id);
+    $loaded_entity = entity_load('test_cacheable', $entity->id);
     $ids = array($entity->id);
-    $data = cache_get_multiple($ids, 'cache_entity_entity_test');
-    $this->assertTrue(empty($data), "'entity_test' is not cached.");
+    $data = cache_get_multiple($ids, 'cache_entity_test_cacheable');
+    $this->assertTrue(!empty($data), "Entity 'test_cacheable' is cached.");
 
-    $entity = entity_create('entity_docache', array('name' => 'docache', 'uid' => $user1->uid));
+    // Create an entity whose caching has been disabled.
+    $entity = entity_create('test_disable_cache', array('name' => 'disable_cache', 'uid' => $user1->uid));
     $entity->save();
-    $loaded_entity = entity_load('entity_docache', $entity->id);
+    $loaded_entity = entity_load('test_disable_cache', $entity->id);
     $ids = array($entity->id);
-    $data = cache_get_multiple($ids, 'cache_entity_entity_docache');
-    $this->assertTrue(!empty($data), "'entity_docache' is cached.");
+    $data = cache_get_multiple($ids, 'cache_entity_test_disable_cache');
+    $this->assertTrue(empty($data), "Entity 'test_disable_cache' is not cached.");
 
-    $entity = entity_create('entity_bundle_nocache', array('name' => 'bundle_nocache', 'uid' => $user1->uid));
+    // Create an entity/bundle that is cached.
+    $entity = entity_create('test_multibundle', array('type' => 'docache', 'name' => 'bundle_cached', 'uid' => $user1->uid));
     $entity->save();
-    $loaded_entity = entity_load('entity_bundle_nocache', $entity->id);
+    $loaded_entity = entity_load('test_multibundle', $entity->id);
     $ids = array($entity->id);
-    $data = cache_get_multiple($ids, 'cache_entity_entity_bundle_nocache');
-    $this->assertTrue(empty($data), "'entity_bundle_nocache' is not cached.");
+    $data = cache_get_multiple($ids, 'cache_entity_test_multibundle');
+    $this->assertTrue(!empty($data), "Entity 'test_multibundle' of type 'docache' is cached.");
+
+    // Create an entity/bundle that is not cached.
+    $entity = entity_create('test_multibundle', array('type' => 'nocache', 'name' => 'bundle_not_cached', 'uid' => $user1->uid));
+    $entity->save();
+    $loaded_entity = entity_load('test_multibundle', $entity->id);
+    $ids = array($entity->id);
+    $data = cache_get_multiple($ids, 'cache_entity_test_multibundle');
+    $this->assertTrue(empty($data), "Entity 'test_multibundle' of type 'nocache' is not cached.");
   }
 
   /**

--- a/core/modules/entity/tests/entity.test
+++ b/core/modules/entity/tests/entity.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Entity CRUD API tests.
@@ -55,6 +54,35 @@ class EntityAPITestCase extends BackdropWebTestCase {
 
     $all = entity_test_load_multiple(FALSE);
     $this->assertTrue(empty($all), 'Deleted all entities.');
+  }
+
+  /**
+   * Tests caching (and not caching) of entities in the Entity API.
+   */
+  function testCaching() {
+    $user1 = $this->backdropCreateUser();
+
+    // Create some test entities of each type.
+    $entity = entity_create('entity_test', array('name' => 'test', 'uid' => $user1->uid));
+    $entity->save();
+    $loaded_entity = entity_load('entity_test', $entity->id);
+    $ids = array($entity->id);
+    $data = cache_get_multiple($ids, 'cache_entity_entity_test');
+    $this->assertTrue(empty($data), "'entity_test' is not cached.");
+
+    $entity = entity_create('entity_docache', array('name' => 'docache', 'uid' => $user1->uid));
+    $entity->save();
+    $loaded_entity = entity_load('entity_docache', $entity->id);
+    $ids = array($entity->id);
+    $data = cache_get_multiple($ids, 'cache_entity_entity_docache');
+    $this->assertTrue(!empty($data), "'entity_docache' is cached.");
+
+    $entity = entity_create('entity_bundle_nocache', array('name' => 'bundle_nocache', 'uid' => $user1->uid));
+    $entity->save();
+    $loaded_entity = entity_load('entity_bundle_nocache', $entity->id);
+    $ids = array($entity->id);
+    $data = cache_get_multiple($ids, 'cache_entity_entity_bundle_nocache');
+    $this->assertTrue(empty($data), "'entity_bundle_nocache' is not cached.");
   }
 
   /**

--- a/core/modules/entity/tests/entity_caching_test/entity_caching_test.info
+++ b/core/modules/entity/tests/entity_caching_test/entity_caching_test.info
@@ -1,0 +1,8 @@
+name = Entity Caching test module
+description = Provides entity types using to test entity caching.
+package = Testing
+version = BACKDROP_VERSION
+type = module
+backdrop = 1.x
+dependencies[] = entity
+hidden = TRUE

--- a/core/modules/entity/tests/entity_caching_test/entity_caching_test.install
+++ b/core/modules/entity/tests/entity_caching_test/entity_caching_test.install
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the entity_caching_test module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function entity_caching_test_schema() {
+  // Entity type used to check whether entities are properly cached.
+  $schema['test_cacheable'] = array(
+    'description' => 'Stores test_cacheable items.',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique test_cacheable item ID.',
+      ),
+      'name' => array(
+        'description' => 'The name of the test entity.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => "The {users}.uid of the associated user.",
+      ),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+    'foreign keys' => array(
+      'uid' => array('users' => 'uid'),
+    ),
+    'primary key' => array('id'),
+  );
+
+  // Entity type used to check whether caching can be disabled via the
+  // 'entity cache' flag.
+  $schema['test_disable_cache'] = array(
+    'description' => 'Stores test_disable_cache items.',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique test_disable_cache item ID.',
+      ),
+      'name' => array(
+        'description' => 'The name of the test entity.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => "The {users}.uid of the associated user.",
+      ),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+    'foreign keys' => array(
+      'uid' => array('users' => 'uid'),
+    ),
+    'primary key' => array('id'),
+  );
+
+  // Entity type used to check whether entity caching can be disabled at the
+  // bundle level via the 'bundle cache' flag.
+  $schema['test_multibundle'] = array(
+    'description' => 'Stores test_multibundle items.',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique test_multibundle item ID.',
+      ),
+      'name' => array(
+        'description' => 'The name of the test entity.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'type' => array(
+        'description' => 'The bundle type of the test entity.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => "The {users}.uid of the associated user.",
+      ),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+    'foreign keys' => array(
+      'uid' => array('users' => 'uid'),
+    ),
+    'primary key' => array('id'),
+  );
+
+  // Add cache tables for entities that may or may not actually be cached.
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_test_cacheable'] = $cache_schema;
+  $schema['cache_entity_test_cacheable']['description'] = "Cache table used to store test_cacheable entity records.";
+  $schema['cache_entity_test_disable_cache'] = $cache_schema;
+  $schema['cache_entity_test_disable_cache']['description'] = "Cache table used to store test_disable_cache entity records.";
+  $schema['cache_entity_test_multibundle'] = $cache_schema;
+  $schema['cache_entity_test_multibundle']['description'] = "Cache table used to store test_multibundle entity records.";
+
+  return $schema;
+}

--- a/core/modules/entity/tests/entity_caching_test/entity_caching_test.module
+++ b/core/modules/entity/tests/entity_caching_test/entity_caching_test.module
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @file
+ * Test module for the entity API providing an entity type for testing.
+ */
+
+/**
+ * Implements hook_entity_info().
+ */
+function entity_caching_test_entity_info() {
+  $return = array(
+    'test_cacheable' => array(
+      'label' => t('Test cacheable entity'),
+      'entity class' => 'TestCacheable',
+      'controller class' => 'EntityDatabaseStorageController',
+      'base table' => 'test_cacheable',
+      'fieldable' => TRUE,
+      'entity keys' => array(
+        'id' => 'id',
+      ),
+    ),
+    'test_disable_cache' => array(
+      'label' => t('Test disabled cache entity'),
+      'entity class' => 'TestCacheable',
+      'controller class' => 'EntityDatabaseStorageController',
+      'base table' => 'test_disable_cache',
+      'fieldable' => TRUE,
+      'entity keys' => array(
+        'id' => 'id',
+      ),
+    ),
+    'test_multibundle' => array(
+      'label' => t('Test multiple bundle entity'),
+      'entity class' => 'TestMultiBundle',
+      'controller class' => 'EntityDatabaseStorageController',
+      'base table' => 'test_multibundle',
+      'fieldable' => TRUE,
+      'entity keys' => array(
+        'id' => 'id',
+        'bundle' => 'type',
+      ),
+      'bundles' => array(
+        'docache' => array(
+          'label' => 'Do Cache',
+        ),
+        'nocache' => array(
+          'label' => 'No Cache',
+        ),
+      ),
+    ),
+  );
+  return $return;
+}
+
+/**
+ * Implements hook_entity_info_alter().
+ */
+function entity_caching_test_entity_info_alter(&$entity_info) {
+  // Enable caching on the 'test_disable_cache' entity at the entity level.
+  $entity_info['test_cacheable']['entity cache'] = TRUE;
+
+  // Disable caching on the 'test_disable_cache' entity at the entity level.
+  $entity_info['test_disable_cache']['entity cache'] = FALSE;
+
+  // Enable caching on the 'test_multibundle' entity at the entity level, but
+  // disable caching on one of the bundles  at the bundle level.
+  $entity_info['test_multibundle']['entity cache'] = TRUE;
+  $entity_info['test_multibundle']['bundles']['nocache']['bundle cache'] = FALSE;
+}
+
+/**
+ * Implements hook_autoload_info().
+ */
+function entity_caching_test_autoload_info() {
+  return array(
+    'TestCacheable' => 'test_cacheable.entity.inc',
+    'TestDisableCache' => 'test_disable_cache.entity.inc',
+    'TestMultiBundle' => 'test_multibundle.entity.inc',
+  );
+}

--- a/core/modules/entity/tests/entity_caching_test/test_cacheable.entity.inc
+++ b/core/modules/entity/tests/entity_caching_test/test_cacheable.entity.inc
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @file
+ * Test entity classes.
+ */
+
+/**
+ * Test class for the test_cacheable entity type.
+ */
+class TestCacheable extends Entity {
+  public $id;
+
+  /**
+   * Implements EntityInterface::id().
+   */
+  public function id() {
+    return $this->id;
+  }
+
+  /**
+   * Implements EntityInterface::entityType().
+   */
+  public function entityType() {
+    return 'test_cacheable';
+  }
+
+  /**
+   * Implements EntityInterface::label().
+   */
+  public function label() {
+    return 'label';
+  }
+
+  /**
+   * Implements EntityInterface::uri().
+   */
+  public function uri() {
+    return array(
+      'path' => 'test_cacheable/' . $this->id,
+    );
+  }
+
+  /**
+   * Implements EntityInterface::createAccess().
+   */
+  public static function createAccess($bundle = NULL, $account = NULL) {
+    return NULL;
+  }
+
+  /**
+   * Implements EntityInterface::access().
+   */
+  public function access($op, $account = NULL) {
+    return NULL;
+  }
+}

--- a/core/modules/entity/tests/entity_caching_test/test_disable_cache.entity.inc
+++ b/core/modules/entity/tests/entity_caching_test/test_disable_cache.entity.inc
@@ -5,9 +5,9 @@
  */
 
 /**
- * Test class for the entity_bundle_nocache entity type.
+ * Test class for the test_cacheable entity type.
  */
-class TestEntityBundleNoCache extends Entity {
+class TestDisableCache extends Entity {
   public $id;
 
   /**
@@ -21,7 +21,7 @@ class TestEntityBundleNoCache extends Entity {
    * Implements EntityInterface::entityType().
    */
   public function entityType() {
-    return 'entity_bundle_nocache';
+    return 'test_disable_cache';
   }
 
   /**
@@ -36,7 +36,7 @@ class TestEntityBundleNoCache extends Entity {
    */
   public function uri() {
     return array(
-      'path' => 'bundle-no-cache/' . $this->id,
+      'path' => 'test_disable_cache/' . $this->id,
     );
   }
 

--- a/core/modules/entity/tests/entity_caching_test/test_multibundle.entity.inc
+++ b/core/modules/entity/tests/entity_caching_test/test_multibundle.entity.inc
@@ -5,9 +5,9 @@
  */
 
 /**
- * Test class for the entity_docache entity type.
+ * Test class for the test_multibundle entity type.
  */
-class TestEntityDoCache extends Entity {
+class TestMultiBundle extends Entity {
   public $id;
 
   /**
@@ -21,7 +21,7 @@ class TestEntityDoCache extends Entity {
    * Implements EntityInterface::entityType().
    */
   public function entityType() {
-    return 'entity_docache';
+    return 'test_multibundle';
   }
 
   /**
@@ -32,11 +32,18 @@ class TestEntityDoCache extends Entity {
   }
 
   /**
+   * Implements EntityInterface::bundle().
+   */
+  public function bundle() {
+    return $this->type;
+  }
+
+  /**
    * Implements EntityInterface::uri().
    */
   public function uri() {
     return array(
-      'path' => 'no-cache/' . $this->id,
+      'path' => 'test_multibundle/' . $this->id,
     );
   }
 

--- a/core/modules/entity/tests/entity_test/entity_bundle_nocache.entity.inc
+++ b/core/modules/entity/tests/entity_test/entity_bundle_nocache.entity.inc
@@ -5,9 +5,9 @@
  */
 
 /**
- * Test class for the entity_test entity type.
+ * Test class for the entity_bundle_nocache entity type.
  */
-class TestEntity extends Entity {
+class TestEntityBundleNoCache extends Entity {
   public $id;
 
   /**
@@ -21,7 +21,7 @@ class TestEntity extends Entity {
    * Implements EntityInterface::entityType().
    */
   public function entityType() {
-    return 'entity_test';
+    return 'entity_bundle_nocache';
   }
 
   /**
@@ -36,7 +36,7 @@ class TestEntity extends Entity {
    */
   public function uri() {
     return array(
-      'path' => 'test/' . $this->id,
+      'path' => 'bundle-no-cache/' . $this->id,
     );
   }
 

--- a/core/modules/entity/tests/entity_test/entity_docache.entity.inc
+++ b/core/modules/entity/tests/entity_test/entity_docache.entity.inc
@@ -5,9 +5,9 @@
  */
 
 /**
- * Test class for the entity_test entity type.
+ * Test class for the entity_docache entity type.
  */
-class TestEntity extends Entity {
+class TestEntityDoCache extends Entity {
   public $id;
 
   /**
@@ -21,7 +21,7 @@ class TestEntity extends Entity {
    * Implements EntityInterface::entityType().
    */
   public function entityType() {
-    return 'entity_test';
+    return 'entity_docache';
   }
 
   /**
@@ -36,7 +36,7 @@ class TestEntity extends Entity {
    */
   public function uri() {
     return array(
-      'path' => 'test/' . $this->id,
+      'path' => 'no-cache/' . $this->id,
     );
   }
 

--- a/core/modules/entity/tests/entity_test/entity_test.install
+++ b/core/modules/entity/tests/entity_test/entity_test.install
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Install, update and uninstall functions for the entity_test module.
@@ -35,13 +34,14 @@ function entity_test_install() {
  * Implements hook_schema().
  */
 function entity_test_schema() {
+  // Entity type used for most testing.
   $schema['entity_test'] = array(
     'description' => 'Stores entity_test items.',
     'fields' => array(
       'id' => array(
         'type' => 'serial',
         'not null' => TRUE,
-        'description' => 'Primary Key: Unique entity-test item ID.',
+        'description' => 'Primary Key: Unique entity_test item ID.',
       ),
       'name' => array(
         'description' => 'The name of the test entity.',
@@ -66,5 +66,82 @@ function entity_test_schema() {
     ),
     'primary key' => array('id'),
   );
+
+  // Entity type used to check whether entities are properly cached.
+  $schema['entity_docache'] = array(
+    'description' => 'Stores entity_docache items.',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique entity_docache item ID.',
+      ),
+      'name' => array(
+        'description' => 'The name of the test entity.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => "The {users}.uid of the associated user.",
+      ),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+    'foreign keys' => array(
+      'uid' => array('users' => 'uid'),
+    ),
+    'primary key' => array('id'),
+  );
+
+  // Entity type used to check whether entity caching can be disabled at the
+  // bundle level.
+  $schema['entity_bundle_nocache'] = array(
+    'description' => 'Stores entity_bundle_nocache items.',
+    'fields' => array(
+      'id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique entity_bundle_nocache item ID.',
+      ),
+      'name' => array(
+        'description' => 'The name of the test entity.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => "The {users}.uid of the associated user.",
+      ),
+    ),
+    'indexes' => array(
+      'uid' => array('uid'),
+    ),
+    'foreign keys' => array(
+      'uid' => array('users' => 'uid'),
+    ),
+    'primary key' => array('id'),
+  );
+
+  // Add cache tables for entities that may or may not actually be cached.
+  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
+  $schema['cache_entity_entity_test'] = $cache_schema;
+  $schema['cache_entity_entity_test']['description'] = "Cache table used to store entity_test entity records.";
+  $schema['cache_entity_entity_docache'] = $cache_schema;
+  $schema['cache_entity_entity_docache']['description'] = "Cache table used to store entity_docache entity records.";
+  $schema['cache_entity_entity_bundle_nocache'] = $cache_schema;
+  $schema['cache_entity_entity_bundle_nocache']['description'] = "Cache table used to store entity_bundle_nocache entity records.";
+
   return $schema;
 }

--- a/core/modules/entity/tests/entity_test/entity_test.install
+++ b/core/modules/entity/tests/entity_test/entity_test.install
@@ -34,7 +34,6 @@ function entity_test_install() {
  * Implements hook_schema().
  */
 function entity_test_schema() {
-  // Entity type used for most testing.
   $schema['entity_test'] = array(
     'description' => 'Stores entity_test items.',
     'fields' => array(
@@ -66,82 +65,5 @@ function entity_test_schema() {
     ),
     'primary key' => array('id'),
   );
-
-  // Entity type used to check whether entities are properly cached.
-  $schema['entity_docache'] = array(
-    'description' => 'Stores entity_docache items.',
-    'fields' => array(
-      'id' => array(
-        'type' => 'serial',
-        'not null' => TRUE,
-        'description' => 'Primary Key: Unique entity_docache item ID.',
-      ),
-      'name' => array(
-        'description' => 'The name of the test entity.',
-        'type' => 'varchar',
-        'length' => 32,
-        'not null' => TRUE,
-        'default' => '',
-      ),
-      'uid' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'default' => NULL,
-        'description' => "The {users}.uid of the associated user.",
-      ),
-    ),
-    'indexes' => array(
-      'uid' => array('uid'),
-    ),
-    'foreign keys' => array(
-      'uid' => array('users' => 'uid'),
-    ),
-    'primary key' => array('id'),
-  );
-
-  // Entity type used to check whether entity caching can be disabled at the
-  // bundle level.
-  $schema['entity_bundle_nocache'] = array(
-    'description' => 'Stores entity_bundle_nocache items.',
-    'fields' => array(
-      'id' => array(
-        'type' => 'serial',
-        'not null' => TRUE,
-        'description' => 'Primary Key: Unique entity_bundle_nocache item ID.',
-      ),
-      'name' => array(
-        'description' => 'The name of the test entity.',
-        'type' => 'varchar',
-        'length' => 32,
-        'not null' => TRUE,
-        'default' => '',
-      ),
-      'uid' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => FALSE,
-        'default' => NULL,
-        'description' => "The {users}.uid of the associated user.",
-      ),
-    ),
-    'indexes' => array(
-      'uid' => array('uid'),
-    ),
-    'foreign keys' => array(
-      'uid' => array('users' => 'uid'),
-    ),
-    'primary key' => array('id'),
-  );
-
-  // Add cache tables for entities that may or may not actually be cached.
-  $cache_schema = backdrop_get_schema_unprocessed('system', 'cache');
-  $schema['cache_entity_entity_test'] = $cache_schema;
-  $schema['cache_entity_entity_test']['description'] = "Cache table used to store entity_test entity records.";
-  $schema['cache_entity_entity_docache'] = $cache_schema;
-  $schema['cache_entity_entity_docache']['description'] = "Cache table used to store entity_docache entity records.";
-  $schema['cache_entity_entity_bundle_nocache'] = $cache_schema;
-  $schema['cache_entity_entity_bundle_nocache']['description'] = "Cache table used to store entity_bundle_nocache entity records.";
-
   return $schema;
 }

--- a/core/modules/entity/tests/entity_test/entity_test.module
+++ b/core/modules/entity/tests/entity_test/entity_test.module
@@ -19,44 +19,8 @@ function entity_test_entity_info() {
         'id' => 'id',
       ),
     ),
-    'entity_docache' => array(
-      'label' => t('Test entity (no cache)'),
-      'entity class' => 'TestEntityDoCache',
-      'controller class' => 'EntityDatabaseStorageController',
-      'base table' => 'entity_docache',
-      'fieldable' => TRUE,
-      'entity keys' => array(
-        'id' => 'id',
-      ),
-    ),
-    'entity_bundle_nocache' => array(
-      'label' => t('Test entity (bundle no cache)'),
-      'entity class' => 'TestEntityBundleNoCache',
-      'controller class' => 'EntityDatabaseStorageController',
-      'base table' => 'entity_bundle_nocache',
-      'fieldable' => TRUE,
-      'entity keys' => array(
-        'id' => 'id',
-      ),
-    ),
   );
   return $return;
-}
-
-/**
- * Implements hook_entity_info_alter().
- */
-function entity_test_entity_info_alter(&$entity_info) {
-  // Disable caching on the 'entity_test' type at the entity level.
-  $entity_info['entity_test']['entity cache'] = FALSE;
-
-  // Enable caching on the 'entity_docache' type at the entity level.
-  $entity_info['entity_docache']['entity cache'] = TRUE;
-
-  // Disable caching on the 'entity_bundle_nocache' type at the bundle level
-  // even though it is set to cache at the entity level.
-  $entity_info['entity_bundle_nocache']['entity cache'] = TRUE;
-  $entity_info['entity_bundle_nocache']['bundles']['entity_bundle_nocache']['bundle cache'] = FALSE;
 }
 
 /**
@@ -65,8 +29,6 @@ function entity_test_entity_info_alter(&$entity_info) {
 function entity_test_autoload_info() {
   return array(
     'TestEntity' => 'entity_test.entity.inc',
-    'TestEntityDoCache' => 'entity_docache.entity.inc',
-    'TestEntityBundleNoCache' => 'entity_bundle_nocache.entity.inc',
   );
 }
 

--- a/core/modules/entity/tests/entity_test/entity_test.module
+++ b/core/modules/entity/tests/entity_test/entity_test.module
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Test module for the entity API providing an entity type for testing.
@@ -20,8 +19,44 @@ function entity_test_entity_info() {
         'id' => 'id',
       ),
     ),
+    'entity_docache' => array(
+      'label' => t('Test entity (no cache)'),
+      'entity class' => 'TestEntityDoCache',
+      'controller class' => 'EntityDatabaseStorageController',
+      'base table' => 'entity_docache',
+      'fieldable' => TRUE,
+      'entity keys' => array(
+        'id' => 'id',
+      ),
+    ),
+    'entity_bundle_nocache' => array(
+      'label' => t('Test entity (bundle no cache)'),
+      'entity class' => 'TestEntityBundleNoCache',
+      'controller class' => 'EntityDatabaseStorageController',
+      'base table' => 'entity_bundle_nocache',
+      'fieldable' => TRUE,
+      'entity keys' => array(
+        'id' => 'id',
+      ),
+    ),
   );
   return $return;
+}
+
+/**
+ * Implements hook_entity_info_alter().
+ */
+function entity_test_entity_info_alter(&$entity_info) {
+  // Disable caching on the 'entity_test' type at the entity level.
+  $entity_info['entity_test']['entity cache'] = FALSE;
+
+  // Enable caching on the 'entity_docache' type at the entity level.
+  $entity_info['entity_docache']['entity cache'] = TRUE;
+
+  // Disable caching on the 'entity_bundle_nocache' type at the bundle level
+  // even though it is set to cache at the entity level.
+  $entity_info['entity_bundle_nocache']['entity cache'] = TRUE;
+  $entity_info['entity_bundle_nocache']['bundles']['entity_bundle_nocache']['bundle cache'] = FALSE;
 }
 
 /**
@@ -30,6 +65,8 @@ function entity_test_entity_info() {
 function entity_test_autoload_info() {
   return array(
     'TestEntity' => 'entity_test.entity.inc',
+    'TestEntityDoCache' => 'entity_docache.entity.inc',
+    'TestEntityBundleNoCache' => 'entity_bundle_nocache.entity.inc',
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5632.

The lines 20–22 changes fix the @return so that it will render nicely on the API site (as opposed to [the current version](https://docs.backdropcms.org/api/backdrop/core%21modules%21entity%21entity.api.php/function/hook_entity_info/1) which bolds and inserts a colon partway through a sentence.
