### PR TITLE
Fixes #6429 removes redundant filters

### DIFF
--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -32,7 +32,7 @@ function standard_install() {
     'filters' => array(
       'filter_url' => array(
         'weight' => 0,
-        'status' => 1,
+        'status' => 0,
       ),
       'filter_html' => array(
         'weight' => 1,
@@ -41,7 +41,7 @@ function standard_install() {
       // Line break filter.
       'filter_autop' => array(
         'weight' => 2,
-        'status' => 1,
+        'status' => 0,
       ),
       'filter_image_caption' => array(
         'weight' => 4,


### PR DESCRIPTION
Removes the redundant and problematic filter_url and filter_autop from default formats that have the Text Editor enabled. (Only the Basic format.)

Fixes https://github.com/backdrop/backdrop-issues/issues/6429

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
