### PR TITLE
Issue #6083: Follow-up: remove inaccurate inline comment

### DIFF
--- a/core/modules/search/search.admin.inc
+++ b/core/modules/search/search.admin.inc
@@ -146,9 +146,6 @@ function search_admin_settings($form, &$form_state) {
     '#type' => 'radios',
     '#title' => t('Pager type'),
     '#title_display' => 'invisible',
-    // The options keys here should be kept the same as the name of theme
-    // function to be called for the pager. See how $variables['pager'] is being
-    // set in template_preprocess_search_results().
     '#options' => array(
       'full' => t('Full pager'),
       'mini' => t('Mini pager'),


### PR DESCRIPTION
@backdrop/core-committers can we please merge this? That inline comment was only relevant beofre @quicksketch committed these changes: [`2f2213c` (#4424)](https://github.com/backdrop/backdrop/pull/4424/commits/2f2213ca56481656bd3edc258a1dc213d41d7daf#diff-5bf34dcb9275eef11c0705c2b32c9b9abb747a9edbb664c79d8e1ab0517fa896R153)

Follow-up for https://github.com/backdrop/backdrop-issues/issues/6083