### PR TITLE
Issue #5650: remove superfluous test files if present.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3324,6 +3324,26 @@ function system_update_1084() {
 }
 
 /**
+ * Remove superfluous test files if they are present.
+ */
+function system_update_1085() {
+  // Crufty files that may have been left behind after PR 3911.
+  // @see https://github.com/backdrop/backdrop-issues/issues/5465
+  $base = BACKDROP_ROOT . '/core/modules/system/tests/';
+  $filenames = array(
+    $base . 'cron_queue_test.module',
+    $base . 'system_cron_test.module',
+  );
+  foreach ($filenames as $filename) {
+    if (file_exists($filename)) {
+      if (!unlink($filename)) {
+        backdrop_set_message(t('Unable to remove file %filename, which is no longer used in its current location. Please remove it from the file system.', array('filename' => $filename)), 'warning');
+      }
+    }
+  }
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5650.

Rebase of https://github.com/backdrop/backdrop/pull/4090.