### PR TITLE
Issue 6347. Avoid creating a CKE5 editor if it already exists in the page.

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -5,8 +5,7 @@
   Backdrop.editors.ckeditor5 = {
 
     attach: function (element, format) {
-      // Bail out if the editor already exists in the page; for example, when
-      // this attach method is called after an ajax request.
+      // Bail out if the editor has already been attached to the element.
       if (typeof element.ckeditor5AttachedEditor != 'undefined') {
         return;
       }

--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -5,6 +5,12 @@
   Backdrop.editors.ckeditor5 = {
 
     attach: function (element, format) {
+      // Bail out if the editor already exists in the page; for example, when
+      // this attach method is called after an ajax request.
+      if (typeof element.ckeditor5AttachedEditor != 'undefined') {
+        return;
+      }
+
       if (!$('#ckeditor5-modal').length) {
         $('<div id="ckeditor5-modal" />').hide().appendTo('body');
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6347