### PR TITLE
Issue 6745. Use key 'language' instead of 'langcode' in views handler.

### DIFF
--- a/core/modules/node/views/views_handler_field_node.inc
+++ b/core/modules/node/views/views_handler_field_node.inc
@@ -58,10 +58,10 @@ class views_handler_field_node extends views_handler_field {
           $languages = language_list();
           $language = $this->get_value($values, 'langcode');
           if (isset($languages[$language])) {
-            $this->options['alter']['langcode'] = $languages[$language];
+            $this->options['alter']['language'] = $languages[$language];
           }
           else {
-            unset($this->options['alter']['langcode']);
+            unset($this->options['alter']['language']);
           }
         }
       }

--- a/core/modules/node/views/views_handler_field_node_revision.inc
+++ b/core/modules/node/views/views_handler_field_node_revision.inc
@@ -61,7 +61,7 @@ class views_handler_field_node_revision extends views_handler_field_node {
         $language = $this->get_value($values, 'langcode');
         $languages = language_list();
         if (isset($languages[$language])) {
-          $this->options['alter']['langcode'] = $languages[$language];
+          $this->options['alter']['language'] = $languages[$language];
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6745