### PR TITLE
Issue #6139: Set install.sh to executable.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -34,6 +34,7 @@ services:
         # Generate and store a random password for the admin user.
         - openssl rand -hex 6 > $TUGBOAT_ROOT/.tugboat/password
         # Install Backdrop.
+        - chmod +x $TUGBOAT_ROOT/core/scripts/install.sh
         - cd $TUGBOAT_ROOT && ./core/scripts/install.sh --db-url=mysql://tugboat:tugboat@mariadb/tugboat --account-pass=`cat .tugboat/password`
         # Fix config permissions after install.
         - chown -R www-data:www-data $TUGBOAT_ROOT/files/config/active


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6139

Hopefully the last set of changes to the Tugboat configuration. Fixing the permissions of install.sh before running the installer. The permissions were changed as part of https://github.com/backdrop/backdrop/pull/4454