### PR TITLE
Issue 5679. Fix name of Layout::getContexts static cache

### DIFF
--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -878,7 +878,7 @@ class Layout {
    */
   function clearContexts($key) {
     unset($this->contexts[$key]);
-    backdrop_static_reset('getContexts');
+    backdrop_static_reset('Layout::getContexts');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5679

IMPORTANT: this needs to be merged ONLY if PR #4105 gets merged. That PR changes the name of the static cache.
