### PR TITLE
Issue #6300: Lonely comma is inserted in date popup field after failing validation

### DIFF
--- a/core/modules/date/date.elements.inc
+++ b/core/modules/date/date.elements.inc
@@ -1251,8 +1251,9 @@ function date_popup_validate($element, &$form_state) {
   }
 
   // If the created date is valid, set it.
-  $value = date_is_date($date) ? $date->format(DATE_FORMAT_DATETIME) : NULL;
-  form_set_value($element, $value, $form_state);
+  if (date_is_date($date)) {
+    form_set_value($element, $date->format(DATE_FORMAT_DATETIME), $form_state);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6300

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
