### PR TITLE
Since #value can be an empty array for checkbox widgets, add this cla…

### DIFF
--- a/core/includes/form.inc
+++ b/core/includes/form.inc
@@ -2176,7 +2176,7 @@ function _form_builder_handle_input_element($form_id, &$element, &$form_state) {
       }
     }
     // Load defaults.
-    if (!isset($element['#value'])) {
+    if (!isset($element['#value']) || empty($element['#value'])) {
       // Call #type_value without a second argument to request default_value handling.
       if (function_exists($value_callback)) {
         $element['#value'] = $value_callback($element, FALSE, $form_state);


### PR DESCRIPTION
…use and it ensures the #value gets set correctly, which then avoids problems with false validation failures.

Fixes https://github.com/backdrop/backdrop-issues/issues/6664

I realise that this change fixes the symptom rather than the cause. It seems safe enough though.