### PR TITLE
Issue #6655: Error: Call to undefined function `backdrop_load_updates()` in `drupal_load_updates()`

### DIFF
--- a/core/includes/drupal.inc
+++ b/core/includes/drupal.inc
@@ -1855,6 +1855,7 @@ function install_drupal() {
  */
 function drupal_load_updates() {
   watchdog_deprecated_function('drupal', __FUNCTION__);
+  include_once BACKDROP_ROOT . '/core/includes/install.inc';
   backdrop_load_updates();
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6655