### PR TITLE
Issue 5925. Avoid passing null as parameter 3 to preg_replace

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -485,7 +485,10 @@ function system_requirements($phase) {
         // Check for an incompatible version.
         $required_file = $files[$required_module];
         $required_name = $required_file->info['name'];
-        $version = preg_replace('/^' . preg_quote(BACKDROP_CORE_COMPATIBILITY, '/') . '-/', '', $required_file->info['version']);
+        $version = '';
+        if (!empty($required_file->info['version'])) {
+          $version = preg_replace('/^' . preg_quote(BACKDROP_CORE_COMPATIBILITY, '/') . '-/', '', $required_file->info['version']);
+        }
         $compatibility = backdrop_check_incompatibility($requirement, $version);
         if ($compatibility) {
           $compatibility = rtrim(substr($compatibility, 2), ')');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5925

This is a simple fix. The result is that $version remains an empty string when there is no version, which is exactly what happens with PHP 7.4, when `preg_replace` accepted an empty 3rd argument.