### PR TITLE
Issue #5797: Sort the results of the UNION SELECT queries to ensure a well-known order.

### DIFF
--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -1529,6 +1529,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
     $query_1->union($query_2);
 
     $names = $query_1->execute()->fetchCol();
+    sort($names);
 
     // Ensure we only get 2 records.
     $this->assertEqual(count($names), 2, 'UNION correctly discarded duplicates.');
@@ -1552,6 +1553,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
     $query_1->union($query_2, 'ALL');
 
     $names = $query_1->execute()->fetchCol();
+    sort($names);
 
     // Ensure we get all 3 records.
     $this->assertEqual(count($names), 3, 'UNION ALL correctly preserved duplicates.');


### PR DESCRIPTION

Fixes backdrop/backdrop-issues#5797

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
