### PR TITLE
Issue #5645. Reset static cache after clearing contexts

### DIFF
--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -879,6 +879,7 @@ class Layout {
    */
   function clearContexts($key) {
     unset($this->contexts[$key]);
+    backdrop_static_reset('getContexts');
   }
 
   /**


### PR DESCRIPTION
Fixes [#5645](https://github.com/backdrop/backdrop-issues/issues/5645)
