### PR TITLE
Issue 6311. Remove config info for date.settings

### DIFF
--- a/core/modules/date/date.module
+++ b/core/modules/date/date.module
@@ -644,10 +644,6 @@ function date_field_widget_properties_alter(&$widget, $context) {
  * Implements hook_config_info().
  */
 function date_config_info() {
-  $prefixes['date.settings'] = array(
-    'label' => t('Date settings'),
-    'group' => t('Configuration'),
-  );
   $prefixes['date_views.settings'] = array(
     'label' => t('Date views settings'),
     'group' => t('Configuration'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6311