### PR TITLE
Issue 5835. Apply needed css property to ui-dialog-content before ajax

### DIFF
--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -1790,6 +1790,9 @@ div.add-or-remove-shortcuts {
   -moz-box-shadow: 0 0 12px -8px #666;
   box-shadow: 0 0 12px -8px #666;
 }
+.ui-dialog-content {
+  overflow: auto;
+}
 .ui-dialog-titlebar {
   border: 1px solid #d0d0d0;
   border-bottom: none;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5835