### PR TITLE
Issue #3802: Add @since for the $settings parameter in hook_block_configure()

### DIFF
--- a/core/modules/layout/layout.api.php
+++ b/core/modules/layout/layout.api.php
@@ -545,6 +545,8 @@ function hook_block_info_alter(&$blocks) {
  *
  * @see hook_block_info()
  * @see hook_block_save()
+ *
+ * @since 1.0.6 $settings parameter added.
  */
 function hook_block_configure($delta = '', $settings = array()) {
   // This example comes from node.module.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3802

Follow-up for https://github.com/backdrop/backdrop/pull/3924
