### PR TITLE
Issue #6384: Make alignment of linked captioned images work regardless of filter order

### DIFF
--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -2670,6 +2670,11 @@ function _filter_image_align($text) {
       if ($parent && $parent->nodeName === 'figure') {
         $target = $parent;
       }
+      // Consider more deeply nested structures. A link wrapped around a
+      // captioned image.
+      elseif ($parent && $parent->nodeName === 'a' && $parent->parentNode && $parent->parentNode->nodeName === 'figure') {
+        $target = $parent->parentNode;
+      }
       else {
         $target = $node;
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6384