### PR TITLE
Issue #6139: Switch to mariadb-admin for setting up databases.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -50,4 +50,4 @@ services:
         - echo "[mysqld]\ninnodb_large_prefix=true\ninnodb_file_format=barracuda\ninnodb_file_per_table=true" >> /etc/mysql/conf.d/utf8mb.conf
       build:
         # Drop and re-create the database (needed when rebuilding/reinstalling).
-        - mysqladmin -f drop tugboat && mysqladmin create tugboat
+        - mariadb-admin -f drop tugboat && mariadb-admin create tugboat


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6139

Newer versions of the `mariadb` docker image no longer include the mysql symlinks. Switching to `mariadb-admin` instead of `mysqladmin` for initializing the database.