### PR TITLE
Issue #6093: Fixing typo in menu block settings.

### DIFF
--- a/core/modules/system/system.menu.inc
+++ b/core/modules/system/system.menu.inc
@@ -163,8 +163,8 @@ function system_menu_block_form($config) {
     ),
   );
   $form['collapse']['default']['#description'] = t('Parent expands on first tap, acts as a link on second tap.');
-  $form['collapse']['toggle']['#description'] = t('Parent expands or collapses on each tap and does not act a link.');
-  $form['collapse']['link']['#description'] = t('Parent text is a link, +/- element expands or collapses.');
+  $form['collapse']['toggle']['#description'] = t('Parent expands or collapses on each tap and does not act as a link.');
+  $form['collapse']['link']['#description'] = t('Parent text acts as a link and the +/- element expands or collapses.');
 
   $form['accordion'] = array('#type' => 'checkbox',
     '#title' => t('Accordion-style'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6093

Follow-up to address the typo in the menu block settings.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
