### PR TITLE
Issue #6359: Load ImageUtils when backdropLink button is used in CKEditor 5 toolbar.

### DIFF
--- a/core/modules/ckeditor5/ckeditor5.module
+++ b/core/modules/ckeditor5/ckeditor5.module
@@ -743,7 +743,11 @@ function ckeditor5_ckeditor5_plugins() {
         'required_html' => array('<a href target class title rel data-file-id>'),
         // Include a dependency on ImageUtils to help detect linked images, even
         // if the backdropImage button is not enabled.
-        'plugin_dependencies' => array('link.Link', 'link.LinkUI', 'image.ImageUtils'),
+        'plugin_dependencies' => array(
+          'link.Link',
+          'link.LinkUI',
+          'image.ImageUtils',
+        ),
       ),
     ),
     'library' => array('ckeditor5', 'backdrop.ckeditor5.backdrop-link'),

--- a/core/modules/ckeditor5/ckeditor5.module
+++ b/core/modules/ckeditor5/ckeditor5.module
@@ -741,7 +741,9 @@ function ckeditor5_ckeditor5_plugins() {
         // @todo: The id attribute is being flagged as disallowed by core's
         // blocking of on* attributes. It should be included here.
         'required_html' => array('<a href target class title rel data-file-id>'),
-        'plugin_dependencies' => array('link.Link', 'link.LinkUI'),
+        // Include a dependency on ImageUtils to help detect linked images, even
+        // if the backdropImage button is not enabled.
+        'plugin_dependencies' => array('link.Link', 'link.LinkUI', 'image.ImageUtils'),
       ),
     ),
     'library' => array('ckeditor5', 'backdrop.ckeditor5.backdrop-link'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6359

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
