### PR TITLE
Issue #6459: Disable gzip on image style test responses.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['5.6', '7.4', '8.3']
-        fraction: ['1/3', '2/3', '3/3']
+#        fraction: ['1/3', '2/3', '3/3']
         database-versions: ['mariadb-10.3']
 
     steps:
@@ -75,7 +75,7 @@ jobs:
           echo Running fraction ${{ matrix.fraction }} with PHP ${{ matrix.php-versions }}
           # Pipe stderr to stdout so that GitHub Actions displays errors inline
           # with the rest of the results, otherwise it prints them afterwards.
-          core/scripts/run-tests.sh --force --cache --verbose --color --directory=core --split=${{ matrix.fraction }} --concurrency 7 2>&1
+          core/scripts/run-tests.sh --force --cache --verbose --color ImageStylesPathAndUrlUnitTest 2>&1
 
       - name: System status
         if: ${{ always() }}

--- a/core/modules/image/image.module
+++ b/core/modules/image/image.module
@@ -792,7 +792,12 @@ function image_style_deliver($style, $scheme) {
     image_style_remove_allowed_uri($derivative_uri);
 
     $image = image_load($derivative_uri);
-    file_transfer($image->source, array('Content-Type' => $image->info['mime_type'], 'Content-Length' => $image->info['file_size']));
+    file_transfer($image->source, array(
+      'Content-Type' => $image->info['mime_type'],
+      'Content-Length' => $image->info['file_size'],
+      'Connection' => 'close',
+      'X-Test-Response' => $_SERVER['HTTP_ACCEPT_ENCODING'] ?? 'FALSE',
+    ));
   }
   else {
     watchdog('image', 'Unable to generate the derived image located at %path.', array('%path' => $derivative_uri));

--- a/core/modules/image/tests/image.test
+++ b/core/modules/image/tests/image.test
@@ -36,7 +36,18 @@ class ImageFieldTestCase extends BackdropWebTestCase {
    */
   public function setUp() {
     parent::setUp('image');
-    $this->admin_user = $this->backdropCreateUser(array('access content', 'access administration pages', 'administer site configuration', 'administer content types', 'administer fields', 'administer nodes', 'create post content', 'edit any post content', 'delete any post content', 'administer image styles'));
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access content',
+      'access administration pages',
+      'administer site configuration',
+      'administer content types',
+      'administer fields',
+      'administer nodes',
+      'create post content',
+      'edit any post content',
+      'delete any post content',
+      'administer image styles',
+    ));
     $this->backdropLogin($this->admin_user);
 
     // Disable default path patterns for nodes.
@@ -114,8 +125,6 @@ class ImageFieldTestCase extends BackdropWebTestCase {
  */
 class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
   protected $style_name;
-  protected $image_info;
-  protected $image_filepath;
 
   /**
    * {@inheritdoc}
@@ -124,7 +133,10 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
     parent::setUp('image_module_test');
 
     $this->style_name = 'style_foo';
-    image_style_save(array('name' => $this->style_name, 'label' => $this->randomName()));
+    image_style_save(array(
+      'name' => $this->style_name,
+      'label' => $this->randomName(),
+    ));
   }
 
   /**
@@ -240,13 +252,31 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
     config_set('system.core', 'file_default_scheme', 'temporary');
 
     // Fetch the URL that generates the file.
-    $this->backdropGet($generate_url);
+    $this->backdropGet($generate_url, array(), array(
+      'Accept-Encoding: identity;q=1.0, *;q=0',
+    ));
     $this->assertResponse(200, 'Image was generated at the URL.');
     $this->assertTrue(file_exists($generated_uri), 'Generated file does exist after we accessed it.');
     $this->assertRaw(file_get_contents($generated_uri), 'URL returns expected file.');
     $generated_image_info = image_get_info($generated_uri);
-    $this->assertEqual($this->backdropGetHeader('Content-Type'), $generated_image_info['mime_type'], 'Expected Content-Type was reported.');
-    $this->assertEqual($this->backdropGetHeader('Content-Length'), $generated_image_info['file_size'], 'Expected Content-Length was reported.');
+
+    $expected_type = $generated_image_info['mime_type'];
+    $actual_type = $this->backdropGetHeader('Content-Type');
+    $this->assertEqual($expected_type, $actual_type, format_string('Expected Content-Type (@expected) matches actual Content-Type (@actual) at @url.', array(
+      '@expected' => $expected_type,
+      '@actual' => $actual_type,
+      '@url' => $generate_url,
+    )));
+
+    $expected_size = $generated_image_info['file_size'];
+    $actual_size = $this->backdropGetHeader('Content-Length');
+    $this->assertEqual($expected_size, $actual_size, format_string('Expected Content-Length (@expected) matches actual Content-Length (@actual) at @url.', array(
+      '@expected' => $expected_size,
+      '@actual' => $actual_size,
+      '@url' => $generate_url,
+    )));
+    $this->fail(print_r($this->backdropGetHeaders(), TRUE));
+
     if ($scheme == 'private') {
       $this->assertEqual($this->backdropGetHeader('Expires'), 'Fri, 16 Jan 2015 07:50:00 GMT', 'Expires header was sent.');
       $this->assertEqual($this->backdropGetHeader('Cache-Control'), 'no-cache, must-revalidate', 'Cache-Control header was set to prevent caching.');
@@ -265,13 +295,13 @@ class ImageStylesPathAndUrlUnitTest extends BackdropWebTestCase {
 
       // Repeat this with a different file that we do not have access to and
       // make sure that access is denied.
-      $file_noaccess = array_shift($files);
-      $original_uri_noaccess = file_unmanaged_copy($file_noaccess->uri, $scheme . '://', FILE_EXISTS_RENAME);
-      $generated_uri_noaccess = $scheme . '://styles/' . $this->style_name . '/' . $scheme . '/'. backdrop_basename($original_uri_noaccess);
-      $this->assertFalse(file_exists($generated_uri_noaccess), 'Generated file does not exist.');
-      $generate_url_noaccess = image_style_url($this->style_name, $original_uri_noaccess);
+      $file_no_access = array_shift($files);
+      $original_uri_no_access = file_unmanaged_copy($file_no_access->uri, $scheme . '://', FILE_EXISTS_RENAME);
+      $generated_uri_no_access = $scheme . '://styles/' . $this->style_name . '/' . $scheme . '/'. backdrop_basename($original_uri_no_access);
+      $this->assertFalse(file_exists($generated_uri_no_access), 'Generated file does not exist.');
+      $generate_url_no_access = image_style_url($this->style_name, $original_uri_no_access);
 
-      $this->backdropGet($generate_url_noaccess);
+      $this->backdropGet($generate_url_no_access);
       $this->assertResponse(403, 'Confirmed that access is denied for the private image style.');
       // Verify that images are not appended to the response. Currently this test only uses PNG images.
       if (strpos($generate_url, '.png') === FALSE ) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6459

This is an in-progress PR and has not demonstrated a viable fix yet.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
