### PR TITLE
Issue #6272: PoC: Use PHP instead of JS for the dummy permission checkboxes

### DIFF
--- a/core/modules/user/js/user.permissions.js
+++ b/core/modules/user/js/user.permissions.js
@@ -97,13 +97,6 @@ Backdrop.behaviors.permissions = {
       // submitted form. If we'd automatically check existing checkboxes, the
       // permission table would be polluted with redundant entries. This
       // is deliberate, but desirable when we automatically check them.
-      var $dummy = $('<input type="checkbox" class="form-checkbox dummy-checkbox" disabled="disabled" checked="checked" />')
-        .attr('title', Backdrop.t("This permission is inherited from the authenticated user role."))
-        .hide();
-
-      $('input[type=checkbox]', this).not('.role-authenticated, .role-anonymous').addClass('real-checkbox').each(function () {
-        $dummy.clone().insertAfter(this);
-      });
 
       // Initialize the authenticated user checkbox.
       $table.on('click.permissions', 'input[type=checkbox].role-authenticated', function(e) {
@@ -117,21 +110,36 @@ Backdrop.behaviors.permissions = {
   },
 
   /**
-   * Toggles all dummy checkboxes based on the checkboxes' state.
+   * Toggles visibility of all dummy/real checkboxes.
    *
-   * If the "authenticated user" checkbox is checked, the checked and disabled
-   * checkboxes are shown, the real checkboxes otherwise.
+   * If the "authenticated user" checkbox is checked for a specific permission,
+   * the respective (checked and disabled) dummy checkboxes in the same row are
+   * shown, and the respective real checkboxes are hidden.
+   *
+   * If the "authenticated user" checkbox is unchecked, the dummy checkboxes are
+   * hidden, and the real checkboxes are shown.
    */
   toggle: function () {
     var authCheckbox = this, $row = $(this).closest('tr');
     // jQuery performs too many layout calculations for .hide() and .show(),
     // leading to a major page rendering lag on sites with many roles and
-    // permissions. Therefore, we toggle visibility directly.
+    // permissions. Therefore, we toggle visibility directly by adding/removing
+    // the 'element-hidden' CSS class.
     $row.find('.real-checkbox').each(function () {
-      this.style.display = (authCheckbox.checked ? 'none' : '');
+      if (authCheckbox.checked) {
+        $(this).addClass('element-hidden');
+      }
+      else {
+        $(this).removeClass('element-hidden');
+      }
     });
     $row.find('.dummy-checkbox').each(function () {
-      this.style.display = (authCheckbox.checked ? '' : 'none');
+      if (authCheckbox.checked) {
+        $(this).removeClass('element-hidden');
+      }
+      else {
+        $(this).addClass('element-hidden');
+      }
     });
   }
 };

--- a/core/modules/user/js/user.permissions.js
+++ b/core/modules/user/js/user.permissions.js
@@ -69,7 +69,36 @@ Backdrop.behaviors.permissionsFilter = {
 };
 
 /**
- * Shows checked and disabled checkboxes for inherited permissions.
+ * Shows dummy (checked and disabled) checkboxes for inherited permissions.
+ *
+ * When the checkbox for a specific permission for the "Authenticated" role is
+ * checked, the rest of the non-anonymous user roles inherit the same
+ * permission. We are indicating that visually by checking and "locking" the
+ * checkboxes for the same permission for the other roles in the same row on
+ * the permissions table (with the exception of the respective checkbox for the
+ * "Anonymous" role).
+ *
+ * When a permission is inherited that way, instead of checking/unchecking the
+ * real checkboxes of the same permission for other user roles, we are visually
+ * toggling between real and "dummy" checkboxes. The dummy checkboxes:
+ * - always have their 'checked' attribute set.
+ * - are always locked via the 'disabled' attribute, so that they cannot be
+ *   manually checked/unchecked.
+ * - do not have a 'name' attribute set, so their values are not being submitted
+ *   with the form.
+ *
+ * If we'd automatically check the actual/real checkboxes, the respective
+ * permissions would be saved in the configuration files of the user roles,
+ * which is not desired (inheritance of a permission is done by checking whether
+ * that permission has been granted to the "Authenticated" role - not by
+ * checking whether the permission has been explicitly granted).
+ *
+ * Because we are not altering the value of the actual checkboxes during form
+ * submission (we are simply visually showing/hiding them on the table), we are
+ * not "polluting" configuration files of user roles with any permissions that
+ * have not been explicitly granted to them. That way, permissions are only
+ * retained in configuration if they have been previously explicitly granted (as
+ * opposed to being inherited by the "Authenticated" role).
  */
 Backdrop.behaviors.permissions = {
   attach: function (context) {
@@ -91,12 +120,6 @@ Backdrop.behaviors.permissions = {
         method = 'append';
       }
       $table.detach();
-
-      // Create dummy checkboxes. We use dummy checkboxes instead of reusing
-      // the existing checkboxes here because new checkboxes don't alter the
-      // submitted form. If we'd automatically check existing checkboxes, the
-      // permission table would be polluted with redundant entries. This
-      // is deliberate, but desirable when we automatically check them.
 
       // Initialize the authenticated user checkbox.
       $table.on('click.permissions', 'input[type=checkbox].role-authenticated', function(e) {

--- a/core/modules/user/js/user.permissions.js
+++ b/core/modules/user/js/user.permissions.js
@@ -111,13 +111,6 @@ Backdrop.behaviors.permissions = {
 
   /**
    * Toggles visibility of all dummy/real checkboxes.
-   *
-   * If the "authenticated user" checkbox is checked for a specific permission,
-   * the respective (checked and disabled) dummy checkboxes in the same row are
-   * shown, and the respective real checkboxes are hidden.
-   *
-   * If the "authenticated user" checkbox is unchecked, the dummy checkboxes are
-   * hidden, and the real checkboxes are shown.
    */
   toggle: function () {
     var authCheckbox = this, $row = $(this).closest('tr');
@@ -125,22 +118,28 @@ Backdrop.behaviors.permissions = {
     // leading to a major page rendering lag on sites with many roles and
     // permissions. Therefore, we toggle visibility directly by adding/removing
     // the 'element-hidden' CSS class.
-    $row.find('.real-checkbox').each(function () {
-      if (authCheckbox.checked) {
+    if (authCheckbox.checked) {
+      // If the "authenticated user" checkbox is checked for a specific
+      // permission, hide the respective real checkboxes in the same row...
+      $row.find('.real-checkbox').each(function () {
         $(this).addClass('element-hidden');
-      }
-      else {
+      });
+      // ...and show the respective (checked and disabled) dummy checkboxes.
+      $row.find('.dummy-checkbox').each(function () {
         $(this).removeClass('element-hidden');
-      }
-    });
-    $row.find('.dummy-checkbox').each(function () {
-      if (authCheckbox.checked) {
+      });
+    }
+    else {
+      // If the "authenticated user" checkbox is unchecked, show the real
+      // checkboxes in the same row...
+      $row.find('.real-checkbox').each(function () {
         $(this).removeClass('element-hidden');
-      }
-      else {
+      });
+      // ...and hide the dummy checkboxes.
+      $row.find('.dummy-checkbox').each(function () {
         $(this).addClass('element-hidden');
-      }
-    });
+      });
+    }
   }
 };
 

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1351,7 +1351,14 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   function setUp() {
     parent::setUp();
 
-    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'access user profiles', 'administer site configuration', 'administer account settings', 'administer content types', 'administer modules'));
+    $this->admin_user = $this->backdropCreateUser(array(
+      'administer permissions',
+      'access user profiles',
+      'administer site configuration',
+      'administer account settings',
+      'administer content types',
+      'administer modules',
+    ));
     $this->editor_user = $this->backdropCreateUser(array('access content'));
 
     // Find the new role names.
@@ -1441,7 +1448,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     $this->backdropGet('admin/structure/types/add');
     $this->assertRaw(t('The %admin and %editor roles have been assigned permissions to create, edit, and delete content of this type.', array(
       '%admin' => $this->admin_role_name,
-      '%editor' => $this->editor_role_name
+      '%editor' => $this->editor_role_name,
     )));
     // Opposite of the above assertNoFieldByXPath(), confirm that there are at
     // least some permission checkboxes checked.
@@ -1554,7 +1561,7 @@ class UserAdminTestCase extends BackdropWebTestCase {
     $this->assertNoText($user_b->name, 'User B not on filtered by role on admin users page');
     $this->assertText($user_c->name, 'User C on filtered by role on admin users page');
 
-    // Test blocking of a user.
+    // Test blocking a user account.
     $user_c = user_load($user_c->uid, TRUE);
     $this->assertEqual($user_c->status, 1, 'User C not blocked');
 
@@ -1569,16 +1576,18 @@ class UserAdminTestCase extends BackdropWebTestCase {
     $status_result = $this->xpath('//form[@id="views-form-user-admin-page"]//tr[last()]//td[position()=3]');
     $this->assertEqual(trim($status_result[0]), 'Blocked', 'User C blocked');
 
-    // Test unblocking of a user from /admin/people page and sending of activation mail
-    $editunblock = array();
-    $editunblock['action'] = 'user_unblock_user_action';
-    $editunblock[$user_c_checkbox] = TRUE;
-    $this->backdropPost('admin/people', $editunblock, t('Execute'), array('query' => array('order' => 'created', 'sort' => 'asc')));
+    // Test unblocking a user account via the /admin/people page and sending the
+    // activation mail.
+    $edit_unblock = array();
+    $edit_unblock['action'] = 'user_unblock_user_action';
+    $edit_unblock[$user_c_checkbox] = TRUE;
+    $this->backdropPost('admin/people', $edit_unblock, t('Execute'), array('query' => array('order' => 'created', 'sort' => 'asc')));
     $status_result = $this->xpath('//form[@id="views-form-user-admin-page"]//tr[last()]//td[position()=3]');
     $this->assertEqual(trim($status_result[0]), 'Active', 'User C unblocked');
     $this->assertMail("to", $user_c->mail, "Activation mail sent to user C");
 
-    // Test blocking and unblocking another user from /user/[uid]/edit form and sending of activation mail
+    // Test blocking and unblocking another user account via the
+    // /user/[uid]/edit form and sending the activation mail.
     $user_d = $this->backdropCreateUser(array());
     $account1 = user_load($user_d->uid, TRUE);
     $this->backdropPost('user/' . $account1->uid . '/edit', array('status' => 0), t('Save'));
@@ -2312,7 +2321,11 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
 
   function setUp() {
     parent::setUp();
-    $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'administer users', 'assign roles'));
+    $this->admin_user = $this->backdropCreateUser(array(
+      'administer permissions',
+      'administer users',
+      'assign roles',
+    ));
   }
 
   /**

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -1426,7 +1426,10 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
     // assigned on new content types.
     $this->backdropGet('admin/structure/types/add');
     $this->assertRaw(t('No permissions assigned for this content type. Content of this type may not be able to be created, updated or deleted until permissions have been configured appropriately.'));
-    $this->assertNoFieldByXPath("//table[@id='permissions']//input[@checked]");
+    // We are only looking for checked permission checkboxes that aren't dummy.
+    // Dummy permission checkboxes are always checked (but visually hidden by
+    // default), but we can exclude them by their 'dummy-checkbox' class.
+    $this->assertNoFieldByXPath("//table[@id='permissions']//input[not(contains(@class, 'dummy-checkbox')) and @checked]");
 
     // Set both an admin role and editor role.
     $edit = array();

--- a/core/modules/user/user.theme.inc
+++ b/core/modules/user/user.theme.inc
@@ -132,6 +132,7 @@ function theme_user_admin_permissions($variables) {
       $permission_text = '<div class="permission-name table-filter-text-source">' . $form['permission'][$key]['#markup'] . '</div>';
       $permission_text .= $form['permission'][$key]['#description'];
 
+      $row['class'] = array('permission-row');
       $row['data'][] = array(
         'data' => $permission_text,
         'class' => array('permission', 'table-filter-text'),
@@ -140,6 +141,27 @@ function theme_user_admin_permissions($variables) {
       foreach (element_children($form['checkboxes']) as $role_name) {
         $form['checkboxes'][$role_name][$key]['#title'] = $roles[$role_name] . ': ' . $form['permission'][$key]['#markup'];
         $form['checkboxes'][$role_name][$key]['#title_display'] = 'attribute';
+        if (!in_array($role_name, array('anonymous', 'authenticated'))) {
+          $form['checkboxes'][$role_name][$key]['#attributes']['class'][] = 'real-checkbox';
+
+          $dummy_checkbox = array(
+            '#type' => 'checkbox',
+            '#title' => t('This permission is inherited from the authenticated user role.'),
+            '#title_display' => 'attribute',
+            '#disabled' => TRUE,
+            // '#post_render' => ???,
+            // Remove the entire wrapper <div> around the dummy checkbox.
+            '#theme_wrappers' => array(),
+            '#attributes' => array(
+              // Dummy checkboxes are hidden by default.
+              'class' => array('dummy-checkbox', 'element-hidden'),
+              'disabled' => TRUE,
+              'checked' => TRUE,
+            ),
+          );
+          $form['checkboxes'][$role_name][$key]['#field_suffix'] = backdrop_render($dummy_checkbox);
+        }
+
         $row['data'][] = array(
           'data' => backdrop_render($form['checkboxes'][$role_name][$key]),
           'class' => array('checkbox'),
@@ -148,11 +170,16 @@ function theme_user_admin_permissions($variables) {
     }
     $rows[] = $row;
   }
-  $header[] = (t('Permission'));
+
+  $header = array();
+  $header[] = array(
+    'data' => t('Permission'),
+    'class' => array('permission-module-column'),
+  );
   foreach (element_children($form['role_names']) as $role_name) {
     $header_cell = array(
       'data' => backdrop_render($form['role_names'][$role_name]),
-      'class' => array('checkbox'),
+      'class' => array('role-checkboxes-column'),
     );
     // Output a role description if present as a title attribute on the cell.
     if (isset($form['role_names'][$role_name]['#description'])) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6272