### PR TITLE
Issue #6197: PHP 8.2 support for taxonomy vocabularies

### DIFF
--- a/core/modules/taxonomy/taxonomy_vocabulary.class.inc
+++ b/core/modules/taxonomy/taxonomy_vocabulary.class.inc
@@ -5,7 +5,7 @@
  * This class is responsible for saving and storing configuration files for
  * vocabularies.
  */
-class TaxonomyVocabulary {
+class TaxonomyVocabulary extends stdClass {
 
   /**
    * Human-readable of the vocabulary.

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -414,6 +414,21 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
     field_create_instance($instance);
   }
 
+  /**
+   * Test that adding properties via hook_taxonomy_vocabulary_load() works.
+   */
+  protected function testTaxonomyVocabularyLoadProp() {
+    module_enable(array('taxonomy_vocab_load_test'));
+    // Create two more vocabularies to load.
+    $this->createVocabulary();
+    $this->createVocabulary();
+
+    $vocabs = taxonomy_vocabulary_load_multiple(FALSE);
+    foreach ($vocabs as $name => $vocab) {
+      $this->assertTrue(!empty($vocab->dynamicProp), 'Dynamic property via load hook is set.');
+    }
+  }
+
 }
 
 /**

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -425,7 +425,9 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
 
     $vocabs = taxonomy_vocabulary_load_multiple(FALSE);
     foreach ($vocabs as $name => $vocab) {
-      $this->assertTrue(!empty($vocab->dynamicProp), 'Dynamic property via load hook is set.');
+      $this->assertTrue(!empty($vocab->dynamicProp), format_string('Dynamic property via load hook for vocabulary %vocab is set.', array(
+        '%vocab' => $name,
+      )));
     }
   }
 

--- a/core/modules/taxonomy/tests/taxonomy_vocab_load_test/taxonomy_vocab_load_test.info
+++ b/core/modules/taxonomy/tests/taxonomy_vocab_load_test/taxonomy_vocab_load_test.info
@@ -1,0 +1,7 @@
+name = Taxonomy vocabulary load test
+type = module
+description = Test for hook_taxonomy_vocabulary_load.
+package = Testing
+version = VERSION
+backdrop = 1.x
+hidden = TRUE

--- a/core/modules/taxonomy/tests/taxonomy_vocab_load_test/taxonomy_vocab_load_test.module
+++ b/core/modules/taxonomy/tests/taxonomy_vocab_load_test/taxonomy_vocab_load_test.module
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file
+ * Dummy module implementing hook_taxonomy_vocabulary_load().
+ */
+
+/**
+ * Implements hook_taxonomy_vocabulary_load().
+ */
+function taxonomy_vocab_load_test_taxonomy_vocabulary_load(array $vocabularies) {
+  foreach ($vocabularies as $vocabulary) {
+    // No condition, just a dynamic property with a random string.
+    $vocabulary->dynamicProp = backdrop_random_key(16);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6197

Step 1: add a test, that fails on 8.2