### PR TITLE
#2491353: Cookies from previous tests are still present when a new test starts

### DIFF
--- a/core/modules/simpletest/backdrop_web_test_case.php
+++ b/core/modules/simpletest/backdrop_web_test_case.php
@@ -993,7 +993,7 @@ class BackdropWebTestCase extends BackdropTestCase {
   protected $cookieFile = NULL;
 
   /**
-   * An array of cookies set in the most recent cURL request.
+   * The cookies of the page currently loaded in the internal browser.
    *
    * @var array
    */
@@ -1926,8 +1926,10 @@ class BackdropWebTestCase extends BackdropTestCase {
     $language = $this->originalLanguage;
     $language_url = $this->originalLanguageUrl;
 
-    // Close the CURL handler.
+    // Close the CURL handler and reset the cookies array, so that test classes
+    // containing multiple tests are not polluted.
     $this->curlClose();
+    $this->cookies = array();
   }
 
   /**

--- a/core/modules/simpletest/tests/simpletest.test
+++ b/core/modules/simpletest/tests/simpletest.test
@@ -389,7 +389,7 @@ EOF;
     // Check that the $this->cookies property is populated when a user logs in.
     $user = $this->backdropCreateUser();
     $edit = array('name' => $user->name, 'pass' => $user->pass_raw);
-    $this->backdropPost('<front>', $edit, t('Log in'));
+    $this->backdropPost('user/login', $edit, t('Log in'));
     $this->assertEqual(count($this->cookies), 1, 'A cookie is set when the user logs in.');
 
     // Check that the name and value of the cookie match the request data.

--- a/core/modules/simpletest/tests/simpletest.test
+++ b/core/modules/simpletest/tests/simpletest.test
@@ -323,6 +323,13 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
  * Test internal testing framework browser.
  */
 class SimpleTestBrowserTestCase extends BackdropWebTestCase {
+  /**
+   * A flag indicating whether a cookie has been set in a test.
+   *
+   * @var bool
+   */
+  protected static $cookieSet = FALSE;
+
   function setUp() {
     parent::setUp();
     config_set('system.core', 'user_register', USER_REGISTER_VISITORS);
@@ -373,6 +380,45 @@ EOF;
 
     $urls = $this->xpath('//a[text()=:text]', array(':text' => 'A second "even more weird" link, in memory of George O\'Malley'));
     $this->assertEqual($urls[0]['href'], 'link2', 'Match with mixed single and double quotes.');
+  }
+
+  /**
+   * Tests that cookies set during a request are available for testing.
+   */
+  public function testCookies() {
+    // Check that the $this->cookies property is populated when a user logs in.
+    $user = $this->backdropCreateUser();
+    $edit = array('name' => $user->name, 'pass' => $user->pass_raw);
+    $this->backdropPost('<front>', $edit, t('Log in'));
+    $this->assertEqual(count($this->cookies), 1, 'A cookie is set when the user logs in.');
+
+    // Check that the name and value of the cookie match the request data.
+    $cookie_header = $this->backdropGetHeader('set-cookie', TRUE);
+
+    // The name and value are located at the start of the string, separated by
+    // an equals sign and ending in a semicolon.
+    preg_match('/^([^=]+)=([^;]+)/', $cookie_header, $matches);
+    $name = $matches[1];
+    $value = $matches[2];
+
+    $this->assertTrue(array_key_exists($name, $this->cookies), 'The cookie name is correct.');
+    $this->assertEqual($value, $this->cookies[$name]['value'], 'The cookie value is correct.');
+
+    // Set a flag indicating that a cookie has been set in this test.
+    // @see SimpleTestBrowserTestCase::testCookieDoesNotBleed().
+    self::$cookieSet = TRUE;
+  }
+
+  /**
+   * Tests that the cookies from a previous test do not bleed into a new test.
+   *
+   * @see SimpleTestBrowserTestCase::testCookies().
+   */
+  public function testCookieDoesNotBleed() {
+    // In order for this test to be effective it should always run after the
+    // testCookies() test.
+    $this->assertTrue(self::$cookieSet, 'Tests have been executed in the expected order.');
+    $this->assertEqual(count($this->cookies), 0, 'No cookies are present at the start of a new test.');
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2013

Replaces https://github.com/backdrop/backdrop/pull/1887

d.org issue: https://www.drupal.org/node/2491353

7.x commit: https://git.drupalcode.org/project/drupal/-/commit/1fea8c83c9bcd26b709f709ac05470fcd97f001f