### PR TITLE
Issue #6580: file_display_form() shows as options formatters without a view callback for which file_view_file() shows a link to the file

### DIFF
--- a/core/modules/file/file.admin.inc
+++ b/core/modules/file/file.admin.inc
@@ -312,6 +312,11 @@ function file_display_form($form, &$form_state, $file_type, $view_mode) {
     if (!empty($formatter['hidden'])) {
       unset($formatters[$name]);
     }
+    if (!isset($formatter['view callback']) || !function_exists($formatter['view callback'])) {
+      // Don't include the formatters for which file_view_file() would show a
+      // link to the file as fallback.
+      unset($formatters[$name]);
+    }
     if (isset($formatter['mime types'])) {
       if (file_match_mimetypes($formatter['mime types'], $file_type->mimetypes)) {
         continue;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6580

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
