### PR TITLE
Issue #6302: Add multipass to dictionary.

### DIFF
--- a/.cspell/backdrop.dic
+++ b/.cspell/backdrop.dic
@@ -274,6 +274,7 @@ msword
 multibundle
 multilanguage
 multipage
+multipass
 multisite
 multisites
 Műveletek

--- a/core/includes/batch.queue.inc
+++ b/core/includes/batch.queue.inc
@@ -6,7 +6,7 @@
  * These implementations:
  * - Ensure FIFO ordering.
  * - Allow an item to be repeatedly claimed until it is actually deleted (no
- *   notion of lease time or 'expire' date), to allow multi-pass operations.
+ *   notion of lease time or 'expire' date), to allow multipass operations.
  */
 
 /**

--- a/core/modules/node/node.admin.inc
+++ b/core/modules/node/node.admin.inc
@@ -52,7 +52,7 @@ function node_mass_update($nodes, $updates) {
       ),
       'finished' => '_node_mass_update_batch_finished',
       'title' => t('Processing'),
-      // We use a single multi-pass operation, so the default
+      // We use a single multipass operation, so the default
       // 'Remaining x of y operations' message will be confusing here.
       'progress_message' => '',
       'error_message' => t('The update has encountered an error.'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6302

"Multipass" is used in 5 different places in core, in reference to batch operations. I was going to change to `multi-pass` but there's a usage of `non-multipass` that would awkwardly change to `non-multi-pass`. So let's just formalize this word as acceptable.
