### PR TITLE
Remove info variables from phpinfo page.

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -2298,7 +2298,7 @@ function system_run_cron() {
  * Menu callback: return information about PHP.
  */
 function system_php() {
-  phpinfo();
+  phpinfo(~(INFO_VARIABLES | INFO_ENVIRONMENT));
   backdrop_exit();
 }
 


### PR DESCRIPTION
Fixes https://backdropcms.org/security/backdrop-sa-core-2023-004