### PR TITLE
Issue #6370: DatabaseConnection_mysql::$utf8mb4Supported is never initialized

### DIFF
--- a/core/includes/database/mysql/database.inc
+++ b/core/includes/database/mysql/database.inc
@@ -379,9 +379,11 @@ class DatabaseConnection_mysql extends DatabaseConnection {
       $this->query("CREATE TABLE {backdrop_utf8mb4_test} (id VARCHAR(255), PRIMARY KEY(id(255))) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci ROW_FORMAT=DYNAMIC ENGINE=INNODB");
     }
     catch (Exception $e) {
+      $this->utf8mb4Supported = FALSE;
       return FALSE;
     }
     $this->query("DROP TABLE IF EXISTS {backdrop_utf8mb4_test}");
+    $this->utf8mb4Supported = TRUE;
     return TRUE;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6370

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
