### PR TITLE
Issue 6410. Add node/%/translate as a contextual link.

### DIFF
--- a/core/modules/translation/translation.module
+++ b/core/modules/translation/translation.module
@@ -35,6 +35,7 @@ function translation_menu() {
     'access callback' => '_translation_tab_access',
     'access arguments' => array(1),
     'type' => MENU_LOCAL_TASK,
+    'context' => MENU_CONTEXT_PAGE | MENU_CONTEXT_INLINE,
     'weight' => 2,
     'file' => 'translation.pages.inc',
   );


### PR DESCRIPTION
Fixed https://github.com/backdrop/backdrop-issues/issues/6410