### PR TITLE
Issue #2557: Cast config values to match default values.

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -3028,6 +3028,7 @@ function _backdrop_bootstrap_configuration() {
   set_exception_handler('_backdrop_exception_handler');
 
   // Load configuration classes and functions.
+  include_once BACKDROP_ROOT . '/core/includes/module.inc';
   require_once BACKDROP_ROOT . '/core/includes/config.inc';
 
   // Redirect the user to the installation script if Backdrop has not been

--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -48,6 +48,56 @@ function config($config_file, $type = 'active') {
 }
 
 /**
+ * Retrieves configuration information provided by modules.
+ *
+ * @param string $config_name
+ *   (optional) The name of the config file whose information should be
+ *   retrieved. If not specified, information for all configuration prefixes is
+ *   returned.
+ * @return array
+ *   An array of all configuration information, either for the single
+ *   configuration file based on its prefix, or configuration information for
+ *   all installed modules if no $config_name is specified.
+ *
+ * @see hook_config_info()
+ * @see hook_config_info_alter()
+ *
+ * @since 1.28.0 The returned array now includes the "module" key for each item.
+ */
+function config_get_info($config_name = NULL) {
+  $config_info = &backdrop_static(__FUNCTION__, array());
+  if (empty($config_info)) {
+    $modules = module_implements('config_info');
+    foreach ($modules as $module) {
+      $module_config_info = module_invoke($module, 'config_info');
+      foreach ($module_config_info as $config_name_single => $config_info_single) {
+        // Populate defaults:
+        $config_info_single += array(
+          'module' => $module,
+          'enforce_data_types' => FALSE,
+        );
+        $config_info[$config_name_single] = $config_info_single;
+      }
+    }
+    backdrop_alter('config_info', $config_info);
+  }
+
+  if ($config_name) {
+    $return_config_info = FALSE;
+    foreach ($config_info as $prefix => $this_config_info) {
+      if ($config_name === $prefix || strpos($config_name, $prefix . '.') === 0) {
+        $return_config_info = $this_config_info;
+        break;
+      }
+    }
+    return $return_config_info;
+  }
+  else {
+    return $config_info;
+  }
+}
+
+/**
  * A shortcut function to delete a single value from a config file.
  *
  * Note that this function immediately writes the config file to disk and clears
@@ -270,6 +320,33 @@ function config_load_multiple($names, $type = 'active') {
 }
 
 /**
+ * Reads the default data from a project's default JSON configuration file.
+ *
+ * @param string $project
+ *   The name of the project providing the configuration file.
+ * @param string $config_name
+ *   The configuration file name without the extension.
+ *
+ * @return array
+ *   The configuration data provided by the default project configuration file.
+ */
+function config_get_default_config_data($project, $config_name) {
+  // Determine if this is a module or theme:
+  foreach (array('module', 'theme') as $project_type) {
+    if ($project_path = backdrop_get_path($project_type, $project)) {
+      break;
+    }
+  }
+  $project_path = backdrop_get_path($project_type, $project);
+  $project_config_dir = $project_path . '/config';
+  $config_file_path = $project_config_dir . '/' . $config_name . '.json';
+  if (is_dir($project_config_dir) && is_file($config_file_path)) {
+    $storage = new ConfigFileStorage($project_config_dir);
+    return $storage->read($config_name);
+  }
+}
+
+/**
  * Moves the default config supplied by a project to the live config directory.
  *
  * @param string $project
@@ -289,7 +366,6 @@ function config_install_default_config($project, $config_name = NULL) {
   }
   $project_config_dir = $project_path . '/config';
   if (is_dir($project_config_dir)) {
-    $storage = new ConfigFileStorage($project_config_dir);
     $files = glob($project_config_dir . '/*.json');
     foreach ($files as $file) {
       // Load config data into the active store and write it out to the
@@ -299,7 +375,7 @@ function config_install_default_config($project, $config_name = NULL) {
       $file = array_pop($parts);
       $file_config_name = str_replace('.json', '', $file);
       if (is_null($config_name) || $file_config_name === $config_name) {
-        $data = $storage->read($file_config_name);
+        $data = config_get_default_config_data($project, $file_config_name);
         $config = config($file_config_name);
         // We only create new configs, and do not overwrite existing ones.
         if ($config->isNew()) {
@@ -1002,6 +1078,25 @@ class Config {
     }
     // Ensure config name is saved in the result.
     $this->data = array_merge(array('_config_name' => $this->name), $this->data);
+
+    // Cast data types to match the default configuration.
+    $config_info = config_get_info($this->name);
+    if ($config_info && $config_info['enforce_data_types']) {
+      $default_data = config_get_default_config_data($config_info['module'], $this->name);
+      $copy_types = array('boolean', 'integer', 'double', 'string', 'array');
+      // @todo: Deep data type copying? Right now this only enforces the first
+      // level of data types.
+      foreach ($default_data as $default_key => $default_value) {
+        if (isset($this->data[$default_key])) {
+          $default_type = gettype($default_value);
+          if (in_array($default_type, $copy_types)) {
+            settype($this->data[$default_key], $default_type);
+          }
+        }
+      }
+    }
+
+    // Write the config to storage.
     $this->storage->write($this->name, $this->data);
     $this->isNew = FALSE;
 

--- a/core/modules/admin_bar/admin_bar.module
+++ b/core/modules/admin_bar/admin_bar.module
@@ -77,6 +77,7 @@ function admin_bar_config_info() {
   $prefixes['admin_bar.settings'] = array(
     'label' => t('Admin bar settings'),
     'group' => t('Configuration'),
+    'enforce_data_types' => TRUE,
   );
   return $prefixes;
 }

--- a/core/modules/admin_bar/config/admin_bar.settings.json
+++ b/core/modules/admin_bar/config/admin_bar.settings.json
@@ -1,7 +1,7 @@
 {
     "_config_name": "admin_bar.settings",
-    "margin_top": 1,
-    "position_fixed": 1,
+    "margin_top": true,
+    "position_fixed": true,
     "components": [
         "admin_bar.icon",
         "admin_bar.back_to_site_link",

--- a/core/modules/comment/comment.info
+++ b/core/modules/comment/comment.info
@@ -5,9 +5,9 @@ package = Comments
 tags[] = Content
 version = BACKDROP_VERSION
 backdrop = 1.x
+dependencies[] = entity
 dependencies[] = node
 dependencies[] = text
-dependencies[] = entity
 
 configure = admin/content/comment
 

--- a/core/modules/config/config.api.php
+++ b/core/modules/config/config.api.php
@@ -27,6 +27,14 @@
  *     not suitable for generating a label, a function may be specified as a
  *     label callback.
  *   - group: A translated string to be used as the configuration group.
+ *   - enforce_data_types: Boolean indicator as to whether the data type from
+ *     the default configuration file will be applied to saved values. For
+ *     example if the default "my_module.settings.json" file had a key for
+ *     "enabled" that had the value of TRUE, and the form that updated the
+ *     configuration saved that value as "0" or 0, the value would be cast to
+ *     FALSE, matching the original data type.
+ *
+ * @since 1.28.0 The "enforce_data_types" key was added.
  */
 function hook_config_info() {
   // If there are a large number of configuration files prefixed with this

--- a/core/modules/config/config.module
+++ b/core/modules/config/config.module
@@ -108,43 +108,6 @@ function config_file_download($uri) {
 }
 
 /**
- * Retrieves configuration information provided by modules.
- *
- * @param string $config_name
- *   (optional) The name of the config file whose information should be
- *   retrieved. If not specified, information for all configuration prefixes is
- *   returned.
- * @return array
- *   An array of all configuration information, either for the single
- *   configuration file based on its prefix, or configuration information for
- *   all installed modules if no $config_name is specified.
- *
- * @see hook_config_info()
- * @see hook_config_info_alter()
- */
-function config_get_info($config_name = NULL) {
-  $config_info = &backdrop_static(__FUNCTION__, array());
-  if (empty($config_info)) {
-    $config_info = module_invoke_all('config_info');
-    backdrop_alter('config_info', $config_info);
-  }
-
-  if ($config_name) {
-    $return_config_info = FALSE;
-    foreach ($config_info as $prefix => $this_config_info) {
-      if ($config_name === $prefix || strpos($config_name, $prefix . '.') === 0) {
-        $return_config_info = $this_config_info;
-        break;
-      }
-    }
-    return $return_config_info;
-  }
-  else {
-    return $config_info;
-  }
-}
-
-/**
  * Get a list of all configuration prefixes and groups.
  *
  * This list provided by hook_config_info().

--- a/core/modules/dashboard/dashboard.info
+++ b/core/modules/dashboard/dashboard.info
@@ -5,3 +5,4 @@ version = BACKDROP_VERSION
 type = module
 backdrop = 1.x
 configure = admin/dashboard/settings
+dependencies[] = layout

--- a/core/modules/simpletest/tests/boot_test_2.module
+++ b/core/modules/simpletest/tests/boot_test_2.module
@@ -7,6 +7,7 @@
 /**
  * Implements hook_config_info().
  */
-function boot_test_2_config_info($path, $arg) {
+function boot_test_2_config_info() {
   // Empty hook.
+  return array();
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2557

This is a proof-of-concept PR so far. If the approach looks good we'd want/need to update `hook_config_info()` throughout core to apply to all config files we want stronger typing on. Also test coverage needed.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
