### PR TITLE
The error message doesn't mention all the allowed extensions

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1883,7 +1883,7 @@ function file_validate_is_image(File $file) {
 
   $info = image_get_info($file->uri);
   if (!$info || empty($info['extension'])) {
-    $errors[] = t('Only JPEG, PNG and GIF images are allowed.');
+    $errors[] = t('The image type is not recognized.');
   }
 
   return $errors;

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1044,7 +1044,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
     // Try to upload a file that is not an image for the user picture.
     $not_an_image = current($this->backdropGetTestFiles('html'));
     $this->saveUserPicture($not_an_image);
-    $this->assertRaw(t('Only JPEG, PNG and GIF images are allowed.'), 'Non-image files are not accepted.');
+    $this->assertRaw(t('The image type is not recognized.'), 'Non-image files are not accepted.');
   }
 
   /**


### PR DESCRIPTION
The error message returned by file_validate_is_image() doesn't mention all the allowed extensions

Fixes https://github.com/backdrop/backdrop-issues/issues/5917

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
