### PR TITLE
Issue 5886. Avoid adding the base path twice to ckeditor links

### DIFF
--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -461,9 +461,7 @@ function filter_format_editor_link_form_submit($form, &$form_state) {
     }
   }
   else {
-    // Modify references to other URIs if not an external link.
-    $url = (substr($uri, 0, 4) == 'http') ? $uri : substr(base_path(), 0, -1) . $uri;
-    $form_state['values']['attributes']['href'] = $url;
+    $form_state['values']['attributes']['href'] = $uri;
     // Remove any reference to a data file.
     unset($form_state['values']['fid']);
     $form_state['values']['attributes']['data-file-id'] = NULL;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5886