### PR TITLE
Issue #5689: Fix type hint in doc block for function arg

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -3788,7 +3788,7 @@ function request_path() {
  * @param $path
  *   A path to break into components. Defaults to the path of the current page.
  *
- * @return string|NULL
+ * @return string|NULL|array
  *   The component specified by $index, or NULL if the specified component was
  *   not found. If called without arguments, it returns an array containing all
  *   the components of the current path.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5689