### PR TITLE
Issue #5866 - Fix deprecate error in backdrop_basename

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -2546,7 +2546,7 @@ function backdrop_basename($uri, $suffix = NULL) {
     $separators .= DIRECTORY_SEPARATOR;
   }
   // Remove right-most slashes when $uri points to directory.
-  $uri = rtrim($uri, $separators);
+  $uri = rtrim((string) $uri, $separators);
   // Returns the trailing part of the $uri starting after one of the directory
   // separators.
   $filename = preg_match('@[^' . preg_quote($separators, '@') . ']+$@', $uri, $matches) ? $matches[0] : '';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5866

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
