### PR TITLE
Issue #6734: Remove deprecated mbstring options from .htaccess.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,24 +23,18 @@ DirectoryIndex index.php index.html index.htm
 # for settings that can be changed at runtime.
 <IfModule mod_php.c>
   php_flag session.auto_start               off
-  php_value mbstring.http_input             pass
-  php_value mbstring.http_output            pass
   php_value max_input_vars                  10007
   php_flag mbstring.encoding_translation    off
 </IfModule>
 # Same settings again for PHP 7 versions.
 <IfModule mod_php7.c>
   php_flag session.auto_start               off
-  php_value mbstring.http_input             pass
-  php_value mbstring.http_output            pass
   php_value max_input_vars                  10007
   php_flag mbstring.encoding_translation    off
 </IfModule>
 # Same settings again for PHP 5 versions.
 <IfModule mod_php5.c>
   php_flag session.auto_start               off
-  php_value mbstring.http_input             pass
-  php_value mbstring.http_output            pass
   php_value max_input_vars                  10007
   php_flag mbstring.encoding_translation    off
 </IfModule>


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6734
