### PR TITLE
Issue #5944: Add since line for changed field.

### DIFF
--- a/core/modules/user/user.entity.inc
+++ b/core/modules/user/user.entity.inc
@@ -62,6 +62,8 @@ class User extends Entity implements UserInterface {
    * The timestamp when the user was changed.
    *
    * @var integer
+   *
+   * @since 1.25.0 Property added.
    */
   public $changed;
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5944

Follow-up to add a `@since` line to the new `changed` property.
