### PR TITLE
Fixes #6437 - Empty search result mini pager error

### DIFF
--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -1138,6 +1138,11 @@ function theme_views_form_views_form($variables) {
 function theme_views_mini_pager($variables) {
   global $pager_page_array, $pager_total;
 
+  // Both $pager_page_array and $pager_total must be set for this theme function to work.
+  if (!$pager_page_array || ! $pager_total) {
+    return;
+  }
+
   $tags = $variables['tags'];
   $element = $variables['element'];
   $parameters = $variables['parameters'];

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -1138,9 +1138,9 @@ function theme_views_form_views_form($variables) {
 function theme_views_mini_pager($variables) {
   global $pager_page_array, $pager_total;
 
-  // Both $pager_page_array and $pager_total must be set for this theme function to work.
+  // Pager is only needed if there are results.
   if (!$pager_page_array || ! $pager_total) {
-    return;
+    return '';
   }
 
   $tags = $variables['tags'];

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -1139,7 +1139,7 @@ function theme_views_mini_pager($variables) {
   global $pager_page_array, $pager_total;
 
   // Pager is only needed if there are results.
-  if (!$pager_page_array || ! $pager_total) {
+  if (!isset($pager_page_array[$element]) || empty($pager_total)) {
     return '';
   }
 

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -1138,14 +1138,14 @@ function theme_views_form_views_form($variables) {
 function theme_views_mini_pager($variables) {
   global $pager_page_array, $pager_total;
 
+  $tags = $variables['tags'];
+  $element = $variables['element'];
+  $parameters = $variables['parameters'];
+
   // Pager is only needed if there are results.
   if (!isset($pager_page_array[$element]) || empty($pager_total)) {
     return '';
   }
-
-  $tags = $variables['tags'];
-  $element = $variables['element'];
-  $parameters = $variables['parameters'];
 
   // Current is the page we are currently paged to.
   $pager_current = $pager_page_array[$element] + 1;


### PR DESCRIPTION
The theme_views_mini_pager() function was not checking that the global variables $pager_page_array and $pager_total were set, resulting in an error when the view results were empty. Added code to check.

Fixes https://github.com/backdrop/backdrop-issues/issues/6437

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
