### PR TITLE
Change the default value for flood_uid_only

### DIFF
--- a/core/modules/user/config/user.flood.json
+++ b/core/modules/user/config/user.flood.json
@@ -1,6 +1,6 @@
 {
     "_config_name": "user.flood",
-    "flood_uid_only": "false",
+    "flood_uid_only": "0",
     "flood_ip_limit": 50,
     "flood_ip_window": 3600,
     "flood_log_failed_attempts": 1,

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -380,15 +380,15 @@ function user_login_settings($form, &$form_state) {
     '#type' => 'radios',
     '#title' => t('Identify users attempting to log in, using'),
     '#options' => array(
-      '0' => t('User ID and IP address combination'),
       '1' => t('User ID only'),
+      '0' => t('User ID and IP address combination'),
     ),
     '#default_value' => $flood_config->get('flood_uid_only'),
-    FALSE => array(
-      '#description' => ' Less secure, less likely to lock out users.',
-    ),
-    TRUE => array(
+    '1' => array(
       '#description' => 'More secure, more likely to lock out users.',
+    ),
+    '0' => array(
+      '#description' => ' Less secure, less likely to lock out users.',
     ),
   );
 

--- a/core/modules/user/user.admin.inc
+++ b/core/modules/user/user.admin.inc
@@ -385,10 +385,10 @@ function user_login_settings($form, &$form_state) {
     ),
     '#default_value' => $flood_config->get('flood_uid_only'),
     '1' => array(
-      '#description' => 'More secure, more likely to lock out users.',
+      '#description' => t('More secure, more likely to lock out users.'),
     ),
     '0' => array(
-      '#description' => ' Less secure, less likely to lock out users.',
+      '#description' => t('Less secure, less likely to lock out users.'),
     ),
   );
 

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -2358,13 +2358,13 @@ function user_update_1025() {
 }
 
 /**
- * Correct the value for flood_uid_only.
+ * Correct the default config value for "flood_uid_only" setting.
  */
 function user_update_1026() {
   $config = config('user.flood');
 
-  // Only update if the value is "false".
-  if ($config->get('flood_uid_only') == 'false') {
+  // Only update if the value is exactly the string "false".
+  if ($config->get('flood_uid_only') === 'false') {
     $config->set('flood_uid_only', '0');
     $config->save();
   }

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -2358,5 +2358,18 @@ function user_update_1025() {
 }
 
 /**
+ * Correct the value for flood_uid_only.
+ */
+function user_update_1026() {
+  $config = config('user.flood');
+
+  // Only update if the value is "false".
+  if ($config->get('flood_uid_only') == 'false') {
+    $config->set('flood_uid_only', '0');
+    $config->save();
+  }
+}
+
+/**
  * @} End of "addtogroup updates-7.x-to-1.x"
  */

--- a/core/modules/user/user.install
+++ b/core/modules/user/user.install
@@ -2358,7 +2358,7 @@ function user_update_1025() {
 }
 
 /**
- * Correct the default config value for "flood_uid_only" setting.
+ * Correct the default config value for the "flood_uid_only" setting.
  */
 function user_update_1026() {
   $config = config('user.flood');


### PR DESCRIPTION
Changed the default value for flood_uid_only

Fixes https://github.com/backdrop/backdrop-issues/issues/6162

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
