### PR TITLE
Issue #6107: Add new theme_settings_get() function - deprecate theme_get_setting()

### DIFF
--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -1437,21 +1437,45 @@ function backdrop_find_theme_templates($cache, $extension, $path) {
 /**
  * Retrieves a setting for the current theme or for a given theme.
  *
+ * Legacy function no longer used by core, but preserved for backwards
+ * compatibility.
+ *
+ * @deprecated since 1.26.0 this is only a wrapper around theme_settings_get(),
+ * which was introduced to allow a default value to be defined.
+ *
+ * @see theme_settings_get()
+ */
+function theme_get_setting($setting_name, $theme = NULL) {
+  watchdog_deprecated_function('system', __FUNCTION__);
+  return theme_settings_get($setting_name, NULL, $theme);
+}
+
+/**
+ * Retrieves a setting for the current theme or for a given theme.
+ *
  * The final setting is obtained from the last value found in the following
  * sources:
- * - the default theme-specific settings defined in any base theme's .info file
- * - the default theme-specific settings defined in the theme's .info file
- * - the saved values from the theme's settings form
+ * - the default theme-specific settings defined in any base theme's .info file.
+ * - the default theme-specific settings defined in the theme's .info file.
+ * - the saved values from the theme's settings form.
+ * - the value provided as the optional $default parameter in the function.
  *
  * @param $setting_name
  *   The name of the setting to be retrieved.
- * @param $theme
+ * @param $default (optional)
+ *   The default value to use if this setting is not set.
+ * @param $theme (optional)
  *   The name of a given theme; defaults to the current theme.
  *
- * @return
- *   The value of the requested setting, NULL if the setting does not exist.
+ * @return mixed|NULL
+ *   - the value of the requested setting if found,
+ *   - or the value provided as the $default parameter if the setting was not
+ *     found,
+ *   - or NULL if the setting does not exist and no default value was provided.
+ * 
+ * @since 1.26.0 function added.
  */
-function theme_get_setting($setting_name, $theme = NULL) {
+function theme_settings_get($setting_name, $default = NULL, $theme = NULL) {
   $configs = &backdrop_static(__FUNCTION__, array());
 
   // If no key is given, use the current theme if we can determine it.
@@ -1479,7 +1503,13 @@ function theme_get_setting($setting_name, $theme = NULL) {
 
   // Loop up through any base themes.
   if (is_null($value) && isset($theme_info->info['base theme'])) {
-    $value = theme_get_setting($setting_name, $theme_info->info['base theme']);
+    $value = theme_settings_get($setting_name, NULL, $theme_info->info['base theme']);
+  }
+
+  // If nothing found after all, then fall back to the $default value if one was
+  // provided.
+  if (is_null($value)) {
+    $value = $default;
   }
 
   return $value;

--- a/core/includes/theme.inc
+++ b/core/includes/theme.inc
@@ -2282,8 +2282,8 @@ function theme_table(array $variables) {
     $sections['tfoot'] = $variables['footer'];
   }
 
-  // tbody and tfoot have the same structure, and are built using the same
-  // procedure.
+  // The tbody and tfoot tags have the same structure, and are built using the
+  // same procedure.
   foreach ($sections as $tag => $content) {
     $output .= "<$tag>\n";
     $flip = array('even' => 'odd', 'odd' => 'even');

--- a/core/modules/color/color.legacy.inc
+++ b/core/modules/color/color.legacy.inc
@@ -17,7 +17,7 @@
  * @deprecated since 1.3.0
  */
 function bartik_form_system_theme_settings_alter(&$form, &$form_state) {
-  if (theme_get_setting('color_legacy', 'bartik')) {
+  if (theme_settings_get('color_legacy', NULL, 'bartik')) {
     $form['color']['scheme']['#default_value'] = 'blue_lagoon';
     $palette = $form['color']['info']['#value']['schemes']['blue_lagoon']['colors'];
     foreach ($palette as $key => $color) {

--- a/core/modules/color/color.module
+++ b/core/modules/color/color.module
@@ -45,7 +45,7 @@ function color_form_system_theme_settings_alter(&$form, &$form_state) {
 
     // See if we're using a predefined scheme.
     // Note: we use the original theme when the default scheme is chosen.
-    $current_scheme = theme_get_setting('color.palette', $theme_name);
+    $current_scheme = theme_settings_get('color.palette', NULL, $theme_name);
     foreach ($schemes as $key => $scheme) {
       if ($current_scheme == $scheme) {
         $scheme_name = $key;
@@ -208,7 +208,7 @@ function color_css_alter(&$css) {
   }
   if (!isset($preview_data)) {
     // Override stylesheets.
-    $color_paths = theme_get_setting('color.stylesheets');
+    $color_paths = theme_settings_get('color.stylesheets');
 
     if (!empty($color_paths)) {
       $info = color_get_info($theme_key);
@@ -413,7 +413,7 @@ function color_get_palette($theme, $default = FALSE) {
   $palette = $info['schemes']['default']['colors'];
 
   // Load config.
-  if (!$default && ($theme_palette = theme_get_setting('color.palette', $theme))) {
+  if (!$default && ($theme_palette = theme_settings_get('color.palette', NULL, $theme))) {
     foreach ($theme_palette as $color_name => $color_code) {
       $palette[$color_name] = $color_code;
     }
@@ -585,7 +585,7 @@ function color_rebuild_settings($theme_name = NULL) {
  */
 function color_save_configuration($theme_name, $theme_info, $palette) {
   // Delete any old color files.
-  $files = theme_get_setting('color.files', $theme_name);
+  $files = theme_settings_get('color.files', NULL, $theme_name);
   if ($files) {
     foreach ($files as $file) {
       @backdrop_unlink($file);
@@ -595,7 +595,7 @@ function color_save_configuration($theme_name, $theme_info, $palette) {
     @backdrop_rmdir($file);
   }
 
-  // Don't render the default colorscheme, use the standard theme instead.
+  // Don't render the default color scheme; use the standard theme instead.
   if (empty($palette) || implode(',', color_get_palette($theme_name, TRUE)) == implode(',', $palette)) {
     return NULL;
   }

--- a/core/modules/color/tests/color.test
+++ b/core/modules/color/tests/color.test
@@ -67,7 +67,7 @@ class ColorTestCase extends BackdropWebTestCase {
       $this->backdropPost($settings_path, $edit, t('Save theme settings'));
 
       $this->backdropGet('<front>');
-      $stylesheets = theme_get_setting('color.stylesheets', $theme);
+      $stylesheets = theme_settings_get('color.stylesheets', NULL, $theme);
       $this->assertPattern('|' . file_create_url($stylesheets[0]) . '|', 'Make sure the color stylesheet is included in the content. (' . $theme . ')');
 
       $stylesheet_content = implode("\n", file($stylesheets[0]));
@@ -80,7 +80,7 @@ class ColorTestCase extends BackdropWebTestCase {
 
       $this->backdropGet('<front>');
       backdrop_static_reset();
-      $stylesheets = theme_get_setting('color.stylesheets', $theme);
+      $stylesheets = theme_settings_get('color.stylesheets', NULL, $theme);
       $stylesheet_content = implode("\n", file($stylesheets[0]));
       $this->assertTrue(strpos($stylesheet_content, 'color: ' . $test_values['scheme_color']) !== FALSE, 'Make sure the color we changed is in the color stylesheet. (' . $theme . ')');
 
@@ -147,7 +147,7 @@ class ColorTestCase extends BackdropWebTestCase {
     $this->backdropPost($import_path, $edit, t('Import'));
 
     // Check that the new color shows up in the css files.
-    $stylesheets = theme_get_setting('color.stylesheets', 'bartik');
+    $stylesheets = theme_settings_get('color.stylesheets', NULL, 'bartik');
     $stylesheet_content = '';
     foreach ($stylesheets as $stylesheet) {
       $stylesheet_content .= implode("\n", file($stylesheet));

--- a/core/modules/simpletest/tests/theme.test
+++ b/core/modules/simpletest/tests/theme.test
@@ -225,7 +225,7 @@ class ThemeTableUnitTest extends BackdropWebTestCase {
   /**
    * Tests that the 'footer' option works correctly.
    */
-  function testThemeTableFooter() {
+  public function testThemeTableFooter() {
     $footer = array(
       array(
         'data' => array(1),

--- a/core/modules/simpletest/tests/theme.test
+++ b/core/modules/simpletest/tests/theme.test
@@ -134,13 +134,13 @@ class ThemeUnitTest extends BackdropWebTestCase {
   }
 
   /**
-   * Test the theme_get_setting() function.
+   * Test the theme_settings_get() function.
    */
-  function testThemeGetSetting() {
+  function testThemeSettingsGet() {
     $GLOBALS['theme_key'] = 'test_theme';
-    $this->assertIdentical(theme_get_setting('theme_test_setting'), 'default value', 'theme_get_setting() uses the default theme automatically.');
-    $this->assertNotEqual(theme_get_setting('subtheme_override', 'test_basetheme'), theme_get_setting('subtheme_override', 'test_subtheme'), 'Base theme\'s default settings values can be overridden by subtheme.');
-    $this->assertIdentical(theme_get_setting('basetheme_only', 'test_subtheme'), 'base theme value', 'Base theme\'s default settings values are inherited by subtheme.');
+    $this->assertIdentical(theme_settings_get('theme_test_setting'), 'default value', 'theme_settings_get() uses the default theme automatically.');
+    $this->assertNotEqual(theme_settings_get('subtheme_override', NULL, 'test_basetheme'), theme_settings_get('subtheme_override', NULL, 'test_subtheme'), 'Base theme\'s default settings values can be overridden by subtheme.');
+    $this->assertIdentical(theme_settings_get('basetheme_only', NULL, 'test_subtheme'), 'base theme value', 'Base theme\'s default settings values are inherited by subtheme.');
   }
 
   /**

--- a/core/modules/simpletest/tests/themes/test_theme/theme-settings.php
+++ b/core/modules/simpletest/tests/themes/test_theme/theme-settings.php
@@ -6,7 +6,17 @@
 $form['test_theme_checkbox'] = array(
   '#type' => 'checkbox',
   '#title' => 'Test theme checkbox',
-  '#default_value' => theme_get_setting('test_theme_checkbox', 'test_theme'),
+  '#default_value' => theme_settings_get('test_theme_checkbox', NULL, 'test_theme'),
+);
+$form['test_theme_checkbox_default_value_true'] = array(
+  '#type' => 'checkbox',
+  '#title' => 'Test theme checkbox with its default value set to TRUE',
+  '#default_value' => theme_settings_get('test_theme_checkbox_default_value', TRUE, 'test_theme'),
+);
+$form['test_theme_checkbox_default_value_false'] = array(
+  '#type' => 'checkbox',
+  '#title' => 'Test theme checkbox with default value set to FALSE',
+  '#default_value' => theme_settings_get('test_theme_checkbox_default_value', FALSE, 'test_theme'),
 );
 // Force the form to be cached so we can test that this file is properly
 // loaded and the custom submit handler is properly called even on a cached

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -1743,12 +1743,21 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
     theme_enable(array('test_theme'));
 
     // Test that the theme-specific settings form can be saved and that the
-    // theme-specific checkbox is checked and unchecked as appropriate.
+    // theme-specific checkboxes are checked and unchecked as appropriate.
     $this->backdropGet('admin/appearance/settings/test_theme');
     $this->assertNoFieldChecked('edit-test-theme-checkbox', 'The test_theme_checkbox setting is unchecked.');
+    // Test that when the form is loaded, the #default_value is set
+    // appropriately for fields with default values set via the optional
+    // $default parameter in theme_settings_get(), when at the same time there
+    // are no respective defaults explicitly set via settings[] in the .info
+    // file.
+    $this->assertFieldChecked('edit-test-theme-checkbox-default-value-true', 'The test_theme_checkbox_default_value_true setting is checked.');
+    $this->assertNoFieldChecked('edit-test-theme-checkbox-default-value-false', 'The test_theme_checkbox_default_value_false setting is unchecked.');
+    // Untick the test_theme_checkbox and save the form.
     $this->backdropPost(NULL, array('test_theme_checkbox' => TRUE), t('Save theme settings'));
     $this->assertText('The configuration options have been saved.');
     $this->assertFieldChecked('edit-test-theme-checkbox', 'The test_theme_checkbox setting is checked.');
+    // Tick the test_theme_checkbox and save the form.
     $this->backdropPost(NULL, array('test_theme_checkbox' => FALSE), t('Save theme settings'));
     $this->assertText('The configuration options have been saved.');
     $this->assertNoFieldChecked('edit-test-theme-checkbox', 'The test_theme_checkbox setting is unchecked.');

--- a/core/modules/system/theme.api.php
+++ b/core/modules/system/theme.api.php
@@ -88,7 +88,7 @@ function hook_form_system_theme_settings_alter(&$form, &$form_state) {
   $form['toggle_breadcrumb'] = array(
     '#type' => 'checkbox',
     '#title' => t('Display the breadcrumb'),
-    '#default_value' => theme_get_setting('toggle_breadcrumb'),
+    '#default_value' => theme_settings_get('toggle_breadcrumb', TRUE),
     '#description'   => t('Show a trail of links from the homepage to the current page.'),
   );
 }

--- a/core/themes/bartik/color/color.inc
+++ b/core/themes/bartik/color/color.inc
@@ -1,7 +1,7 @@
 <?php
 
 // Put the logo path into JavaScript for the live preview.
-backdrop_add_js(array('color' => array('logo' => theme_get_setting('logo', 'bartik'))), 'setting');
+backdrop_add_js(array('color' => array('logo' => theme_settings_get('logo', NULL, 'bartik'))), 'setting');
 
 $info = array(
   // Available colors and color labels used in theme.

--- a/core/themes/bartik/template.php
+++ b/core/themes/bartik/template.php
@@ -21,7 +21,7 @@ function bartik_preprocess_maintenance_page(&$variables) {
 function bartik_css_alter(&$css) {
   // If using the legacy "Blue lagoon" color scheme, load the legacy stylesheet.
   $theme_path = backdrop_get_path('theme', 'bartik');
-  if (theme_get_setting('color_legacy') && isset($css[$theme_path . '/css/colors.css'])) {
+  if (theme_settings_get('color_legacy') && isset($css[$theme_path . '/css/colors.css'])) {
     $css[$theme_path . '/css/colors.css']['data'] = $theme_path . '/css/colors-legacy.css';
   }
 }
@@ -34,7 +34,7 @@ function bartik_css_alter(&$css) {
 function bartik_preprocess_layout(&$variables) {
   if (isset($variables['content']['header'])) {
     $extra_header_classes = array();
-    $extra_header_classes[] = theme_get_setting('main_menu_tabs');
+    $extra_header_classes[] = theme_settings_get('main_menu_tabs');
     $legacy = array('one_column', 'two_column', 'two_column_flipped', 'three_three_four_column');
     if (in_array($variables['layout']->layout_template, $legacy)) {
       $extra_header_classes[] = 'l-header-inner';

--- a/core/themes/bartik/theme-settings.php
+++ b/core/themes/bartik/theme-settings.php
@@ -18,6 +18,6 @@ $form['tabs_wrapper']['main_menu_tabs'] = array(
     'rounded-tabs' => t('Rounded tabs'),
     'square-tabs' => t('Square tabs'),
   ),
-  '#default_value' => theme_get_setting('main_menu_tabs', 'bartik'),
+  '#default_value' => theme_settings_get('main_menu_tabs', 'no-tabs', 'bartik'),
   '#description' => t('When rounded or square tabs are selected, menu link color is overridden and set to #333 for better visibility.'),
 );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6107

- adds a new `theme_settings_get()` function
- deprecates `theme_get_setting()`