### PR TITLE
Issue #6525: Allow formatPlural's plural string not to have '@count' in it in JavaScript

### DIFF
--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -627,17 +627,9 @@ function _locale_parse_js_file($filepath) {
     (                             # capture plural string argument
       (?:                         # non-capturing group to repeat string pieces
         (?:
-          \'                      # match start of single-quoted string
-          (?:\\\\\'|[^\'])*       # match any character except unescaped single-quote
-          @count                  # match "@count"
-          (?:\\\\\'|[^\'])*       # match any character except unescaped single-quote
-          \'                      # match end of single-quoted string
+          \'(?:\\\\\'|[^\'])*\'   # match single-quoted string with any character except unescaped single-quote
           |
-          "                       # match start of double-quoted string
-          (?:\\\\"|[^"])*         # match any character except unescaped double-quote
-          @count                  # match "@count"
-          (?:\\\\"|[^"])*         # match any character except unescaped double-quote
-          "                       # match end of double-quoted string
+          "(?:\\\\"|[^"])*"       # match double-quoted string with any character except unescaped double-quote
         )
         (?:\s*\+\s*)?             # match "+" with possible whitespace, for str concat
       )+                          # match multiple because we supports concatenating strs

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -149,6 +149,9 @@ class LocaleJavascriptTranslationTest extends BackdropWebTestCase {
       "Context Single Quoted @count plural" => "Context string single quoted",
       "Context Double Quoted plural" => "Context string double quoted",
       "Context Double Quoted @count plural" => "Context string double quoted",
+
+      "No count argument plural - singular" => '',
+      "No count argument plural - plural" => '',
     );
 
     // Assert that all strings were found properly.

--- a/core/modules/locale/tests/locale_test/locale_test.js
+++ b/core/modules/locale/tests/locale_test/locale_test.js
@@ -43,4 +43,6 @@ Backdrop.formatPlural(1, "Context Unquoted plural", "Context Unquoted @count plu
 Backdrop.formatPlural(1, "Context Single Quoted plural", "Context Single Quoted @count plural", {}, {'context': "Context string single quoted"});
 Backdrop.formatPlural(1, "Context Double Quoted plural", "Context Double Quoted @count plural", {}, {"context": "Context string double quoted"});
 
-Backdrop.formatPlural(1, "Context !key Args plural", "Context !key Args @count plural", {'!key': 'value'}, {context: "Context string"});
+Backdrop.formatPlural(1, "Context !key Args plural", "Context !key Args @count plural", { '!key': 'value' }, { context: "Context string" });
+
+Backdrop.formatPlural(1, "No count argument plural - singular", "No count argument plural - plural");


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6525

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
