### PR TITLE
Issue #4937: allow altering supported image extensions for regular fi…

### DIFF
--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1883,7 +1883,8 @@ function file_validate_is_image(File $file) {
 
   $info = image_get_info($file->uri);
   if (!$info || empty($info['extension'])) {
-    $errors[] = t('Only JPEG, PNG and GIF images are allowed.');
+    $supported_extensions = image_get_supported_extensions();
+    $errors[] = t('Only images with the following extensions are allowed: @formats.', array('@formats' => implode(', ', $supported_extensions)));
   }
 
   return $errors;

--- a/core/includes/file.inc
+++ b/core/includes/file.inc
@@ -1579,7 +1579,8 @@ function file_save_upload($form_field_name, $validators = array(), $destination 
   else {
     // No validator was provided, so add one using the default list.
     // Build a default non-munged safe list for file_munge_filename().
-    $extensions = 'jpg jpeg gif png txt doc xls pdf ppt pps odt ods odp docx docm pptx pptm xlsx xlsm';
+    $extensions = implode(' ', image_get_supported_extensions()) . ' txt doc xls pdf ppt pps odt ods odp docx docm pptx pptm xlsx xlsm';
+
     $validators['file_validate_extensions'] = array();
     $validators['file_validate_extensions'][0] = $extensions;
   }

--- a/core/includes/image.inc
+++ b/core/includes/image.inc
@@ -112,7 +112,12 @@ function image_get_supported_extensions() {
   if (function_exists($function)) {
     return $function();
   }
-  watchdog('image', 'The selected image handling toolkit %toolkit can not correctly process %function.', array('%toolkit' => $toolkit, '%function' => $function), WATCHDOG_ERROR);
+  watchdog('image', 'The selected image handling toolkit %toolkit can not correctly process %function.',
+    array(
+      '%toolkit' => $toolkit,
+      '%function' => $function),
+    WATCHDOG_ERROR
+  );
   return FALSE;
 }
 

--- a/core/includes/image.inc
+++ b/core/includes/image.inc
@@ -98,21 +98,22 @@ function image_toolkit_invoke($method, stdClass $image, array $params = array())
 }
 
 /**
- * Get supported images extensions.
+ * Gets supported image extensions.
  *
  * Backdrop supports GIF, JPG, PNG, and WEBP file formats when supported by the
- * GD toolkit, and may support others, depending on which toolkits are
- * installed.
+ * GD toolkit, and may support others, depending on the currently used toolkit.
  *
  * @return array
  *   Array of supported extensions.
  */
 function image_get_supported_extensions() {
-  $supported_extensions = array('gif', 'jpg', 'jpeg');
-
-  backdrop_alter('image_supported_extensions', $supported_extensions);
-
-  return $supported_extensions;
+  $toolkit = image_get_toolkit();
+  $function = 'image_' . $toolkit . '_supported_extensions';
+  if (function_exists($function)) {
+    return $function();
+  }
+  watchdog('image', 'The selected image handling toolkit %toolkit can not correctly process %function.', array('%toolkit' => $toolkit, '%function' => $function), WATCHDOG_ERROR);
+  return FALSE;
 }
 
 /**

--- a/core/includes/image.inc
+++ b/core/includes/image.inc
@@ -98,6 +98,24 @@ function image_toolkit_invoke($method, stdClass $image, array $params = array())
 }
 
 /**
+ * Get supported images extensions.
+ *
+ * Backdrop supports GIF, JPG, PNG, and WEBP file formats when supported by the
+ * GD toolkit, and may support others, depending on which toolkits are
+ * installed.
+ *
+ * @return array
+ *   Array of supported extensions.
+ */
+function image_get_supported_extensions() {
+  $supported_extensions = array('gif', 'jpg', 'jpeg');
+
+  backdrop_alter('image_supported_extensions', $supported_extensions);
+
+  return $supported_extensions;
+}
+
+/**
  * Gets details about an image.
  *
  * Backdrop supports GIF, JPG and PNG file formats when used with the GD

--- a/core/includes/image.inc
+++ b/core/includes/image.inc
@@ -118,7 +118,7 @@ function image_get_supported_extensions() {
       '%function' => $function),
     WATCHDOG_ERROR
   );
-  return FALSE;
+  return array();
 }
 
 /**

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -88,7 +88,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#upload_location' => $upload_settings['scheme'] . '://' . $upload_settings['directory'],
     '#default_value' => $fid ? $fid : NULL,
     '#upload_validators' => array(
-      'file_validate_extensions' => array('gif png jpg jpeg'),
+      'file_validate_extensions' => array(implode(' ', image_get_supported_extensions())),
       'file_validate_image_orientation' => array($orientation),
       'file_validate_size' => array($max_filesize),
       'file_validate_image_resolution' => array($max_dimensions),

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -560,6 +560,7 @@ function _filter_format_editor_link_url_validate(&$element, &$form_state) {
  * internal alias.
  *
  * @param string $url
+ *   The URL entered by the user.
  *
  * @return string
  *   A cleaned-up URL that is either a properly formatted external URL or an
@@ -587,7 +588,7 @@ function _filter_cleanup_url($url) {
   // - adding extra prefixes if being re-edited;
   // - a url getting double-encoded;
   // - or domains with relative protocols.
-  // E.g. /fr/node/1, //domain.tld
+  // E.g. /fr/node/1, //domain.tld.
   if (substr($url, 0, 1) == '/') {
     return $url;
   }
@@ -610,7 +611,7 @@ function _filter_cleanup_url($url) {
  * @return string
  *   The URL with the protocol prepended if needed.
  *
- * @see link_cleanup_url().
+ * @see link_cleanup_url()
  */
 function _filter_create_valid_external_url($url) {
   // Skip if it's already a valid external URL with a protocol.
@@ -638,6 +639,7 @@ function _filter_create_valid_external_url($url) {
  * all external URLs even if they have dangerous protocols.
  *
  * @param string $url
+ *   The URL entered by the user.
  *
  * @return bool
  *   TRUE if URL has protocol.

--- a/core/modules/image/image.field.inc
+++ b/core/modules/image/image.field.inc
@@ -437,6 +437,7 @@ function image_field_widget_form(&$form, &$form_state, $field, $instance, $langc
 
     // If not using custom extension validation, ensure this is an image.
     $supported_extensions = image_get_supported_extensions();
+    backdrop_alter('image_supported_extensions', $supported_extensions);
     $extensions = isset($elements[$delta]['#upload_validators']['file_validate_extensions'][0]) ? $elements[$delta]['#upload_validators']['file_validate_extensions'][0] : implode(' ', $supported_extensions);
     $extensions = array_intersect(explode(' ', $extensions), $supported_extensions);
     $elements[$delta]['#upload_validators']['file_validate_extensions'][0] = implode(' ', $extensions);

--- a/core/modules/image/image.field.inc
+++ b/core/modules/image/image.field.inc
@@ -17,7 +17,7 @@ function image_field_info() {
         'default_image' => '',
       ),
       'instance_settings' => array(
-        'file_extensions' => 'png gif jpg jpeg',
+        'file_extensions' => implode(' ', image_get_supported_extensions()),
         'file_directory' => '',
         'max_filesize' => '',
         'alt_field' => 0,

--- a/core/modules/image/image.field.inc
+++ b/core/modules/image/image.field.inc
@@ -436,8 +436,7 @@ function image_field_widget_form(&$form, &$form_state, $field, $instance, $langc
     }
 
     // If not using custom extension validation, ensure this is an image.
-    $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');
-    backdrop_alter('image_supported_extensions', $supported_extensions);
+    $supported_extensions = image_get_supported_extensions();
     $extensions = isset($elements[$delta]['#upload_validators']['file_validate_extensions'][0]) ? $elements[$delta]['#upload_validators']['file_validate_extensions'][0] : implode(' ', $supported_extensions);
     $extensions = array_intersect(explode(' ', $extensions), $supported_extensions);
     $elements[$delta]['#upload_validators']['file_validate_extensions'][0] = implode(' ', $extensions);

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -1170,7 +1170,8 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
 
     // Both, PHP and GD must support WebP. PHP ships with support since 7.1.+,
     // the bundled GD version still might not support it.
-    $webp_supported = (imagetypes() & IMG_WEBP);
+    $gd_info = gd_info();
+    $webp_supported = isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE;
     if (version_compare(PHP_VERSION, '7.1.0', '<') || !$webp_supported) {
       $this->assertText(strip_tags($refused_message), 'WebP image type has been refused');
       // Also check the field description.

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -1178,7 +1178,9 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
     ));
 
     // Both, PHP and GD must support WebP. PHP ships with support since 7.1.+,
-    // the bundled GD version still might not support it.
+    // particularly for getimagesize() so that's the minimum.
+    // @see https://www.php.net/manual/en/function.gd-info.php
+    // @see https://www.php.net/manual/en/function.getimagesize.php
     $gd_info = gd_info();
     $webp_supported = isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE;
     if (version_compare(PHP_VERSION, '7.1.0', '<') || !$webp_supported) {

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -31,6 +31,9 @@ require BACKDROP_ROOT . '/core/modules/simpletest/tests/image.test';
 class ImageFieldTestCase extends BackdropWebTestCase {
   protected $admin_user;
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp('image');
     $this->admin_user = $this->backdropCreateUser(array('access content', 'access administration pages', 'administer site configuration', 'administer content types', 'administer fields', 'administer nodes', 'create post content', 'edit any post content', 'delete any post content', 'administer image styles'));
@@ -114,6 +117,9 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   protected $image_info;
   protected $image_filepath;
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp('image_module_test');
 
@@ -287,6 +293,9 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
 class ImageEffectsUnitTest extends ImageToolkitTestCase {
   protected $profile = 'testing';
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp(array('image', 'image_module_test'));
     module_load_include('inc', 'image', 'image.effects');
@@ -1199,6 +1208,9 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
 class ImageDimensionsUnitTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp(array('image', 'image_module_test'));
   }
@@ -1532,6 +1544,10 @@ class ImageDimensionsScaleTestCase extends BackdropUnitTestCase {
  * Tests default image settings.
  */
 class ImageFieldDefaultImagesTestCase extends ImageFieldTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp(array('field_ui'));
   }
@@ -1819,6 +1835,9 @@ class ImageStyleFloodProtection extends BackdropWebTestCase {
   protected $style_name;
   protected $profile = 'testing';
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp(array('image', 'image_module_test'));
 
@@ -1960,6 +1979,9 @@ class ImageStyleFloodProtection extends BackdropWebTestCase {
  */
 class ImageThemeFunctionWebTestCase extends BackdropWebTestCase {
 
+  /**
+   * {@inheritdoc}
+   */
   public function setUp() {
     parent::setUp(array('image'));
   }

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -31,7 +31,7 @@ require BACKDROP_ROOT . '/core/modules/simpletest/tests/image.test';
 class ImageFieldTestCase extends BackdropWebTestCase {
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('image');
     $this->admin_user = $this->backdropCreateUser(array('access content', 'access administration pages', 'administer site configuration', 'administer content types', 'administer fields', 'administer nodes', 'create post content', 'edit any post content', 'delete any post content', 'administer image styles'));
     $this->backdropLogin($this->admin_user);
@@ -55,7 +55,7 @@ class ImageFieldTestCase extends BackdropWebTestCase {
    * @param $widget_settings
    *   A list of widget settings that will be added to the widget defaults.
    */
-  function createImageField($name, $type_name, $field_settings = array(), $instance_settings = array(), $widget_settings = array()) {
+  public function createImageField($name, $type_name, $field_settings = array(), $instance_settings = array(), $widget_settings = array()) {
     $field = array(
       'field_name' => $name,
       'type' => 'image',
@@ -92,7 +92,7 @@ class ImageFieldTestCase extends BackdropWebTestCase {
    * @param $type
    *   The type of node to create.
    */
-  function uploadNodeImage($image, $field_name, $type) {
+  public function uploadNodeImage($image, $field_name, $type) {
     $edit = array(
       'title' => $this->randomName(),
     );
@@ -114,7 +114,7 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   protected $image_info;
   protected $image_filepath;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('image_module_test');
 
     $this->style_name = 'style_foo';
@@ -124,7 +124,7 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   /**
    * Test image_style_path().
    */
-  function testImageStylePath() {
+  public function testImageStylePath() {
     $scheme = 'public';
     $actual = image_style_path($this->style_name, "$scheme://foo/bar.gif");
     $expected = "$scheme://styles/" . $this->style_name . "/$scheme/foo/bar.gif";
@@ -138,35 +138,35 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   /**
    * Test image_style_url() with a file using the "public://" scheme.
    */
-  function testImageStyleUrlAndPathPublic() {
+  public function testImageStyleUrlAndPathPublic() {
     $this->_testImageStyleUrlAndPath('public');
   }
 
   /**
    * Test image_style_url() with a file using the "private://" scheme.
    */
-  function testImageStyleUrlAndPathPrivate() {
+  public function testImageStyleUrlAndPathPrivate() {
     $this->_testImageStyleUrlAndPath('private');
   }
 
   /**
    * Test image_style_url() with the "public://" scheme and unclean URLs.
    */
-   function testImageStylUrlAndPathPublicUnclean() {
+  public function testImageStyleUrlAndPathPublicUnclean() {
      $this->_testImageStyleUrlAndPath('public', FALSE);
    }
 
   /**
    * Test image_style_url() with the "private://" schema and unclean URLs.
    */
-  function testImageStyleUrlAndPathPrivateUnclean() {
+  public function testImageStyleUrlAndPathPrivateUnclean() {
     $this->_testImageStyleUrlAndPath('private', FALSE);
   }
 
   /**
    * Test that an invalid source image returns a 404.
    */
-  function testImageStyleUrlForMissingSourceImage() {
+  public function testImageStyleUrlForMissingSourceImage() {
     $non_existent_uri = 'public://foo.png';
     $generated_url = image_style_url($this->style_name, $non_existent_uri);
     $this->backdropGet($generated_url);
@@ -176,7 +176,7 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   /**
    * Test that we do not pass an array to backdrop_add_http_header.
    */
-  function testImageContentTypeHeaders() {
+  public function testImageContentTypeHeaders() {
     $files = $this->backdropGetTestFiles('image');
     $file = array_shift($files);
     // Copy the test file to private folder.
@@ -192,7 +192,7 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   /**
    * Test image_style_url().
    */
-  function _testImageStyleUrlAndPath($scheme, $clean_url = TRUE) {
+  public function _testImageStyleUrlAndPath($scheme, $clean_url = TRUE) {
     // Make the default scheme neither "public" nor "private" to verify the
     // functions work for other than the default scheme.
     config_set('system.core', 'file_default_scheme', 'temporary');
@@ -287,7 +287,7 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
 class ImageEffectsUnitTest extends ImageToolkitTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('image', 'image_module_test'));
     module_load_include('inc', 'image', 'image.effects');
   }
@@ -295,7 +295,7 @@ class ImageEffectsUnitTest extends ImageToolkitTestCase {
   /**
    * Test all the image effects provided by core.
    */
-  function testEffects() {
+  public function testEffects() {
     // Test the image_resize_effect() function.
     $this->assertTrue(image_resize_effect($this->image, array('width' => 1, 'height' => 2)), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('resize'));
@@ -366,7 +366,7 @@ class ImageEffectsUnitTest extends ImageToolkitTestCase {
   /**
    * Test image effect caching.
    */
-  function testImageEffectsCaching() {
+  public function testImageEffectsCaching() {
     $image_effect_definitions_called = &backdrop_static('image_module_test_image_effect_info_alter');
 
     // First call should grab a fresh copy of the data.
@@ -390,7 +390,7 @@ class ImageAdminStylesUnitTest extends ImageFieldTestCase {
   /**
    * Given an image style, generate an image.
    */
-  function createSampleImage($style) {
+  public function createSampleImage($style) {
     static $file_path;
 
     // First, we need to make sure we have an image in our testing
@@ -407,7 +407,7 @@ class ImageAdminStylesUnitTest extends ImageFieldTestCase {
   /**
    * Count the number of images currently create for a style.
    */
-  function getImageCount($style) {
+  public function getImageCount($style) {
     return count(file_scan_directory('public://styles/' . $style['name'], '/.*/'));
   }
 
@@ -415,7 +415,7 @@ class ImageAdminStylesUnitTest extends ImageFieldTestCase {
    * Test creating an image style with a numeric name and ensuring it can be
    * applied to an image.
    */
-  function testNumericStyleName() {
+  public function testNumericStyleName() {
     $style_name = rand();
     $style_label = $this->randomName();
     $edit = array(
@@ -432,7 +432,7 @@ class ImageAdminStylesUnitTest extends ImageFieldTestCase {
   /**
    * General test to add a style, add/remove/edit effects to it, then delete it.
    */
-  function testStyle() {
+  public function testStyle() {
     // Setup a style to be created and effects to add to it.
     $style_name = strtolower($this->randomName(10));
     $style_label = $this->randomName();
@@ -587,7 +587,7 @@ class ImageAdminStylesUnitTest extends ImageFieldTestCase {
   /**
    * Test to override, edit, then revert a style.
    */
-  function testDefaultStyle() {
+  public function testDefaultStyle() {
     // Setup a style to be created and effects to add to it.
     $style_name = 'thumbnail';
     $style_label = 'Thumbnail (100x100)';
@@ -651,7 +651,7 @@ class ImageAdminStylesUnitTest extends ImageFieldTestCase {
   /**
    * Test deleting a style and choosing a replacement style.
    */
-  function testStyleReplacement() {
+  public function testStyleReplacement() {
     // Create a new style.
     $style_name = strtolower($this->randomName(10));
     $style_label = $this->randomName();
@@ -707,14 +707,14 @@ class ImageFieldDisplayTestCase extends ImageFieldTestCase {
   /**
    * Test image formatters on node display for public files.
    */
-  function testImageFieldFormattersPublic() {
+  public function testImageFieldFormattersPublic() {
     $this->_testImageFieldFormatters('public');
   }
 
   /**
    * Test image formatters on node display for private files.
    */
-  function testImageFieldFormattersPrivate() {
+  public function testImageFieldFormattersPrivate() {
     // Remove access content permission from anonymous users.
     user_role_change_permissions(BACKDROP_ANONYMOUS_ROLE, array('access content' => FALSE));
     $this->_testImageFieldFormatters('private');
@@ -723,7 +723,7 @@ class ImageFieldDisplayTestCase extends ImageFieldTestCase {
   /**
    * Test image formatters on node display.
    */
-  function _testImageFieldFormatters($scheme) {
+  public function _testImageFieldFormatters($scheme) {
     $field_name = strtolower($this->randomName());
     $this->createImageField($field_name, 'post', array('uri_scheme' => $scheme));
     // Create a new node with an image attached.
@@ -816,7 +816,7 @@ class ImageFieldDisplayTestCase extends ImageFieldTestCase {
   /**
    * Tests for image field settings.
    */
-  function testImageFieldSettings() {
+  public function testImageFieldSettings() {
     $test_image = current($this->backdropGetTestFiles('image'));
     list(, $test_image_extension) = explode('.', $test_image->filename);
     $field_name = strtolower($this->randomName());
@@ -841,7 +841,7 @@ class ImageFieldDisplayTestCase extends ImageFieldTestCase {
     $this->assertText(t('Files must be less than 50 KB.'), 'Image widget max file size is displayed on post form.');
     $this->assertText(t('Allowed file types: ' . $test_image_extension . '.'), 'Image widget allowed file types displayed on post form.');
     $this->assertText(t('Images larger than 100x100 pixels will be scaled down.'), 'Image widget allowed maximum dimensions displayed on post form.');
-    $this->assertText(t('Images must be at least 10x10 pixels.'), 'Image widget allowed mimimum dimensions displayed on post form.');
+    $this->assertText(t('Images must be at least 10x10 pixels.'), 'Image widget allowed minimum dimensions displayed on post form.');
 
     // We have to create the post first and then edit it because the alt
     // and title fields do not display until the image has been attached.
@@ -923,7 +923,7 @@ class ImageFieldDisplayTestCase extends ImageFieldTestCase {
   /**
    * Test use of a default image with an image field.
    */
-  function testImageFieldDefaultImage() {
+  public function testImageFieldDefaultImage() {
     // Create a new image field.
     $field_name = strtolower($this->randomName());
     $this->createImageField($field_name, 'post');
@@ -1001,7 +1001,7 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
   /**
    * Test min/max resolution settings.
    */
-  function testDimensions() {
+  public function testDimensions() {
     $field_name = strtolower($this->randomName());
     $min_dimensions = 50;
     $max_dimensions = 100;
@@ -1037,7 +1037,7 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
    * Test image rotation resulting from EXIF data.
    * Requires a special test image, file rotate90cw.jpg.
    */
-  function testOrientation() {
+  public function testOrientation() {
     // Create an image field.
     $field_name = strtolower($this->randomName());
     $instance_settings = array(
@@ -1081,7 +1081,7 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
   /**
    * Test single width resolution setting.
    */
-  function testWidthDimensions() {
+  public function testWidthDimensions() {
     $field_name = strtolower($this->randomName());
     $min_dimensions = 50;
     $max_dimensions = 100;
@@ -1116,7 +1116,7 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
   /**
    * Test single height resolution setting.
    */
-  function testHeightDimensions() {
+  public function testHeightDimensions() {
     $field_name = strtolower($this->randomName());
     $min_dimensions = 50;
     $max_dimensions = 100;
@@ -1199,14 +1199,14 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
 class ImageDimensionsUnitTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('image', 'image_module_test'));
   }
 
   /**
    * Test styled image dimensions cumulatively.
    */
-  function testImageDimensions() {
+  public function testImageDimensions() {
     // Create a working copy of the file.
     $files = $this->backdropGetTestFiles('image');
     $file = reset($files);
@@ -1402,7 +1402,7 @@ class ImageDimensionsScaleTestCase extends BackdropUnitTestCase {
   /**
    * Tests all control flow branches in image_dimensions_scale().
    */
-  function testImageDimensionsScale() {
+  public function testImageDimensionsScale() {
     // Define input / output datasets to test different branch conditions.
     $test = array();
 
@@ -1532,14 +1532,14 @@ class ImageDimensionsScaleTestCase extends BackdropUnitTestCase {
  * Tests default image settings.
  */
 class ImageFieldDefaultImagesTestCase extends ImageFieldTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('field_ui'));
   }
 
   /**
    * Tests CRUD for fields and fields instances with default images.
    */
-  function testDefaultImages() {
+  public function testDefaultImages() {
     // Create files to use as the default images.
     $files = $this->backdropGetTestFiles('image');
     $default_images = array();
@@ -1722,7 +1722,7 @@ class ImageStyleFlushTest extends ImageFieldTestCase {
   /**
    * Given an image style and a wrapper, generate an image.
    */
-  function createSampleImage($style, $wrapper) {
+  public function createSampleImage($style, $wrapper) {
     static $file;
 
     if (!isset($file)) {
@@ -1742,14 +1742,14 @@ class ImageStyleFlushTest extends ImageFieldTestCase {
   /**
    * Count the number of images currently created for a style in a wrapper.
    */
-  function getImageCount($style, $wrapper) {
+  public function getImageCount($style, $wrapper) {
     return count(file_scan_directory($wrapper . '://styles/' . $style['name'], '/.*/'));
   }
 
   /**
    * General test to flush a style.
    */
-  function testFlush() {
+  public function testFlush() {
 
     // Setup a style to be created and effects to add to it.
     $style_name = strtolower($this->randomName(10));
@@ -1819,7 +1819,7 @@ class ImageStyleFloodProtection extends BackdropWebTestCase {
   protected $style_name;
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('image', 'image_module_test'));
 
     $this->style_name = 'style_foo';
@@ -1839,7 +1839,7 @@ class ImageStyleFloodProtection extends BackdropWebTestCase {
   /**
    * Check the number of images that can be generated simultaneously.
    */
-  function testFloodProtection() {
+  public function testFloodProtection() {
     // Copy sample images.
     $files = $this->backdropGetTestFiles('image');
     $file = reset($files);
@@ -1960,14 +1960,14 @@ class ImageStyleFloodProtection extends BackdropWebTestCase {
  */
 class ImageThemeFunctionWebTestCase extends BackdropWebTestCase {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('image'));
   }
 
   /**
    * Tests usage of the image field formatters.
    */
-  function testImageFormatterTheme() {
+  public function testImageFormatterTheme() {
     // Create an image.
     $files = $this->backdropGetTestFiles('image');
     $file = reset($files);

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -152,7 +152,7 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   /**
    * Test image_style_url() with the "public://" scheme and unclean URLs.
    */
-   function testImageStyleUrlAndPathPublicUnclean() {
+   function testImageStylUrlAndPathPublicUnclean() {
      $this->_testImageStyleUrlAndPath('public', FALSE);
    }
 
@@ -841,7 +841,7 @@ class ImageFieldDisplayTestCase extends ImageFieldTestCase {
     $this->assertText(t('Files must be less than 50 KB.'), 'Image widget max file size is displayed on post form.');
     $this->assertText(t('Allowed file types: ' . $test_image_extension . '.'), 'Image widget allowed file types displayed on post form.');
     $this->assertText(t('Images larger than 100x100 pixels will be scaled down.'), 'Image widget allowed maximum dimensions displayed on post form.');
-    $this->assertText(t('Images must be at least 10x10 pixels.'), 'Image widget allowed minimum dimensions displayed on post form.');
+    $this->assertText(t('Images must be at least 10x10 pixels.'), 'Image widget allowed mimimum dimensions displayed on post form.');
 
     // We have to create the post first and then edit it because the alt
     // and title fields do not display until the image has been attached.
@@ -1171,14 +1171,12 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
     // Both, PHP and GD must support WebP. PHP ships with support since 7.1.+,
     // the bundled GD version still might not support it.
     $webp_supported = (imagetypes() & IMG_WEBP);
-    if (!$webp_supported) {
-      $this->assertFalse($webp_supported, 'WebP image type is not supported for this PHP build.');
+    if (version_compare(PHP_VERSION, '7.1.0', '<') || !$webp_supported) {
       $this->assertText(strip_tags($refused_message), 'WebP image type has been refused');
       // Also check the field description.
       $this->assertText('Allowed file types: jpg.', 'Field allows only jpg extension');
     }
     else {
-      $this->assertTrue($webp_supported, 'WebP image type is supported for this PHP build.');
       // Successful upload and node creation.
       $this->assertNoText(strip_tags($refused_message), 'WebP image type has not been refused');
       $node = node_load($nid);

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -1170,8 +1170,7 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
 
     // Both, PHP and GD must support WebP. PHP ships with support since 7.1.+,
     // the bundled GD version still might not support it.
-    $gd_info = gd_info();
-    $webp_supported = isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE;
+    $webp_supported = (imagetypes() & IMG_WEBP);
     if (!$webp_supported) {
       $this->assertFalse($webp_supported, 'WebP image type is not supported for this PHP build.');
       $this->assertText(strip_tags($refused_message), 'WebP image type has been refused');

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -1172,12 +1172,14 @@ class ImageFieldValidateTestCase extends ImageFieldTestCase {
     // the bundled GD version still might not support it.
     $gd_info = gd_info();
     $webp_supported = isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE;
-    if (version_compare(PHP_VERSION, '7.1.0', '<') || !$webp_supported) {
+    if (!$webp_supported) {
+      $this->assertFalse($webp_supported, 'WebP image type is not supported for this PHP build.');
       $this->assertText(strip_tags($refused_message), 'WebP image type has been refused');
       // Also check the field description.
       $this->assertText('Allowed file types: jpg.', 'Field allows only jpg extension');
     }
     else {
+      $this->assertTrue($webp_supported, 'WebP image type is supported for this PHP build.');
       // Successful upload and node creation.
       $this->assertNoText(strip_tags($refused_message), 'WebP image type has not been refused');
       $node = node_load($nid);

--- a/core/modules/layout/includes/block.hero.inc
+++ b/core/modules/layout/includes/block.hero.inc
@@ -52,8 +52,10 @@ class BlockHero extends BlockText {
   function form(&$form, &$form_state) {
     parent::form($form, $form_state);
 
+    $supported_extensions = image_get_supported_extensions();
+
     $upload_validators = array(
-      'file_validate_extensions' => array('jpg jpeg png gif'),
+      'file_validate_extensions' => array(implode(' ', $supported_extensions)),
       'file_validate_image_resolution' => array('3200x1600', '1200x300'),
     );
     $upload_description = theme('file_upload_help', array(

--- a/core/modules/simpletest/tests/image.test
+++ b/core/modules/simpletest/tests/image.test
@@ -458,7 +458,7 @@ class ImageToolkitGdTestCase extends BackdropWebTestCase {
         $this->assertTrue($correct_dimensions_real, format_string('Image %file after %action action has proper dimensions.', array('%file' => $file, '%action' => $op)));
         $this->assertTrue($correct_dimensions_object, format_string('Image %file object after %action action is reporting the proper height and width values.', array('%file' => $file, '%action' => $op)));
         // JPEG colors will always be messed up due to compression.
-        if ($image->info['extension'] != 'jpg') {
+        if (!in_array($image->info['extension'], array('jpg', 'jpeg'))) {
           $this->assertTrue($correct_colors, format_string('Image %file object after %action action has the correct color placement.', array('%file' => $file, '%action' => $op)));
         }
       }

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -27,6 +27,22 @@ function image_gd_settings() {
 }
 
 /**
+ * Retrieve supported extensions for the GD2 toolkit.
+ */
+function image_gd_supported_extensions() {
+  $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');
+  $gd_info = gd_info();
+  if (isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
+    // Extend mapping of constants to extensions, as the PHP and GD
+    // versions support WebP.
+    // @see https://www.php.net/manual/en/image.constants.php
+    $supported_extensions[] = 'webp';
+  }
+
+  return $supported_extensions;
+}
+
+/**
  * Verify GD2 settings (that the right version is actually installed).
  *
  * @return

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -31,14 +31,16 @@ function image_gd_settings() {
  */
 function image_gd_supported_extensions() {
   $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');
-  $gd_info = gd_info();
-  if (version_compare(PHP_VERSION, '7.1.0', '>=') && isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
-    // Extend mapping of constants to extensions, as the PHP and GD
-    // versions support WebP.
-    // getimagesize() only gets WebP support in PHP 7.1.0.
-    // @see https://www.php.net/manual/en/image.constants.php.
-    // @see https://www.php.net/manual/en/function.getimagesize.php
-    $supported_extensions[] = 'webp';
+  if (defined('IMAGETYPE_WEBP')) {
+    $gd_info = gd_info();
+    if (isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
+      // Extend supported extensions, as the PHP and GD versions support WebP.
+      // IMAGETYPE_WEBP and getimagesize() WebP support were both added in
+      // PHP 7.1.0.
+      // @see https://www.php.net/manual/en/image.constants.php.
+      // @see https://www.php.net/manual/en/function.getimagesize.php
+      $supported_extensions[] = 'webp';
+    }
   }
 
   return $supported_extensions;

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -28,6 +28,8 @@ function image_gd_settings() {
 
 /**
  * Retrieve supported extensions for the GD2 toolkit.
+ *
+ * @since 1.25.0 Function added.
  */
 function image_gd_supported_extensions() {
   $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -356,23 +356,8 @@ function image_gd_get_info(stdClass $image) {
 
   if (isset($data) && is_array($data)) {
     $supported_extensions = image_get_supported_extensions();
-    foreach ($supported_extensions as $supported_extension) {
-      switch ($supported_extension) {
-        case 'gif':
-          $extensions['1'] = $supported_extension;
-          break;
-        case 'jpg':
-          $extensions['2'] = $supported_extension;
-          break;
-        case 'png':
-          $extensions['3'] = $supported_extension;
-          break;
-        case 'webp':
-          $extensions['18'] = $supported_extension;
-          break;
-      }
-    }
-    $extension = isset($extensions[$data[2]]) ? $extensions[$data[2]] : '';
+    $extension = image_type_to_extension($data[2], FALSE) ?: '';
+    $extension = in_array($extension, $supported_extensions) ?: '';
     $details = array(
       'width'     => $data[0],
       'height'    => $data[1],

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -32,10 +32,12 @@ function image_gd_settings() {
 function image_gd_supported_extensions() {
   $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');
   $gd_info = gd_info();
-  if (isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
+  if (version_compare(PHP_VERSION, '7.1.0', '>=') && isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
     // Extend mapping of constants to extensions, as the PHP and GD
     // versions support WebP.
-    // @see https://www.php.net/manual/en/image.constants.php
+    // getimagesize() only gets WebP support in PHP 7.1.0.
+    // @see https://www.php.net/manual/en/image.constants.php.
+    // @see https://www.php.net/manual/en/function.getimagesize.php
     $supported_extensions[] = 'webp';
   }
 

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -339,17 +339,24 @@ function image_gd_get_info(stdClass $image) {
   $data = @getimagesize($image->source);
 
   if (isset($data) && is_array($data)) {
-    $extensions = array('1' => 'gif', '2' => 'jpg', '3' => 'png');
-    if (defined('IMAGETYPE_WEBP')) {
-      $gd_info = gd_info();
-      if (isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
-        // Extend mapping of constants to extensions, as the PHP and GD
-        // versions support WebP.
-        // @see https://www.php.net/manual/en/image.constants.php
-        $extensions['18'] = 'webp';
+    $supported_extensions = image_get_supported_extensions();
+    foreach ($supported_extensions as $supported_extension) {
+      switch ($supported_extension) {
+        case 'gif':
+          $extensions['1'] = $supported_extension;
+          break;
+        case 'jpg':
+          $extensions['2'] = $supported_extension;
+          break;
+        case 'png':
+          $extensions['3'] = $supported_extension;
+          break;
+        case 'webp':
+          $extensions['18'] = $supported_extension;
+          break;
       }
     }
-    $extension = isset($extensions[$data[2]]) ?  $extensions[$data[2]] : '';
+    $extension = isset($extensions[$data[2]]) ? $extensions[$data[2]] : '';
     $details = array(
       'width'     => $data[0],
       'height'    => $data[1],

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -356,8 +356,12 @@ function image_gd_get_info(stdClass $image) {
 
   if (isset($data) && is_array($data)) {
     $supported_extensions = image_get_supported_extensions();
+    // Only extensions that exist in GD.
     $extension = image_type_to_extension($data[2], FALSE) ?: '';
+    // Only extensions supported by Backdrop at this time.
     $extension = in_array($extension, $supported_extensions) ? $extension : '';
+    // Treat jpeg as jpg.
+    $extension = $extension == 'jpeg' ? 'jpg' : $extension;
     $details = array(
       'width'     => $data[0],
       'height'    => $data[1],

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -37,7 +37,7 @@ function image_gd_supported_extensions() {
       // Extend supported extensions, as the PHP and GD versions support WebP.
       // IMAGETYPE_WEBP and getimagesize() WebP support were both added in
       // PHP 7.1.0.
-      // @see https://www.php.net/manual/en/image.constants.php.
+      // @see https://www.php.net/manual/en/image.constants.php
       // @see https://www.php.net/manual/en/function.getimagesize.php
       $supported_extensions[] = 'webp';
     }

--- a/core/modules/system/image.gd.inc
+++ b/core/modules/system/image.gd.inc
@@ -357,7 +357,7 @@ function image_gd_get_info(stdClass $image) {
   if (isset($data) && is_array($data)) {
     $supported_extensions = image_get_supported_extensions();
     $extension = image_type_to_extension($data[2], FALSE) ?: '';
-    $extension = in_array($extension, $supported_extensions) ?: '';
+    $extension = in_array($extension, $supported_extensions) ? $extension : '';
     $details = array(
       'width'     => $data[0],
       'height'    => $data[1],

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3818,6 +3818,9 @@ function system_image_supported_extensions_alter(&$supported_extensions) {
   if (config_get('system.core', 'image_toolkit') == 'gd' && defined('IMAGETYPE_WEBP')) {
     $gd_info = gd_info();
     if (isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
+      // Extend mapping of constants to extensions, as the PHP and GD
+      // versions support WebP.
+      // @see https://www.php.net/manual/en/image.constants.php
       $supported_extensions[] = 'webp';
     }
   }

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3809,24 +3809,6 @@ function system_image_toolkits() {
 }
 
 /**
- * Implements hook_image_supported_extensions_alter().
- *
- * Add webp to supported file extensions if GD is the active image toolkit and
- * the GD version supports WebP.
- */
-function system_image_supported_extensions_alter(&$supported_extensions) {
-  if (config_get('system.core', 'image_toolkit') == 'gd' && defined('IMAGETYPE_WEBP')) {
-    $gd_info = gd_info();
-    if (isset($gd_info['WebP Support']) && $gd_info['WebP Support'] == TRUE) {
-      // Extend mapping of constants to extensions, as the PHP and GD
-      // versions support WebP.
-      // @see https://www.php.net/manual/en/image.constants.php
-      $supported_extensions[] = 'webp';
-    }
-  }
-}
-
-/**
  * Attempts to get a file using backdrop_http_request and to store it locally.
  *
  * @param string $url

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1045,7 +1045,8 @@ class UserPictureTestCase extends BackdropWebTestCase {
     // Try to upload a file that is not an image for the user picture.
     $not_an_image = current($this->backdropGetTestFiles('html'));
     $this->saveUserPicture($not_an_image);
-    $this->assertRaw(t('Only JPEG, PNG and GIF images are allowed.'), 'Non-image files are not accepted.');
+    $supported_extensions = image_get_supported_extensions();
+    $this->assertRaw(t('Only images with the following extensions are allowed: @formats.', array('@formats' => implode(', ', $supported_extensions))), 'Non-image files are not accepted.');
   }
 
   /**

--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -280,7 +280,7 @@ function standard_install() {
 
     'settings' => array(
       'file_directory' => 'field/image',
-      'file_extensions' => 'png gif jpg jpeg',
+      'file_extensions' => implode(' ', image_get_supported_extensions()),
       'max_filesize' => '',
       'max_resolution' => '',
       'min_resolution' => '',
@@ -328,7 +328,7 @@ function standard_install() {
 
     'settings' => array(
       'file_directory' => 'field/image',
-      'file_extensions' => 'png gif jpg jpeg',
+      'file_extensions' => implode(' ', image_get_supported_extensions()),
       'max_filesize' => '',
       'max_resolution' => '',
       'min_resolution' => '',


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/4937

This works. It could use some feedback on the approach.

It moves the `hook_image_supported_extensions` out of the image module and into a new function in includes/image.inc. Then the image module calls `image_get_supported_extensions()` and also `file_validate_is_image`. So now it works for user pictures, hero blocks, and ckeditor.

I also changed it so `image_gd_get_info` calls `image_get_supported_extensions()` as well to attempt to reduce duplication. But it still needs the right keys in the array so it still has duplication.

Instead of allowing all image extensions that GD supports it still restricts it to GIF, JPG, PNG and WEBP if supported in the GD version. Plus if someone is using Imagemagick then it can use the same hook to change what is supported (much like it could to some extent before).
