### PR TITLE
Issue #5756: Allow rendered tables to have columns that default to DESC

### DIFF
--- a/core/includes/tablesort.inc
+++ b/core/includes/tablesort.inc
@@ -47,13 +47,17 @@ function tablesort_header($cell, $header, $ts) {
       $image = theme('tablesort_indicator', array('style' => $ts['sort']));
     }
     else {
-      // If the user clicks a different header, we want to sort ascending initially.
-      $ts['sort'] = 'asc';
+      // This determines the sort order when the column gets first clicked by
+      // the user. It is "asc" by default but the sort can be changed if
+      // $cell['initial_click_sort'] is defined. The possible values are "asc"
+      // or "desc".
+      $ts['sort'] = $cell['initial_click_sort'] ? $cell['initial_click_sort'] : 'asc';
+
       $image = '';
     }
     $cell['data'] = l($cell['data'] . $image, $_GET['q'], array('attributes' => array('title' => $title), 'query' => array_merge($ts['query'], array('sort' => $ts['sort'], 'order' => $cell['data'])), 'html' => TRUE));
 
-    unset($cell['field'], $cell['sort']);
+    unset($cell['field'], $cell['sort'], $cell['initial_click_sort']);
   }
   return $cell;
 }
@@ -154,8 +158,13 @@ function tablesort_get_sort($headers) {
     // Find out which header is currently being sorted.
     $ts = tablesort_get_order($headers);
     foreach ($headers as $header) {
-      if (is_array($header) && isset($header['data']) && $header['data'] == $ts['name'] && isset($header['sort'])) {
-        return $header['sort'];
+      if (is_array($header) && isset($header['data']) && $header['data'] == $ts['name']) {
+        if (isset($header['sort'])) {
+          return $header['sort'];
+        }
+        if (isset($header['initial_click_sort'])) {
+          return $header['initial_click_sort'];
+        }
       }
     }
   }

--- a/core/includes/tablesort.inc
+++ b/core/includes/tablesort.inc
@@ -51,7 +51,7 @@ function tablesort_header($cell, $header, $ts) {
       // the user. It is "asc" by default but the sort can be changed if
       // $cell['initial_click_sort'] is defined. The possible values are "asc"
       // or "desc".
-      $ts['sort'] = $cell['initial_click_sort'] ? $cell['initial_click_sort'] : 'asc';
+      $ts['sort'] = isset($cell['initial_click_sort']) ? $cell['initial_click_sort'] : 'asc';
 
       $image = '';
     }

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2041,11 +2041,15 @@ function theme_breadcrumb($variables) {
  *   - header: An array containing the table headers. Each element of the array
  *     can be either a localized string or an associative array with the
  *     following keys:
- *     - "data": The localized title of the table column.
- *     - "field": The database field represented in the table column (required
+ *     - data: The localized title of the table column.
+ *     - field: The database field represented in the table column (required
  *       if user is to be able to sort on this column).
- *     - "sort": A default sort order for this column ("asc" or "desc").
- *     - "class": An array of values for the 'class' attribute. In particular,
+ *     - sort: A default sort order for this column ("asc" or "desc"). Only
+ *       one column should be given a default sort order because table sorting
+ *       only applies to one column at a time.
+ *     - initial_click_sort: Set the initial sort of the column when clicked.
+ *       Defaults to "asc".
+ *     - class: An array of values for the 'class' attribute. In particular,
  *       the least important columns that can be hidden on narrow and medium
  *       width screens should have a 'priority-low' class, referenced with the
  *       RESPONSIVE_PRIORITY_LOW constant. Columns that should be shown on
@@ -2064,14 +2068,14 @@ function theme_breadcrumb($variables) {
  *     for the table footer.
  *   - rows: An array of table rows. Every row is an array of cells, or an
  *     associative array with the following keys:
- *     - "data": an array of cells
+ *     - data: an array of cells
  *     - Any HTML attributes, such as "class", to apply to the table row.
- *     - "no_striping": a boolean indicating that the row should receive no
+ *     - no_striping: a boolean indicating that the row should receive no
  *       'even / odd' styling. Defaults to FALSE.
  *     Each cell can be either a string or an associative array with the
  *     following keys:
- *     - "data": The string to display in the table cell.
- *     - "header": Indicates this cell is a header.
+ *     - data: The string to display in the table cell.
+ *     - header: Indicates this cell is a header.
  *     - Any HTML attributes, such as "colspan", to apply to the table cell.
  *     Here's an example for $rows:
  *     @code

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2131,6 +2131,7 @@ function theme_breadcrumb($variables) {
  *   The HTML output.
  *
  * @since 1.18.4 "footer" key added to $variables parameter.
+ * @since 1.23.1 optional "initial_click_sort" key added to $header.
  */
 function theme_table(array $variables) {
   $header = (array) $variables['header'];

--- a/core/modules/simpletest/tests/tablesort.test
+++ b/core/modules/simpletest/tests/tablesort.test
@@ -113,7 +113,6 @@ class TableSortTest extends BackdropUnitTestCase {
 
     // Test complex table headers plus $_GET parameters that should _not_
     // override the default.
-
     $_GET = array(
       'q' => 'jahwohl',
       // This should not override the table order because this header does not
@@ -131,15 +130,14 @@ class TableSortTest extends BackdropUnitTestCase {
     $this->assertEqual($ts, $expected_ts, 'Complex table headers plus non-overriding $_GET parameters sorted correctly.');
     unset($_GET['sort'], $_GET['order'], $_GET['alpha']);
 
-    // Test complex table headers plus $_GET parameters that _should_
-    // override the default.
-
+    // Test complex table headers plus $_GET parameters that _should_ override
+    // the default.
     $_GET = array(
       'q' => 'jahwohl',
       'order' => '1',
       'sort' => 'ASC',
-      // Add an unrelated parameter to ensure that tablesort will include
-      // it in the links that it creates.
+      // Add an unrelated parameter to ensure that tablesort will include it in
+      // the links that it creates.
       'alpha' => 'beta',
     );
     $expected_ts = array(
@@ -152,6 +150,111 @@ class TableSortTest extends BackdropUnitTestCase {
     $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
     $this->assertEqual($ts, $expected_ts, 'Complex table headers plus $_GET parameters sorted correctly.');
     unset($_GET['sort'], $_GET['order'], $_GET['alpha']);
+
+    // Test the initial_click_sort parameter.
+    $headers = array()
+      'foo',
+      array(
+        'data' => '1',
+        'field' => 'one',
+        'initial_click_sort' => 'desc',
+        'colspan' => 1,
+      ),
+      array(
+        'data' => '2',
+        'field' => 'two',
+      ),
+      array(
+        'data' => '3',
+        'field' => 'three',
+        'initial_click_sort' => 'desc',
+        'sort' => 'asc',
+      ),
+      array(
+        'data' => '4',
+        'field' => 'four',
+        'initial_click_sort' => 'asc',
+      ),
+      array(
+        'data' => '5',
+        'field' => 'five',
+        'initial_click_sort' => 'foo',
+      ),
+    );
+    $_GET = array(
+      'order' => '1',
+    );
+    $ts = tablesort_init($headers);
+    $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
+    $expected_ts = array(
+      'name' => '1',
+      'sql' => 'one',
+      'sort' => 'desc',
+      'query' => array(),
+    );
+    $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
+    $this->assertEqual($ts, $expected_ts, 'Complex table headers using the initial_click_sort parameter are sorted correctly.');
+
+    // Test that if the initial_click_sort parameter is not defined, the default
+    // must be used instead (which is "asc").
+    $_GET = array(
+      'order' => '2',
+    );
+    $ts = tablesort_init($headers);
+    $expected_ts = array(
+      'name' => '2',
+      'sql' => 'two',
+      'sort' => 'asc',
+      'query' => array(),
+    );
+    $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
+    $this->assertEqual($ts, $expected_ts, 'Complex table headers without using the initial_click_sort parameter are sorted correctly.');
+
+    // Test that if the initial_click_sort parameter is defined, and the sort
+    // parameter is defined as well, the sort parameter has precedence.
+    $_GET = array(
+      'order' => '3',
+    );
+    $ts = tablesort_init($headers);
+    $expected_ts = array(
+      'name' => '3',
+      'sql' => 'three',
+      'sort' => 'asc',
+      'query' => array(),
+    );
+    $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
+    $this->assertEqual($ts, $expected_ts, 'Complex table headers using the initial_click_sort and sort parameters are sorted correctly.');
+
+    // Test that if the initial_click_sort parameter is defined and the value
+    // is "asc" it should be sorted correctly.
+    $_GET = array(
+      'order' => '4',
+    );
+    $ts = tablesort_init($headers);
+    $expected_ts = array(
+      'name' => '4',
+      'sql' => 'four',
+      'sort' => 'asc',
+      'query' => array(),
+    );
+    $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
+    $this->assertEqual($ts, $expected_ts, 'Complex table headers with the initial_click_sort set as ASC are sorted correctly.');
+
+    // Tests that if the initial_click_sort is defined with a non expected value
+    // that value will be passed as the "sort" value.
+    $_GET = array(
+      'order' => '5',
+    );
+    $ts = tablesort_init($headers);
+    $expected_ts = array(
+      'name' => '5',
+      'sql' => 'five',
+      'sort' => 'foo',
+      'query' => array(),
+    );
+    $this->verbose(strtr('$ts: <pre>!ts</pre>', array('!ts' => check_plain(var_export($ts, TRUE)))));
+    $this->assertEqual($ts, $expected_ts, 'Complex table headers with the initial_click_sort set as foo are sorted correctly.');
+
 
   }
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5756

Respective Drupal commit: https://www.drupal.org/commitlog/commit/2/c0881f91e2a74f0617acd968f081722dd8d2e97a