### PR TITLE
Issue #6371: The autop filter should not add br tags before closing heading tags.

### DIFF
--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -1950,7 +1950,7 @@ function filter_filter_info() {
     'settings callback' => '_filter_html_settings',
     'allowed html callback' => '_filter_html_allowed_html',
     'default settings' => array(
-      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h3> <h4> <h5> <p> <img> <figure> <figcaption>',
+      'allowed_html' => '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h3> <h4> <h5> <p> <br> <img> <figure> <figcaption>',
       'filter_html_help' => 1,
       'filter_html_nofollow' => 0,
     ),

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -2502,6 +2502,7 @@ function _filter_autop($text) {
       }
     }
     elseif (!$ignore) {
+      $chunk = preg_replace('|<br>|', '<br />', $chunk); // Normalize break tags for consistency in matching
       $chunk = preg_replace('|\n*$|', '', $chunk) . "\n\n"; // just to make things a little easier, pad the end
       $chunk = preg_replace('|<br />\s*<br />|', "\n\n", $chunk);
       $chunk = preg_replace('!(<' . $block . '[^>]*>)!', "\n$1", $chunk); // Space things out a little
@@ -2517,7 +2518,7 @@ function _filter_autop($text) {
       $chunk = preg_replace('!(</?' . $block . '[^>]*>)\s*</p>!', "$1", $chunk);
       $chunk = preg_replace('|(?<!<br />)\s*\n|', "<br />\n", $chunk); // make line breaks
       $chunk = preg_replace('!(</?' . $block . '[^>]*>)\s*<br />!', "$1", $chunk);
-      $chunk = preg_replace('!<br />(\s*</?(?:p|li|div|th|pre|td|ul|ol|h[1-6])>)!', '$1', $chunk);
+      $chunk = preg_replace('!<br />(\s*</?(?:p|li|div|th|pre|td|ul|ol|h[1-6])>)!', '$1', $chunk); // Remove added break tags before closing block tags
       $chunk = preg_replace('/&([^#])(?![A-Za-z0-9]{1,8};)/', '&amp;$1', $chunk);
     }
     $output .= $chunk;

--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -2517,7 +2517,7 @@ function _filter_autop($text) {
       $chunk = preg_replace('!(</?' . $block . '[^>]*>)\s*</p>!', "$1", $chunk);
       $chunk = preg_replace('|(?<!<br />)\s*\n|', "<br />\n", $chunk); // make line breaks
       $chunk = preg_replace('!(</?' . $block . '[^>]*>)\s*<br />!', "$1", $chunk);
-      $chunk = preg_replace('!<br />(\s*</?(?:p|li|div|th|pre|td|ul|ol)>)!', '$1', $chunk);
+      $chunk = preg_replace('!<br />(\s*</?(?:p|li|div|th|pre|td|ul|ol|h[1-6])>)!', '$1', $chunk);
       $chunk = preg_replace('/&([^#])(?![A-Za-z0-9]{1,8};)/', '&amp;$1', $chunk);
     }
     $output .= $chunk;

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -1062,6 +1062,14 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
         "<p>\n    indented line<br />\n    second indented line<br />\n</p>" => FALSE,
         "<p>\n    indented line\n    second indented line\n</p>" => FALSE,
       ),
+      // Check that manually added <br> tags at end of lines don't duplicate
+      // another <br /> tag after them. Line breaks are normalized from <br>
+      // to <br /> as part of this filter.
+      "<p>\n    line before break<br>\n    line after break</p>" => array(
+        "<p>\n    line before break<br />\n    line after break</p>"  => TRUE,
+        "<p>\n    line before break<br><br />\n    line after break</p>"  => FALSE,
+        "<p>\n    line before break<br /><br />\n    line after break</p>"  => FALSE,
+      ),
     );
     $this->assertFilteredString($filter, $tests);
 

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -1048,6 +1048,20 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
       "<iframe>aaa</iframe>\n\n" => array(
         "<p><iframe>aaa</iframe></p>" => FALSE,
       ),
+      // Check that tags that close on a separate line do not get an extra
+      // <br /> before the closing tag. This is the default formatting output by
+      // CKEditor 5 in Backdrop.
+      "<h3>\n    indented line\n</h3>" => array(
+        "<h3>\n    indented line\n</h3>" => TRUE,
+        "<h3>\n    indented line<br />\n</h3>" => FALSE,
+      ),
+      // Check that new lines within block elements have <br /> tags added, but
+      // not before the closing tag on a new line.
+      "<p>\n    indented line\n    second indented line\n</p>" => array(
+        "<p>\n    indented line<br />\n    second indented line\n</p>" => TRUE,
+        "<p>\n    indented line<br />\n    second indented line<br />\n</p>" => FALSE,
+        "<p>\n    indented line\n    second indented line\n</p>" => FALSE,
+      ),
     );
     $this->assertFilteredString($filter, $tests);
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6371

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
