### PR TITLE
Fix bug in conditional for system_get_date_types().

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -2557,6 +2557,15 @@ function system_get_date_types($type = NULL) {
   $formats = system_get_date_formats($type);
 
   if ($type) {
+    $formats['type'] = $formats['name'];
+    $formats['title'] = $formats['label'];
+    $formats['locked'] = isset($formats['hidden']) ? $formats['hidden'] : '0';
+    if (!isset($formats['module'])) {
+      $formats['module'] = '';
+    }
+    $formats['is_new'] = FALSE;
+  }
+  else {
     foreach ($formats as &$format) {
       $format['type'] = $format['name'];
       $format['title'] = $format['label'];
@@ -2566,15 +2575,6 @@ function system_get_date_types($type = NULL) {
       }
       $format['is_new'] = FALSE;
     }
-  }
-  else {
-    $formats['type'] = $formats['name'];
-    $formats['title'] = $formats['label'];
-    $formats['locked'] = isset($formats['hidden']) ? $formats['hidden'] : '0';
-    if (!isset($formats['module'])) {
-      $formats['module'] = '';
-    }
-    $formats['is_new'] = FALSE;
   }
 
   return $formats;


### PR DESCRIPTION
If a `$type` argument is used, it makes sense that we would expect a single format and would adjust return array by adding keys directly to the base array itself. This looks reversed from the current logic which is resulting in additional array keys with empty values like `type`, `title` and `module` getting added to the root of the array when no `$type` argument is used. This throws errors in some contrib modules that use this function, like `workflow_node`.

Fixes https://github.com/backdrop/backdrop-issues/issues/6556