### PR TITLE
Issue #2485221: token_pre_render_field_token() parameter should not be passed by reference

### DIFF
--- a/core/modules/field/field.tokens.inc
+++ b/core/modules/field/field.tokens.inc
@@ -93,7 +93,7 @@ function field_tokens($type, $tokens, array $data = array(), array $options = ar
 /**
  * Pre-render callback for field output used with tokens.
  */
-function field_pre_render_token(&$elements) {
+function field_pre_render_token($elements) {
   // Remove the field theme hook, attachments, and JavaScript states.
   unset($elements['#theme']);
   unset($elements['#states']);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5014

See:
- https://www.drupal.org/node/2485221
- https://git.drupalcode.org/project/token/-/commit/4c39c41c481956b61433c63130c34eae69aaa20b