### PR TITLE
Issue #3902: Add Config::getData() for API symmetry with Config::setData()

### DIFF
--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -596,6 +596,8 @@ class Config {
    *   All of the data from this config object.
    *
    * @see Config::get()
+   *
+   * @since 1.23.0 Method added.
    */
   public function getData() {
     return $this->get();

--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -588,6 +588,20 @@ class Config {
   }
 
   /**
+   * Gets all data from this configuration object.
+   *
+   * This call provides API symmetry with Config::setData().
+   *
+   * @return array
+   *   All of the data from this config object.
+   *
+   * @see Config::get()
+   */
+  public function getData() {
+    return $this->get();
+  }
+
+  /**
    * Gets data from this configuration object.
    *
    * @param string $key

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -87,7 +87,9 @@ class ConfigurationTest extends BackdropWebTestCase {
       'favorite_animal' => 'cats',
       'favorite_color' => 'blue',
     );
-    $this->assertEqual($config->get(), $expected_config, 'The configuration file contained the expected configuration.');
+    // Test both paths.
+    $this->assertEqual($config->get(), $expected_config, 'The configuration file via Config::get() contained the expected configuration.');
+    $this->assertEqual($config->getData(), $expected_config, 'The configuration file via Config::getData() contained the expected configuration.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3902