### PR TITLE
Issue #6609: Add update hook to fix icon display for customized system menu items

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -3548,6 +3548,45 @@ function system_update_1095() {
 }
 
 /**
+ * Fix icon display for customized system menu items.
+ */
+function system_update_1096() {
+  $icon_mapping = array(
+    'admin/dashboard' => 'speedometer-fill',
+    'admin/content' => 'pencil-fill',
+    'admin/people' => 'users-fill',
+    'admin/appearance' => 'palette-fill',
+    'admin/modules' => 'puzzle-piece-fill',
+    'admin/structure' => 'stack-fill',
+    'admin/config' => 'gear-fill',
+    'admin/reports' => 'info-fill',
+  );
+
+  $items = db_select('menu_links')
+    ->fields('menu_links')
+    ->condition('menu_name', 'management')
+    ->condition('module', 'system')
+    ->condition('depth', 2)
+    ->condition('customized', 1)
+    ->execute()->fetchAllAssoc('router_path');
+
+  foreach ($items as $router_path => $item) {
+    if (!array_key_exists($router_path, $icon_mapping)) {
+      continue;
+    }
+    $existing_item = (array) $item;
+    $options = unserialize($existing_item['options']);
+    if (isset($options['icon'])) {
+      continue;
+    }
+    $updated_item = $existing_item;
+    $options['icon'] = $icon_mapping[$router_path];
+    $updated_item['options'] = $options;
+    menu_link_save($updated_item, $existing_item);
+  }
+}
+
+/**
  * @} End of "defgroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.
  */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6609