### PR TITLE
Issue #3983: Add “Configure page title” tab to layout admin pages

### DIFF
--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -272,7 +272,9 @@ function layout_menu() {
     'title' => 'Configure page title',
     'page callback' => 'backdrop_get_form',
     'page arguments' => array('layout_title_settings_form', 4),
+    'type' => MENU_LOCAL_TASK,
     'file' => 'layout.admin.inc',
+    'weight' => 11,
   ) + $base;
 
   $items['admin/structure/layouts/manage/%layout_tempstore/configure-block/%/%layout_tempstore_block'] = array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3983.