### PR TITLE
Issue #1528 allow additional paths

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -107,15 +107,18 @@
 #layout-path-matches {
   margin-bottom: 0.5em;
 }
-.layout-placeholder-examples {
+.layout-placeholder-examples,
+.layout-additional-paths-examples {
   margin-top: 0.5em;
 }
 
-/* Toggle for the placeholder examples */
-.layout-placeholder-examples-toggle {
+/* Toggle for the path examples */
+.layout-placeholder-examples-toggle,
+.layout-additional-paths-examples-toggle {
   white-space: nowrap;
 }
-.layout-placeholder-examples-toggle .arrow {
+.layout-placeholder-examples-toggle .arrow,
+.layout-additional-paths-examples-toggle .arrow {
   border-bottom-color: transparent;
   border-left-color: transparent;
   border-right-color: transparent;
@@ -128,7 +131,8 @@
   overflow: hidden;
   margin: 0.15em 0.3333em;
 }
-.layout-placeholder-examples-toggle .arrow.close {
+.layout-placeholder-examples-toggle .arrow.close,
+.layout-additional-paths-examples-toggle .arrow.close {
   border-top-color: transparent;
   border-bottom-color: #0074bd;
   border-width: 0 0.3333em 0.3333em;

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -194,6 +194,19 @@ class Layout {
   var $removed_blocks = array();
 
   /**
+   * An array of additional paths.
+   *
+   * This is being used to to keep track of additional paths in the layout being
+   * edited. If the layout edits are saved, this is used in
+   * layout_layout_presave() in order save the paths.
+   *
+   * @var array
+   * @see layout_settings_form_validate()
+   * @see layout_layout_presave()
+   */
+  public $additional_paths = array();
+
+  /**
    * @var bool
    */
   public $is_new;
@@ -929,7 +942,7 @@ class Layout {
         }
       }
     }
-    
+
     return empty(array_filter($context_counts));
   }
 

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -161,14 +161,14 @@ class Layout {
    *
    * @var array
    */
-  var $orphaned_blocks = array();
+  public $orphaned_blocks = array();
 
   /**
    * The region where orphaned blocks are placed in new template.
    *
    * @var string
    */
-  var $refuge_region;
+  public $refuge_region;
 
   /**
    * An array of LayoutContext instances used by this menu item.
@@ -191,7 +191,7 @@ class Layout {
    * @see removeBlock()
    * @see layout_layout_presave()
    */
-  var $removed_blocks = array();
+  public $removed_blocks = array();
 
   /**
    * An array of additional paths.

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -35,7 +35,7 @@ Backdrop.behaviors.layoutConfigure = {
   attach: function(context) {
 
     /**
-     * Toggle handler for the placeholder examples.
+     * Toggle handler for the examples.
      */
     function examples_toggle_handler(e) {
       var $examples = $(this).next().toggle();
@@ -62,6 +62,7 @@ Backdrop.behaviors.layoutConfigure = {
 
       // (Re)install placeholder examples toggle handler.
       $('a.layout-placeholder-examples-toggle').on('click', examples_toggle_handler);
+      $('a.layout-additional-paths-examples-toggle').on('click', examples_toggle_handler);
 
       };
       // Update contexts after a slight typing delay.
@@ -72,11 +73,13 @@ Backdrop.behaviors.layoutConfigure = {
       });
     }
 
-    // Hide the placeholder examples.
+    // Hide the examples.
     $form.find('.layout-placeholder-examples').hide();
+    $form.find('.layout-additional-paths-examples').hide();
 
-    // Handle toggling the placeholder examples.
+    // Handle toggling the examples.
     $('a.layout-placeholder-examples-toggle').on('click', examples_toggle_handler);
+    $('a.layout-additional-paths-examples-toggle').on('click', examples_toggle_handler);
 
     // Convert AJAX buttons to links.
     var $linkButtons = $(context).find('.layout-link-button').once('link-button');

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -795,6 +795,19 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     );
   }
 
+  if (isset($form_state['build_info']['args'][0]->settings['additional_paths'])) {
+    $default_value = implode("\n", $form_state['build_info']['args'][0]->settings['additional_paths']);
+  }
+  else {
+    $default_value = '';
+  }
+  $form['additional_paths'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Additional paths'),
+    '#description' => t('Optionally specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. Use the percent symbol ("%") to indicate a placeholder in the path. e.g. "node/%" or "node/%/edit". The number of placeholders must be the same as, or greater than, the number of placeholders in the primary path.'),
+    '#default_value' => $default_value,
+  );
+
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
     '#type' => 'submit',
@@ -883,6 +896,25 @@ function layout_settings_form_validate(&$form, &$form_state) {
     $required_contexts = $condition->getRequiredContexts();
     if (array_diff($required_contexts, $context_plugins)) {
       form_error($form['conditions']['active'][$key], t('The condition \'!condition\' does not have the required contexts at this path. Remove the condition to save the layout.', array('!condition' => $condition->summary())));
+    }
+  }
+
+  global $_layout_additional_paths;
+  $_layout_additional_paths = array();
+  if (isset($form_state['values']['additional_paths'])) {
+    $primary_path = $form_state['values']['path'];
+    $num_placeholders = count(_layout_placeholder_positions($primary_path));
+    $paths = explode("\n", $form_state['values']['additional_paths']);
+    foreach($paths as $path){
+      $path = trim($path);
+      if(!empty($path)) {
+        if ($num_placeholders > count(_layout_placeholder_positions($path))) {
+          form_set_error('additional_paths', t('Additional path %path should have the same, or greater, number of placeholders as primary path %primary_path.', array('%path' => $path, '%primary_path' => $primary_path)));
+        }
+        else {
+          $_layout_additional_paths[] = $path;
+        }
+      }
     }
   }
 }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -876,7 +876,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
   }
 
   // Ensure path is properly formed.
-  _layout_validate_path($form, 'path', $path);
+  _layout_set_message_on_path_error($form, 'path', $path);
 
   // Ensure that all conditions have context requirements met.
   $context_plugins = array(
@@ -910,7 +910,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
             )
           ));
         }
-        elseif(_layout_validate_path($form, 'additional_paths', $path)) {
+        elseif(_layout_set_message_on_path_error($form, 'additional_paths', $path)) {
           continue;
         }
         else {

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -876,13 +876,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
   }
 
   // Ensure path is properly formed.
-  $parts = explode('/', $path);
-  foreach ($parts as $part) {
-    $wildcard_position = strpos($part, '%');
-    if ($wildcard_position !== FALSE && ($wildcard_position > 0 || strlen($part) > 1)) {
-      form_error($form['path'], t('Placeholders must be the only character in their part of the path i.e. "@part" should be "%".', array('@part' => $part)));
-    }
-  }
+  _layout_validate_path($form, 'path', $path);
 
   // Ensure that all conditions have context requirements met.
   $context_plugins = array(
@@ -915,6 +909,9 @@ function layout_settings_form_validate(&$form, &$form_state) {
               '%primary_path' => $primary_path,
             )
           ));
+        }
+        elseif(_layout_validate_path($form, 'additional_paths', $path)) {
+          continue;
         }
         else {
           $_layout_additional_paths[] = $path;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -909,7 +909,12 @@ function layout_settings_form_validate(&$form, &$form_state) {
       $path = trim($path);
       if(!empty($path)) {
         if ($num_placeholders > count(_layout_placeholder_positions($path))) {
-          form_set_error('additional_paths', t('Additional path %path should have the same, or greater, number of placeholders as primary path %primary_path.', array('%path' => $path, '%primary_path' => $primary_path)));
+          form_set_error('additional_paths', t('Additional path %path should have the same, or greater, number of placeholders as primary path %primary_path.',
+            array(
+              '%path' => $path,
+              '%primary_path' => $primary_path,
+            )
+          ));
         }
         else {
           $_layout_additional_paths[] = $path;

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -919,7 +919,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
         }
         switch (TRUE) {
           case ($num_placeholders != $num_additional_placeholders):
-            // E.g. Cannot have "node/%" and "node".
+            // For example, it cannot have "node/%" nor "node".
             form_set_error('additional_paths', t('Additional path %path should have the same number of placeholders as primary path %primary_path.',
               array(
                 '%path' => $path,

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -804,7 +804,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   $form['additional_paths'] = array(
     '#type' => 'textarea',
     '#title' => t('Additional paths'),
-    '#description' => t('Optionally specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. Use the percent symbol ("%") to indicate a placeholder in the path. e.g. "node/%" or "node/%/edit". The number of placeholders must be the same as, or greater than, the number of placeholders in the primary path.'),
+    '#description' => t('Optionally specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. Use the percent symbol ("%") to indicate a placeholder in the path. e.g. "node/%" or "node/%/edit". The number of placeholders must be the same as the number of placeholders in the primary path.'),
     '#default_value' => $default_value,
   );
 
@@ -899,22 +899,60 @@ function layout_settings_form_validate(&$form, &$form_state) {
     $primary_path = $form_state['values']['path'];
     $num_placeholders = count(_layout_placeholder_positions($primary_path));
     $paths = explode("\n", $form_state['values']['additional_paths']);
-    foreach($paths as $path){
+    foreach ($paths as $path){
       $path = trim($path);
-      if(!empty($path)) {
-        if ($num_placeholders == count(_layout_placeholder_positions($path))) {
-          form_set_error('additional_paths', t('Additional path %path should have the same, or greater, number of placeholders as primary path %primary_path.',
-            array(
-              '%path' => $path,
-              '%primary_path' => $primary_path,
-            )
-          ));
+      if (!empty($path)) {
+        $layout_provides_path = layout_provides_path($path);
+        $router_item = menu_get_item($path);
+        $router_item_path = $router_item ? (string) $router_item['path'] : '';
+        $num_additional_placeholders = count(_layout_placeholder_positions($path));
+        $alias = NULL;
+        if (strpos($path, '%') === FALSE) {
+          $alias = db_query('SELECT * FROM {url_alias} WHERE alias = :path', array(':path' => $path))->fetchObject();
         }
-        elseif(_layout_set_message_on_path_error($form, 'additional_paths', $path)) {
-          continue;
-        }
-        else {
-          $_layout_additional_paths[] = $path;
+        switch (TRUE) {
+          case ($num_placeholders != $num_additional_placeholders):
+            form_set_error('additional_paths', t('Additional path %path should have the same number of placeholders as primary path %primary_path.',
+              array(
+                '%path' => $path,
+                '%primary_path' => $primary_path,
+              )
+            ));
+            break;
+          case (!empty($alias)):
+            form_set_error('additional_paths', t('Additional path %path is currently assigned to be an alias for "@alias" and cannot be used.',
+              array(
+                '%path' => $path,
+                '@alias' => $alias->source,
+              )
+            ));
+            break;
+          case ($layout_provides_path === TRUE):
+            form_set_error('additional_paths', t('Additional path %path is already used as the primary path of another layout.',
+              array(
+                '%path' => $path,
+              )
+            ));
+            break;
+          case ($router_item_path !== $path && substr_count($router_item_path, '/') === substr_count($path, '/') && layout_context_required_by_path($router_item_path)):
+            form_set_error('additional_paths', t('Additional path %path cannot be used as an additional path.',
+              array(
+                '%path' => $path,
+              )
+            ));
+            break;
+          case ($router_item_path !== $path):
+            form_set_error('additional_paths', t('Additional path %path does not exist in the system.',
+              array(
+                '%path' => $path,
+              )
+            ));
+            break;
+          case (_layout_set_message_on_path_error($form, 'additional_paths', $path)):
+            break;
+          default:
+            $_layout_additional_paths[] = $path;
+            break;
         }
       }
     }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -801,10 +801,17 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   else {
     $default_value = '';
   }
+  $toggle_additional = ' <a class="layout-additional-paths-examples-toggle" href="#">' . t('Show examples') . '<span class="arrow"></span></a>';
+  $description_additional_items = array(
+    t('Content: <code>node/%/edit</code> if primary path is <code>node/%</code>'),
+    t('Views page: <code>user/%/posts</code> if primary path is <code>user/%</code>'),
+    t('Login: <code>user/register</code> if primary path is <code>user/login</code>'),
+  );
+  $description_additional_list = '<div class="layout-additional-paths-examples">' . t('Some common examples of additional paths include:') . theme('item_list', array('items' => $description_additonal_items)) . '</div>';
   $form['additional_paths'] = array(
     '#type' => 'textarea',
     '#title' => t('Additional paths'),
-    '#description' => t('Optionally specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. Use the percent symbol ("%") to indicate a placeholder in the path. e.g. "node/%" or "node/%/edit". The number of placeholders must be the same as the number of placeholders in the primary path.'),
+    '#description' => t('Optionally, specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. If an additional path contains a placeholder it must be a child path of the primary path.') . $$toggle_additional . $description_additional_list,
     '#default_value' => $default_value,
   );
 

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -795,8 +795,8 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     );
   }
 
-  if (isset($form_state['build_info']['args'][0]->settings['additional_paths'])) {
-    $default_value = implode("\n", $form_state['build_info']['args'][0]->settings['additional_paths']);
+  if (isset($layout->settings['additional_paths'])) {
+    $default_value = implode("\n", $layout->settings['additional_paths']);
   }
   else {
     $default_value = '';
@@ -900,8 +900,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
     }
   }
 
-  global $_layout_additional_paths;
-  $_layout_additional_paths = array();
+  $layout->additional_paths = array();
   if (isset($form_state['values']['additional_paths'])) {
     $primary_path = $form_state['values']['path'];
     $num_placeholders = count(_layout_placeholder_positions($primary_path));
@@ -965,7 +964,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
           case (_layout_set_message_on_path_error($form, 'additional_paths', $path)):
             break;
           default:
-            $_layout_additional_paths[] = $path;
+            $layout->additional_paths[] = $path;
             break;
         }
       }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -902,27 +902,26 @@ function layout_settings_form_validate(&$form, &$form_state) {
 
   $layout->additional_paths = array();
   if (isset($form_state['values']['additional_paths'])) {
-    $primary_path = $form_state['values']['path'];
-    $num_placeholders = count(_layout_placeholder_positions($primary_path));
-    $paths = explode("\n", $form_state['values']['additional_paths']);
-    foreach ($paths as $path){
-      $path = trim($path);
-      if (!empty($path)) {
-        $layout_provides_path = layout_provides_path($path);
-        $router_item = menu_get_item($path);
+    $num_placeholders = count(_layout_placeholder_positions($path));
+    $additional_paths = explode("\n", $form_state['values']['additional_paths']);
+    foreach ($additional_paths as $additional_path){
+      $additional_path = trim($additional_path);
+      if (!empty($additional_path)) {
+        $layout_provides_path = layout_provides_path($additional_path);
+        $router_item = menu_get_item($additional_path);
         $router_item_path = $router_item ? (string) $router_item['path'] : '';
-        $num_additional_placeholders = count(_layout_placeholder_positions($path));
+        $num_additional_placeholders = count(_layout_placeholder_positions($additional_path));
         $alias = NULL;
-        if (strpos($path, '%') === FALSE) {
-          $alias = db_query('SELECT * FROM {url_alias} WHERE alias = :path', array(':path' => $path))->fetchObject();
+        if (strpos($additional_path, '%') === FALSE) {
+          $alias = db_query('SELECT * FROM {url_alias} WHERE alias = :path', array(':path' => $additional_path))->fetchObject();
         }
         switch (TRUE) {
           case ($num_placeholders != $num_additional_placeholders):
             // For example, it cannot have "node/%" nor "node".
             form_set_error('additional_paths', t('Additional path %path should have the same number of placeholders as primary path %primary_path.',
               array(
-                '%path' => $path,
-                '%primary_path' => $primary_path,
+                '%path' => $additional_path,
+                '%primary_path' => $path,
               )
             ));
             break;
@@ -930,7 +929,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
             // E.g. "about" is an alias of "node/2".
             form_set_error('additional_paths', t('Additional path %path is currently assigned to be an alias for "@alias" and cannot be used.',
               array(
-                '%path' => $path,
+                '%path' => $additional_path,
                 '@alias' => $alias->source,
               )
             ));
@@ -940,31 +939,31 @@ function layout_settings_form_validate(&$form, &$form_state) {
             // cannot be used in the additional paths.
             form_set_error('additional_paths', t('Additional path %path is already used as the primary path of another layout.',
               array(
-                '%path' => $path,
+                '%path' => $additional_path,
               )
             ));
             break;
-          case ($router_item_path !== $path && strpos($router_item_path, '%') !== FALSE):
+          case ($router_item_path !== $additional_path && strpos($router_item_path, '%') !== FALSE):
             // E.g. "node/2" cannot be used since it requires a context.
             form_set_error('additional_paths', t('Additional path %path cannot be used as an additional path. It requires a context in the primary path.',
               array(
-                '%path' => $path,
+                '%path' => $additional_path,
               )
             ));
             break;
-          case (!$router_item_path && strpos($path, '%') === FALSE):
+          case (!$router_item_path && strpos($additional_path, '%') === FALSE):
             // E.g. Only allow "pages/2" if the router item exists. But allow
             // "node/%/edit" to pass.
             form_set_error('additional_paths', t('Additional path %path cannot be used as an additional path. It does not exist in the system.',
               array(
-                '%path' => $path,
+                '%path' => $additional_path,
               )
             ));
             break;
-          case (_layout_set_message_on_path_error($form, 'additional_paths', $path)):
+          case (_layout_set_message_on_path_error($form, 'additional_paths', $additional_path)):
             break;
           default:
-            $layout->additional_paths[] = $path;
+            $layout->additional_paths[] = $additional_path;
             break;
         }
       }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -912,6 +912,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
         }
         switch (TRUE) {
           case ($num_placeholders != $num_additional_placeholders):
+            // E.g. Cannot have "node/%" and "node".
             form_set_error('additional_paths', t('Additional path %path should have the same number of placeholders as primary path %primary_path.',
               array(
                 '%path' => $path,
@@ -920,6 +921,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
             ));
             break;
           case (!empty($alias)):
+            // E.g. "about" is an alias of "node/2".
             form_set_error('additional_paths', t('Additional path %path is currently assigned to be an alias for "@alias" and cannot be used.',
               array(
                 '%path' => $path,
@@ -928,21 +930,26 @@ function layout_settings_form_validate(&$form, &$form_state) {
             ));
             break;
           case ($layout_provides_path === TRUE):
+            // E.g. "home" is the primary path of the default Home layout and
+            // cannot be used in the additional paths.
             form_set_error('additional_paths', t('Additional path %path is already used as the primary path of another layout.',
               array(
                 '%path' => $path,
               )
             ));
             break;
-          case ($router_item_path !== $path && substr_count($router_item_path, '/') === substr_count($path, '/') && layout_context_required_by_path($router_item_path)):
-            form_set_error('additional_paths', t('Additional path %path cannot be used as an additional path.',
+          case ($router_item_path !== $path && strpos($router_item_path, '%') !== FALSE):
+            // E.g. "node/2" cannot be used since it requires a context.
+            form_set_error('additional_paths', t('Additional path %path cannot be used as an additional path. It requires a context in the primary path.',
               array(
                 '%path' => $path,
               )
             ));
             break;
-          case ($router_item_path !== $path):
-            form_set_error('additional_paths', t('Additional path %path does not exist in the system.',
+          case (!$router_item_path && strpos($path, '%') === FALSE):
+            // E.g. Only allow "pages/2" if the router item exists. But allow
+            // "node/%/edit" to pass.
+            form_set_error('additional_paths', t('Additional path %path cannot be used as an additional path. It does not exist in the system.',
               array(
                 '%path' => $path,
               )

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -807,11 +807,11 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     t('Views page: <code>user/%/posts</code> if primary path is <code>user/%</code>'),
     t('Login: <code>user/register</code> if primary path is <code>user/login</code>'),
   );
-  $description_additional_list = '<div class="layout-additional-paths-examples">' . t('Some common examples of additional paths include:') . theme('item_list', array('items' => $description_additonal_items)) . '</div>';
+  $description_additional_list = '<div class="layout-additional-paths-examples">' . t('Some common examples of additional paths include:') . theme('item_list', array('items' => $description_additional_items)) . '</div>';
   $form['additional_paths'] = array(
     '#type' => 'textarea',
     '#title' => t('Additional paths'),
-    '#description' => t('Optionally, specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. If an additional path contains a placeholder it must be a child path of the primary path.') . $$toggle_additional . $description_additional_list,
+    '#description' => t('Optionally, specify one or more additional paths to be handled by this layout (in addition to the primary path above). These paths must already be provided by the system or another module. If an additional path contains a placeholder it must be a child path of the primary path.') . $toggle_additional . $description_additional_list,
     '#default_value' => $default_value,
   );
 

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -902,7 +902,7 @@ function layout_settings_form_validate(&$form, &$form_state) {
     foreach($paths as $path){
       $path = trim($path);
       if(!empty($path)) {
-        if ($num_placeholders > count(_layout_placeholder_positions($path))) {
+        if ($num_placeholders == count(_layout_placeholder_positions($path))) {
           form_set_error('additional_paths', t('Additional path %path should have the same, or greater, number of placeholders as primary path %primary_path.',
             array(
               '%path' => $path,

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2748,7 +2748,7 @@ function layout_flexible_row_styles() {
  * Utility function to clean CSS for Layout UI.
  *
  * @param string $classes
- *  CSS classes, as entered into the Layout user interface.
+ *   CSS classes, as entered into the Layout user interface.
  *
  * @return string
  *   String of sanitized classes separated by spaces.
@@ -2786,8 +2786,8 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
 
   // Check for additional paths.
   // We'll use any layout whose additional path matches the requested path AND
-  // that has the same, or greater, number of placeholders so that contexts can be
-  // appropriately set. (We check for this during form validation, but check
+  // that has the same, or greater, number of placeholders so that contexts can
+  // be appropriately set. (We check for this during form validation, but check
   // again here in case the user edited the config file directly or something
   // like that).
   foreach ($configs as $config) {
@@ -2825,7 +2825,8 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
     $altered_contexts = array();
     foreach ($contexts as $context) {
       if (isset($context->position)) {
-        // The added layout has a positioned context that may need to be repositioned.
+        // The added layout has a positioned context that may need to be
+        // repositioned.
         $position = $context->position;
         $new_position = $placeholder_map[$position];
         if ($position != $new_position) {

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -1290,6 +1290,7 @@ function layout_load_multiple_by_path($path, $skip_menu_items = NULL) {
     }
 
     $layouts = layout_load_multiple($layout_names, $skip_menu_items);
+    $layouts = layout_load_multiple_by_additional_path($layouts, $path);
     cache('layout_path')->set($path, $layouts);
   }
 
@@ -2774,10 +2775,12 @@ function layout_field_delete_instance($instance) {
 }
 
 /**
- * Implements hook_layout_load_by_router_item_alter().
+ * Load layouts that match additional paths.
+ *
+ * @param Layout[] $layouts
+ * @param string $path
  */
-function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
-  $path = $router_item['path'];
+function layout_load_multiple_by_additional_path($layouts, $path) {
   $placeholder_positions = _layout_placeholder_positions($path);
   $num_placeholders = count($placeholder_positions);
   $configs = layout_get_all_configs('layout');
@@ -2841,19 +2844,22 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
   }
 
   // Note that either default or admin default layouts should come last, so
-  // we'll check for those in the original list, pull them out if present, and
+  // check for those in the original list, pull them out if present, and
   // add them at the end.
-  $default_layouts = array();
-  if (isset($layouts['default'])) {
-    $default_layouts['default'] = $layouts['default'];
-    unset($layouts['default']);
-  }
-  if (isset($layouts['admin_default'])) {
-    $default_layouts['admin_default'] = $layouts['admin_default'];
-    unset($layouts['admin_default']);
+  if (!empty($added_layouts)) {
+    $default_layouts = array();
+    if (isset($layouts['default'])) {
+      $default_layouts['default'] = $layouts['default'];
+      unset($layouts['default']);
+    }
+    if (isset($layouts['admin_default'])) {
+      $default_layouts['admin_default'] = $layouts['admin_default'];
+      unset($layouts['admin_default']);
+    }
+    $layouts = array_merge($layouts, $added_layouts, $default_layouts);
   }
 
-  $layouts = array_merge($layouts, $added_layouts, $default_layouts);
+  return $layouts;
 }
 
 /**

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2512,6 +2512,11 @@ function layout_layout_template_info() {
  * Implements hook_layout_presave().
  */
 function layout_layout_presave($layout) {
+  global $_layout_additional_paths;
+  if (isset($_layout_additional_paths)) {
+    $layout->settings['additional_paths'] = $_layout_additional_paths;
+  }
+
   if (!empty($layout->removed_blocks)) {
     foreach ($layout->removed_blocks as $uuid => $block) {
       // @todo: Follow-up for other block types with files/images.
@@ -2767,4 +2772,100 @@ function _layout_clean_custom_css($classes = array()) {
  */
 function layout_field_delete_instance($instance) {
   cache('layout_path')->flush();
+}
+
+/**
+ * Implements hook_layout_load_by_router_item_alter().
+ */
+function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
+  $path = $router_item['path'];
+  $placeholder_positions = _layout_placeholder_positions($path);
+  $num_placeholders = count($placeholder_positions);
+  $configs = layout_get_all_configs('layout');
+  $added_layout_names = $added_layout_placeholder_positions = array();
+
+  // Check for additional paths.
+  // We'll use any layout whose additional path matches the requested path AND
+  // that has the same, or greater, number of placeholders so that contexts can be
+  // appropriately set. (We check for this during form validation, but check
+  // again here in case the user edited the config file directly or something
+  // like that).
+  foreach ($configs as $config) {
+    $disabled = isset($config['disabled']) ? $config['disabled'] : FALSE;
+    if ($disabled || empty($config['settings']['additional_paths'])) {
+      continue;
+    }
+    $name = $config['name'];
+    foreach ($config['settings']['additional_paths'] as $additional_path) {
+      if ($additional_path == $path && !isset($layouts[$name]) && !isset($added_layout_names[$name])) {
+        $add_placeholder_positions = _layout_placeholder_positions($config['path']);
+        if ($num_placeholders <= count($add_placeholder_positions)) {
+          $added_layout_names[$name] = $name;
+          $added_layout_placeholder_positions[$name] = $add_placeholder_positions;
+          break;
+        }
+      }
+    }
+  }
+
+  $added_layouts = layout_load_multiple($added_layout_names);
+
+  // Check contexts on the added layouts. If the positions don't line up between
+  // the request path and the added layout's primary path, alter the positions
+  // of the contexts so that positional contexts will fetch the right variable
+  // from the path.
+  foreach ($added_layouts as $layout) {
+    // Create a map from layout path positions to request path positions.
+    $add_placeholder_positions = $added_layout_placeholder_positions[$layout->name];
+    $placeholder_map = array();
+    for ($i = 0; $i < $num_placeholders; $i++) {
+      $placeholder_map[$add_placeholder_positions[$i]] = $placeholder_positions[$i];
+    }
+    $contexts = $layout->getContexts();
+    $altered_contexts = array();
+    foreach ($contexts as $context) {
+      if (isset($context->position)) {
+        // The added layout has a positioned context that may need to be repositioned.
+        $position = $context->position;
+        $new_position = $placeholder_map[$position];
+        if ($position != $new_position) {
+          $context->position = $new_position;
+          $altered_contexts[$new_position] = $context;
+          $layout->clearContexts($position);
+        }
+      }
+    }
+    foreach ($altered_contexts as $position => $context) {
+      $layout->setContexts($position, $context);
+    }
+  }
+
+  // Note that either default or admin default layouts should come last, so
+  // we'll check for those in the original list, pull them out if present, and
+  // add them at the end.
+  $default_layouts = array();
+  if (isset($layouts['default'])) {
+    $default_layouts['default'] = $layouts['default'];
+    unset($layouts['default']);
+  }
+  if (isset($layouts['admin_default'])) {
+    $default_layouts['admin_default'] = $layouts['admin_default'];
+    unset($layouts['admin_default']);
+  }
+
+  $layouts = array_merge($layouts, $added_layouts, $default_layouts);
+}
+
+/**
+ * Returns an array of placeholder positions in a path.
+ */
+function _layout_placeholder_positions($path) {
+  $path_parts = explode('/', $path);
+  $placeholder_positions = array();
+  for ($i = 0; $i < count($path_parts); $i++) {
+    if ($path_parts[$i] == '%') {
+      $placeholder_positions[] = $i;
+    }
+  }
+  return $placeholder_positions;
 }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2799,7 +2799,7 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
     foreach ($config['settings']['additional_paths'] as $additional_path) {
       if ($additional_path == $path && !isset($layouts[$name]) && !isset($added_layout_names[$name])) {
         $add_placeholder_positions = _layout_placeholder_positions($config['path']);
-        if ($num_placeholders <= count($add_placeholder_positions)) {
+        if ($num_placeholders == count($add_placeholder_positions)) {
           $added_layout_names[$name] = $name;
           $added_layout_placeholder_positions[$name] = $add_placeholder_positions;
           break;

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2861,7 +2861,7 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
  * Returns an array of placeholder positions in a path.
  *
  * @param string $path
- *    The menu routing path, with all placeholders represented by "%" symbols.
+ *   The menu routing path, with all placeholders represented by "%" symbols.
  *
  * @return array
  *   An array of placeholder positions.
@@ -2881,16 +2881,16 @@ function _layout_placeholder_positions($path) {
  * Ensure path is properly formed.
  *
  * @param array $form
- *    An associative array containing the structure of the form.
+ *   An associative array containing the structure of the form.
  * @param string $field_name
- *    The machine name of the field.
+ *   The machine name of the field.
  * @param string $path
- *    The menu routing path, with all placeholders represented by "%" symbols.
+ *   The menu routing path, with all placeholders represented by "%" symbols.
  *
  * @return bool
  *   TRUE if error found, else FALSE
  */
-function _layout_set_message_on_path_error(&$form, $field_name, $path) {
+function _layout_set_message_on_path_error(array &$form, $field_name, $path) {
   $parts = explode('/', $path);
   foreach ($parts as $part) {
     $wildcard_position = strpos($part, '%');

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2861,8 +2861,10 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
  * Returns an array of placeholder positions in a path.
  *
  * @param string $path
+ *    The menu routing path, with all placeholders represented by "%" symbols.
  *
  * @return array
+ *   An array of placeholder positions.
  */
 function _layout_placeholder_positions($path) {
   $path_parts = explode('/', $path);
@@ -2879,13 +2881,16 @@ function _layout_placeholder_positions($path) {
  * Ensure path is properly formed.
  *
  * @param array $form
+ *    An associative array containing the structure of the form.
  * @param string $field_name
+ *    The machine name of the field.
  * @param string $path
+ *    The menu routing path, with all placeholders represented by "%" symbols.
  *
  * @return bool
  *   TRUE if error found, else FALSE
  */
-function _layout_validate_path(&$form, $field_name, $path) {
+function _layout_set_message_on_path_error(&$form, $field_name, $path) {
   $parts = explode('/', $path);
   foreach ($parts as $part) {
     $wildcard_position = strpos($part, '%');

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2859,6 +2859,10 @@ function layout_layout_load_by_router_item_alter(&$layouts, $router_item) {
 
 /**
  * Returns an array of placeholder positions in a path.
+ *
+ * @param string $path
+ *
+ * @return array
  */
 function _layout_placeholder_positions($path) {
   $path_parts = explode('/', $path);
@@ -2869,4 +2873,26 @@ function _layout_placeholder_positions($path) {
     }
   }
   return $placeholder_positions;
+}
+
+/**
+ * Ensure path is properly formed.
+ *
+ * @param array $form
+ * @param string $field_name
+ * @param string $path
+ *
+ * @return bool
+ *   TRUE if error found, else FALSE
+ */
+function _layout_validate_path(&$form, $field_name, $path) {
+  $parts = explode('/', $path);
+  foreach ($parts as $part) {
+    $wildcard_position = strpos($part, '%');
+    if ($wildcard_position !== FALSE && ($wildcard_position > 0 || strlen($part) > 1)) {
+      form_error($form[$field_name], t('Placeholders must be the only character in their part of the path i.e. "@part" should be "%".', array('@part' => $part)));
+      return TRUE;
+    }
+  }
+  return FALSE;
 }

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -2512,9 +2512,8 @@ function layout_layout_template_info() {
  * Implements hook_layout_presave().
  */
 function layout_layout_presave($layout) {
-  global $_layout_additional_paths;
-  if (isset($_layout_additional_paths)) {
-    $layout->settings['additional_paths'] = $_layout_additional_paths;
+  if (!empty($layout->additional_paths)) {
+    $layout->settings['additional_paths'] = $layout->additional_paths;
   }
 
   if (!empty($layout->removed_blocks)) {

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3736,7 +3736,7 @@ class LayoutPathTest extends BackdropWebTestCase {
       'name' => $layout_name,
       'layout_template' => 'boxton',
       'path' => 'node/%',
-      'additional_paths' => 'node/%/edit'
+      'additional_paths' => 'node/%/edit',
     );
     $this->backdropPost('admin/structure/layouts/add', $edit, t('Create layout'));
 

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3688,11 +3688,19 @@ class LayoutPathTest extends BackdropWebTestCase {
   public function setUp() {
     parent::setUp(array('layout_test'));
 
+    // Create content types for testing.
+    $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
+    $this->backdropCreateContentType(array('type' => 'post', 'name' => 'Post'));
+
     // Create and login admin user.
     $this->admin_user = $this->backdropCreateUser(array(
+      'access administration pages',
       'access content',
       'administer layouts',
       'access user profiles',
+      'edit any page content',
+      'edit any post content',
+      'administer nodes',
     ));
     $this->backdropLogin($this->admin_user);
   }
@@ -3713,6 +3721,66 @@ class LayoutPathTest extends BackdropWebTestCase {
 
     // Make sure backdrop_match_path() can handle a NULL path.
     backdrop_match_path($path, "foo\nbar");
+  }
+
+  /**
+   * Test additional layout paths.
+   */
+  public function testAdditionalLayoutPaths() {
+    config_set('system.core', 'node_admin_theme', 0);
+
+    // Create a new layout using the UI.
+    $layout_name = 'test_page_layout';
+    $edit = array(
+      'title' => 'Page test',
+      'name' => $layout_name,
+      'layout_template' => 'boxton',
+      'path' => 'node/%',
+      'additional_paths' => 'node/%/edit'
+    );
+    $this->backdropPost('admin/structure/layouts/add', $edit, t('Create layout'));
+
+    // Add a few blocks via the API.
+    $test_layout_1 = layout_load($layout_name);
+    $test_layout_1->addBlock('layout_test', 'foo', 'content');
+    $test_layout_1->addBlock('layout_test', 'foo', 'sidebar');
+    $test_layout_1->save();
+
+    $this->assertRaw($layout_name);
+
+    $this->backdropGet('admin/structure/layouts/manage/' . $layout_name . '/configure');
+    $this->backdropPost(NULL, $edit, t('Add condition'));
+    $edit = array(
+      'condition' => 'node_type',
+    );
+    $this->backdropPost(NULL, $edit, t('Load condition'));
+    $edit = array(
+      'bundles[page]' => TRUE,
+    );
+    $this->backdropPost(NULL, $edit, t('Add condition'));
+    $this->backdropPost(NULL, array(), t('Save layout'));
+
+    $test_node1 = $this->backdropCreateNode(array(
+      'type' => 'page',
+      'title' => "Test page title",
+    ));
+
+    $test_node2 = $this->backdropCreateNode(array(
+      'type' => 'post',
+      'title' => "Test post title",
+    ));
+
+    $this->backdropGet('node/' . $test_node1->nid);
+    $this->assertResponse(200);
+    $this->assertRaw('Foo subject', 'Testing block is present on page layout');
+
+    $this->backdropGet('node/' . $test_node1->nid . '/edit');
+    $this->assertResponse(200);
+    $this->assertRaw('Foo subject', 'Testing block is present on page layout');
+
+    $this->backdropGet('node/' . $test_node2->nid . '/edit');
+    $this->assertResponse(200);
+    $this->assertNoRaw('Foo subject', 'Testing block is not present on page layout');
   }
 }
 

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -3686,7 +3686,7 @@ class LayoutPathTest extends BackdropWebTestCase {
    * Set up environment.
    */
   public function setUp() {
-    parent::setUp(array('layout_test'));
+    parent::setUp(array('layout_test', 'path'));
 
     // Create content types for testing.
     $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
@@ -3701,6 +3701,7 @@ class LayoutPathTest extends BackdropWebTestCase {
       'edit any page content',
       'edit any post content',
       'administer nodes',
+      'create url aliases',
     ));
     $this->backdropLogin($this->admin_user);
   }
@@ -3729,14 +3730,33 @@ class LayoutPathTest extends BackdropWebTestCase {
   public function testAdditionalLayoutPaths() {
     config_set('system.core', 'node_admin_theme', 0);
 
+    $test_node1 = $this->backdropCreateNode(array(
+      'type' => 'page',
+      'title' => "Test page title",
+    ));
+
+    $test_node2 = $this->backdropCreateNode(array(
+      'type' => 'post',
+      'title' => "Test post title",
+    ));
+
     // Create a new layout using the UI.
     $layout_name = 'test_page_layout';
     $edit = array(
       'title' => 'Page test',
       'name' => $layout_name,
       'layout_template' => 'boxton',
-      'path' => 'node/%',
-      'additional_paths' => 'node/%/edit',
+      'path' => 'node',
+    );
+    $this->backdropPost('admin/structure/layouts/add', $edit, t('Create layout'));
+
+    // Create a second layout using the UI.
+    $layout_name = 'second_page_layout';
+    $edit = array(
+      'title' => 'Page test2',
+      'name' => $layout_name,
+      'layout_template' => 'boxton',
+      'path' => 'second',
     );
     $this->backdropPost('admin/structure/layouts/add', $edit, t('Create layout'));
 
@@ -3747,6 +3767,51 @@ class LayoutPathTest extends BackdropWebTestCase {
     $test_layout_1->save();
 
     $this->assertRaw($layout_name);
+
+    // Test validation.
+    $this->backdropGet('admin/structure/layouts/manage/' . $layout_name . '/configure');
+    $edit = array(
+      'additional_paths' => 'foobar',
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
+    $this->assertText('Additional path foobar cannot be used as an additional path. It does not exist in the system.', 'Error message: path route does not exist');
+
+    $edit = array(
+      'additional_paths' => 'foobar%',
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
+    $this->assertText('Placeholders must be the only character in their part of the path i.e. "foobar%" should be "%".', 'Error message: placeholders must be separate');
+
+    $edit = array(
+      'additional_paths' => 'node/2',
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
+    $this->assertText('Additional path node/2 cannot be used as an additional path. It requires a context in the primary path.', 'Error message: path requires context');
+
+    $edit = array(
+      'additional_paths' => 'second',
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
+    $this->assertText('Additional path second is already used as the primary path of another layout.', 'Error message: path already used for other layout primary path');
+
+    $alias = backdrop_get_path_alias('node/' . $test_node1->nid);
+    $edit = array(
+      'additional_paths' => $alias,
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
+    $this->assertText('Additional path ' . $alias . ' is currently assigned to be an alias for "node/1" and cannot be used.', 'Error message: cannot use an alias');
+
+    $edit = array(
+      'path' => 'node/%',
+      'additional_paths' => 'foobar',
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
+    $this->assertText('Additional path foobar should have the same number of placeholders as primary path node/%.', 'Error message: must have the same number of placeholders');
+
+    $edit = array(
+      'additional_paths' => 'node/%/edit',
+    );
+    $this->backdropPost(NULL, $edit, t('Save layout'));
 
     $this->backdropGet('admin/structure/layouts/manage/' . $layout_name . '/configure');
     $this->backdropPost(NULL, $edit, t('Add condition'));
@@ -3759,16 +3824,6 @@ class LayoutPathTest extends BackdropWebTestCase {
     );
     $this->backdropPost(NULL, $edit, t('Add condition'));
     $this->backdropPost(NULL, array(), t('Save layout'));
-
-    $test_node1 = $this->backdropCreateNode(array(
-      'type' => 'page',
-      'title' => "Test page title",
-    ));
-
-    $test_node2 = $this->backdropCreateNode(array(
-      'type' => 'post',
-      'title' => "Test post title",
-    ));
 
     $this->backdropGet('node/' . $test_node1->nid);
     $this->assertResponse(200);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/1528

This needs automated tests and testing. So far it basically just borrows the alternative_paths functionality out of `layout_wildcard`, but it allows the additional paths to have more placeholders than the primary path. So that `node/%/revisions/%/revert` works when using `node/%` (in theory).

Update: it has tests. It requires the same number of placeholders now.