### PR TITLE
#3952: Hide page title from breadcrumb when there are no crumbs.

### DIFF
--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -3436,7 +3436,7 @@ function system_header_block($settings) {
  */
 function system_breadcrumb_block($settings = array()) {
   $crumbs = backdrop_get_breadcrumb();
-  if (isset($settings['current']) && $settings['current'] == TRUE) {
+  if (isset($settings['current']) && $settings['current'] == TRUE && !empty($crumbs)) {
     $crumbs[] = '<span aria-current="page">' . backdrop_get_title() . '</span>';
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3952

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
