### PR TITLE
Do not show an empty "Region and language" fieldset when accounts are registered

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2431,8 +2431,7 @@ function system_form_user_profile_form_alter(&$form, &$form_state) {
  * Implements hook_form_FORM_ID_alter().
  */
 function system_form_user_register_form_alter(&$form, &$form_state) {
-  $config = config('system.date');
-  if ($config->get('user_configurable_timezones') && $config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT) {
+  if (config_get('system.date', 'user_configurable_timezones')) {
     system_user_timezone($form, $form_state);
   }
 }

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2431,8 +2431,7 @@ function system_form_user_profile_form_alter(&$form, &$form_state) {
  * Implements hook_form_FORM_ID_alter().
  */
 function system_form_user_register_form_alter(&$form, &$form_state) {
-  $config = config('system.date');
-  if ($config->get('user_configurable_timezones') && $config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT) {
+  if ($config_get('system.date', 'user_configurable_timezones')) {
     system_user_timezone($form, $form_state);
   }
 }

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2431,7 +2431,7 @@ function system_form_user_profile_form_alter(&$form, &$form_state) {
  * Implements hook_form_FORM_ID_alter().
  */
 function system_form_user_register_form_alter(&$form, &$form_state) {
-  if ($config_get('system.date', 'user_configurable_timezones')) {
+  if (config_get('system.date', 'user_configurable_timezones')) {
     system_user_timezone($form, $form_state);
   }
 }

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -2431,7 +2431,8 @@ function system_form_user_profile_form_alter(&$form, &$form_state) {
  * Implements hook_form_FORM_ID_alter().
  */
 function system_form_user_register_form_alter(&$form, &$form_state) {
-  if (config_get('system.date', 'user_configurable_timezones')) {
+  $config = config('system.date');
+  if ($config->get('user_configurable_timezones') && $config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT) {
     system_user_timezone($form, $form_state);
   }
 }

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -606,7 +606,7 @@ function user_permission() {
 /**
  * Implements hook_config_info().
  */
-function user_config_info() {F
+function user_config_info() {
   $prefixes['user.flood'] = array(
     'label' => t('User flood'),
     'group' => t('Configuration'),

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -996,7 +996,7 @@ function user_account_form(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) || (module_exists('locale') && language_multilingual()),
+    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) && config_get('system.date', 'user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT || (module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -996,7 +996,7 @@ function user_account_form(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) && config_get('system.date', 'user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT || (module_exists('locale') && language_multilingual()),
+    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) || (module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -992,12 +992,11 @@ function user_account_form(&$form, &$form_state) {
     $form['#validate'][] = 'user_validate_picture';
   }
 
-  $timezone_selector = $user->uid == $form['#user']->uid && config_get('system.date', 'user_configurable_timezones');
   $form['region_language'] = array(
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => $timezone_selector || ($user->uid > 0 && module_exists('locale') && language_multilingual()),
+    '#access' => config_get('system.date', 'user_configurable_timezones') || ($user->uid > 0 && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -992,7 +992,7 @@ function user_account_form(&$form, &$form_state) {
     $form['#validate'][] = 'user_validate_picture';
   }
 
-  $timezone_selector = $user->uid == $form['#user']->uid && config_get('system.date', 'user_configurable_timezones'));
+  $timezone_selector = $user->uid == $form['#user']->uid && config_get('system.date', 'user_configurable_timezones');
   $form['region_language'] = array(
     '#type' => 'fieldset',
     '#title' => t('Region and language'),

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -992,11 +992,12 @@ function user_account_form(&$form, &$form_state) {
     $form['#validate'][] = 'user_validate_picture';
   }
 
+  $system_config = config('system.date');
   $form['region_language'] = array(
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => config_get('system.date', 'user_configurable_timezones') || ($user->uid > 0 && module_exists('locale') && language_multilingual()),
+    '#access' => $system_config->get('user_configurable_timezones') && $system_config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT || (user_access('administer users') && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -997,7 +997,7 @@ function user_account_form(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => ($system_config->get('user_configurable_timezones') && $system_config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT) || (user_access('administer users') && module_exists('locale') && language_multilingual()),
+    '#access' => ($account->uid == 0 && $system_config->get('user_configurable_timezones') && $system_config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT) || (user_access('administer users') && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -996,7 +996,7 @@ function user_account_form(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) || (module_exists('locale') && language_multilingual()),
+    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) || (!$register && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form
@@ -1584,7 +1584,8 @@ function user_menu_alter(&$items) {
  */
 function user_admin_bar_output_alter(&$content) {
   // Admin menu shows both the parent menu item and its children.
-  // Remove the duplicate child element so "Manage fields" doesn't show up twice.
+  // Remove the duplicate child element so "Manage fields" doesn't show up
+  // twice.
   unset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage']['admin/config/people/manage/fields']);
 }
 

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -606,7 +606,7 @@ function user_permission() {
 /**
  * Implements hook_config_info().
  */
-function user_config_info() {
+function user_config_info() {F
   $prefixes['user.flood'] = array(
     'label' => t('User flood'),
     'group' => t('Configuration'),
@@ -996,7 +996,7 @@ function user_account_form(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => (!$register && config_get('system.date', 'user_configurable_timezones')) || (!$register && module_exists('locale') && language_multilingual()),
+    '#access' => ($user->uid > 0 && config_get('system.date', 'user_configurable_timezones')) || ($user->uid > 0 && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -997,7 +997,7 @@ function user_account_form(&$form, &$form_state) {
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => $system_config->get('user_configurable_timezones') && $system_config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT || (user_access('administer users') && module_exists('locale') && language_multilingual()),
+    '#access' => ($system_config->get('user_configurable_timezones') && $system_config->get('user_default_timezone') == BACKDROP_USER_TIMEZONE_SELECT) || (user_access('administer users') && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -992,11 +992,12 @@ function user_account_form(&$form, &$form_state) {
     $form['#validate'][] = 'user_validate_picture';
   }
 
+  $timezone_selector = $user->uid == $form['#user']->uid && config_get('system.date', 'user_configurable_timezones'));
   $form['region_language'] = array(
     '#type' => 'fieldset',
     '#title' => t('Region and language'),
     '#weight' => 6,
-    '#access' => ($user->uid > 0 && config_get('system.date', 'user_configurable_timezones')) || ($user->uid > 0 && module_exists('locale') && language_multilingual()),
+    '#access' => $timezone_selector || ($user->uid > 0 && module_exists('locale') && language_multilingual()),
     '#group' => 'additional_settings',
   );
   // See system_user_timezone() and locale_language_selector_form() for the form


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6073

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
