### PR TITLE
Issue #6774: Prevent Filter from double-binding editors.

### DIFF
--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -90,7 +90,9 @@ Backdrop.behaviors.filterEditors = {
       var $this = $(this);
       var activeEditor = $this.val();
       var field = $this.closest('.text-format-wrapper').find('textarea').get(-1);
-      $this.removeOnce('filterEditors');
+      if (trigger !== 'serialize') {
+        $this.removeOnce('filterEditors');
+      }
       if (field && Backdrop.settings.filter.formats[activeEditor]) {
         Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor], trigger);
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6774

Parallel fix to https://github.com/backdrop/backdrop/pull/4923 (both should be applied).

This PR fixes Filter module's attachment of editors. It was incorrectly detaching editors on all AJAX requests. So this PR fixes CKEditor by only calling `.attach()` once. Whereas the other PR makes CKEditor handle rapid `.attach()` calls. They're both valid fixes at different levels.