### PR TITLE
Clarify Timezone Handling UI help text.

### DIFF
--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -602,7 +602,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
       ),
     ),
   );
-  $description = t('Select the timezone handling method for this date field.');
+  $description = t('Select the timezones should be displayed for this date field. ');
   $form['tz_handling'] = array(
     '#type' => 'select',
     '#title' => t('Time zone handling'),
@@ -708,8 +708,8 @@ function date_field_settings_validate(&$form, &$form_state) {
 function date_timezone_handling_options() {
   return array(
     'site' => t("Site's time zone"),
-    'date' => t("Date's time zone"),
     'user' => t("User's time zone"),
+    'date' => t("Server time zone"),
     'utc'  => 'UTC',
     'none' => t('No time zone conversion'),
   );

--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -602,7 +602,7 @@ function _date_field_settings_form($field, $instance, $has_data) {
       ),
     ),
   );
-  $description = t('Select the timezones should be displayed for this date field. ');
+  $description = t('Select how timezones should be displayed for this date field.');
   $form['tz_handling'] = array(
     '#type' => 'select',
     '#title' => t('Time zone handling'),


### PR DESCRIPTION
After most of a decade away from Drop-oriented CMS's, today I couldnt figure out what exactly I was being asked to decide for "timezone handling" without digging into the code base. Hopefully this minor change will help others understand that this choice is primarily about *display* of timezones, and not the database storage.

Fixes: https://github.com/backdrop/backdrop-issues/issues/6596