### PR TITLE
Issue 5842. Fix misspelling of dialog's resizable

### DIFF
--- a/core/modules/system/system.pages.inc
+++ b/core/modules/system/system.pages.inc
@@ -24,7 +24,7 @@ function system_token_output() {
       'dialogClass' => 'token-dialog',
       'modal' => FALSE,
       'draggable' => TRUE,
-      'resizeable' => TRUE,
+      'resizable' => TRUE,
       'autoResize' => FALSE,
       'width' => '600',
       'height' => '500',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5842