### PR TITLE
Issue #5447: Remove MySQL prefix from MariaDB version number.

### DIFF
--- a/core/includes/database/mysql/database.inc
+++ b/core/includes/database/mysql/database.inc
@@ -199,6 +199,29 @@ class DatabaseConnection_mysql extends DatabaseConnection {
     return 'mysql';
   }
 
+  /**
+   * Returns the version of the database server.
+   */
+  public function version() {
+    $version = parent::version();
+
+    // Some MariaDB version strings prepend a fake MySQL version to the front,
+    // which is always "5.5.5-". This was done to so that old MySQL clients
+    // could connect to newer MariaDB servers.
+    // For example, 5.5.5-10.5.11-MariaDB:
+    // - 5.5.5 is a fake MySQL version.
+    // - 10.5.11 would be the actual MariaDB version.
+    // See https://github.com/MariaDB/server/blob/f6633bf058802ad7da8196d01fd19d75c53f7274/include/mysql_com.h#L42
+    // Remove any leading MySQL 5.5.5- prefixes:
+    $regex = '/^(?:5\.5\.5-)?(\d+\.\d+\.\d+.*-mariadb.*)/i';
+    preg_match($regex, $version, $matches);
+    if (!empty($matches[1])) {
+      $version = $matches[1];
+    }
+
+    return $version;
+  }
+
   public function databaseType() {
     return 'mysql';
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5447

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
