### PR TITLE
Issue #5764: Fix typo in testCommentInterface()

### DIFF
--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -453,7 +453,7 @@ class CommentInterfaceTest extends CommentHelperCase {
     $this->backdropGet('comment/reply/' . $this->node->nid . '/' . $comment->id);
     $this->assertNoText($title_text, 'Individual comment-reply title not found.');
     $reply = $this->postComment(NULL, $this->randomName(), NULL, TRUE);
-    $reply_loaded = comment_load($reply->id
+    $reply_loaded = comment_load($reply->id);
 
     // Test rendered comment for hidden title.
     $this->backdropGet('node/' . $this->node->nid);

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -432,7 +432,7 @@ class CommentInterfaceTest extends CommentHelperCase {
     $this->assertEqual(rtrim($comment_loaded->thread, '/') . '.01/', $reply_loaded->thread, 'Thread of second reply grows correctly.');
     // Test rendered comment for title.
     $this->backdropGet('node/' . $this->node->nid);
-    $this->assertText($title_text, 'Individual comment title not found.');
+    $this->assertText($title_text, 'Individual comment title found.');
 
     // Edit reply.
     $this->backdropLogin($this->web_user);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5764