### PR TITLE
Issue #6374: Flush the layout path cache when toggling the theme for content edit

### DIFF
--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2667,7 +2667,7 @@ function node_form_system_themes_admin_form_submit($form, &$form_state) {
   config_set('system.core', 'node_admin_theme', $form_state['values']['node_admin_theme']);
   // The default and admin layout are tied directly to this setting, so clear
   // the Layout cache.
-  layout_reset_caches()
+  layout_reset_caches();
 }
 
 /**

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2665,7 +2665,9 @@ function node_form_system_themes_admin_form_alter(&$form, &$form_state, $form_id
  */
 function node_form_system_themes_admin_form_submit($form, &$form_state) {
   config_set('system.core', 'node_admin_theme', $form_state['values']['node_admin_theme']);
-  cache('layout_path')->flush();
+  // The default and admin layout are tied directly to this setting, so clear
+  // the Layout cache.
+  layout_reset_caches()
 }
 
 /**

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -2665,6 +2665,7 @@ function node_form_system_themes_admin_form_alter(&$form, &$form_state, $form_id
  */
 function node_form_system_themes_admin_form_submit($form, &$form_state) {
   config_set('system.core', 'node_admin_theme', $form_state['values']['node_admin_theme']);
+  cache('layout_path')->flush();
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6374