### PR TITLE
Issue #1821902: Fixed false positives in recursive token check in _token_build_tree()

### DIFF
--- a/core/includes/token.inc
+++ b/core/includes/token.inc
@@ -609,7 +609,7 @@ function _token_build_tree($token_type, array $options, $parent_restricted = FAL
       // parent.
       $token_parents[] = $token_type;
     }
-    elseif (in_array($token, array_slice($token_parents, 1))) {
+    elseif (in_array($token, array_slice($token_parents, 1), TRUE)) {
       // Prevent duplicate recursive tokens. For example, this will prevent
       // the tree from generating the following tokens or deeper:
       // [comment:parent:parent]


### PR DESCRIPTION
Fixes [5014](https://github.com/backdrop/backdrop-issues/issues/5014)

Issue #1821902: Fixed false positives in recursive token check in `_token_build_tree()` for tokens that had a name of `'0'`.

See:
- https://www.drupal.org/i/1821902
- https://git.drupalcode.org/project/token/-/commit/d04c7b83e330f65aa5f6f91858d72f8098651c8a