### PR TITLE
Issue #5835: Resize dialogs after jQuery UI CSS has been loaded.

### DIFF
--- a/core/misc/dialog.js
+++ b/core/misc/dialog.js
@@ -36,7 +36,7 @@ Backdrop.dialog = function (element, options) {
     $(window).trigger('dialog:beforecreate', [dialog, $element, settings]);
     $element.dialog(settings);
 
-    if (settings.autoResize === true || settings.autoResize === 'true') {
+    if (settings.autoResize === true || settings.autoResize === 'true') {
       // Add a class specifically to help to lock scrolling.
       $('html').addClass('dialog-auto-resize');
 
@@ -78,25 +78,17 @@ Backdrop.dialog = function (element, options) {
 
       // Because of Chromium's behavior, we must wait until the ajax-loaded
       // jquery.ui.dialog.css is applied.
-      var computedStyle = getComputedStyle($element[0]);
-      var cssOverflowProperty = computedStyle.getPropertyValue('overflow');
-      if (cssOverflowProperty != 'auto') {
-        setTimeout(
-          function waitForCss() {
-            var cssOverflowProperty = computedStyle.getPropertyValue('overflow');
-            // If the overflow is not 'auto' yet, schedule this function again.
-            if (cssOverflowProperty != 'auto') {
-              setTimeout(waitForCss, 0);
-            }
-            else {
-              resetPosition();
-            }
-          }, 0
-        )
+      var waitForCss = function() {
+        var cssOverflowProperty = getComputedStyle($element[0]).getPropertyValue('overflow');
+        // If the overflow is not 'auto' yet, schedule this function again.
+        if (cssOverflowProperty != 'auto') {
+          setTimeout(waitForCss, 10);
+        }
+        else {
+          resetPosition();
+        }
       }
-      else {
-        resetPosition();
-      }
+      setTimeout(waitForCss, 0);
     }
     dialog.open = true;
     $(window).trigger('dialog:aftercreate', [dialog, $element, settings]);

--- a/core/misc/dialog.js
+++ b/core/misc/dialog.js
@@ -76,16 +76,9 @@ Backdrop.dialog = function (element, options) {
         .dialog('widget').css('position', 'fixed');
       Backdrop.optimizedResize.add(resetPosition, 'dialogResize.' + dialogId);
 
-      // Because of a bug in Chromium, we must wait until the ajax-loaded
-      // jquery.ui.dialog.css is applied to the content of the modal through the
-      // class .ui-dialog-content. 
-
-      // First, get the computed style for the content element. Note: this
-      // variable changes automatically when the element's style is changed. 
+      // Because of Chromium's behavior, we must wait until the ajax-loaded
+      // jquery.ui.dialog.css is applied.
       var computedStyle = getComputedStyle($element[0]);
-
-      // Get the current value for the overflow property, which must by 'auto'
-      // after jquery.ui.dialog.css has been applied. 
       var cssOverflowProperty = computedStyle.getPropertyValue('overflow');
       if (cssOverflowProperty != 'auto') {
         setTimeout(

--- a/core/misc/dialog.js
+++ b/core/misc/dialog.js
@@ -78,8 +78,9 @@ Backdrop.dialog = function (element, options) {
 
       // Because of Chromium's behavior, we must wait until the ajax-loaded
       // jquery.ui.dialog.css is applied.
+      var computedStyle = getComputedStyle($element[0]);
       var waitForCss = function() {
-        var cssOverflowProperty = getComputedStyle($element[0]).getPropertyValue('overflow');
+        var cssOverflowProperty = computedStyle.getPropertyValue('overflow');
         // If the overflow is not 'auto' yet, schedule this function again.
         if (cssOverflowProperty != 'auto') {
           setTimeout(waitForCss, 10);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5835

Replaces https://github.com/backdrop/backdrop/pull/4247