### PR TITLE
Issue #6037: Disable the Drupal compatibility layer when running tests.

### DIFF
--- a/.github/misc/settings.local.php
+++ b/.github/misc/settings.local.php
@@ -1,8 +1,13 @@
 <?php
 /**
  * @file
- * Disable sending of telemetry data from GitHub Action runners.
+ * Settings applied during automated test runs.
+ *
  * @see .github/workflows/functional-tests.yml
  */
 
+// Disable sending of telemetry data from GitHub Action runners.
 $settings['telemetry_enabled'] = FALSE;
+
+// Turn off Drupal compatibility layer for tests.
+$settings['backdrop_drupal_compatibility'] = FALSE;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6037

Not sure if this will pass, it is a test PR to see how well Backdrop tests run with simply toggling off all compatibility.