### PR TITLE
Issue #364: Adding since docblocks for Icon API.

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5545,6 +5545,8 @@ function backdrop_get_library($module, $name = NULL) {
  *   - immutable: Whether to use the original icon instead of any overrides.
  *
  * @see icon()
+ *
+ * @since 1.28.0 Function added.
  */
 function backdrop_add_icons(array $icon_names) {
   $icon_paths = array();

--- a/core/includes/icon.inc
+++ b/core/includes/icon.inc
@@ -2,6 +2,9 @@
 /**
  * @file
  * Provides the Backdrop API for placing icons.
+ *
+ * For comprehensive documentation on the icon API, see
+ * https://docs.backdropcms.org/documentation/icon-api
  */
 
 /**
@@ -33,6 +36,10 @@
  *     overridden, but an icon can still be added.
  *
  * @return string
+ *
+ * @see https://docs.backdropcms.org/documentation/icon-api
+ *
+ * @since 1.28.0 Function added.
  */
 function icon($icon_name, array $options = array()) {
   // Populate default options.
@@ -83,6 +90,8 @@ function icon($icon_name, array $options = array()) {
  *
  * @see hook_icon_info()
  * @see hook_icon_info_alter()
+ *
+ * @since 1.28.0 Function added.
  */
 function icon_get_path($icon_name, $immutable = FALSE) {
   // Save into a static cache with both normal and immutable paths.
@@ -228,7 +237,10 @@ function _icon_from_core($icon_name) {
  * @param string|null $icon_name
  *   An icon name, with no extension, such as "home" or "info". If omitted,
  *   all icon info will be returned.
+ *
  * @return array
+ *
+ * @since 1.28.0 Function added.
  */
 function icon_get_info($icon_name = NULL) {
   $icon_info = &backdrop_static(__FUNCTION__);
@@ -268,6 +280,11 @@ function icon_get_info($icon_name = NULL) {
  *     value is added as a <title> tag within the SVG. If not specified, the
  *     icon will automatically be assigned the aria-hidden="true" attribute.
  *   - attributes: Attributes to be added to the icon itself.
+ *
+ * @return string
+ *    The HTML output.
+ *
+ * @since 1.28.0 Function added.
  */
 function theme_icon(array $variables) {
   // Ensure the filename is .svg.

--- a/core/includes/image.inc
+++ b/core/includes/image.inc
@@ -555,8 +555,11 @@ function image_hex2rgba(&$hex) {
  *
  * @param string $uri
  *   A path or URI to an image.
+ *
  * @return bool
  *   TRUE if the image is an SVG. FALSE if it is not.
+ *
+ * @since 1.28.0 Function added.
  */
 function image_is_svg($uri) {
   $mimetype = file_get_mimetype($uri);
@@ -575,6 +578,8 @@ function image_is_svg($uri) {
  *
  * @return string
  *   The SVG image contents with the attributes added.
+ *
+ * @since 1.28.0 Function added.
  */
 function image_add_svg_attributes($svg_content, array $attributes) {
   $doc = new DOMDocument();
@@ -619,6 +624,8 @@ function image_add_svg_attributes($svg_content, array $attributes) {
  *   image is an SVG but no set dimensions are available, these keys will have
  *   NULL values. If the image is not an SVG, or the SVG file is empty or
  *   invalid, FALSE will be returned.
+ *
+ * @since 1.28.0 Function added.
  */
 function image_get_svg_dimensions($uri) {
   // Safety check.

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -338,6 +338,8 @@ function hook_js_alter(&$javascript) {
  * @see system_library_info()
  * @see backdrop_add_library()
  * @see backdrop_get_library()
+ *
+ * @since 1.28.0 Added "icons" key to library info.
  */
 function hook_library_info() {
   // Library One.
@@ -453,6 +455,8 @@ function hook_css_alter(&$css) {
  *     relative to the Backdrop installation root.
  *
  * @see hook_icon_info_alter()
+ *
+ * @since 1.28.0 Hook added.
  */
 function hook_icon_info() {
   // For icons simply located in a module's "icons" directory, just provide the
@@ -499,6 +503,8 @@ function hook_icon_info() {
  *   module-provided icons, keyed by the icon name.
  *
  * @see hook_icon_info()
+ *
+ * @since 1.28.0 Hook added.
  */
 function hook_icon_info_alter(&$icons) {
   // Remove a different module's override of a core icon.
@@ -753,6 +759,9 @@ function hook_menu_get_item_alter(&$router_item, $path, $original_map) {
  *   - title arguments: (optional) Arguments to send to t() or your custom
  *     callback, with path component substitution as described above.
  *   - description: (optional) The untranslated description of the menu item.
+ *   - icon: (optional) The icon name to be used for this menu item. Icons may
+ *     be used in places like the admin bar or on system landing pages such as
+ *     "admin/config". See the icon() function for more information on icons.
  *   - page callback: (optional) The function to call to display a web page when
  *     the user visits the path. If omitted, the parent menu item's callback
  *     will be used instead.
@@ -891,6 +900,7 @@ function hook_menu_get_item_alter(&$router_item, $path, $original_map) {
  * http://drupal.org/node/102338.
  *
  * @since 1.24.2 Support for the "position" key removed.
+ * @since 1.28.0 Added "icon" key.
  */
 function hook_menu() {
   $items['example'] = array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/364

Adds missing `@since` lines and documentation to functions. Corresponds to the change record at https://docs.backdropcms.org/change-records/new-icon-api

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
