### PR TITLE
Issue #3192956: Fixed PHP 7.4 compatibility for the [array:value:*] token.

### DIFF
--- a/.cspell/backdrop.dic
+++ b/.cspell/backdrop.dic
@@ -468,6 +468,7 @@ timeentry
 timestep
 titleslogan
 Título
+tnid
 tnids
 todate
 tookit's

--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -950,6 +950,7 @@ class TokenArrayTestCase extends TokenTestHelper {
       'last' => 'b',
       'value:0' => 'a',
       'value:2' => 'c',
+      'value:#property' => NULL,
       'count' => 4,
       'keys' => '2, 0, 4, 1',
       'keys:value:3' => '1',

--- a/core/modules/system/system.tokens.inc
+++ b/core/modules/system/system.tokens.inc
@@ -477,7 +477,7 @@ function system_tokens($type, $tokens, array $data = array(), array $options = a
     // [array:value:*] dynamic tokens.
     if ($value_tokens = token_find_with_prefix($tokens, 'value')) {
       foreach ($value_tokens as $key => $original) {
-        if (substr($key, 0, 1) !== '#' && isset($array[$key])) {
+        if (array_key_exists($key, $array) && in_array($key, $keys)) {
           $replacements[$original] = token_render_array_value($array[$key], $options);
         }
       }


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#5013

See:
- https://www.drupal.org/node/3192956
- https://git.drupalcode.org/project/token/-/commit/bea4928e059deda192cbeca72544545e24482e40

This seems to have initially been addressed in Backdrop as part of the larger set of changes with backdrop/backdrop-issues#4308 in https://github.com/backdrop/backdrop/pull/3079/files#diff-152c7faef6b7bcac4ea1f73b0c918e0d9b84827e52daf07b2d8fec2a1cd16003L480, which seems to have used the earlier approach in https://www.drupal.org/project/token/issues/3192956#comment-14008045, which was then superseded by what was finally committed in the 7.x branch of the Token module.