### PR TITLE
Issue #6557: Make sure tha 'version' in hook_library_info() is optional

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -8822,6 +8822,16 @@ function backdrop_flush_all_caches() {
  *
  * Changing the dummy query string appended to CSS and JavaScript files forces
  * all browsers to reload fresh files.
+ *
+ * Note that .js assets added with a `'version'` specified in the respective
+ * hook_library_info() implementation will not be affected by this, since in
+ * that case the the version sting is used for the query instead of the random
+ * string. This may affect cache flushing of these assets when JS aggregation
+ * is disabled.
+ *
+ * @see hook_library_info()
+ * @see backdrop_pre_render_scripts()
+ * @see backdrop_pre_render_styles()
  */
 function _backdrop_flush_css_js() {
   // The timestamp is converted to base 36 in order to make it more compact.

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5514,7 +5514,10 @@ function backdrop_get_library($module, $name = NULL) {
           'icons' => array(),
         );
         foreach ($module_libraries[$key]['js'] as $file => $options) {
-          $module_libraries[$key]['js'][$file]['version'] = $module_libraries[$key]['version'];
+          // Make sure that 'version' can be optional - see hook_library_info().
+          if (isset($module_libraries[$key]['version'])) {
+            $module_libraries[$key]['js'][$file]['version'] = $module_libraries[$key]['version'];
+          }
         }
       }
     }

--- a/core/modules/ckeditor5/ckeditor5.module
+++ b/core/modules/ckeditor5/ckeditor5.module
@@ -64,11 +64,10 @@ function ckeditor5_editor_info() {
  */
 function ckeditor5_library_info() {
   $module_path = backdrop_get_path('module', 'ckeditor5');
-  $info = system_get_info('module', 'ckeditor5');
 
   $libraries['backdrop.ckeditor5.admin'] = array(
     'title' => 'Administrative library for configuring CKEditor.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/ckeditor5.admin.js' => array(),
     ),
@@ -82,7 +81,7 @@ function ckeditor5_library_info() {
   );
   $libraries['backdrop.ckeditor5'] = array(
     'title' => 'Backdrop behavior to enable CKEditor on textareas.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/ckeditor5.js' => array(),
       $module_path . '/js/ckeditor5.formatter.js' => array(),
@@ -117,35 +116,35 @@ function ckeditor5_library_info() {
 
   $libraries['backdrop.ckeditor5.backdrop-basic-styles'] = array(
     'title' => 'CKEditor plugin to convert basic HTML tags to preferred tags.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/plugins/backdrop-basic-styles/backdrop-basic-styles.js' => array(),
     ),
   );
   $libraries['backdrop.ckeditor5.backdrop-html-engine'] = array(
     'title' => 'CKEditor plugin that writes the HTML source from the editor.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/plugins/backdrop-html-engine/backdrop-html-engine.js' => array(),
     ),
   );
   $libraries['backdrop.ckeditor5.backdrop-image'] = array(
     'title' => 'Integrates uploading images with CKEditor 5.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/plugins/backdrop-image/backdrop-image.js' => array(),
     ),
   );
   $libraries['backdrop.ckeditor5.backdrop-link'] = array(
     'title' => 'Provides a CKEditor 5 plugin for linking with a dialog.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/plugins/backdrop-link/backdrop-link.js' => array(),
     ),
   );
   $libraries['backdrop.ckeditor5.maximize'] = array(
     'title' => 'Provides a CKEditor 5 plugin to maximize the editor.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       $module_path . '/js/plugins/backdrop-maximize/backdrop-maximize.js' => array(),
     ),
@@ -156,7 +155,7 @@ function ckeditor5_library_info() {
 
   $libraries['ckeditor5'] = array(
     'title' => 'Loads the main CKEditor library.',
-    'version' => $info['version'],
+    'version' => CKEDITOR5_VERSION,
     'js' => array(
       // CKEditor is a large library but already compressed. Do not aggregate.
       $module_path . '/lib/ckeditor5/build/ckeditor5-dll.js' => array(

--- a/core/modules/system/system.api.php
+++ b/core/modules/system/system.api.php
@@ -304,29 +304,44 @@ function hook_js_alter(&$javascript) {
  * Registers JavaScript/CSS libraries associated with a module.
  *
  * Modules implementing this return an array of arrays. The key to each
- * sub-array is the machine readable name of the library. Each library may
+ * sub-array is the machine-readable name of the library. Each library may
  * contain the following items:
  *
- * - 'title': The human readable name of the library.
+ * - 'title': The human-readable name of the library.
  * - 'website': The URL of the library's web site.
- * - 'version': A string specifying the version of the library; intentionally
- *   not a float because a version like "1.2.3" is not a valid float. Use PHP's
- *   version_compare() to compare different versions.
+ * - 'version': (optional) A string specifying the version of the library.
+ *     Notes:
+ *     - This is intentionally not a float, because a version like "1.2.3" is
+ *         not a valid float. Use PHP's version_compare() when comparing
+ *         versions.
+ *     - Although not mandated, specifying a version string should be reserved
+ *         for 3rd-party libraries. Specifying a version will cause that
+ *         version string to be appended as a query string when a .js asset is
+ *         loaded individually when JS aggregation is disabled (for example:
+ *         .../my_script.js?v=1.2.3. See backdrop_pre_render_scripts() and
+ *         backdrop_get_library()). That does not apply to .css assets - these
+ *         always get a random string as their query string (see
+ *         backdrop_pre_render_styles()). Because the query strings for assets
+ *         are taken into account when clearing caches (see
+ *         _backdrop_flush_css_js()), and because adding a version will cause
+ *         the query string to be specific instead of randomized on cache clear,
+ *         this may cause undesired/unexpected results when working with JS code
+ *         (changes not being applied even after clearing caches for instance).
  * - 'js': An array of JavaScript elements; each element's key is used as $data
- *   argument, each element's value is used as $options array for
- *   backdrop_add_js(). To add library-specific (not module-specific) JavaScript
- *   settings, the key may be skipped, the value must specify
- *   'type' => 'setting', and the actual settings must be contained in a 'data'
- *   element of the value.
+ *     argument, each element's value is used as $options array for
+ *     JavaScript backdrop_add_js(). To add library-specific settings (as
+ *     opposed to module-specific settings), the key may be skipped, the value
+ *     must specify 'type' => 'setting', and the actual settings must be
+ *     contained in a 'data' element of the value.
  * - 'css': Like 'js', an array of CSS elements passed to backdrop_add_css().
  * - 'icons': A simple array with only icon names. Each icon in the list will be
- *   resolved to a file path and then added to the page as both a JavaScript
- *   variable (Backdrop.icons['icon-name']) and as a CSS variable
- *   (--icon-[icon-name]).
+ *     resolved to a file path and then added to the page as both a JavaScript
+ *     variable (Backdrop.icons['icon-name']) and as a CSS variable
+ *     (--icon-[icon-name]).
  * - 'dependencies': An array of libraries that are required for a library. Each
- *   element is an array listing the module and name of another library. Note
- *   that all dependencies for each dependent library will also be added when
- *   this library is added.
+ *     element is an array listing the module and name of another library. Note
+ *     that all dependencies for each dependent library will also be added when
+ *     this library is added.
  *
  * Registered information for a library should contain re-usable data only.
  * Module- or implementation-specific data and integration logic should be added
@@ -338,6 +353,11 @@ function hook_js_alter(&$javascript) {
  * @see system_library_info()
  * @see backdrop_add_library()
  * @see backdrop_get_library()
+ * @see backdrop_pre_render_scripts()
+ * @see backdrop_pre_render_styles()
+ * @see _backdrop_flush_css_js()
+ * @see hook_icon_info()
+ * @see https://docs.backdropcms.org/documentation/icon-api
  *
  * @since 1.28.0 Added "icons" key to library info.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6557