### PR TITLE
Issue #5694: Remove the entity_reference removal notice.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3295,14 +3295,7 @@ function system_update_1081() {
  * Notify if a non-core version of Entity Reference module is present.
  */
 function system_update_1082() {
-  $path = backdrop_get_path('module', 'entityreference');
-  if ($path && strpos($path, 'core/modules/entityreference') === FALSE) {
-    backdrop_set_message(t('Backdrop core provides a bundled @name module. A different copy of @name module is at %path. Remove this module from your installation to use the core @name module. For more information see the <a href="!url" target="_blank">@name change notice</a>.', array(
-      '@name' => t('Entity Reference'),
-      '%path' => $path,
-      '!url' => 'https://docs.backdropcms.org/node/47321',
-    )), 'warning');
-  }
+  // Move update hook to 1.23.0.
 }
 
 /**


### PR DESCRIPTION
Related to https://github.com/backdrop/backdrop-issues/issues/5694

**PR for 1.22.2** the `1.x22.x` branch.

See also https://github.com/backdrop/backdrop/pull/4144