### PR TITLE
Issue #6439: Preserve whitespace within pre tags on CKEditor 5 save.

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.formatter.js
+++ b/core/modules/ckeditor5/js/ckeditor5.formatter.js
@@ -218,7 +218,7 @@
      * @param {String|false} isPreviousLinePreFormatted
      *   Information on whether the previous line was preformatted (and how).
      */
-     _isPreformattedBlockLine(line, isPreviousLinePreFormatted) {
+    _isPreformattedBlockLine(line, isPreviousLinePreFormatted) {
       if (new RegExp('<pre( .*?)?>').test(line)) {
         return 'first';
       }

--- a/core/modules/ckeditor5/js/ckeditor5.formatter.js
+++ b/core/modules/ckeditor5/js/ckeditor5.formatter.js
@@ -143,7 +143,7 @@
       let isPreformattedLine = false;
 
       return lines
-        .filter((line) => { return line.trim().length })
+        .filter((line) => { return line.length })
         .map((line) => {
           isPreformattedLine = this._isPreformattedBlockLine(line, isPreformattedLine);
           if (this._isNonVoidOpeningTag(line)) {

--- a/core/modules/ckeditor5/js/ckeditor5.formatter.js
+++ b/core/modules/ckeditor5/js/ckeditor5.formatter.js
@@ -140,16 +140,22 @@
         .split('\n');
 
       let indentCount = 0;
+      let isPreformattedLine = false;
 
       return lines
         .filter((line) => { return line.trim().length })
         .map((line) => {
+          isPreformattedLine = this._isPreformattedBlockLine(line, isPreformattedLine);
           if (this._isNonVoidOpeningTag(line)) {
             return this._indentLine(line, indentCount++);
           }
 
           if (this._isClosingTag(line)) {
             return this._indentLine(line, --indentCount);
+          }
+
+          if (isPreformattedLine === 'middle' || isPreformattedLine === 'last') {
+            return line;
           }
 
           return this._indentLine(line, indentCount);
@@ -202,6 +208,29 @@
     _indentLine(line, indentCount, indentChar = '    ' ) {
       // More about Math.max() here in https://github.com/ckeditor/ckeditor5/issues/10698.
       return indentChar.repeat(Math.max(0, indentCount)) + line.trim();
+    }
+
+    /**
+     * Checks whether a line belongs to a preformatted (`<pre>`) block.
+     *
+     * @param {String} line
+     *   String to check.
+     * @param {String|false} isPreviousLinePreFormatted
+     *   Information on whether the previous line was preformatted (and how).
+     */
+     _isPreformattedBlockLine(line, isPreviousLinePreFormatted) {
+      if (new RegExp('<pre( .*?)?>').test(line)) {
+        return 'first';
+      }
+      else if (new RegExp('</pre>').test(line)) {
+        return 'last';
+      }
+      else if (isPreviousLinePreFormatted === 'first' || isPreviousLinePreFormatted === 'middle') {
+        return 'middle';
+      }
+      else {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6439

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
