### PR TITLE
Issue #2074: Remove 'default' tag from views config (follow-up)

### DIFF
--- a/core/profiles/standard/config/views.view.promoted_cards.json
+++ b/core/profiles/standard/config/views.view.promoted_cards.json
@@ -2,7 +2,7 @@
     "_config_name": "views.view.promoted_cards",
     "name": "promoted_cards",
     "description": "Provides a block of 3 promoted Cards. Used by default on the home page.",
-    "tag": "default",
+    "tag": "",
     "disabled": false,
     "base_table": "node",
     "human_name": "Promoted cards",


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2074

Follow-up to https://github.com/backdrop/backdrop/pull/3364
