### PR TITLE
Issue #5844: fix PHP 8.1 deprecation notice when bootstrapping from CLI

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -957,6 +957,7 @@ function backdrop_settings_initialize() {
     $session_name = $cookie_domain;
   }
   else {
+    $cookie_domain = '';
     // Otherwise use $base_url as session name, without the protocol
     // to use the same session identifiers across HTTP and HTTPS.
     list( , $session_name) = explode('://', $base_url, 2);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5844.