### PR TITLE
Isse #6406: Deprecated function: str_replace(): Passing null to parameter #3

### DIFF
--- a/core/modules/date/views/date_views_filter_handler_simple.inc
+++ b/core/modules/date/views/date_views_filter_handler_simple.inc
@@ -114,7 +114,9 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
         return str_replace(' ', 'T', $this->date_default_value($prefix));
       }
       elseif (isset($this->options['expose']['identifier']) && !isset($_GET[$this->options['expose']['identifier']])) {
-        return str_replace(' ', 'T', $this->date_default_value($prefix));
+        if ($this->date_default_value($prefix) != NULL) {
+          return str_replace(' ', 'T', $this->date_default_value($prefix));
+        }
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6406