### PR TITLE
Issue  #6600: [UX] Regional settings: Fix UI inconsistencies in the "Time zones" fieldset

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -2101,12 +2101,13 @@ function system_regional_settings($form, &$form_state) {
   $configurable_timezones = $system_date->get('user_configurable_timezones');
   $form['timezone']['configurable_timezones'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Users may set their own time zone.'),
+    '#title' => t('Users may set their own time zone'),
     '#default_value' => $configurable_timezones,
   );
 
   $form['timezone']['configurable_timezones_wrapper'] =  array(
     '#type' => 'container',
+    '#indentation' => 1,
     '#states' => array(
       // Hide the user configured timezone settings when users are forced to use
       // the default setting.
@@ -2115,11 +2116,12 @@ function system_regional_settings($form, &$form_state) {
       ),
     ),
   );
+  $description = t('Only applied if users may set their own time zone.');
   $form['timezone']['configurable_timezones_wrapper']['empty_timezone_message'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Remind users at login if their time zone is not set.'),
+    '#title' => t('Remind users at login if their time zone is not set'),
     '#default_value' => $system_date->get('user_empty_timezone_message'),
-    '#description' => t('Only applied if users may set their own time zone.')
+    '#description' => $description,
   );
 
   $form['timezone']['configurable_timezones_wrapper']['user_default_timezone'] = array(
@@ -2127,11 +2129,11 @@ function system_regional_settings($form, &$form_state) {
     '#title' => t('Time zone for new users'),
     '#default_value' => $system_date->get('user_default_timezone'),
     '#options' => array(
-      BACKDROP_USER_TIMEZONE_DEFAULT => t('Default time zone.'),
-      BACKDROP_USER_TIMEZONE_EMPTY   => t('Empty time zone.'),
-      BACKDROP_USER_TIMEZONE_SELECT  => t('Users may set their own time zone at registration.'),
+      BACKDROP_USER_TIMEZONE_DEFAULT => t('Default time zone'),
+      BACKDROP_USER_TIMEZONE_EMPTY   => t('Empty time zone'),
+      BACKDROP_USER_TIMEZONE_SELECT  => t('Users may set their own time zone at registration'),
     ),
-    '#description' => t('Only applied if users may set their own time zone.')
+    '#description' => $description,
   );
 
   $form['actions']['#type'] = 'actions';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6600
