### PR TITLE
Issue #6101: Don't assign the delete any content permission to the editor role

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2812,28 +2812,6 @@ function node_list_permissions($type = '') {
     ),
   );
 
-
-
-
-
-$content_type_permissions = array_keys($permissions);
-dpm($content_type_permissions);
-
-
-$simple_array = array(
-    'create content',
-    'edit own content',
-    'edit any content',
-    'delete own content',
-    'delete any content',
-  );
-dpm($simple_array, 'simple_array');
-
-
-
-
-
-
   // Existing content type. Generate the list of actual permissions, by adding
   // the content type name in the names and descriptions of the placeholder
   // permissions.

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2772,37 +2772,92 @@ function node_node_access($node, $op, $account) {
 }
 
 /**
- * Helper function to generate standard node permission list for a given type.
+ * Generates a list of permissions for a specific content type.
  *
  * @param $type
- *   The machine-readable name of the node type.
+ *   The machine-readable name of the content type.
+ *
+ *   If $type is empty or omitted, the default content-related permissions are
+ *   returned. These are "placeholder" permissions - the actual permissions
+ *   include the content type name in their name. For example, if the content
+ *   type is called "test", the actual permission for creating content of this
+ *   type will be "create test content" instead of just "create content" (which
+ *   is the respective placeholder permission). This is useful when the content
+ *   type name has not been created yet (for instance, when creating a new
+ *   content type in node_type_form_permissions().
  *
  * @return array
  *   An array of permission names and descriptions.
+ *
+ * @since 1.25.0 $type is optional.
  */
-function node_list_permissions($type) {
-  $info = node_type_get_type($type);
-
-  // Build standard list of node permissions for this type.
-  $perms = array(
-    "create $type content" => array(
-      'title' => t('%type_name: Create new content', array('%type_name' => $info->name)),
+function node_list_permissions($type = '') {
+  // Default, "placeholder" permissions when creating a new content type (the
+  // content type name has not been created yet).
+  $permissions = array(
+    'create content' => array(
+      'title' => t('Create new content'),
     ),
-    "edit own $type content" => array(
-      'title' => t('%type_name: Edit own content', array('%type_name' => $info->name)),
+    'edit own content' => array(
+      'title' => t('Edit own content'),
     ),
-    "edit any $type content" => array(
-      'title' => t('%type_name: Edit any content', array('%type_name' => $info->name)),
+    'edit any content' => array(
+      'title' => t('Edit any content'),
     ),
-    "delete own $type content" => array(
-      'title' => t('%type_name: Delete own content', array('%type_name' => $info->name)),
+    'delete own content' => array(
+      'title' => t('Delete own content'),
     ),
-    "delete any $type content" => array(
-      'title' => t('%type_name: Delete any content', array('%type_name' => $info->name)),
+    'delete any content' => array(
+      'title' => t('Delete any content'),
     ),
   );
 
-  return $perms;
+  // Existing content type. Generate the list of actual permissions, by adding
+  // the content type name in the names and descriptions of the placeholder
+  // permissions.
+  if (!empty($type)) {
+    $info = node_type_get_type($type);
+
+    foreach ($permissions as $placeholder_permission => $placeholder_permission_info) {
+      // Inject the content type name in the new permission name.
+      $actual_permission = node_generate_permission_from_placeholder($placeholder_permission, $type);
+      // Add the content type name as a prefix to the permission description.
+      $actual_permission_title = $info->name . ': ' . $placeholder_permission_info['title'];
+      // Add the updated permission to the array.
+      $permissions[$actual_permission]['title'] = $actual_permission_title;
+      // Remove the placeholder permission from the array.
+      unset($permissions[$placeholder_permission]);
+    }
+  }
+
+  return $permissions;
+}
+
+/**
+ * Convert a placeholder content type permission to an actual permission.
+ *
+ * When a new content type is created or being saved, the permissions in the
+ * content type edit form and the respective $form_state values are in the
+ * format 'create content'. When saving the type, we need to include the content
+ * type name in the permission name in the format 'create $type content'.
+ *
+ * @param $placeholder_permission
+ *   The machine-readable name of the placeholder permission to be converted.
+ * @param $type
+ *   The machine-readable name of the content type.
+ *
+ * @return string
+ *   The name of the actual permission, converted to the format that includes
+ *   the content type name.
+ *
+ * @see node_list_permissions()
+ * @see node_type_form_submit()
+ */
+function node_generate_permission_from_placeholder($placeholder_permission, $type) {
+  $parts = explode('content', $placeholder_permission);
+  $permission = $parts[0] . $type . ' content';
+
+  return $permission;
 }
 
 /**

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2815,9 +2815,7 @@ function node_list_permissions($type = '') {
   // Existing content type. Generate the list of actual permissions, by adding
   // the content type name in the names and descriptions of the placeholder
   // permissions.
-  if (!empty($type)) {
-    $info = node_type_get_type($type);
-
+  if (!empty($type) && $info = node_type_get_type($type)) {
     foreach ($permissions as $placeholder_permission => $placeholder_permission_info) {
       // Inject the content type name in the new permission name.
       $actual_permission = node_generate_permission_from_placeholder($placeholder_permission, $type);

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2812,6 +2812,28 @@ function node_list_permissions($type = '') {
     ),
   );
 
+
+
+
+
+$content_type_permissions = array_keys($permissions);
+dpm($content_type_permissions);
+
+
+$simple_array = array(
+    'create content',
+    'edit own content',
+    'edit any content',
+    'delete own content',
+    'delete any content',
+  );
+dpm($simple_array, 'simple_array');
+
+
+
+
+
+
   // Existing content type. Generate the list of actual permissions, by adding
   // the content type name in the names and descriptions of the placeholder
   // permissions.

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -563,8 +563,8 @@ function node_type_form_submit($form, &$form_state) {
       $permissions = array();
       // Convert the placeholder permissions (from the format 'create content')
       // to the actual permission (in the format 'create $type content').
-      foreach ($form_state['values'][$role->name] as $placeholder => $permission) {
-        if ($permission) {
+      foreach ($form_state['values'][$role->name] as $placeholder_permission => $permission_granted) {
+        if ($permission_granted) {
           $permissions[] = node_generate_permission_from_placeholder($placeholder_permission, $type->type);
         }
       }

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -551,26 +551,24 @@ function node_type_form_submit($form, &$form_state) {
   menu_rebuild();
 
   if ($status == SAVED_UPDATED) {
-    // Update node type permissions
+    // Update node type permissions.
     foreach ($form_state['values']['roles'] as $role_name => $role) {
       user_role_change_permissions($role->name, $form_state['values'][$role->name]);
     }
     backdrop_set_message(t('The content type %name has been updated.', array('%name' => $type->name)));
   }
   elseif ($status == SAVED_NEW) {
-    // Save new permissions
+    // Save new permissions.
     foreach ($form_state['values']['roles'] as $role_name => $role) {
-      $valid_perms = array();
-      // Re-create the permissions string in the format 'create $type content'
-      // from the default 'create content' for saving permissions.
-      foreach ($form_state['values'][$role->name] as $string => $perm) {
-        if ($perm) {
-          $parts = explode('content', $string);
-          $valid_string = $parts[0] . $type->type . ' content';
-          $valid_perms[] = $valid_string;
+      $permissions = array();
+      // Convert the placeholder permissions (from the format 'create content')
+      // to the actual permission (in the format 'create $type content').
+      foreach ($form_state['values'][$role->name] as $placeholder => $permission) {
+        if ($permission) {
+          $permissions[] = node_generate_permission_from_placeholder($placeholder_permission, $type->type);
         }
       }
-      user_role_grant_permissions($role->name, $valid_perms);
+      user_role_grant_permissions($role->name, $permissions);
     }
     if ($form_state['values']['body']) {
       node_add_body_field($type);
@@ -579,7 +577,8 @@ function node_type_form_submit($form, &$form_state) {
     watchdog('node', 'Added content type %name.', array('%name' => $type->name), WATCHDOG_NOTICE, l(t('view'), 'admin/structure/types'));
   }
 
-  // Make the new content type indexable by default if Search module is enabled.
+  // Make the new content type indexable by default if the Search module is
+  // enabled.
   if (module_exists('search')) {
     $search_content_types = config_get('search.settings', 'content_types');
     // If no types are specified, then all types are enabled and there's no need
@@ -604,10 +603,11 @@ function node_type_form_submit($form, &$form_state) {
  * @see node_type_form()
  */
 function node_type_form_permissions($type) {
-  // Retrieve role names for columns.
-  $roles = user_roles(FALSE, NULL, TRUE);
+  $type_is_new = empty($type);
   $admin_role = config_get('system.core', 'user_admin_role');
   $editor_role = config_get('system.core', 'user_editor_role');
+  // Retrieve role names for the columns of the permission matrix.
+  $roles = user_roles(FALSE, NULL, TRUE);
 
   // Note that in node_theme(), the 'node_type_form_permissions' theme callback
   // reuses theme_user_admin_permissions(), to make it identical to the user
@@ -622,30 +622,16 @@ function node_type_form_permissions($type) {
     '#value' => $roles,
   );
 
-  // Render role/permission overview:
-  $options = array();
+  // Get the list of permissions for this content type. If this is a new content
+  // type, get the set of default "placeholder" permissions.
+  $permissions = node_list_permissions($type);
+  $default_admin_permissions = $default_editor_permissions = $permissions;
+  // If the default editor role is configured, it should have the same default
+  // permissions as the default administrator, except the "delete any content"
+  // permission.
+  unset($default_editor_permissions['delete any content']);
 
-  $default_perms = array(
-    "create content" => array(
-      'title' => t('Create new content'),
-    ),
-    "edit own content" => array(
-      'title' => t('Edit own content'),
-    ),
-    "edit any content" => array(
-      'title' => t('Edit any content'),
-    ),
-    "delete own content" => array(
-      'title' => t('Delete own content'),
-    ),
-    "delete any content" => array(
-      'title' => t('Delete any content'),
-    ),
-  );
-
-  $permissions = !empty($type) ? node_list_permissions($type) : $default_perms;
-
-  $status = array();
+  $role_permissions = array();
   foreach ($permissions as $perm => $perm_item) {
     // Fill in default values for the permission.
     $perm_item += array(
@@ -653,21 +639,41 @@ function node_type_form_permissions($type) {
       'restrict access' => FALSE,
       'warning' => '',
     );
-    $options[$perm] = '';
     $form['permission'][$perm] = array(
       '#type' => 'item',
       '#markup' => $perm_item['title'],
       '#description' => theme('user_permission_description', array('permission_item' => $perm_item)),
     );
+
+    // Build the arrays of ticked checkboxes for each role.
     foreach ($roles as $role_name => $role) {
-      // Builds arrays for checked boxes for each role. For new content types,
-      // if user_admin_role and/or user_editor_role have been configured, then
-      // select sensible permissions for these roles.
-      if (in_array($perm, $role->permissions) || (!$type && ($role->name == $admin_role || $role->name == $editor_role))) {
-        // Do not allow editors to delete any content.
-        if (!($role->name == $editor_role && strstr($perm, 'delete any'))) {
-          $status[$role_name][] = $perm;
-        }
+      // For existing content types, the respective checkbox should be ticked if
+      // the permission is among the permissions a role already has.
+      $role_has_permission = !$type_is_new && in_array($perm, $role->permissions);
+
+      // For new content types, if the default admin and/or default editor role
+      // has been configured, then select some sensible permissions.
+      switch ($role->name) {
+        // The default admin role gets all content-related permissions.
+        case $admin_role:
+          $allowed_perms = array_keys($default_admin_permissions);
+          break;
+
+        // The default editor role gets the same permissions as the default
+        // admin role, except the "Delete any content" one.
+        case $editor_role:
+          $allowed_perms = array_keys($default_editor_permissions);
+          break;
+
+        // The default for all other roles is not to have any permission
+        // auto-assigned.
+        default:
+          $allowed_perms = array();
+      }
+      $role_should_have_permission = $type_is_new && in_array($perm, $allowed_perms);
+
+      if ($role_has_permission || $role_should_have_permission) {
+        $role_permissions[$role_name][] = $perm;
       }
     }
   }
@@ -676,8 +682,8 @@ function node_type_form_permissions($type) {
   foreach ($roles as $role_name => $role) {
     $form['checkboxes'][$role_name] = array(
       '#type' => 'checkboxes',
-      '#options' => $options,
-      '#default_value' => isset($status[$role_name]) ? $status[$role_name] : array(),
+      '#options' => array_fill_keys(array_keys($permissions), ''),
+      '#default_value' => isset($role_permissions[$role_name]) ? $role_permissions[$role_name] : array(),
       '#attributes' => array('class' => array('role-' . $role_name)),
     );
     $form['role_names'][$role_name] = array(

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -650,10 +650,6 @@ function node_type_form_permissions($type) {
 
     // Build the arrays of ticked checkboxes for each role.
     foreach ($roles as $role_name => $role) {
-      // For existing content types, the respective checkbox should be ticked if
-      // the permission is among the permissions a role already has.
-      $role_has_permission = !$type_is_new && in_array($permission_name, $role->permissions);
-
       // For new content types, if the default admin and/or default editor role
       // has been configured, then select some sensible permissions.
       switch ($role->name) {
@@ -674,6 +670,10 @@ function node_type_form_permissions($type) {
           $allowed_permissions = array();
       }
       $role_should_have_permission = $type_is_new && in_array($permission_name, $allowed_permissions);
+
+      // For existing content types, the respective checkbox should be ticked if
+      // the permission is among the permissions a role already has.
+      $role_has_permission = !$type_is_new && in_array($permission_name, $role->permissions);
 
       if ($role_has_permission || $role_should_have_permission) {
         $role_permissions[$role_name][] = $permission_name;

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -182,8 +182,8 @@ function node_type_form($form, &$form_state, $type = NULL) {
   if (!empty($auto_permission_roles) && empty($type->type)) {
     $permissions_message = format_plural(
       count($auto_permission_roles),
-      'The %role role has been assigned permissions to create, edit, and delete any content of this type.',
-      'The %admin and %editor roles have been assigned permissions to create, edit, and delete any content of this type.',
+      'The %role role has been assigned permissions to create, edit, and delete content of this type.',
+      'The %admin and %editor roles have been assigned permissions to create, edit, and delete content of this type.',
       $auto_permission_roles
     );
     $permissions_message_type = 'info';
@@ -661,11 +661,13 @@ function node_type_form_permissions($type) {
     );
     foreach ($roles as $role_name => $role) {
       // Builds arrays for checked boxes for each role. For new content types,
-      // if user_admin_role and/or user_editor_role have been configured in the
-      // "Default roles" section in admin/config/people/roles, then always
-      // select all permissions for these roles.
+      // if user_admin_role and/or user_editor_role have been configured, then
+      // select sensible permissions for these roles.
       if (in_array($perm, $role->permissions) || (!$type && ($role->name == $admin_role || $role->name == $editor_role))) {
-        $status[$role_name][] = $perm;
+        // Do not allow editors to delete any content.
+        if (!($role->name == $editor_role && strstr($perm, 'delete any'))) {
+          $status[$role_name][] = $perm;
+        }
       }
     }
   }

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -208,7 +208,9 @@ function node_type_form($form, &$form_state, $type = NULL) {
     // to people even if they don't have access to the "Permissions" tab.
     $form['permissions_message_container'] = array(
       '#type' => 'container',
-      '#attributes' => array('class' => array('messages', $permissions_message_type)),
+      '#attributes' => array('class' => array(
+        'messages', $permissions_message_type),
+      ),
     );
     $form['permissions_message_container']['message'] = array(
       '#type' => 'markup',

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -632,48 +632,48 @@ function node_type_form_permissions($type) {
   unset($default_editor_permissions['delete any content']);
 
   $role_permissions = array();
-  foreach ($permissions as $perm => $perm_item) {
+  foreach ($permissions as $permission_name => $permission_item) {
     // Fill in default values for the permission.
-    $perm_item += array(
+    $permission_item += array(
       'description' => '',
       'restrict access' => FALSE,
       'warning' => '',
     );
-    $form['permission'][$perm] = array(
+    $form['permission'][$permission_name] = array(
       '#type' => 'item',
-      '#markup' => $perm_item['title'],
-      '#description' => theme('user_permission_description', array('permission_item' => $perm_item)),
+      '#markup' => $permission_item['title'],
+      '#description' => theme('user_permission_description', array('permission_item' => $permission_item)),
     );
 
     // Build the arrays of ticked checkboxes for each role.
     foreach ($roles as $role_name => $role) {
       // For existing content types, the respective checkbox should be ticked if
       // the permission is among the permissions a role already has.
-      $role_has_permission = !$type_is_new && in_array($perm, $role->permissions);
+      $role_has_permission = !$type_is_new && in_array($permission_name, $role->permissions);
 
       // For new content types, if the default admin and/or default editor role
       // has been configured, then select some sensible permissions.
       switch ($role->name) {
         // The default admin role gets all content-related permissions.
         case $admin_role:
-          $allowed_perms = array_keys($default_admin_permissions);
+          $allowed_permissions = array_keys($default_admin_permissions);
           break;
 
         // The default editor role gets the same permissions as the default
         // admin role, except the "Delete any content" one.
         case $editor_role:
-          $allowed_perms = array_keys($default_editor_permissions);
+          $allowed_permissions = array_keys($default_editor_permissions);
           break;
 
         // The default for all other roles is not to have any permission
         // auto-assigned.
         default:
-          $allowed_perms = array();
+          $allowed_permissions = array();
       }
-      $role_should_have_permission = $type_is_new && in_array($perm, $allowed_perms);
+      $role_should_have_permission = $type_is_new && in_array($permission_name, $allowed_permissions);
 
       if ($role_has_permission || $role_should_have_permission) {
-        $role_permissions[$role_name][] = $perm;
+        $role_permissions[$role_name][] = $permission_name;
       }
     }
   }

--- a/core/modules/node/node.types.inc
+++ b/core/modules/node/node.types.inc
@@ -622,8 +622,11 @@ function node_type_form_permissions($type) {
     '#value' => $roles,
   );
 
-  // Get the list of permissions for this content type. If this is a new content
-  // type, get the set of default "placeholder" permissions.
+  // - If this is an existing content type, get the list of permissions for it.
+  //   These permissions include the content type name in their name.
+  // - If this is a new content type being created, this returns the default set
+  //   of "placeholder" permissions. These permissions do NOT include the name
+  //   of the content type in their names.
   $permissions = node_list_permissions($type);
   $default_admin_permissions = $default_editor_permissions = $permissions;
   // If the default editor role is configured, it should have the same default

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -9,7 +9,7 @@ include_once(BACKDROP_ROOT . '/core/modules/simpletest/tests/system_config_test.
 class UserLoginTestBase extends BackdropWebTestCase {
   protected $profile = 'minimal';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp('dblog', 'user_flood_test');
   }
 
@@ -26,7 +26,7 @@ class UserLoginTestBase extends BackdropWebTestCase {
    *   Whether or not to expect that the flood control mechanism will be
    *   triggered..
    */
-  function assertFailedLogin($account, $by_email = FALSE, $incorrect_pass = FALSE, $flood_trigger = NULL) {
+  public function assertFailedLogin($account, $by_email = FALSE, $incorrect_pass = FALSE, $flood_trigger = NULL) {
     if ($this->loggedInUser) {
       $this->backdropLogout();
     }
@@ -85,7 +85,7 @@ class UserLoginTestBase extends BackdropWebTestCase {
 class UserRegistrationTestCase extends UserLoginTestBase {
   protected $profile = 'testing';
 
-  function testRegistrationWithEmailVerification() {
+  public function testRegistrationWithEmailVerification() {
     $config = config('system.core');
 
     // Require email verification.
@@ -119,7 +119,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $this->assertFalse($new_user->status, 'New account is blocked until approved by an administrator.');
   }
 
-  function testRegistrationWithoutEmailVerification() {
+  public function testRegistrationWithoutEmailVerification() {
     $config = config('system.core');
 
     // Don't require email verification.
@@ -170,7 +170,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $this->assertText(t('Member for'), 'User can log in after administrator approval.');
   }
 
-  function testRegistrationEmailDuplicates() {
+  public function testRegistrationEmailDuplicates() {
     $config = config('system.core');
 
     // Don't require email verification.
@@ -197,7 +197,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $this->assertRaw(t('The email address %email is already registered.', array('%email' => $duplicate_user->mail)), 'Supplying a duplicate email address with added whitespace displays an error message');
   }
 
-  function testRegistrationDefaultValues() {
+  public function testRegistrationDefaultValues() {
     $config_user_settings = config('system.core');
 
     // Allow registration by site visitors without administrator approval.
@@ -241,7 +241,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
   /**
    * Tests Field API fields on user registration forms.
    */
-  function testRegistrationWithUserFields() {
+  public function testRegistrationWithUserFields() {
     module_enable(array('field', 'field_test'));
     $config_user_settings = config('system.core');
 
@@ -330,7 +330,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
   /**
    * Tests new users username matches their email if username is an email.
    */
-  function testRegistrationEmailAsUsername() {
+  public function testRegistrationEmailAsUsername() {
     // Don't require email verification.
     // Allow registration by site visitors without administrator approval.
     config('system.core')
@@ -365,7 +365,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
   /**
    * Tests new users username not matching their email if username is an email.
    */
-  function testRegistrationEmailAsUsernameDisabled() {
+  public function testRegistrationEmailAsUsernameDisabled() {
     // Test that 'user_email_match' turned off allows emails that don't match.
     config('system.core')
       ->set('user_email_match', FALSE)
@@ -391,7 +391,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
 
 class UserValidationTestCase extends BackdropUnitTestCase {
   // Username validation.
-  function testUsernames() {
+  public function testUsernames() {
     $test_cases = array( // '<username>' => array('<description>', 'assert<testName>'),
       'foo'                    => array('Valid username', 'assertNull'),
       'FOO'                    => array('Valid username', 'assertNull'),
@@ -425,14 +425,14 @@ class UserValidationTestCase extends BackdropUnitTestCase {
 class UserLoginTestCase extends UserLoginTestBase {
   protected $profile = 'testing';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp('user_session_test');
   }
 
   /**
    * Test that login credentials work (or not) in different login modes.
    */
-  function testLoginMethods() {
+  public function testLoginMethods() {
     $account = $this->backdropCreateUser(array());
 
     // Login via name or email (both succeed). The default for new sites.
@@ -464,7 +464,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test the global login flood control.
    */
-  function testGlobalLoginFloodControl() {
+  public function testGlobalLoginFloodControl() {
     config('user.flood')
       ->set('flood_ip_limit', 10)
       // Set a high per-user limit out so that it is not relevant in the test.
@@ -501,7 +501,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test the per-user login flood control.
    */
-  function testPerUserLoginFloodControl() {
+  public function testPerUserLoginFloodControl() {
     config('user.flood')
       // Set a high global limit out so that it is not relevant in the test.
       ->set('floo_ip_limit', 4000)
@@ -541,7 +541,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test that user password is re-hashed upon login after changing $count_log2.
    */
-  function testPasswordRehashOnLogin() {
+  public function testPasswordRehashOnLogin() {
     // Load password hashing API.
     require_once BACKDROP_ROOT . '/' . settings_get('password_inc', 'core/includes/password.inc');
     // Set initial $count_log2 to the default, BACKDROP_HASH_COUNT.
@@ -573,7 +573,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test logging in when an anon session already exists.
    */
-  function testLoginWithAnonSession() {
+  public function testLoginWithAnonSession() {
     // Visit the callback to generate a session for this anon user.
     $this->backdropGet('user_session_test_anon_session');
     // Now login.
@@ -584,7 +584,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Attempt to login with an unregistered username.
    */
-  function testAccountNotFound() {
+  public function testAccountNotFound() {
     $edit = array(
       'name' => $this->randomName(8),
       'pass' => $this->randomName(8),
@@ -596,7 +596,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Attempt to login with an invalid array users and passwords.
    */
-  function testArrayLoginValues() {
+  public function testArrayLoginValues() {
     $edit = array(
       'pass' => $this->randomName(8),
     );
@@ -627,7 +627,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Attempt to cancel account without permission.
    */
-  function testUserCancelWithoutPermission() {
+  public function testUserCancelWithoutPermission() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a user.
@@ -661,7 +661,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
    * This should never be possible, or the site owner would become unable to
    * administer the site.
    */
-  function testUserCancelUid1() {
+  public function testUserCancelUid1() {
     // Update uid 1's name and password to we know it.
     $password = user_password();
     require_once BACKDROP_ROOT . '/' . settings_get('password_inc', 'core/includes/password.inc');
@@ -697,7 +697,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Attempt invalid account cancellations.
    */
-  function testUserCancelInvalid() {
+  public function testUserCancelInvalid() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a user.
@@ -739,7 +739,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Disable account and keep all content.
    */
-  function testUserBlock() {
+  public function testUserBlock() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_block');
 
     // Create a user.
@@ -774,7 +774,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Disable account and unpublish all content.
    */
-  function testUserBlockUnpublish() {
+  public function testUserBlockUnpublish() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_block_unpublish');
 
     // Create a user.
@@ -818,7 +818,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Delete account and anonymize all content.
    */
-  function testUserAnonymize() {
+  public function testUserAnonymize() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a user.
@@ -869,7 +869,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Delete account and remove all content.
    */
-  function testUserDelete() {
+  public function testUserDelete() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_delete');
 
     // Create a user.
@@ -936,7 +936,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Create an administrative user and delete another user.
    */
-  function testUserCancelByAdmin() {
+  public function testUserCancelByAdmin() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a regular user.
@@ -961,7 +961,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Create an administrative user and mass-delete other users.
    */
-  function testMassUserCancelByAdmin() {
+  public function testMassUserCancelByAdmin() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
     // Enable account cancellation notification.
     config_set('system.core', 'user_mail_status_canceled_notify', TRUE);
@@ -1018,7 +1018,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   protected $user;
   protected $_directory_test;
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp(array('image'));
 
     // Enable user pictures.
@@ -1039,7 +1039,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
     $this->assertTrue($this->_directory_test, "The directory $picture_path doesn't exist or is not writable. Further tests won't be made.");
   }
 
-  function testNoPicture() {
+  public function testNoPicture() {
     $this->backdropLogin($this->user);
 
     // Try to upload a file that is not an image for the user picture.
@@ -1056,7 +1056,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image should be uploaded because ImageGDToolkit resizes the picture
    */
-  function testWithGDinvalidDimension() {
+  public function testWithGDinvalidDimension() {
     if ($this->_directory_test && image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1091,7 +1091,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image should be uploaded because ImageGDToolkit resizes the picture
    */
-  function testWithGDinvalidSize() {
+  public function testWithGDinvalidSize() {
     if ($this->_directory_test && image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1129,7 +1129,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image shouldn't be uploaded
    */
-  function testWithoutGDinvalidDimension() {
+  public function testWithoutGDinvalidDimension() {
     if ($this->_directory_test && !image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1163,7 +1163,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image shouldn't be uploaded
    */
-  function testWithoutGDinvalidSize() {
+  public function testWithoutGDinvalidSize() {
     if ($this->_directory_test && !image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1197,7 +1197,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image should be uploaded
    */
-  function testPictureIsValid() {
+  public function testPictureIsValid() {
     if ($this->_directory_test) {
       $this->backdropLogin($this->user);
 
@@ -1243,7 +1243,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   /**
    * Test HTTP schema working with user pictures.
    */
-  function testExternalPicture() {
+  public function testExternalPicture() {
     $this->backdropLogin($this->user);
     // Set the default picture to an URI with a HTTP schema.
     $images = $this->backdropGetTestFiles('image');
@@ -1263,7 +1263,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   /**
    * Tests deletion of user pictures.
    */
-  function testDeletePicture() {
+  public function testDeletePicture() {
     $this->backdropLogin($this->user);
 
     $image = current($this->backdropGetTestFiles('image'));
@@ -1306,7 +1306,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
     $this->assertFalse(is_file($pic_path), 'File is removed from file system');
   }
 
-  function saveUserPicture($image) {
+  public function saveUserPicture($image) {
     $edit = array('files[picture_upload]' => backdrop_realpath($image->uri));
     $this->backdropPost('user/' . $this->user->uid . '/edit', $edit, t('Save'));
 
@@ -1318,7 +1318,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   /**
    * Tests the admin form validates user picture settings.
    */
-  function testUserPictureAdminFormValidation() {
+  public function testUserPictureAdminFormValidation() {
     $this->backdropLogin($this->backdropCreateUser(array('administer account settings')));
 
     // The default values are valid.
@@ -1342,7 +1342,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   protected $admin_role_name;
   protected $editor_role_name;
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp();
 
     $this->admin_user = $this->backdropCreateUser(
@@ -1367,7 +1367,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Change user permissions and check user_access().
    */
-  function testUserPermissionChanges() {
+  public function testUserPermissionChanges() {
     $this->backdropLogin($this->admin_user);
     $role_name = $this->admin_role_name;
     $account = $this->admin_user;
@@ -1396,7 +1396,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Test assigning of permissions for the administrator role.
    */
-  function testAdministratorRole() {
+  public function testAdministratorRole() {
     $this->backdropLogin($this->admin_user);
     $this->backdropGet('admin/config/people/roles');
 
@@ -1417,7 +1417,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Test assigning of permissions for the default editor role.
    */
-  function testEditorRole() {
+  public function testEditorRole() {
     $this->backdropLogin($this->admin_user);
     $this->backdropGet('admin/config/people/roles');
 
@@ -1524,7 +1524,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Verify proper permission changes by user_role_change_permissions().
    */
-  function testUserRoleChangePermissions() {
+  public function testUserRoleChangePermissions() {
     $role_name = $this->admin_role_name;
     $account = $this->admin_user;
 
@@ -1551,7 +1551,7 @@ class UserAdminTestCase extends BackdropWebTestCase {
   /**
    * Registers a user and deletes it.
    */
-  function testUserAdmin() {
+  public function testUserAdmin() {
     // Create admin user to delete registered user.
     $admin_user = $this->backdropCreateUser(array('administer users', 'access user profiles'));
     $admin_user->created -= 2;
@@ -1668,7 +1668,7 @@ class UserTimeZoneFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the display of dates and time when user-configurable time zones are set.
    */
-  function testUserTimeZone() {
+  public function testUserTimeZone() {
     // Setup date/time settings for Los Angeles time.
     config('system.date')
       ->set('user_configurable_timezones', 1)
@@ -1725,7 +1725,7 @@ class UserTimeZoneFunctionalTest extends BackdropWebTestCase {
 class UserAutocompleteTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp();
 
     // Set up two users with different permissions to test access.
@@ -1736,7 +1736,7 @@ class UserAutocompleteTestCase extends BackdropWebTestCase {
   /**
    * Tests access to user autocompletion and verify the correct results.
    */
-  function testUserAutocomplete() {
+  public function testUserAutocomplete() {
     // Check access from unprivileged user, should be denied.
     $this->backdropLogin($this->unprivileged_user);
     $this->backdropGet('user/autocomplete/' . $this->unprivileged_user->name[0]);
@@ -1763,7 +1763,7 @@ class UserAccountLinksUnitTests extends BackdropWebTestCase {
   /**
    * Test the user login block.
    */
-  function testAccountMenu() {
+  public function testAccountMenu() {
     // Create a regular user.
     $user = $this->backdropCreateUser(array());
 
@@ -1806,7 +1806,7 @@ class UserBlocksUnitTests extends BackdropWebTestCase {
   /**
    * Tests the secondary menu.
    */
-  function testUserLoginBlock() {
+  public function testUserLoginBlock() {
     // Create a user with some permission that anonymous users lack.
     $user = $this->backdropCreateUser(array('administer permissions'));
 
@@ -1839,14 +1839,14 @@ class UserBlocksUnitTests extends BackdropWebTestCase {
     $this->assertEqual(url('node', array('absolute' => TRUE)), $this->getUrl(), 'Redirected to frontpage and not external site after login.');
   }
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp('menu');
   }
 
   /**
    * Tests disabling the 'My account' link.
    */
-  function testDisabledAccountLink() {
+  public function testDisabledAccountLink() {
     // Create an admin user and log in.
     $this->backdropLogin($this->backdropCreateUser(array('access administration pages', 'administer menu')));
 
@@ -1885,7 +1885,7 @@ class UserSaveTestCase extends BackdropWebTestCase {
   /**
    * Test creating a user with arbitrary uid.
    */
-  function testUserImport() {
+  public function testUserImport() {
     // User ID must be a number that is not in the database.
     $max_uid = db_query('SELECT MAX(uid) FROM {users}')->fetchField();
     $test_uid = $max_uid + mt_rand(1000, 1000000);
@@ -1918,7 +1918,7 @@ class UserSaveTestCase extends BackdropWebTestCase {
 class UserCreateTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp(array('views'));
   }
 
@@ -1926,7 +1926,7 @@ class UserCreateTestCase extends BackdropWebTestCase {
    * Create a user through the administration interface and ensure that it
    * displays in the user list.
    */
-  protected function testUserAdd() {
+  public function testUserAdd() {
     $user = $this->backdropCreateUser(array('administer users'));
     $this->backdropLogin($user);
 
@@ -2047,7 +2047,7 @@ class UserEditTestCase extends BackdropWebTestCase {
   /**
    * Test user edit page.
    */
-  function testUserEdit() {
+  public function testUserEdit() {
     // Test user edit functionality with user pictures disabled.
     $config = config('system.core');
     $config->set('user_pictures', 0)->save();
@@ -2125,14 +2125,14 @@ class UserEditTestCase extends BackdropWebTestCase {
  */
 class UserEditRebuildTestCase extends BackdropWebTestCase {
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp('user_form_test');
   }
 
   /**
    * Test user edit page when the form is set to rebuild.
    */
-  function testUserEditFormRebuild() {
+  public function testUserEditFormRebuild() {
     $user1 = $this->backdropCreateUser(array('change own username'));
     $this->backdropLogin($user1);
 
@@ -2165,7 +2165,7 @@ class UserEditRebuildTestCase extends BackdropWebTestCase {
  * Test case for user signatures.
  */
 class UserSignatureTestCase extends BackdropWebTestCase {
-  function setUp() {
+  protected function setUp() {
     parent::setUp('comment');
 
     // Enable user signatures.
@@ -2190,7 +2190,7 @@ class UserSignatureTestCase extends BackdropWebTestCase {
    * Test that a user can change their signature format and that it is respected
    * upon display.
    */
-  function testUserSignature() {
+  public function testUserSignature() {
     // Enable comment subjects on 'page' nodes
     $node_type = node_type_get_type('page');
     $node_type->settings['comment_title_options'] = COMMENT_TITLE_CUSTOM;
@@ -2250,7 +2250,7 @@ class UserEditedOwnAccountTestCase extends BackdropWebTestCase {
   /**
    * Tests a user editing their own account.
    */
-  function testUserEditedOwnAccount() {
+  public function testUserEditedOwnAccount() {
     // Change account setting 'Who can register accounts?' to Administrators
     // only.
     config_set('system.core', 'user_register', USER_REGISTER_ADMINISTRATORS_ONLY);
@@ -2302,7 +2302,7 @@ class UserEditedOwnAccountTestCase extends BackdropWebTestCase {
 class UserRoleAdminTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'administer users', 'assign roles'));
   }
@@ -2310,7 +2310,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
   /**
    * Test adding, renaming and deleting roles.
    */
-  function testRoleAdministration() {
+  public function testRoleAdministration() {
     $this->backdropLogin($this->admin_user);
 
     // Visit the main roles administration page.
@@ -2440,7 +2440,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
   /**
    * Test user role weight change operation.
    */
-  function testRoleWeightChange() {
+  public function testRoleWeightChange() {
     $this->backdropLogin($this->admin_user);
 
     // Pick up a role and get its weight.
@@ -2470,7 +2470,7 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Creates a user, then tests the tokens generated from it.
    */
-  function testUserTokenReplacement() {
+  public function testUserTokenReplacement() {
     global $language;
     $url_options = array(
       'absolute' => TRUE,
@@ -2528,11 +2528,11 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
 class UserUserSearchTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp(array('search'));
   }
 
-  function testUserSearch() {
+  public function testUserSearch() {
     // Verify that a user without 'administer users' permission cannot search
     // for users by email address. Additionally, ensure that the username has a
     // plus sign to ensure searching works with that.
@@ -2597,7 +2597,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array(
       'administer permissions',
@@ -2611,7 +2611,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
    * Tests that a user can be assigned a role and that the role can be removed
    * again.
    */
-  function testAssignAndRemoveRole()  {
+  public function testAssignAndRemoveRole()  {
     $role_name = $this->backdropCreateRole(array('administer content types'));
     $account = $this->backdropCreateUser();
 
@@ -2634,7 +2634,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
    * Tests that when creating a user the role can be assigned. And that it can
    * be removed again.
    */
-  function testCreateUserWithRole() {
+  public function testCreateUserWithRole() {
     $role_name = $this->backdropCreateRole(array('administer content types'));
     // Create a new user and add the role at the same time.
     $edit = array(
@@ -2695,7 +2695,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
    */
   protected $adminUser;
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp('user_form_test');
     // Create two users
     $this->accessUser = $this->backdropCreateUser(array('access content'));
@@ -2705,7 +2705,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
   /**
    * Tests that user_validate_current_pass can be reused on a custom form.
    */
-  function testUserValidateCurrentPassCustomForm() {
+  public function testUserValidateCurrentPassCustomForm() {
     $this->backdropLogin($this->adminUser);
 
     // Check that filling out a single password field does not validate.
@@ -2737,7 +2737,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
 class UserEntityCallbacksTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  protected function setUp() {
     parent::setUp();
     $this->account = $this->backdropCreateUser();
     $this->anonymous = backdrop_anonymous_user();
@@ -2746,7 +2746,7 @@ class UserEntityCallbacksTestCase extends BackdropWebTestCase {
   /**
    * Test label callback.
    */
-  function testLabelCallback() {
+  public function testLabelCallback() {
     $this->assertEqual(entity_label('user', $this->account), $this->account->name, t('The username should be used as label'));
 
     // Setup a random anonymous name to be sure the name is used.
@@ -2758,7 +2758,7 @@ class UserEntityCallbacksTestCase extends BackdropWebTestCase {
   /**
    * Test URI callback.
    */
-  function testUriCallback() {
+  public function testUriCallback() {
     $uri = entity_uri('user', $this->account);
     $this->assertEqual('user/' . $this->account->uid, $uri['path'], t('Correct user URI.'));
   }

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1406,19 +1406,19 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   }
 
   /**
-   * Test assigning of permissions for the editor role.
+   * Test assigning of permissions for the default editor role.
    */
   function testEditorRole() {
     $this->backdropLogin($this->admin_user);
     $this->backdropGet('admin/config/people/roles');
 
-    // Before setting an admin role, check that no permissions are automatically
-    // assigned on new content types.
+    // Before setting a default admin role, check that no permissions are
+    // automatically assigned on new content types.
     $this->backdropGet('admin/structure/types/add');
     $this->assertRaw(t('No permissions assigned for this content type. Content of this type may not be able to be created, updated or deleted until permissions have been configured appropriately.'));
     $this->assertNoFieldByXPath("//table[@id='permissions']//input[@checked]");
 
-    // Set both an admin role and editor role.
+    // Set both a default admin role and a default editor role.
     $edit = array();
     $edit['user_admin_role'] = $this->admin_role_name;
     $edit['user_editor_role'] = $this->editor_role_name;
@@ -1434,23 +1434,34 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     // least some permission checkboxes checked.
     $this->assertFieldByXPath("//table[@id='permissions']//input[@checked]");
 
-    $content_type_permissions = array(
-      'create content',
-      'edit own content',
-      'edit any content',
-      'delete own content',
-      'delete any content',
-    );
-    // In this case, both admin and editor checkboxes are checked.
+    $content_type_permissions = array_keys(node_list_permissions());
     $role_names = array(
       $this->admin_role_name,
       $this->editor_role_name,
     );
     foreach ($content_type_permissions as $type_permission) {
       foreach ($role_names as $role_name) {
-        if (!($type_permission == 'delete any content' && $role_name == $this->editor_role_name)) {
-          $checkbox_id = backdrop_strtolower(str_replace(' ', '-', "edit $role_name $type_permission"));
-          $this->assertFieldChecked($checkbox_id);
+        $checkbox_id = backdrop_html_id("edit $role_name $type_permission");
+        // Check that the 'delete any content' permission is ticked for the
+        // default admin role, but not for the default editor role.
+        if ($type_permission == 'delete any content') {
+          if ($role_name == $this->editor_role_name) {
+            $this->assertNoFieldChecked($checkbox_id);
+          }
+          if ($role_name == $this->admin_role_name) {
+            $this->assertFieldChecked($checkbox_id);
+          }
+        }
+        else {
+          // Check that other permissions for this content type are ticked for
+          // the default admin role, but not for the default editor role.
+          if ($role_name == $this->editor_role_name || $role_name == $this->admin_role_name) {
+            $this->assertFieldChecked($checkbox_id);
+          }
+          else {
+            // These permissions should not be ticked for all other roles.
+            $this->assertNoFieldChecked($checkbox_id);
+          }
         }
       }
     }
@@ -1463,18 +1474,31 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     );
     $this->backdropPost(NULL, $edit, t('Save content type'));
 
-    // Now check permissions were correctly assigned.
+    // Check that permissions have been assigned properly.
     $user_accounts = array(
       $this->admin_user,
       $this->editor_user,
     );
     backdrop_static_reset('user_roles');
     backdrop_static_reset('user_access');
+    $content_type_permissions = array_keys(node_list_permissions($content_type_name));
     foreach ($content_type_permissions as $type_permission) {
-      $permission_name = backdrop_strtolower(str_replace('content', "$content_type_name content", $type_permission));
       foreach ($user_accounts as $user_account) {
-        if (!($type_permission == 'delete any content' && $user_account == $this->editor_user)) {
-          $this->assertTrue(user_access($permission_name, $user_account));
+        if ($type_permission == "delete any $content_type_name content") {
+          if ($user_account == $this->editor_user) {
+            $this->assertFalse(user_access($permission_name, $user_account));
+          }
+          if ($user_account == $this->admin_user) {
+            $this->assertTrue(user_access($permission_name, $user_account));
+          }
+        }
+        else {
+          if ($user_account == $this->editor_user || $user_account == $this->admin_user) {
+            $this->assertTrue(user_access($permission_name, $user_account));
+          }
+          else {
+            $this->assertFalse(user_access($permission_name, $user_account));
+          }
         }
       }
     }

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1491,12 +1491,13 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     backdrop_static_reset('user_roles');
     backdrop_static_reset('user_access');
     $content_type_permissions = array_keys(node_list_permissions($content_type_name));
+    $delete_content_type_permission = node_generate_permission_from_placeholder('delete any content', $content_type_name);
     foreach ($content_type_permissions as $type_permission) {
       foreach ($user_accounts as $user_account) {
         // Check that the 'delete any content' permission for the newly created
         // content type has been assigned to the default admin role, but not to
         // the default editor role.
-        if ($type_permission == "delete any $content_type_name content") {
+        if ($type_permission == $delete_content_type_permission) {
           if ($user_account == $this->editor_user) {
             $this->assertFalse(user_access($type_permission, $user_account), format_string('The default editor role does not have the @permission permission.'), array('@permission' => $type_permission));
           }

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1455,21 +1455,21 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
         // default admin role, but not for the default editor role.
         if ($type_permission == 'delete any content') {
           if ($role_name == $this->editor_role_name) {
-            $this->assertNoFieldChecked($checkbox_id);
+            $this->assertNoFieldChecked($checkbox_id, format_string('The checkbox for the @permission permission is not ticked for the default editor role.'), array('@permission' => $type_permission));
           }
           if ($role_name == $this->admin_role_name) {
-            $this->assertFieldChecked($checkbox_id);
+            $this->assertFieldChecked($checkbox_id), format_string('The checkbox for the @permission permission is ticked for the default admin role.'), array('@permission' => $type_permission);
           }
         }
         else {
           // Check that other permissions for this content type are ticked for
           // both the default admin role and the default editor role.
           if ($role_name == $this->editor_role_name || $role_name == $this->admin_role_name) {
-            $this->assertFieldChecked($checkbox_id);
+            $this->assertFieldChecked($checkbox_id, format_string('The checkbox for the @permission permission is ticked for the default role.'), array('@permission' => $type_permission));
           }
           else {
             // These permissions should not be ticked for all other roles.
-            $this->assertNoFieldChecked($checkbox_id);
+            $this->assertNoFieldChecked($checkbox_id, format_string('The checkbox for the @permission permission is not ticked for the non-default role.'), array('@permission' => $type_permission));
           }
         }
       }
@@ -1498,10 +1498,10 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
         // the default editor role.
         if ($type_permission == "delete any $content_type_name content") {
           if ($user_account == $this->editor_user) {
-            $this->assertFalse(user_access($type_permission, $user_account));
+            $this->assertFalse(user_access($type_permission, $user_account), format_string('The default editor role does not have the @permission permission.'), array('@permission' => $type_permission));
           }
           if ($user_account == $this->admin_user) {
-            $this->assertTrue(user_access($type_permission, $user_account));
+            $this->assertTrue(user_access($type_permission, $user_account), format_string('The default admin role has the @permission permission.'), array('@permission' => $type_permission));
           }
         }
         else {
@@ -1509,12 +1509,12 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
           // assigned to both the default admin role and the default editor
           // role.
           if ($user_account == $this->editor_user || $user_account == $this->admin_user) {
-            $this->assertTrue(user_access($type_permission, $user_account));
+            $this->assertTrue(user_access($type_permission, $user_account), format_string('Default role has the @permission permission.'), array('@permission' => $type_permission));
           }
           else {
             // These permissions should not have been assigned to any of the
             // other roles.
-            $this->assertFalse(user_access($type_permission, $user_account));
+            $this->assertFalse(user_access($type_permission, $user_account), format_string('Non-default role does not have the @permission permission.'), array('@permission' => $type_permission));
           }
         }
       }

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1345,7 +1345,16 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   function setUp() {
     parent::setUp();
 
-    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'access user profiles', 'administer site configuration', 'administer account settings', 'administer content types', 'administer modules'));
+    $this->admin_user = $this->backdropCreateUser(
+      array(
+        'administer permissions',
+        'access user profiles',
+        'administer site configuration',
+        'administer account settings',
+        'administer content types',
+        'administer modules',
+      ),
+    );
     $this->editor_user = $this->backdropCreateUser(array('access content'));
 
     // Find the new role names.
@@ -1428,7 +1437,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     $this->backdropGet('admin/structure/types/add');
     $this->assertRaw(t('The %admin and %editor roles have been assigned permissions to create, edit, and delete content of this type.', array(
       '%admin' => $this->admin_role_name,
-      '%editor' => $this->editor_role_name
+      '%editor' => $this->editor_role_name,
     )));
     // Opposite of the above assertNoFieldByXPath(), confirm that there are at
     // least some permission checkboxes checked.

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1426,7 +1426,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
 
     // Create a new content type and confirm the permissions are added.
     $this->backdropGet('admin/structure/types/add');
-    $this->assertRaw(t('The %admin and %editor roles have been assigned permissions to create, edit, and delete any content of this type.', array(
+    $this->assertRaw(t('The %admin and %editor roles have been assigned permissions to create, edit, and delete content of this type.', array(
       '%admin' => $this->admin_role_name,
       '%editor' => $this->editor_role_name
     )));
@@ -1448,8 +1448,10 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     );
     foreach ($content_type_permissions as $type_permission) {
       foreach ($role_names as $role_name) {
-        $checkbox_id = backdrop_strtolower(str_replace(' ', '-', "edit $role_name $type_permission"));
-        $this->assertFieldChecked($checkbox_id);
+        if (!($type_permission == 'delete any content' && $role_name == $this->editor_role_name)) {
+          $checkbox_id = backdrop_strtolower(str_replace(' ', '-', "edit $role_name $type_permission"));
+          $this->assertFieldChecked($checkbox_id);
+        }
       }
     }
 
@@ -1471,7 +1473,9 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     foreach ($content_type_permissions as $type_permission) {
       $permission_name = backdrop_strtolower(str_replace('content', "$content_type_name content", $type_permission));
       foreach ($user_accounts as $user_account) {
-        $this->assertTrue(user_access($permission_name, $user_account));
+        if (!($type_permission == 'delete any content' && $user_account == $this->editor_user)) {
+          $this->assertTrue(user_access($permission_name, $user_account));
+        }
       }
     }
   }

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1454,7 +1454,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
         }
         else {
           // Check that other permissions for this content type are ticked for
-          // the default admin role, but not for the default editor role.
+          // both the default admin role and the default editor role.
           if ($role_name == $this->editor_role_name || $role_name == $this->admin_role_name) {
             $this->assertFieldChecked($checkbox_id);
           }
@@ -1484,6 +1484,9 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     $content_type_permissions = array_keys(node_list_permissions($content_type_name));
     foreach ($content_type_permissions as $type_permission) {
       foreach ($user_accounts as $user_account) {
+        // Check that the 'delete any content' permission for the newly created
+        // content type has been assigned to the default admin role, but not to
+        // the default editor role.
         if ($type_permission == "delete any $content_type_name content") {
           if ($user_account == $this->editor_user) {
             $this->assertFalse(user_access($permission_name, $user_account));
@@ -1493,10 +1496,15 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
           }
         }
         else {
+          // Check that other permissions for this content type have been
+          // assigned to both the default admin role and the default editor
+          // role.
           if ($user_account == $this->editor_user || $user_account == $this->admin_user) {
             $this->assertTrue(user_access($permission_name, $user_account));
           }
           else {
+            // These permissions should not have been assigned to any of the
+            // other roles.
             $this->assertFalse(user_access($permission_name, $user_account));
           }
         }

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1498,10 +1498,10 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
         // the default editor role.
         if ($type_permission == "delete any $content_type_name content") {
           if ($user_account == $this->editor_user) {
-            $this->assertFalse(user_access($permission_name, $user_account));
+            $this->assertFalse(user_access($type_permission, $user_account));
           }
           if ($user_account == $this->admin_user) {
-            $this->assertTrue(user_access($permission_name, $user_account));
+            $this->assertTrue(user_access($type_permission, $user_account));
           }
         }
         else {
@@ -1509,12 +1509,12 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
           // assigned to both the default admin role and the default editor
           // role.
           if ($user_account == $this->editor_user || $user_account == $this->admin_user) {
-            $this->assertTrue(user_access($permission_name, $user_account));
+            $this->assertTrue(user_access($type_permission, $user_account));
           }
           else {
             // These permissions should not have been assigned to any of the
             // other roles.
-            $this->assertFalse(user_access($permission_name, $user_account));
+            $this->assertFalse(user_access($type_permission, $user_account));
           }
         }
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6106

This is a follow-up to https://github.com/backdrop/backdrop/pull/4428

Things addressed:
- We had multiple places where we converted content-related "placeoholder" permissions (those that do not yet include the content type name) back and forth between including vs. removing the content type name. This seemed very prone to errors + the lack of inline comments everywhere this was done made it confusing if people were not familiar with what the code does and why it does it. So I have moved the default set of permissions in the `node_list_permissions()` function. The return value of that function doesn't change if a content type name is provided to it (same as before). If however the `$type` parameter is omitted, it now returns the default set of permissions.
- I have moved the logic that adds the content type name to the permission name in a separate `node_generate_permission_from_placeholder()` function (suggestions on the name of the function are welcomed). This function is curently reused in a couple of places in core, but it can now also be reused by contrib that provides similar "placeholder" permissions that need to be converted to proper/actual permissions upon saving a new content type.
- Changed all variable names from abbreviated and/or cryptic/vague ones to proper names that are self-explanatory, which now makes the code easier to read/understand/debug.
- Expanded tests and use `node_list_permissions()` and `backdrop_html_id()` instead of crufting logic to determine permission names and respective checkbox IDs.
- Nice "byproduct" of the cleanup: Reduced the translatable strings for content type permissions. Previouly, each content type on the site would get its own translatable string, because of all the `t('%type_name: Create new content', array('%type_name' => $info->name))` and friends in `node_list_permissions()`. Now the only translatable strings are those of the titles of the default "placeholder" permissions (so only `t('Create new content')`), and because the name of the content type is being prefixed without being part of a `t()`, all permissions for any exisiting content types and any that may be created in the future will be translated 😉 