### PR TITLE
Issue 5805. DatabaseCondition::__toString() should return string

### DIFF
--- a/core/includes/database/query.inc
+++ b/core/includes/database/query.inc
@@ -1922,7 +1922,7 @@ class DatabaseCondition implements QueryConditionInterface, Countable {
   public function __toString() {
     // If the caller forgot to call compile() first, refuse to run.
     if ($this->changed) {
-      return NULL;
+      return '';
     }
     return $this->stringVersion;
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5805