### PR TITLE
Issue 6348. Use not identical rather than not equal to compare config files

### DIFF
--- a/core/modules/config/config.admin.inc
+++ b/core/modules/config/config.admin.inc
@@ -520,7 +520,7 @@ function config_get_statuses() {
         try {
           $active_config = $active_storage->read($filename);
           $staging_config = $staging_storage->read($filename);
-          if ($active_config != $staging_config) {
+          if ($active_config !== $staging_config) {
             $config_statuses[$filename] = 'update';
           }
         }

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -540,6 +540,34 @@ class ConfigurationUITest extends BackdropWebTestCase {
   }
 
   /**
+   * Test comparing configs whose elements are in different order.
+   */
+  public function testConfigOrderChange() {
+    $config_name = 'foo.bar';
+    $content = array(
+      0 => 'Foo',
+      1 => 'Bar',
+    );
+    $config = config($config_name);
+    $config->setData($content);
+    $config->save();
+
+    // Copy all configuration to staging before modification.
+    $this->copyConfig('active', 'staging');
+
+    // Reverse the content of the array.
+    krsort($content);
+
+    // Store the config to staging.
+    $staging_storage = new ConfigFileStorage(config_get_config_directory('staging'));
+    $staging_storage->write($config_name, $content);
+
+    // Verify that the file appears as ready to import.
+    $this->backdropGet('admin/config/development/configuration');
+    $this->assertText($config_name, 'The configuration name appears in the list of changed configurations.');
+  }
+
+  /**
    * Copies configuration objects from source storage to target storage.
    *
    * @param string $source

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -545,8 +545,8 @@ class ConfigurationUITest extends BackdropWebTestCase {
   public function testConfigOrderChange() {
     $config_name = 'foo.bar';
     $content = array(
-      0 => 'Foo',
-      1 => 'Bar',
+      'a' => 'Foo',
+      'b' => 'Bar',
     );
     $config = config($config_name);
     $config->setData($content);
@@ -558,9 +558,9 @@ class ConfigurationUITest extends BackdropWebTestCase {
     // Reverse the content of the array.
     krsort($content);
 
-    // Store the config to staging.
-    $staging_storage = new ConfigFileStorage(config_get_config_directory('staging'));
-    $staging_storage->write($config_name, $content);
+    // Store the reversed config.
+    $config->setData($content);
+    $config->save();
 
     // Verify that the file appears as ready to import.
     $this->backdropGet('admin/config/development/configuration');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6348