### PR TITLE
Issue #6598: Use `#states` instead of custom JS in the date field settings form

### DIFF
--- a/core/modules/date/date.admin.inc
+++ b/core/modules/date/date.admin.inc
@@ -609,8 +609,14 @@ function _date_field_settings_form($field, $instance, $has_data) {
     '#default_value' => $tz_handling,
     '#options' => date_timezone_handling_options(),
     '#description' => $description,
-    '#attached' => array(
-      'js' => array(backdrop_get_path('module', 'date') . '/js/date.admin.js'),
+    '#states' => array(
+      'invisible' => array(
+        // Remove the timezone handling options for fields without hours
+        // granularity.
+        ':input[name="field[settings][granularity][hour]"]' => array(
+          'checked' => FALSE,
+        ),
+      ),
     ),
   );
   // Force this value to hidden because we don't want to allow it to be changed

--- a/core/modules/date/js/date.admin.js
+++ b/core/modules/date/js/date.admin.js
@@ -1,16 +1,5 @@
 (function ($) {
 
-Backdrop.behaviors.dateAdmin = {};
-
-Backdrop.behaviors.dateAdmin.attach = function (context, settings) {
-  // Remove timezone handling options for fields without hours granularity.
-  var $hour = $('#edit-field-settings-granularity-hour').once('date-admin');
-  if ($hour.length) {
-    new Backdrop.dateAdmin.TimezoneHandler($hour);
-  }
-};
-
-
 Backdrop.dateAdmin = {};
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6598