### PR TITLE
Issue #5818: Preserve utf8mb4 value when upgrading from Drupal.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3344,6 +3344,23 @@ function system_update_1085() {
 }
 
 /**
+ * Preserve 4-byte UTF-8 database update value if set.
+ */
+function system_update_1086() {
+  $connection = Database::getConnection();
+  $utf8mb4_active = $connection->utf8mb4IsActive();
+  $utf8mb4_supported = $connection->utf8mb4IsSupported();
+  // This variable is set by Drupal 7 on new installations that support UTF8-MB4
+  // and when the update is performed by the "utf8mb4_convert" project.
+  $d7_utf8mb4_run = update_variable_get('drupal_all_databases_are_utf8mb4', FALSE);
+  $utf8mb4_state = state_get('database_utf8mb4_active', FALSE);
+  if ($utf8mb4_supported && $utf8mb4_active && $d7_utf8mb4_run && !$utf8mb4_state) {
+    state_set('database_utf8mb4_active', TRUE);
+    update_variable_del('drupal_all_databases_are_utf8mb4');
+  }
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5818

