### PR TITLE
Issue #5398: Add link to $_SESSIONS superglobal in sessions.inc docblocks

### DIFF
--- a/core/includes/session.inc
+++ b/core/includes/session.inc
@@ -13,6 +13,8 @@
  * are assigned by session_set_save_handler() in bootstrap.inc and are called
  * automatically by PHP. These functions should not be called directly. Session
  * data should instead be accessed via the $_SESSION superglobal.
+ *
+ * @see https://www.php.net/manual/en/reserved.variables.session.php
  */
 
 /**
@@ -59,6 +61,8 @@ function _backdrop_session_close() {
  * Doing so may result in logging out the current user, corrupting session data
  * or other unexpected behavior. Session data must always be accessed via the
  * $_SESSION superglobal.
+ *
+ * @see https://www.php.net/manual/en/reserved.variables.session.php
  *
  * @param $sid
  *   The session ID of the session to retrieve.
@@ -144,6 +148,8 @@ function _backdrop_session_read($sid) {
  * This function is an internal function and must not be called directly.
  * Doing so may result in corrupted session data or other unexpected behavior.
  * Session data must always be accessed via the $_SESSION superglobal.
+ *
+ * @see https://www.php.net/manual/en/reserved.variables.session.php
  *
  * @param $sid
  *   The session ID of the session to write to.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5998.