### PR TITLE
Issue #6143: display pointer cursor in token browser

### DIFF
--- a/core/modules/system/css/token.css
+++ b/core/modules/system/css/token.css
@@ -150,6 +150,7 @@
   text-indent: -9999em;
   white-space: nowrap;
   width: 2em;
+  cursor: pointer;
 }
 
 .tree-grid button:after {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6143

All this does is add a pointer so it's obvious where to click to expand the token tree.