### PR TITLE
Issue #6137: Uses database defaults for number field min and max values.

### DIFF
--- a/core/modules/field/modules/number/number.module
+++ b/core/modules/field/modules/number/number.module
@@ -76,14 +76,14 @@ function number_field_instance_settings_form($field, $instance) {
     '#type' => 'textfield',
     '#title' => t('Minimum'),
     '#default_value' => $settings['min'],
-    '#description' => t('The minimum value that should be allowed in this field. Leave blank for no minimum.'),
+    '#description' => t('The minimum value that should be allowed in this field. Leave blank for the lowest possible value that can be saved to the database.'),
     '#element_validate' => array('form_validate_number'),
   );
   $form['max'] = array(
     '#type' => 'textfield',
     '#title' => t('Maximum'),
     '#default_value' => $settings['max'],
-    '#description' => t('The maximum value that should be allowed in this field. Leave blank for no maximum.'),
+    '#description' => t('The maximum value that should be allowed in this field. Leave blank for the highest possible value that can be saved to the database.'),
     '#element_validate' => array('form_validate_number'),
   );
   $form['prefix'] = array(
@@ -395,12 +395,18 @@ function number_field_widget_form(&$form, &$form_state, $field, $instance, $lang
   $element += array(
     '#type' => 'number',
     '#default_value' => $value,
-    '#max' => 1000000,
   );
 
-  // Set the step for floating point and decimal numbers.
+  // Set default field values based on the number type.
   switch ($field['type']) {
     case 'number_decimal':
+      // Calculate the minimum and maximum value of the decimal field based on
+      // precision and scale settings.
+      $number_value = intval(('1e+' . ($field['settings']['precision'] - $field['settings']['scale'])) - 1);
+      $decimal_value = intval(('1e+' . $field['settings']['scale']) - 1);
+      $element['#min'] = (float) ('-' . $number_value . '.' . $decimal_value);
+      $element['#max'] = (float) ($number_value . '.' . $decimal_value);
+
       // Avoid small float as base in function pow() for better results
       // regarding floating point precision.
       $scale = (int) $field['settings']['scale'];
@@ -408,11 +414,17 @@ function number_field_widget_form(&$form, &$form_state, $field, $instance, $lang
       break;
 
     case 'number_float':
+      $element['#min'] = -3.402823466E+38;
+      $element['#max'] = 3.402823466E+38;
       $element['#step'] = 'any';
       break;
+
+    case 'number_integer':
+      $element['#min'] = '-2147483647';
+      $element['#max'] = '2147483647';
   }
 
-  // Set minimum and maximum.
+  // Override the default minimum and maximum settings if configured.
   if (is_numeric($instance['settings']['min'])) {
     $element['#min'] = $instance['settings']['min'];
   }


### PR DESCRIPTION
Fixes [#6137](https://github.com/backdrop/backdrop-issues/issues/6137)

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
