### PR TITLE
Issue #5014: Soften token status report messages, split into individual items with different severity values.

### DIFF
--- a/core/includes/token.inc
+++ b/core/includes/token.inc
@@ -405,19 +405,24 @@ function token_get_token_problems() {
   $token_info = token_info();
   $token_problems = array(
     'not-array' => array(
-      'label' => t('The following tokens or token types are not defined as arrays:'),
+      'label' => t('Tokens or token types not defined as arrays'),
+      'severity' => REQUIREMENT_ERROR,
     ),
     'missing-info' => array(
-      'label' => t('The following tokens or token types are missing required name and/or description information:'),
+      'label' => t('Tokens or token types missing name property'),
+      'severity' => REQUIREMENT_WARNING,
     ),
     'type-no-tokens' => array(
-      'label' => t('The following token types do not have any tokens defined:'),
+      'label' => t('Token types do not have any tokens defined'),
+      'severity' => REQUIREMENT_INFO,
     ),
     'tokens-no-type' => array(
-      'label' => t('The following token types are not defined but have tokens:'),
+      'label' => t('Token types are not defined but have tokens'),
+      'severity' => REQUIREMENT_INFO,
     ),
     'duplicate' => array(
-      'label' => t('The following token or token types are defined by multiple modules:')
+      'label' => t('Token or token types are defined by multiple modules'),
+      'severity' => REQUIREMENT_ERROR,
     ),
   );
 
@@ -428,8 +433,11 @@ function token_get_token_problems() {
       $token_problems['not-array']['problems'][] = "\$info['types']['$type']";
       continue;
     }
-    elseif (!isset($type_info['name']) || !isset($type_info['description'])) {
+    elseif (!isset($type_info['name'])) {
       $token_problems['missing-info']['problems'][] = "\$info['types']['$type']";
+    }
+    elseif (is_array($type_info['name'])) {
+      $token_problems['duplicate']['problems'][] = "\$info['types']['$type']";
     }
     elseif (empty($token_info['tokens'][$real_type])) {
       $token_problems['type-no-tokens']['problems'][] = "\$info['tokens']['$real_type']";
@@ -448,10 +456,10 @@ function token_get_token_problems() {
           $token_problems['not-array']['problems'][] = "\$info['tokens']['$type']['$token']";
           continue;
         }
-        elseif (!isset($tokens[$token]['name']) || !isset($tokens[$token]['description'])) {
+        elseif (!isset($tokens[$token]['name'])) {
           $token_problems['missing-info']['problems'][] = "\$info['tokens']['$type']['$token']";
         }
-        elseif (is_array($tokens[$token]['name']) || is_array($tokens[$token]['description'])) {
+        elseif (is_array($tokens[$token]['name'])) {
           $token_problems['duplicate']['problems'][] = "\$info['tokens']['$type']['$token']";
         }
       }

--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -534,18 +534,12 @@ function system_requirements($phase) {
         $problems = array_unique($problem['problems']);
         $problems = array_map('check_plain', $problems);
         $token_problems[$problem_key] = $problem['label'] . theme('item_list', array('items' => $problems));
+        $requirements['token-' . $problem_key] = array(
+          'title' => $problem['label'],
+          'value' => theme('item_list', array('items' => $problems)),
+          'severity' => $problem['severity'],
+        );
       }
-      else {
-        unset($token_problems[$problem_key]);
-      }
-    }
-    if (!empty($token_problems)) {
-      $requirements['token_problems'] = array(
-        'title' => $t('Tokens'),
-        'value' => $t('Problems detected'),
-        'severity' => REQUIREMENT_WARNING,
-        'description' => '<p>' . implode('</p><p>', $token_problems) . '</p>',
-      );
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5014

See: https://git.drupalcode.org/project/token/-/commit/b189c11160e8ef4a517f3e749ac8ebb791c29a99

NOTE!!!: This includes some of the changes in https://github.com/backdrop/backdrop/pull/4488 (which is an earlier commit than this one here) - pay attention to not revert changes, depending on which PR gets merged first.

Example of a status warning before:
![image](https://github.com/backdrop/backdrop/assets/2423362/43438601-f188-453c-8695-c18950511dd2)

After this change it becomes an "info" message:
![image](https://github.com/backdrop/backdrop/assets/2423362/f9ae874a-bd4b-4924-b4f1-983cbdaff336)