### PR TITLE
Issue #6774: Prevent CKEditor 5 from double-binding to the same element - combined fix.

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -6,7 +6,7 @@
 
     attach: function (element, format) {
       // Bail out if the editor has already been attached to the element.
-      if (typeof element.ckeditor5AttachedEditor != 'undefined') {
+      if (typeof element.ckeditor5Processed !== 'undefined') {
         return;
       }
 
@@ -69,8 +69,9 @@
         }
       });
 
-      // Hide the resizable grippie while CKEditor is active.
-      $(element).siblings('.grippie').hide();
+      // Indicate that this element is about to receive an editor. This prevents
+      // double-binding if the .attach() method is called twice very quickly.
+      element.ckeditor5Processed = true;
 
       const beforeAttachValue = element.value;
       CKEditor5.editorClassic.ClassicEditor
@@ -88,6 +89,7 @@
           return true;
         })
         .catch(error => {
+          element.ckeditor5Processed = false;
           console.error('The CKEditor instance could not be initialized.');
           console.error(error);
           return false;
@@ -117,14 +119,13 @@
         editor.destroy();
         Backdrop.ckeditor5.instances.delete(editor.id);
         delete element.ckeditor5AttachedEditor;
+        delete element.ckeditor5Processed;
       }
 
       // Save formatted value after destroying the editor, which can also
       // update the element value.
       element.value = newData;
 
-      // Restore the resize grippie.
-      $(element).siblings('.grippie').show();
       return !!editor;
     },
 

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -90,7 +90,9 @@ Backdrop.behaviors.filterEditors = {
       var $this = $(this);
       var activeEditor = $this.val();
       var field = $this.closest('.text-format-wrapper').find('textarea').get(-1);
-      $this.removeOnce('filterEditors');
+      if (trigger !== 'serialize') {
+        $this.removeOnce('filterEditors');
+      }
       if (field && Backdrop.settings.filter.formats[activeEditor]) {
         Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor], trigger);
       }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6774

Combines https://github.com/backdrop/backdrop/pull/4923 and https://github.com/backdrop/backdrop/pull/4924 into the same pull request.