### PR TITLE
Passing null to parameter of type string is deprecated

### DIFF
--- a/core/includes/unicode.inc
+++ b/core/includes/unicode.inc
@@ -474,8 +474,9 @@ function decode_entities($text) {
  * @ingroup php_wrappers
  */
 function backdrop_strlen($text) {
-  // Bail early if no string provided (if $text is NULL for example).
-  if (!is_string($text)) {
+  // Bail early if $text is NULL.
+  // @todo Remove this in 2.x.
+  if (is_null($text)) {
     return 0;
   }
 
@@ -492,7 +493,7 @@ function backdrop_strlen($text) {
 /**
  * Uppercase a UTF-8 string.
  *
- * @param $text
+ * @param string $text
  *   The string to run the operation on.
  *
  * @return string
@@ -501,6 +502,12 @@ function backdrop_strlen($text) {
  * @ingroup php_wrappers
  */
 function backdrop_strtoupper($text) {
+  // Bail early if $text is NULL.
+  // @todo Remove this in 2.x.
+  if (is_null($text) {
+    return "";
+  }
+
   global $multibyte;
   if ($multibyte == UNICODE_MULTIBYTE) {
     return mb_strtoupper($text);
@@ -517,7 +524,7 @@ function backdrop_strtoupper($text) {
 /**
  * Lowercase a UTF-8 string.
  *
- * @param $text
+ * @param string $text
  *   The string to run the operation on.
  *
  * @return string
@@ -526,6 +533,12 @@ function backdrop_strtoupper($text) {
  * @ingroup php_wrappers
  */
 function backdrop_strtolower($text) {
+  // Bail early if $text is NULL.
+  // @todo Remove this in 2.x.
+  if (is_null($text) {
+    return "";
+  }
+
   global $multibyte;
   if ($multibyte == UNICODE_MULTIBYTE) {
     return mb_strtolower($text);
@@ -577,19 +590,25 @@ function backdrop_ucfirst($text) {
  * cutting off a string at a known character/substring location, the usage of
  * PHP's normal strpos/substr is safe and much faster.
  *
- * @param $text
+ * @param string $text
  *   The input string.
- * @param $start
+ * @param int $start
  *   The position at which to start reading.
- * @param $length
+ * @param int $length
  *   The number of characters to read.
  *
- * @return
+ * @return string
  *   The shortened string.
  *
  * @ingroup php_wrappers
  */
 function backdrop_substr($text, $start, $length = NULL) {
+  // Bail early if $text is NULL.
+  // @todo Remove this in 2.x.
+  if (is_null($text)) {
+    return "";
+  }
+
   global $multibyte;
   $text = (string) $text;
   if ($multibyte == UNICODE_MULTIBYTE) {

--- a/core/includes/unicode.inc
+++ b/core/includes/unicode.inc
@@ -504,7 +504,7 @@ function backdrop_strlen($text) {
 function backdrop_strtoupper($text) {
   // Bail early if $text is NULL.
   // @todo Remove this in 2.x.
-  if (is_null($text) {
+  if (is_null($text)) {
     return "";
   }
 
@@ -535,7 +535,7 @@ function backdrop_strtoupper($text) {
 function backdrop_strtolower($text) {
   // Bail early if $text is NULL.
   // @todo Remove this in 2.x.
-  if (is_null($text) {
+  if (is_null($text)) {
     return "";
   }
 

--- a/core/includes/unicode.inc
+++ b/core/includes/unicode.inc
@@ -465,7 +465,7 @@ function decode_entities($text) {
  *
  * This is less than or equal to the byte count.
  *
- * @param $text
+ * @param string $text
  *   The string to run the operation on.
  *
  * @return integer
@@ -475,6 +475,9 @@ function decode_entities($text) {
  */
 function backdrop_strlen($text) {
   global $multibyte;
+  if (!isset($text)) {
+    return 0;
+  }
   if ($multibyte == UNICODE_MULTIBYTE) {
     return mb_strlen($text);
   }

--- a/core/includes/unicode.inc
+++ b/core/includes/unicode.inc
@@ -474,10 +474,12 @@ function decode_entities($text) {
  * @ingroup php_wrappers
  */
 function backdrop_strlen($text) {
-  global $multibyte;
-  if (!isset($text)) {
+  // Bail early if no string provided (if $text is NULL for example).
+  if (!is_string($text)) {
     return 0;
   }
+
+  global $multibyte;
   if ($multibyte == UNICODE_MULTIBYTE) {
     return mb_strlen($text);
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5890

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
