### PR TITLE
Issue #2299039: Remove unused $sanitize variable from field_tokens().

### DIFF
--- a/core/modules/field/field.tokens.inc
+++ b/core/modules/field/field.tokens.inc
@@ -45,7 +45,6 @@ function field_token_info_alter(&$info) {
  */
 function field_tokens($type, $tokens, array $data = array(), array $options = array()) {
   $replacements = array();
-  $sanitize = !empty($options['sanitize']);
   $langcode = isset($options['language']) ? $options['language']->langcode : NULL;
 
   // Entity tokens.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5014

See:
- https://www.drupal.org/node/2299039
- https://git.drupalcode.org/project/token/-/commit/7695dd94eee9e12cc6f3c740742ea36b2aa959ab
