### PR TITLE
Issue 3492. Restore definitions of variables $v_version and $v_magic

### DIFF
--- a/core/modules/system/system.tar.inc
+++ b/core/modules/system/system.tar.inc
@@ -1655,6 +1655,8 @@ class Archive_Tar
         $v_mtime = sprintf("%011s", 0);
         $v_typeflag = ($is_link ? 'K' : 'L');
         $v_linkname = '';
+        $v_magic = 'ustar ';
+        $v_version = ' ';
         $v_uname = '';
         $v_gname = '';
         $v_devmajor = '';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3492