### PR TITLE
Issue 5806. Table alias missing in query condition in taxonomy_select_nodes()

### DIFF
--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -249,7 +249,7 @@ function taxonomy_select_nodes($tid, $pager = TRUE, $limit = FALSE, $order = arr
   }
   $query = db_select('taxonomy_index', 't');
   $query->addTag('node_access');
-  $query->condition('tid', $tid);
+  $query->condition('t.tid', $tid);
   if ($pager) {
     $count_query = clone $query;
     $count_query->addExpression('COUNT(t.nid)');

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -918,6 +918,29 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
     $terms = taxonomy_term_load_multiple_by_name($term2->name, 'non_existing_vocabulary');
     $this->assertEqual(count($terms), 0, 'No terms loaded when restricted by a non-existing vocabulary.');
   }
+
+  /**
+   * Tests that taxonomy term detail page is working even after the default
+   * taxonomy_select_nodes() query is altered.
+   */
+  public function testTaxonomySelectNodesAlter() {
+    // Create a new term.
+    $term = $this->createTerm($this->vocabulary);
+
+    // Create an article.
+    $settings = array(
+      'type' => 'article',
+      $this->instance['field_name'] => array(LANGUAGE_NONE => array(array('tid' => $term->tid))),
+    );
+    $this->backdropCreateNode($settings);
+
+    // Check if the taxonomy term detail page is working.
+    module_enable(array('taxonomy_nodes_test'));
+    state_set('taxonomy_nodes_test_query_node_access_alter', TRUE);
+    $this->backdropGet('taxonomy/term/' . $term->tid);
+    $this->assertResponse(200, 'The taxonomy term page is working.');
+    state_set('taxonomy_nodes_test_query_node_access_alter', FALSE);
+  }
 }
 
 /**

--- a/core/modules/taxonomy/tests/taxonomy_nodes_test/taxonomy_nodes_test.info
+++ b/core/modules/taxonomy/tests/taxonomy_nodes_test/taxonomy_nodes_test.info
@@ -1,0 +1,7 @@
+name = "Taxonomy module node list tests"
+type = module
+description = "Support module for taxonomy node list related testing."
+package = Testing
+version = VERSION
+backdrop = 1.x
+hidden = TRUE

--- a/core/modules/taxonomy/tests/taxonomy_nodes_test/taxonomy_nodes_test.info
+++ b/core/modules/taxonomy/tests/taxonomy_nodes_test/taxonomy_nodes_test.info
@@ -1,6 +1,6 @@
-name = "Taxonomy module node list tests"
+name = Taxonomy module node list tests
 type = module
-description = "Support module for taxonomy node list related testing."
+description = Support module for taxonomy node list related testing.
 package = Testing
 version = VERSION
 backdrop = 1.x

--- a/core/modules/taxonomy/tests/taxonomy_nodes_test/taxonomy_nodes_test.module
+++ b/core/modules/taxonomy/tests/taxonomy_nodes_test/taxonomy_nodes_test.module
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Dummy module implementing hook_query_TAG_alter.
+ */
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function taxonomy_nodes_test_query_node_access_alter(QueryAlterableInterface $query) {
+  if (state_get('taxonomy_nodes_test_query_node_access_alter', FALSE)) {
+    $taxonomy_index = FALSE;
+    foreach ($query->getTables() as $alias => $table) {
+      if ($table['table'] == 'taxonomy_index') {
+        $taxonomy_index = TRUE;
+      }
+    }
+
+    if ($taxonomy_index) {
+      // Verify that additional data can be added to the default
+      // taxonomy_select_nodes() query by altering it.
+      $query->leftJoin('taxonomy_term_data', 'ttd', 'ttd.tid = t.tid');
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5806