### PR TITLE
Issue #316: Add additional formatters for multi-value fields.

### DIFF
--- a/core/modules/field/field.module
+++ b/core/modules/field/field.module
@@ -1493,3 +1493,155 @@ function _field_create_entity_from_ids($ids) {
   }
   return entity_create($ids->entity_type, $id_properties);
 }
+
+/**
+ * Helper to format to get all settings for list formatters.
+ */
+function _field_list_formatter_info_settings() {
+  return array(
+    'list_type' => 'comma',
+    'list_comma_and' => 0,
+    'list_comma_period' => 0,
+  );
+}
+
+/**
+ * Helper to format all list field settings forms.
+ */
+function _field_list_formatter_settings_form($field, $instance, $view_mode, $form, &$form_state, &$element) {
+  $display = $instance['display'][$view_mode];
+  $settings = $display['settings'];
+
+  $element['list_type'] = array(
+    '#title' => t('List type'),
+    '#type' => 'select',
+    '#options' => array(
+      'comma' => t('Comma separated list'),
+      'ul' => t('Bulleted List (ul)'),
+      'ol' => t('Numbered list (ol)'),
+    ),
+    '#default_value' => (!empty($settings['list_type'])) ? $settings['list_type'] : 'comma',
+    '#required' => TRUE,
+  );
+  $element['list_comma_and'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("Add 'and' before the last item"),
+    '#default_value' => (!empty($settings['list_comma_and'])) ? $settings['list_comma_and'] : '',
+    '#states' => array(
+      'visible' => array(
+        ':input[name="fields[' . $field['field_name'] . '][settings_edit_form][settings][list_type]"]' => array('value' => 'comma'),
+      ),
+    ),
+  );
+  $element['list_comma_period'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("Add '.' after the last item"),
+    '#default_value' => (!empty($settings['list_comma_period'])) ? $settings['list_comma_period'] : '',
+    '#states' => array(
+      'visible' => array(
+        ':input[name="fields[' . $field['field_name'] . '][settings_edit_form][settings][list_type]"]' => array('value' => 'comma'),
+      ),
+    ),
+  );
+}
+
+function _field_list_formatter_settings_summary($field, $instance, $view_mode, &$summary) {
+  $display = $instance['display'][$view_mode];
+  $settings = $display['settings'];
+  $summary_items = array();
+
+  switch ($settings['list_type']) {
+    case 'ul':
+      $summary_items[] = t('Bulleted list');
+      break;
+    case 'ol':
+      $summary_items[] = t('Numbered list');
+      break;
+    case 'comma':
+      $summary_items[] = t('Comma separated list');
+      if ($settings['list_comma_and']) {
+        $summary_items[] =  t("with 'and' before the last item");
+      }
+      if ($settings['list_comma_period']) {
+        $summary_items[] =  t("with '.' after the last item");
+      }
+      break;
+  }
+
+
+  $summary = theme('item_list', array('type' => 'ul', 'items' => $summary_items));
+}
+
+/**
+ * Helper to format all list fields.
+ */
+function _field_list_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display, $element) {
+  $settings = $display['settings'];
+  $module = $field['module'];
+  $list_items = $element;
+  $element = array();
+
+  foreach ($items as $delta => $item) {
+    $list_items = _field_list_default_list($entity_type, $entity, $field, $instance, $langcode, $items, $display);
+  }
+
+  // If there are no list items, return and render nothing.
+  if (empty($list_items)) {
+    return;
+  }
+
+  switch ($settings['list_type']) {
+    case 'ul':
+    case 'ol':
+      // Render elements as one piece of markup and theme as item list.
+      $list = array(
+        '#theme' => 'item_list',
+        '#type' => $settings['list_type'],
+        '#items' => $list_items,
+      );
+    break;
+    case 'comma':
+      $dot = '';
+      if ($settings['list_comma_period']) {
+        $dot = '.';
+      }
+      // Render as one element as comma separated list.
+      $list = array(
+        '#theme' => 'container',
+        '#children' => implode(', ', $list_items) . $dot,
+        '#settings' => $settings,
+      );
+    break;
+  }
+
+  return $list;
+}
+
+/**
+ * Default listing callback.
+ */
+function _field_list_default_list($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $list_items = array();
+
+  // Use our helper function to get the value key dynamically.
+  $value_key = _field_list_get_value_key($field);
+
+  foreach ($items as $delta => $item) {
+    $list_items[$delta] = check_plain($item[$value_key]);
+  }
+
+  return $list_items;
+}
+
+/**
+ * Helper to return the value key for a field instance.
+ *
+ * @param $field array
+ *  The whole array of field instance info provided by the field api.
+ *
+ * @return string
+ *  The value key for the field.
+ */
+function _field_list_get_value_key(array $field) {
+  return (array_key_exists('columns', $field) && is_array($field['columns'])) ? key($field['columns']) : 'value';
+}

--- a/core/modules/field/modules/list/list.module
+++ b/core/modules/field/modules/list/list.module
@@ -498,7 +498,7 @@ function list_field_formatter_info() {
         'custom_off' => '',
         'reverse' => 0,
       ),
-    )
+    ),
   );
 }
 

--- a/core/modules/field/modules/number/number.module
+++ b/core/modules/field/modules/number/number.module
@@ -247,7 +247,7 @@ function number_field_formatter_info() {
     'number_integer' => array(
       'label' => t('Default'),
       'field types' => array('number_integer'),
-      'settings' =>  array(
+      'settings' => array(
         'thousand_separator' => '',
         // The 'decimal_separator' and 'scale' settings are not configurable
         // through the UI, and will therefore keep their default values. They
@@ -261,11 +261,24 @@ function number_field_formatter_info() {
     'number_decimal' => array(
       'label' => t('Default'),
       'field types' => array('number_decimal', 'number_float'),
-      'settings' =>  array(
+      'settings' => array(
         'thousand_separator' => '',
         'decimal_separator' => '.',
         'scale' => 2,
         'prefix_suffix' => TRUE,
+      ),
+    ),
+    'number_list' => array(
+      'label' => t('List of numbers'),
+      'field types' => array('number_integer', 'number_decimal', 'number_float'),
+      'settings' => array(
+        'thousand_separator' => '',
+        'decimal_separator' => '.',
+        'scale' => 2,
+        'prefix_suffix' => TRUE,
+        'list_type' => 'comma',
+        'list_comma_and' => 0,
+        'list_comma_period' => 0,
       ),
     ),
     'number_unformatted' => array(
@@ -283,7 +296,7 @@ function number_field_formatter_settings_form($field, $instance, $view_mode, $fo
   $settings = $display['settings'];
   $element = array();
 
-  if ($display['type'] == 'number_decimal' || $display['type'] == 'number_integer') {
+  if ($display['type'] == 'number_decimal' || $display['type'] == 'number_integer' || $display['type'] == 'number_list') {
     $options = array(
       ''  => t('<none>'),
       '.' => t('Decimal point'),
@@ -311,6 +324,10 @@ function number_field_formatter_settings_form($field, $instance, $view_mode, $fo
         '#default_value' => $settings['scale'],
         '#description' => t('The number of digits to the right of the decimal.'),
       );
+
+      if ($display['type'] == 'number_list') {
+        _field_list_formatter_settings_form($field, $instance, $view_mode, $form, $form_state, $element);
+      }
     }
 
     $element['prefix_suffix'] = array(
@@ -338,6 +355,10 @@ function number_field_formatter_settings_summary($field, $instance, $view_mode) 
     }
   }
 
+  if ($display['type'] == 'text_list') {
+    _field_list_formatter_settings_summary($field, $instance, $view_mode, $summary);
+  }
+
   return implode('<br />', $summary);
 }
 
@@ -351,6 +372,7 @@ function number_field_formatter_view($entity_type, $entity, $field, $instance, $
   switch ($display['type']) {
     case 'number_integer':
     case 'number_decimal':
+    case 'number_list':
       foreach ($items as $delta => $item) {
         $output = number_format($item['value'], $settings['scale'], $settings['decimal_separator'], $settings['thousand_separator']);
         if ($settings['prefix_suffix']) {
@@ -361,6 +383,12 @@ function number_field_formatter_view($entity_type, $entity, $field, $instance, $
           $output = $prefix . $output . $suffix;
         }
         $element[$delta] = array('#markup' => $output);
+      }
+      if ($display['type'] == 'number_list') {
+        $list = _field_list_formatter_view($entity_type, $entity, $field, $instance, $langcode,$items, $display, $element);
+        $element = array(
+          '0' => $list,
+        );
       }
       break;
 

--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -245,6 +245,15 @@ function text_field_formatter_info() {
       'label' => t('Plain text'),
       'field types' => array('text', 'text_long', 'text_with_summary'),
     ),
+    'text_list' => array(
+      'label' => t('List of items'),
+      'field types' => array('text'),
+      'settings' => array(
+        'list_type' => 'comma',
+        'list_comma_and' => 0,
+        'list_comma_period' => 0,
+      ),
+    ),
 
     // The text_trimmed formatter displays the trimmed version of the
     // full element of the field. It is intended to be used with text
@@ -295,6 +304,10 @@ function text_field_formatter_settings_form($field, $instance, $view_mode, $form
     $element['trim_length']['#description'] = t('The trimmed %label field will be shorter than this character limit.', array('%label' => $instance['label']));
   }
 
+  if ($display['type'] == 'text_list') {
+    _field_list_formatter_settings_form($field, $instance, $view_mode, $form, $form_state, $element);
+  }
+
   return $element;
 }
 
@@ -311,6 +324,10 @@ function text_field_formatter_settings_summary($field, $instance, $view_mode) {
     $summary = t('Trimmed limit: @trim_length characters', array('@trim_length' => $settings['trim_length']));
   }
 
+  if ($display['type'] == 'text_list') {
+    _field_list_formatter_settings_summary($field, $instance, $view_mode, $summary);
+  }
+
   return $summary;
 }
 
@@ -323,6 +340,7 @@ function text_field_formatter_view($entity_type, $entity, $field, $instance, $la
   switch ($display['type']) {
     case 'text_default':
     case 'text_trimmed':
+    case 'text_list':
       foreach ($items as $delta => $item) {
         if (empty($item['value'])) {
           continue;
@@ -353,9 +371,18 @@ function text_field_formatter_view($entity_type, $entity, $field, $instance, $la
 
     case 'text_plain':
       foreach ($items as $delta => $item) {
-        $element[$delta] = array('#markup' => strip_tags($item['value']));
+        $output = _text_sanitize($instance, $langcode, $item, 'value');
+
+        $element[$delta] = array('#markup' => $output);
       }
       break;
+  }
+
+  if ($display['type'] == 'text_list') {
+    $list = _field_list_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display, $element);
+    $element = array(
+      '0' => $list,
+    );
   }
 
   return $element;

--- a/core/modules/link/link.module
+++ b/core/modules/link/link.module
@@ -983,6 +983,11 @@ function link_field_formatter_info() {
       'field types' => array('link_field'),
       'multiple values' => FIELD_BEHAVIOR_DEFAULT,
     ),
+    'link_list' => array(
+      'label' => t('List of Links'),
+      'field types' => array('link_field'),
+      'settings' => _field_list_formatter_info_settings(),
+    ),
   );
 }
 
@@ -999,6 +1004,9 @@ function link_field_formatter_settings_form($field, $instance, $view_mode, $form
       '#type' => 'checkbox',
       '#default_value' => $settings['strip_www'],
     );
+  }
+  else if ($display['type'] == 'link_list') {
+    _field_list_formatter_settings_form($field, $instance, $view_mode, $form, $form_state, $element);
   }
   return $element;
 }
@@ -1026,7 +1034,7 @@ function link_field_formatter_view($entity_type, $entity, $field, $instance, $la
   $elements = array();
   foreach ($items as $delta => $item) {
     $elements[$delta] = array(
-      '#theme' => 'link_formatter_' . $display['type'],
+      '#theme' => 'link_formatter_link_default',
       '#element' => $item,
       '#field' => $instance,
       '#display' => array(
@@ -1034,6 +1042,14 @@ function link_field_formatter_view($entity_type, $entity, $field, $instance, $la
       ),
     );
   }
+
+  if ($display['type'] == 'link_list') {
+    $list = _field_list_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display, $elements);
+    $elements = array(
+      '0' => $list,
+    );
+  }
+
   return $elements;
 }
 


### PR DESCRIPTION
Not ready yet!

Questions:
1) What should we do with the list field? -- can we use these for single-value displays? 
1) Where should we put the generic field functions? Right now they are in field.module, but I think maybe they should go into list module? 

Has support for:
* Text
* Link (configure form + summary still missing)
* Number (configure form + summary still missing)

Needs:
* Limit to only multi-value fields?
* Taxonomy term support
* Entity reference support

Addresses https://github.com/backdrop/backdrop-issues/issues/316