### PR TITLE
Issue #6536: CSpell: Ignore the files/directories contained in the core/modules/ckeditor5/lib/ckeditor5/ directory

### DIFF
--- a/.cspell/cspell.json
+++ b/.cspell/cspell.json
@@ -57,7 +57,7 @@
     "/core/misc/opensans/",
     "/core/misc/smartmenus/",
     "/core/misc/ui/",
-    "/core/modules/ckeditor5/lib/ckeditor5/build/",
+    "/core/modules/ckeditor5/lib/ckeditor5/",
     "/core/modules/search/tests/UnicodeTest.txt",
     "/core/modules/system/system.tar.inc",
     "/core/themes/bartik/color/preview.html",


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6536

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
