### PR TITLE
Issue 6168. Remove $form['#attributes']['class'] assignment in `installer_browser_install_button_form()`

### DIFF
--- a/core/modules/installer/installer.pages.inc
+++ b/core/modules/installer/installer.pages.inc
@@ -846,7 +846,7 @@ function installer_browser_get_install_list() {
  */
 function installer_browser_install_button_form($form, &$form_state) {
   $project_type = installer_browser_type_from_path();
-  $form['#attributes']['class'] = 'installer-browser-install-button-form';
+  $form['#attributes']['class'] = array('installer-browser-install-button-form');
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Install'),

--- a/core/modules/installer/installer.pages.inc
+++ b/core/modules/installer/installer.pages.inc
@@ -846,7 +846,6 @@ function installer_browser_get_install_list() {
  */
 function installer_browser_install_button_form($form, &$form_state) {
   $project_type = installer_browser_type_from_path();
-  $form['#attributes']['class'] = array('installer-browser-install-button-form');
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Install'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6168