### PR TITLE
Issue #5736: Change the config group "Node types" to "Content types"

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -3651,7 +3651,7 @@ function node_config_info() {
   $prefixes['node.type'] = array(
     'name_key' => 'type',
     'label_key' => 'name',
-    'group' => t('Node types'),
+    'group' => t('Content types'),
   );
   return $prefixes;
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5736