### PR TITLE
Issue #6293: Prevent dashboard loading before layout module in upgrades.

### DIFF
--- a/core/modules/dashboard/dashboard.info
+++ b/core/modules/dashboard/dashboard.info
@@ -5,3 +5,4 @@ version = BACKDROP_VERSION
 type = module
 backdrop = 1.x
 configure = admin/dashboard/settings
+dependencies[] = layout


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6293 (maybe)

I just noticed in another issue I was getting early bootstrap failures because of module loading order. Maybe specifically listing dashboard.module depending on layout.module will prevent it from accidentally loading if layout module isn't yet enabled in the Backdrop upgrade?

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
