### PR TITLE
Issue #6581: file_display_form() does not allow translators to provide the correct translation for the formatter settings title

### DIFF
--- a/core/modules/file/file.admin.inc
+++ b/core/modules/file/file.admin.inc
@@ -347,7 +347,7 @@ function file_display_form($form, &$form_state, $file_type, $view_mode) {
       if (!empty($settings_form)) {
         $form['display']['settings'][$name] = array(
           '#type' => 'fieldset',
-          '#title' => check_plain($formatter['label']) . ' ' . t('settings'),
+          '#title' => t('@label settings', array('@label' => $formatter['label'])),
           '#parents' => array('display', 'settings', $name),
           '#group' => 'display_settings',
           '#states' => array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6581

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
