### PR TITLE
Issue #5761: Log completely unusable when an entry has corrupt serialized data

### DIFF
--- a/core/modules/dblog/dblog.admin.inc
+++ b/core/modules/dblog/dblog.admin.inc
@@ -302,13 +302,19 @@ function dblog_format_message($event, $is_link = FALSE) {
   $output = '';
   // Check for required properties.
   if (isset($event->message) && isset($event->variables)) {
+    $event_variables = @unserialize($event->variables);
     // Messages without variables or user specified text.
-    if ($event->variables === 'N;') {
+    if ($event_variables === NULL) {
       $output = $event->message;
+    }
+    elseif (!is_array($event_variables)) {
+      $output = t('Log data is corrupted and cannot be unserialized: @message', array(
+        '@message' => $event->message,
+      ));
     }
     // Message to translate with injected variables.
     else {
-      $output = t($event->message, unserialize($event->variables));
+      $output = t($event->message, $event_variables);
     }
     // If the output is expected to be a link, strip all the tags and
     // special characters by using filter_xss() without any allowed tags.

--- a/core/modules/dblog/tests/dblog.test
+++ b/core/modules/dblog/tests/dblog.test
@@ -52,10 +52,40 @@ class DBLogTestCase extends BackdropWebTestCase {
     $this->verifyCron($row_limit);
     $this->verifyEvents();
     $this->verifyReports();
+    $this->testDBLogCorrupted();
 
     // Login the regular user.
     $this->backdropLogin($this->any_user);
     $this->verifyReports(403);
+  }
+
+  /**
+   * Tests corrupted log entries can still display available data.
+   */
+  private function testDBLogCorrupted() {
+    global $base_root;
+
+    // Prepare the fields to be logged.
+    $log = array(
+      'type'        => 'custom',
+      'message'     => 'Log entry added to test the unserialize failure.',
+      'variables'   => 'BAD SERIALIZED DATA',
+      'severity'    => WATCHDOG_NOTICE,
+      'link'        => '',
+      'user'        => $this->big_user,
+      'uid'         => isset($this->big_user->uid) ? $this->big_user->uid : 0,
+      'request_uri' => $base_root . request_uri(),
+      'referer'     => $_SERVER['HTTP_REFERER'],
+      'ip'          => ip_address(),
+      'timestamp'   => REQUEST_TIME,
+    );
+    dblog_watchdog($log);
+
+    // View the database log report page.
+    $this->backdropGet('admin/reports/dblog');
+    $this->assertResponse(200);
+    $expected_output = truncate_utf8(filter_xss(t('Log data is corrupted and cannot be unserialized: Log entry added to test unserialize failure.'), array()), 56, TRUE, TRUE);
+    $this->assertText($expected_output, 'Log data is corrupted and cannot be unserialized.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5761

Crossport of this D7 commit: https://git.drupalcode.org/project/drupal/-/commit/30e76c6