### PR TITLE
Issue #6382: CKEditor 5, Basic text format: "Maximize" button missing

### DIFF
--- a/core/modules/ckeditor5/ckeditor5.module
+++ b/core/modules/ckeditor5/ckeditor5.module
@@ -46,7 +46,7 @@ function ckeditor5_editor_info() {
         'bulletedList', 'numberedList', '|',
         'alignment:left', 'alignment:center', 'alignment:right', '|',
         'backdropLink', 'backdropImage', '|',
-        'sourceEditing', 'removeFormat',
+        'sourceEditing', 'removeFormat', 'maximize',
       ),
       'heading_list' => array('p', 'h3', 'h4', 'h5'),
       'style_list' => array(),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6382.