### PR TITLE
Issue #6053: Fix 'more' link on permission descriptions.

### DIFF
--- a/core/modules/user/js/user.permissions.js
+++ b/core/modules/user/js/user.permissions.js
@@ -140,8 +140,8 @@ Backdrop.behaviors.permissionWarnings = {
     $table.find('.permission-warning-description').hide();
 
     // Toggle the warning description.
-    $('a.warning-toggle').click(function(e) {
-      var $description = $(this).closest('.description').find('.permission-warning-description').toggle();
+    $table.on('click', 'a.warning-toggle', function(e) {
+      var $description = $(this).closest('td').find('.permission-warning-description').toggle();
       if ($description.is(':visible')) {
         $(this).text(Backdrop.t('less'));
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6053