### PR TITLE
Issue #6235: PHP 8.1 Deprecated function Notice when passing NULL to trim()

### DIFF
--- a/core/modules/views/handlers/views_handler_field.inc
+++ b/core/modules/views/handlers/views_handler_field.inc
@@ -1195,7 +1195,7 @@ If you would like to have the characters \'[\' and \']\' please use the html ent
       $value = $this->render_altered($alter, $tokens);
     }
 
-    if (!empty($this->options['alter']['trim_whitespace'])) {
+    if (!is_null($value) && !empty($this->options['alter']['trim_whitespace'])) {
       $value = trim($value);
     }
 


### PR DESCRIPTION
Resolves https://github.com/backdrop/backdrop-issues/issues/6235