### PR TITLE
Fixed tokens without a description value were treated as wrong.

### DIFF
--- a/core/includes/token.inc
+++ b/core/includes/token.inc
@@ -408,7 +408,7 @@ function token_get_token_problems() {
       'label' => t('The following tokens or token types are not defined as arrays:'),
     ),
     'missing-info' => array(
-      'label' => t('The following tokens or token types are missing required name and/or description information:'),
+      'label' => t('The following tokens or token types are missing required name information:'),
     ),
     'type-no-tokens' => array(
       'label' => t('The following token types do not have any tokens defined:'),
@@ -428,7 +428,7 @@ function token_get_token_problems() {
       $token_problems['not-array']['problems'][] = "\$info['types']['$type']";
       continue;
     }
-    elseif (!isset($type_info['name']) || !isset($type_info['description'])) {
+    elseif (!isset($type_info['name'])) {
       $token_problems['missing-info']['problems'][] = "\$info['types']['$type']";
     }
     elseif (empty($token_info['tokens'][$real_type])) {
@@ -448,7 +448,7 @@ function token_get_token_problems() {
           $token_problems['not-array']['problems'][] = "\$info['tokens']['$type']['$token']";
           continue;
         }
-        elseif (!isset($tokens[$token]['name']) || !isset($tokens[$token]['description'])) {
+        elseif (!isset($tokens[$token]['name'])) {
           $token_problems['missing-info']['problems'][] = "\$info['tokens']['$type']['$token']";
         }
         elseif (is_array($tokens[$token]['name']) || is_array($tokens[$token]['description'])) {

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -694,12 +694,11 @@ function _token_token_tree_format_row($token, array $token_info, $is_group = FAL
   $row['id'] = backdrop_clean_css_identifier($token);
   $row['data']['name']['data'] = $token_info['name'];
   $row['data']['name']['class'][] = 'token-name';
-  $token_description = isset($token_info['description']) ? '<span class="token-group-description">' . $token_info['description'] . '</span>' : '';
 
   if ($is_group) {
     // This is a token type/group.
     $row['class'][] = 'token-group';
-    $row['data']['token']['data'] = $token_description;
+    $row['data']['token']['data'] = isset($token_info['description']) ? '<span class="token-group-description">' . $token_description . '</span>' : '';
   }
   else {
     // This is a token.
@@ -711,7 +710,7 @@ function _token_token_tree_format_row($token, array $token_info, $is_group = FAL
     if (!empty($token_info['parent'])) {
       $row['parent'] = backdrop_clean_css_identifier($token_info['parent']);
     }
-    $row['data']['token']['data'] .= $token_description;
+    $row['data']['token']['data'] .= isset($token_info['description']) ? '<span class="token-description">' . $token_description . '</span>' : '';
   }
 
   return $row;

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -694,11 +694,12 @@ function _token_token_tree_format_row($token, array $token_info, $is_group = FAL
   $row['id'] = backdrop_clean_css_identifier($token);
   $row['data']['name']['data'] = $token_info['name'];
   $row['data']['name']['class'][] = 'token-name';
+  $token_description = isset($token_info['description']) ? '<span class="token-group-description">' . $token_info['description'] . '</span>' : '';
 
   if ($is_group) {
     // This is a token type/group.
     $row['class'][] = 'token-group';
-    $row['data']['token']['data'] = '<span class="token-group-description">' . $token_info['description'] . '</span>';
+    $row['data']['token']['data'] = $token_description;
   }
   else {
     // This is a token.
@@ -710,7 +711,7 @@ function _token_token_tree_format_row($token, array $token_info, $is_group = FAL
     if (!empty($token_info['parent'])) {
       $row['parent'] = backdrop_clean_css_identifier($token_info['parent']);
     }
-    $row['data']['token']['data'] .= '<span class="token-description">' . $token_info['description'] . '</span>';
+    $row['data']['token']['data'] .= $token_description;
   }
 
   return $row;

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -687,6 +687,7 @@ function _token_token_tree_format_row($token, array $token_info, $is_group = FAL
       'name' => array(),
       'token' => array(),
       'value' => '',
+      'description' => '',
     ),
   );
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5014

See: https://git.drupalcode.org/project/token/-/commit/2187bd6a59fbd9378671028ec57024789a13bbe9