### PR TITLE
Issue #6450: DatabaseSchema_mysql::fieldExists() does not escape the column name and should be removed together DatabaseSchema_mysql::tableExists()

### DIFF
--- a/core/includes/database/mysql/schema.inc
+++ b/core/includes/database/mysql/schema.inc
@@ -502,46 +502,12 @@ class DatabaseSchema_mysql extends DatabaseSchema {
     return preg_replace('/; InnoDB free:.*$/', '', $comment);
   }
 
-  public function tableExists($table) {
-    // The information_schema table is very slow to query under MySQL 5.0.
-    // Instead, we try to select from the table in question.  If it fails,
-    // the most likely reason is that it does not exist. That is dramatically
-    // faster than using information_schema.
-    // @link http://bugs.mysql.com/bug.php?id=19588
-    // @todo: This override should be removed once we require a version of MySQL
-    // that has that bug fixed.
-    try {
-      $this->connection->queryRange("SELECT 1 FROM {" . $table . "}", 0, 1);
-      return TRUE;
-    }
-    catch (Exception $e) {
-      return FALSE;
-    }
-  }
-
   public function findTables($table_expression) {
     // Back-ticks need to be removed when selecting from the information_schema
     // table. These may be added if using DatabaseConnection::prefixTables() on
     // a table name.
     $table_expression = str_replace('`', '', $table_expression);
     return parent::findTables($table_expression);
-  }
-
-  public function fieldExists($table, $column) {
-    // The information_schema table is very slow to query under MySQL 5.0.
-    // Instead, we try to select from the table and field in question. If it
-    // fails, the most likely reason is that it does not exist. That is
-    // dramatically faster than using information_schema.
-    // @link http://bugs.mysql.com/bug.php?id=19588
-    // @todo: This override should be removed once we require a version of MySQL
-    // that has that bug fixed.
-    try {
-      $this->connection->queryRange("SELECT $column FROM {" . $table . "}", 0, 1);
-      return TRUE;
-    }
-    catch (Exception $e) {
-      return FALSE;
-    }
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6450

See also https://github.com/backdrop/backdrop-issues/issues/6120

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
