### PR TITLE
Issue #6456: Use human-readable labels for modules and permissions in user_filters()

### DIFF
--- a/core/modules/simpletest/tests/database_test.module
+++ b/core/modules/simpletest/tests/database_test.module
@@ -31,7 +31,6 @@ function database_test_query_alter(QueryAlterableInterface $query) {
   }
 }
 
-
 /**
  * Implements hook_query_TAG_alter().
  *
@@ -206,6 +205,9 @@ function database_test_theme_tablesort($form, &$form_state) {
 
   $query = db_select('users', 'u');
   $query->condition('u.uid', 0, '<>');
+  // @todo: user_build_filter_query(), as well as user_filters() which is called
+  // by user_build_filter_query(), are slated for removal in Backdrop 2.0. We
+  // will need to build this query here manually when that happens.
   user_build_filter_query($query);
 
   $count_query = clone $query;

--- a/core/modules/simpletest/tests/database_test.module
+++ b/core/modules/simpletest/tests/database_test.module
@@ -31,6 +31,7 @@ function database_test_query_alter(QueryAlterableInterface $query) {
   }
 }
 
+
 /**
  * Implements hook_query_TAG_alter().
  *

--- a/core/modules/simpletest/tests/database_test.module
+++ b/core/modules/simpletest/tests/database_test.module
@@ -205,9 +205,6 @@ function database_test_theme_tablesort($form, &$form_state) {
 
   $query = db_select('users', 'u');
   $query->condition('u.uid', 0, '<>');
-  // @todo: user_build_filter_query(), as well as user_filters() which is called
-  // by user_build_filter_query(), are slated for removal in Backdrop 2.0. We
-  // will need to build this query here manually when that happens.
   user_build_filter_query($query);
 
   $count_query = clone $query;

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -2775,14 +2775,7 @@ function user_role_revoke_permissions($role_name, array $permissions = array()) 
 }
 
 /**
- * Provided filters that could be applied to the user account listing.
- *
- * Same as with user_build_filter_query(), this function was used in the user
- * account listing page in Drupal 7. Since that listing is provided by Views in
- * Backdrop, this function here is slated for removal in Backdrop 2.0. Kept only
- * for backwards-compatibility purposes in Backdrop 1.0.
- *
- * @deprecated since 1.0.
+ * List user administration filters that can be applied.
  */
 function user_filters() {
   $filters = array();
@@ -2832,18 +2825,10 @@ function user_filters() {
 }
 
 /**
- * Extended a query object for user account administration filters based on
- * session.
- *
- * Same as with user_filters(), this function was used in the user account
- * listing page in Drupal 7. Since that listing is provided by Views in
- * Backdrop, this function here is slated for removal in Backdrop 2.0. Kept only
- * for backwards-compatibility purposes in Backdrop 1.0.
+ * Extends a query object for user administration filters based on session.
  *
  * @param $query
  *   Query object that should be filtered.
- *
- * @deprecated since 1.0.
  */
 function user_build_filter_query(SelectQuery $query) {
   $filters = user_filters();

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -2782,7 +2782,7 @@ function user_role_revoke_permissions($role_name, array $permissions = array()) 
  * Backdrop, this function here is slated for removal in Backdrop 2.0. Kept only
  * for backwards-compatibility purposes in Backdrop 1.0.
  *
- * @todo Remove this function in Backdrop 2.0.
+ * @deprecated since 1.0.
  */
 function user_filters() {
   $filters = array();
@@ -2807,7 +2807,7 @@ function user_filters() {
     if ($permissions = $function()) {
       asort($permissions);
       foreach ($permissions as $permission => $permission_info) {
-        $options[$module_group][$permission] = t($permission_info['title']);
+        $options[$module_group][$permission] = $permission_info['title'];
       }
     }
   }
@@ -2843,7 +2843,7 @@ function user_filters() {
  * @param $query
  *   Query object that should be filtered.
  *
- * @todo Remove this function in Backdrop 2.0.
+ * @deprecated since 1.0.
  */
 function user_build_filter_query(SelectQuery $query) {
   $filters = user_filters();

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -2775,13 +2775,20 @@ function user_role_revoke_permissions($role_name, array $permissions = array()) 
 }
 
 /**
- * List user administration filters that can be applied.
+ * Provided filters that could be applied to the user account listing.
+ *
+ * Same as with user_build_filter_query(), this function was used in the user
+ * account listing page in Drupal 7. Since that listing is provided by Views in
+ * Backdrop, this function here is slated for removal in Backdrop 2.0. Kept only
+ * for backwards-compatibility purposes in Backdrop 1.0.
+ *
+ * @todo Remove this function in Backdrop 2.0.
  */
 function user_filters() {
-  // Regular filters
   $filters = array();
   $roles = user_roles(TRUE);
-  unset($roles[BACKDROP_AUTHENTICATED_ROLE]); // Don't list authorized role.
+  // Don't list the authenticated user role.
+  unset($roles[BACKDROP_AUTHENTICATED_ROLE]);
   if (count($roles)) {
     $filters['role'] = array(
       'title' => t('role'),
@@ -2793,12 +2800,14 @@ function user_filters() {
   }
 
   $options = array();
+  $module_info = system_get_info('module');
   foreach (module_implements('permission') as $module) {
     $function = $module . '_permission';
+    $module_group = t('@module module', array('@module' => $module_info[$module]['name']));
     if ($permissions = $function()) {
       asort($permissions);
-      foreach ($permissions as $permission => $description) {
-        $options[t('@module module', array('@module' => $module))][$permission] = t($permission);
+      foreach ($permissions as $permission => $permission_info) {
+        $options[$module_group][$permission] = t($permission_info['title']);
       }
     }
   }
@@ -2823,10 +2832,18 @@ function user_filters() {
 }
 
 /**
- * Extends a query object for user administration filters based on session.
+ * Extended a query object for user account administration filters based on
+ * session.
+ *
+ * Same as with user_filters(), this function was used in the user account
+ * listing page in Drupal 7. Since that listing is provided by Views in
+ * Backdrop, this function here is slated for removal in Backdrop 2.0. Kept only
+ * for backwards-compatibility purposes in Backdrop 1.0.
  *
  * @param $query
  *   Query object that should be filtered.
+ *
+ * @todo Remove this function in Backdrop 2.0.
  */
 function user_build_filter_query(SelectQuery $query) {
   $filters = user_filters();


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6456