### PR TITLE
Issue #214: Deprecated 'browsers' option for adding CSS/JS.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -3475,10 +3475,12 @@ function backdrop_css_defaults($data = NULL) {
  *     styles will be aggregated and compressed. Defaults to TRUE.
  *   - 'browsers': An array containing information specifying which browsers
  *     should load the CSS item. See backdrop_pre_render_conditional_comments()
- *     for details.
+ *     for details. This option is deprecated and no longer has an effect.
  *
- * @return
+ * @return array
  *   An array of queued cascading stylesheets.
+ *
+ * @since 1.27.0 The 'browsers' option is deprecated.
  *
  * @see backdrop_get_css()
  */
@@ -4618,12 +4620,15 @@ function backdrop_region_class($region) {
  *     file will be aggregated. Defaults to TRUE.
  *   - browsers: An array containing information specifying which browsers
  *     should load the JavaScript item. See
- *     backdrop_pre_render_conditional_comments() for details.
+ *     backdrop_pre_render_conditional_comments() for details. This option is
+ *     deprecated and no longer has an effect.
  *
- * @return
+ * @return array
  *   The current array of JavaScript files, settings, and in-line code,
  *   including Backdrop defaults, anything previously added with calls to
  *   backdrop_add_js(), and this function call's additions.
+ *
+ * @since 1.27.0 The 'browsers' option is deprecated.
  *
  * @see backdrop_get_js()
  */
@@ -6378,33 +6383,24 @@ function backdrop_system_listing($mask, $directory, $key = 'name', $min_depth = 
 }
 
 /**
- * Pre-render callback: Renders #browsers into #prefix and #suffix.
+ * Pre-render callback: Provides backwards-compatibility for #browsers property.
  *
  * @param $elements
- *   A render array with a '#browsers' property. The '#browsers' property can
- *   contain any or all of the following keys:
- *   - 'IE': If FALSE, the element is not rendered by Internet Explorer. If
- *     TRUE, the element is rendered by Internet Explorer. Can also be a string
- *     containing an expression for Internet Explorer to evaluate as part of a
- *     conditional comment. For example, this can be set to 'lt IE 7' for the
- *     element to be rendered in Internet Explorer 6, but not in Internet
- *     Explorer 7 or higher. Defaults to TRUE.
- *   - '!IE': If FALSE, the element is not rendered by browsers other than
- *     Internet Explorer. If TRUE, the element is rendered by those browsers.
- *     Defaults to TRUE.
- *   Examples:
- *   - To render an element in all browsers, '#browsers' can be left out or set
- *     to array('IE' => TRUE, '!IE' => TRUE).
- *   - To render an element in Internet Explorer only, '#browsers' can be set
- *     to array('!IE' => FALSE).
- *   - To render an element in Internet Explorer 6 only, '#browsers' can be set
- *     to array('IE' => 'lt IE 7', '!IE' => FALSE).
- *   - To render an element in Internet Explorer 8 and higher and in all other
- *     browsers, '#browsers' can be set to array('IE' => 'gte IE 8').
+ *   A render array with a '#browsers' property. This property formerly provided
+ *   the ability target IE vs. non-IE browsers. However, it no longer provides
+ *   this functionality as this has not been supported since IE10. Now if the
+ *   '#browsers' property is set it will do one of the following:
+ *   - '!IE': If TRUE, the element will be returned with no modifications.
+ *     If FALSE, the element will not be rendered at all.
+ *    - 'IE': Any value passed in this key will be ignored.
  *
- * @return
- *   The passed-in element with markup for conditional comments potentially
- *   added to '#prefix' and '#suffix'.
+ * @return array
+ *   A placeholder array for IE-specific files, or the unmodified element if
+ *   this element would render in any non-IE browser.
+ *
+ * @deprecated Since 1.27.0
+ *
+ * @since 1.27.0 Conditional comments are no longer rendered.
  */
 function backdrop_pre_render_conditional_comments($elements) {
   $browsers = isset($elements['#browsers']) ? $elements['#browsers'] : array();
@@ -6413,41 +6409,12 @@ function backdrop_pre_render_conditional_comments($elements) {
     '!IE' => TRUE,
   );
 
-  // If rendering in all browsers, no need for conditional comments.
-  if ($browsers['IE'] === TRUE && $browsers['!IE']) {
-    return $elements;
-  }
-
-  // Determine the conditional comment expression for Internet Explorer to
-  // evaluate.
-  if ($browsers['IE'] === TRUE) {
-    $expression = 'IE';
-  }
-  elseif ($browsers['IE'] === FALSE) {
-    $expression = '!IE';
-  }
-  else {
-    $expression = $browsers['IE'];
-  }
-
-  // Wrap the element's potentially existing #prefix and #suffix properties with
-  // conditional comment markup. The conditional comment expression is evaluated
-  // by Internet Explorer only. To control the rendering by other browsers,
-  // either the "downlevel-hidden" or "downlevel-revealed" technique must be
-  // used. See http://en.wikipedia.org/wiki/Conditional_comment for details.
-  $elements += array(
-    '#prefix' => '',
-    '#suffix' => '',
-  );
-  if (!$browsers['!IE']) {
-    // "downlevel-hidden".
-    $elements['#prefix'] = "\n<!--[if $expression]>\n" . $elements['#prefix'];
-    $elements['#suffix'] .= "<![endif]-->\n";
-  }
-  else {
-    // "downlevel-revealed".
-    $elements['#prefix'] = "\n<!--[if $expression]><!-->\n" . $elements['#prefix'];
-    $elements['#suffix'] .= "<!--<![endif]-->\n";
+  // If not allowed to output to non-IE browsers, suppress the element entirely.
+  if ($browsers['!IE'] === FALSE) {
+    return array(
+      '#type' => NULL,
+      '#value' => 'Element removed, the "browsers" property targeting only IE browsers is no longer supported.',
+    );
   }
 
   return $elements;

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1473,22 +1473,30 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   }
 
   /**
-   * Test adding JavaScript within conditional comments.
+   * Test deprecated conditional comments are no longer output.
+   *
+   * Since Backdrop 1.27.0, the "browsers" option for backdrop_add_js() and
+   * backdrop_add_css() no longer outputs conditional comments, because
+   * conditional comments only work on IE 4-10 (which is completely
+   * unsupported). The "browsers" attribute still exists to prevent IE-only
+   * files from suddenly appearing on existing sites.
    *
    * @see backdrop_pre_render_conditional_comments()
    */
-  function testBrowserConditionalComments() {
+  function testDeprecatedBrowserConditionalComments() {
     $default_query_string = state_get('css_js_query_string', '0');
 
     backdrop_add_js('core/misc/collapse.js', array('browsers' => array('IE' => 'lte IE 8', '!IE' => FALSE)));
     backdrop_add_js('jQuery(function () { });', array('type' => 'inline', 'browsers' => array('IE' => FALSE)));
     $javascript = backdrop_get_js();
 
-    $expected_1 = "<!--[if lte IE 8]>\n" . '<script src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>' . "\n<![endif]-->";
-    $expected_2 = "<!--[if !IE]><!-->\n" . '<script>jQuery(function () { });</script>' . "\n<!--<![endif]-->";
+    $expected_1 = '<script src="' . file_create_url('core/misc/collapse.js') . '?' . $default_query_string . '"></script>';
+    $expected_2 = '<script>jQuery(function () { });</script>';
 
-    $this->assertTrue(strpos($javascript, $expected_1) > 0, t('Rendered JavaScript within downlevel-hidden conditional comments.'));
-    $this->assertTrue(strpos($javascript, $expected_2) > 0, t('Rendered JavaScript within downlevel-revealed conditional comments.'));
+    $this->assertTrue(strpos($javascript, $expected_1) === FALSE, 'IE-only browser file not output at all.');
+    $this->assertTrue(strpos($javascript, '<!--[if lte IE 8]>') === FALSE, 'IE conditional comment output is suppressed.');
+    $this->assertTrue(strpos($javascript, $expected_2) > 0, 'Browsers except IE file output directly with no conditional comments.');
+    $this->assertTrue(strpos($javascript, '<!--[if !IE]>') === FALSE, 'Not-IE conditional comment output is suppressed.');
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/214 (partially). This deprecates but does not remove the `'browsers` option for `backdrop_add_js()`, `backdrop_add_css()` and render elements.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
