### PR TITLE
Issue #6288: In user_register_form(), use the value of $admin instead of calling again user_access('administer users')

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -3231,7 +3231,7 @@ function user_register_form($form, &$form_state) {
   elseif (isset($_SERVER['HTTP_REFERER'])) {
     $path = $_SERVER['HTTP_REFERER'];
   }
-  elseif (user_access('administer users')) {
+  elseif ($admin) {
     $path = 'admin/people';
   }
   else {

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1625,7 +1625,8 @@ function user_menu_alter(&$items) {
  */
 function user_admin_bar_output_alter(&$content) {
   // Admin menu shows both the parent menu item and its children.
-  // Remove the duplicate child element so "Manage fields" doesn't show up twice.
+  // Remove the duplicate child element, so "Manage fields" doesn't show up
+  // twice.
   unset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage']['admin/config/people/manage/fields']);
 }
 

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -1625,7 +1625,7 @@ function user_menu_alter(&$items) {
  */
 function user_admin_bar_output_alter(&$content) {
   // Admin menu shows both the parent menu item and its children.
-  // Remove the duplicate child element, so "Manage fields" doesn't show up
+  // Remove the duplicate child element so "Manage fields" doesn't show up
   // twice.
   unset($content['menu']['menu']['admin/config']['admin/config/people']['admin/config/people/manage']['admin/config/people/manage/fields']);
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6288

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
