### PR TITLE
Issue #6004: Add scoping to all test methods to bring inline with coding standards.

### DIFF
--- a/core/modules/admin_bar/tests/admin_bar.test
+++ b/core/modules/admin_bar/tests/admin_bar.test
@@ -16,7 +16,7 @@ class AdminBarWebTestCase extends BackdropWebTestCase {
     'node' => 'access content',
   );
 
-  function setUp() {
+  public function setUp() {
     // Enable admin bar module and any other modules.
     $modules = func_get_args();
     $modules = isset($modules[0]) ? $modules[0] : $modules;
@@ -122,14 +122,14 @@ class AdminBarWebTestCase extends BackdropWebTestCase {
  * Tests menu links depending on user permissions.
  */
 class AdminBarPermissionsTestCase extends AdminBarWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node'));
   }
 
   /**
    * Test that the links are added to the page (no JS testing).
    */
-  function testPermissions() {
+  public function testPermissions() {
     module_enable(array('contact'));
     $this->resetAll();
 
@@ -167,7 +167,7 @@ class AdminBarPermissionsTestCase extends AdminBarWebTestCase {
   /**
    * Tests handling of links pointing to category/overview pages.
    */
-  function testCategories() {
+  public function testCategories() {
     // Create a user with minimum permissions.
     $admin_user = $this->backdropCreateUser($this->basePermissions);
     $this->backdropLogin($admin_user);
@@ -197,7 +197,7 @@ class AdminBarPermissionsTestCase extends AdminBarWebTestCase {
   /**
    * Tests that user role and permission changes are properly taken up.
    */
-  function testPermissionChanges() {
+  public function testPermissionChanges() {
     // Create a user who is able to change permissions.
     $permissions = $this->basePermissions + array(
       'administer permissions',
@@ -267,14 +267,14 @@ class AdminBarDynamicLinksTestCase extends AdminBarWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node'));
   }
 
   /**
    * Tests node type links.
    */
-  function testNode() {
+  public function testNode() {
     $this->backdropCreateContentType(array('type' => 'post', 'name' => 'Post'));
     // Create a content-type with special characters.
     $this->backdropCreateContentType(array('type' => 'special', 'name' => 'Cool & Special'));
@@ -347,7 +347,7 @@ class AdminBarDynamicLinksTestCase extends AdminBarWebTestCase {
   /**
    * Tests Add content links.
    */
-  function testNodeAdd() {
+  public function testNodeAdd() {
     $this->backdropCreateContentType(array('type' => 'post', 'name' => 'Post'));
 
     // Verify that "Add content" does not appear for unprivileged users.
@@ -390,7 +390,7 @@ class AdminBarLinkTypesTestCase extends AdminBarWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $permissions = module_invoke_all('permission');
@@ -402,7 +402,7 @@ class AdminBarLinkTypesTestCase extends AdminBarWebTestCase {
   /**
    * Tests appearance of different router item link types.
    */
-  function testLinkTypes() {
+  public function testLinkTypes() {
     // Verify that MENU_NORMAL_ITEMs appear.
     $this->assertLinkTrailByTitle(array(
       t('Configuration'),
@@ -438,7 +438,7 @@ class AdminBarCustomizedTestCase extends AdminBarWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('menu'));
 
     $this->admin_user = $this->backdropCreateUser($this->basePermissions + array(
@@ -450,7 +450,7 @@ class AdminBarCustomizedTestCase extends AdminBarWebTestCase {
   /**
    * Test disabled custom links.
    */
-  function testCustomDisabled() {
+  public function testCustomDisabled() {
     $type = $this->backdropCreateContentType();
     $node = $this->backdropCreateNode(array('type' => $type->type));
     $text = $this->randomName();
@@ -494,7 +494,7 @@ class AdminBarCustomizedTestCase extends AdminBarWebTestCase {
   /**
    * Tests external links.
    */
-  function testCustomExternal() {
+  public function testCustomExternal() {
     // Add a custom link to the node to the menu.
     $edit = array(
       'link_path' => 'http://example.com',

--- a/core/modules/block/tests/block.test
+++ b/core/modules/block/tests/block.test
@@ -7,7 +7,7 @@
 class BlockTestCase extends BackdropWebTestCase {
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('block_test');
 
     // Create and log in an administrative user having access to the Raw HTML
@@ -25,7 +25,7 @@ class BlockTestCase extends BackdropWebTestCase {
   /**
    * Test creating custom block, editing, and then deleting it.
    */
-  function testCustomBlock() {
+  public function testCustomBlock() {
     // Confirm that the add block link appears on block overview pages.
     $this->backdropGet('admin/structure/block');
     $this->assertRaw(l('Add reusable custom block', 'admin/structure/block/add'), 'Add block link is present on block overview page for default theme.');
@@ -95,7 +95,7 @@ class BlockTestCase extends BackdropWebTestCase {
   /**
    * Test creating custom block using Raw HTML (full_html).
    */
-  function testCustomBlockFormat() {
+  public function testCustomBlockFormat() {
     // Add a new custom block by filling out the input form on the admin/structure/block/add page.
     $custom_block = array();
     $custom_block['info'] = $this->randomName(8);
@@ -132,7 +132,7 @@ class BlockTestCase extends BackdropWebTestCase {
   /**
    * Tests the various block hooks get called when needed.
    */
-  function testBlockHooks() {
+  public function testBlockHooks() {
     // Test hook_block_info_alter().
     $this->backdropGet('admin/structure/layouts/manage/default/add-block/editor/content');
     $this->assertText(t('Original description.'), 'Original description found with no alterations.');

--- a/core/modules/block/tests/block.translation.test
+++ b/core/modules/block/tests/block.translation.test
@@ -8,7 +8,7 @@ class BlockTranslationTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     $modules = array(
       'layout',
       'block',
@@ -46,7 +46,7 @@ class BlockTranslationTestCase extends BackdropWebTestCase {
   /**
    * Test creating custom block, translate it, and then deleting it.
    */
-  function testTranslateCustomBlock() {
+  public function testTranslateCustomBlock() {
 
     // Check if language module was enabled.
     $this->assertTrue(module_exists('language'), 'Language module was enabled successfully.');

--- a/core/modules/ckeditor/tests/ckeditor.test
+++ b/core/modules/ckeditor/tests/ckeditor.test
@@ -8,7 +8,7 @@ class CKEditorTestCase extends BackdropWebTestCase {
   protected $admin_user;
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('ckeditor');
 
     // Create Article node type.
@@ -35,7 +35,7 @@ class CKEditorTestCase extends BackdropWebTestCase {
    * With no JavaScript level testing, we can only ensure the library is present
    * on the page.
    */
-  function testLibrary() {
+  public function testLibrary() {
     $this->backdropGet('admin/config/content/formats');
     $this->clickLink(t('Add text format'));
 

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -11,7 +11,7 @@ class CommentHelperCase extends BackdropWebTestCase {
   protected $node;
   protected $profile = 'testing';
 
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -90,7 +90,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    *   Set to NULL for no contact info, TRUE to ignore success checking, and
    *   array of values to set contact info.
    */
-  function postComment($node, $comment, $subject = '', $contact = NULL) {
+  protected function postComment($node, $comment, $subject = '', $contact = NULL) {
     $langcode = LANGUAGE_NONE;
     $edit = array();
     $edit['comment_body[' . $langcode . '][0][value]'] = $comment;
@@ -162,7 +162,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @return boolean
    *   Boolean indicating whether the comment was found.
    */
-  function commentExists($comment, $reply = FALSE) {
+  protected function commentExists($comment, $reply = FALSE) {
     if ($comment && is_object($comment)) {
       $regex = '/' . ($reply ? '<div class="indented">(.*?)' : '');
       $regex .= '<a id="comment-' . $comment->id . '"(.*?)'; // Comment anchor.
@@ -184,7 +184,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @param object $comment
    *   Comment to delete.
    */
-  function deleteComment($comment) {
+  protected function deleteComment($comment) {
     $this->backdropPost('comment/' . $comment->id . '/delete', array(), t('Delete'));
     $this->assertText(t('The comment and all its replies have been deleted.'), 'Comment deleted.');
   }
@@ -195,7 +195,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @param boolean $enabled
    *   Boolean specifying whether the comment title field should be enabled.
    */
-  function setCommentSubject($comment_title_option) {
+  protected function setCommentSubject($comment_title_option) {
 
     switch ($comment_title_option) {
       case COMMENT_TITLE_AUTO:
@@ -220,7 +220,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @param int $mode
    *   The preview mode: BACKDROP_DISABLED, BACKDROP_OPTIONAL or BACKDROP_REQUIRED.
    */
-  function setCommentPreview($mode) {
+  protected function setCommentPreview($mode) {
     switch ($mode) {
       case BACKDROP_DISABLED:
         $mode_text = 'disabled';
@@ -244,7 +244,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    *   TRUE if the comment form should be displayed on the same page as the
    *   comments; FALSE if it should be displayed on its own page.
    */
-  function setCommentForm($enabled) {
+  protected function setCommentForm($enabled) {
     $this->setCommentSettings('comment_form_location', ($enabled ? COMMENT_FORM_BELOW : COMMENT_FORM_SEPARATE_PAGE), 'Comment controls ' . ($enabled ? 'enabled' : 'disabled') . '.');
   }
 
@@ -257,7 +257,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    *   - 1: Contact information allowed but not required.
    *   - 2: Contact information required.
    */
-  function setCommentAnonymous($level) {
+  protected function setCommentAnonymous($level) {
     $this->setCommentSettings('comment_anonymous', $level, format_string('Anonymous commenting set to level @level.', array('@level' => $level)));
   }
 
@@ -267,7 +267,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @param integer $comments
    *   Comments per page value.
    */
-  function setCommentsPerPage($number) {
+  protected function setCommentsPerPage($number) {
     $this->setCommentSettings('comment_per_page', $number, format_string('Number of comments per page set to @number.', array('@number' => $number)));
   }
 
@@ -281,7 +281,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @param string $message
    *   Status message to display.
    */
-  function setCommentSettings($name, $value, $message) {
+  protected function setCommentSettings($name, $value, $message) {
     $node_type = node_type_get_type('post');
     $node_type->settings[$name] = $value;
     node_type_save($node_type);
@@ -295,7 +295,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @return boolean
    *   Contact info is available.
    */
-  function commentContactInfoAvailable() {
+  protected function commentContactInfoAvailable() {
     return preg_match('/(input).*?(name="name").*?(input).*?(name="mail").*?(input).*?(name="homepage")/s', $this->backdropGetContent());
   }
 
@@ -309,7 +309,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @param boolean $approval
    *   Operation is found on approval page.
    */
-  function performCommentOperation($comment, $operation, $approval = FALSE) {
+  protected function performCommentOperation($comment, $operation, $approval = FALSE) {
     $edit = array();
     $edit['operation'] = $operation;
     $edit['comments[' . $comment->id . ']'] = TRUE;
@@ -333,7 +333,7 @@ class CommentHelperCase extends BackdropWebTestCase {
    * @return integer
    *   Comment id.
    */
-  function getUnapprovedComment($subject) {
+  protected function getUnapprovedComment($subject) {
     $this->backdropGet('admin/content/comment/approval');
     preg_match('/href="(.*?)#comment-([^"]+)"(.*?)>(' . $subject . ')/', $this->backdropGetContent(), $match);
 
@@ -356,7 +356,7 @@ class CommentInterfaceTest extends CommentHelperCase {
   /**
    * Tests the comment interface.
    */
-  function testCommentInterface() {
+  public function testCommentInterface() {
     $langcode = LANGUAGE_NONE;
     // Set comments to have auto generated title and preview disabled.
     $this->backdropLogin($this->admin_user);
@@ -596,7 +596,7 @@ class CommentInterfaceTest extends CommentHelperCase {
   /**
    * Tests CSS classes on comments.
    */
-  function testCommentClasses() {
+  public function testCommentClasses() {
     // Create all permutations for comments, users, and nodes.
     $parameters = array(
       'node_uid' => array(0, $this->web_user->uid),
@@ -710,7 +710,7 @@ class CommentInterfaceTest extends CommentHelperCase {
   /**
    * Tests the node comment statistics.
    */
-  function testCommentNodeCommentStatistics() {
+  public function testCommentNodeCommentStatistics() {
     $langcode = LANGUAGE_NONE;
     // Set comments to have title and preview disabled.
     $this->backdropLogin($this->admin_user);
@@ -802,7 +802,7 @@ class CommentInterfaceTest extends CommentHelperCase {
    * possible conditions and tests the expected appearance of comment links in
    * each environment.
    */
-  function testCommentLinks() {
+  public function testCommentLinks() {
     // Bartik theme alters comment links, so use a different theme.
     theme_enable(array('stark'));
     config_set('system.core', 'theme_default', 'stark');
@@ -861,7 +861,7 @@ class CommentInterfaceTest extends CommentHelperCase {
    *     - skip comment approval
    *     - edit own comments
    */
-  function setEnvironment(array $info) {
+  protected function setEnvironment(array $info) {
     static $current;
 
     // Apply defaults to initial environment.
@@ -978,7 +978,7 @@ class CommentInterfaceTest extends CommentHelperCase {
    *   An associative array describing the environment to pass to
    *   setEnvironment().
    */
-  function assertCommentLinks(array $info) {
+  protected function assertCommentLinks(array $info) {
     $info = $this->setEnvironment($info);
 
     $nid = $this->node->nid;
@@ -1085,7 +1085,7 @@ class CommentPreviewTest extends CommentHelperCase {
   /**
    * Tests comment preview.
    */
-  function testCommentPreview() {
+  public function testCommentPreview() {
     $langcode = LANGUAGE_NONE;
 
     // As admin user, configure comment settings.
@@ -1134,7 +1134,7 @@ class CommentPreviewTest extends CommentHelperCase {
   /**
    * Tests comment edit, preview, and save.
    */
-  function testCommentEditPreviewSave() {
+  public function testCommentEditPreviewSave() {
     $langcode = LANGUAGE_NONE;
     $web_user = $this->backdropCreateUser(array('access comments', 'post comments', 'skip comment approval'));
     $this->backdropLogin($this->admin_user);
@@ -1200,7 +1200,7 @@ class CommentPreviewTest extends CommentHelperCase {
  * Tests anonymous commenting.
  */
 class CommentAnonymous extends CommentHelperCase {
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     parent::setUp();
     config_set('system.core', 'user_register', USER_REGISTER_VISITORS);
   }
@@ -1208,7 +1208,7 @@ class CommentAnonymous extends CommentHelperCase {
   /**
    * Tests anonymous comment functionality.
    */
-  function testAnonymous() {
+  public function testAnonymous() {
     $this->backdropLogin($this->admin_user);
     // Enabled anonymous user comments.
     user_role_change_permissions(BACKDROP_ANONYMOUS_ROLE, array(
@@ -1351,7 +1351,7 @@ class CommentPagerTest extends CommentHelperCase {
   /**
    * Confirms comment paging works correctly with flat and threaded comments.
    */
-  function testCommentPaging() {
+  public function testCommentPaging() {
     $this->backdropLogin($this->admin_user);
 
     // Set comment config.
@@ -1424,7 +1424,7 @@ class CommentPagerTest extends CommentHelperCase {
   /**
    * Tests comment ordering and threading.
    */
-  function testCommentOrderingThreading() {
+  public function testCommentOrderingThreading() {
     $this->backdropLogin($this->admin_user);
 
     // Set comment config.
@@ -1504,7 +1504,7 @@ class CommentPagerTest extends CommentHelperCase {
    * @param $expected_order
    *   An array of keys from $comments describing the expected order.
    */
-  function assertCommentOrder(array $comments, array $expected_order) {
+  protected function assertCommentOrder(array $comments, array $expected_order) {
     $expected_cids = array();
 
     // First, rekey the expected order by cid.
@@ -1524,7 +1524,7 @@ class CommentPagerTest extends CommentHelperCase {
   /**
    * Tests comment_new_page_count().
    */
-  function testCommentNewPageIndicator() {
+  public function testCommentNewPageIndicator() {
     $this->backdropLogin($this->admin_user);
 
     // Set comment config.
@@ -1605,7 +1605,7 @@ class CommentPagerTest extends CommentHelperCase {
  * Tests comments with node access.
  */
 class CommentNodeAccessTest extends CommentHelperCase {
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     parent::setUp('search', 'node_access_test');
 
     $web_user_role = $this->web_user->roles[count($this->web_user->roles) - 1];
@@ -1615,7 +1615,7 @@ class CommentNodeAccessTest extends CommentHelperCase {
   /**
    * Test that threaded comments can be viewed.
    */
-  function testThreadedCommentView() {
+  public function testThreadedCommentView() {
     $langcode = LANGUAGE_NONE;
     // Set comments to have title required and preview disabled.
     $this->backdropLogin($this->admin_user);
@@ -1661,7 +1661,7 @@ class CommentApprovalTest extends CommentHelperCase {
   /**
    * Test comment approval functionality through admin/content/comment.
    */
-  function testApprovalAdminInterface() {
+  public function testApprovalAdminInterface() {
     // Set anonymous comments to require approval.
     user_role_change_permissions(BACKDROP_ANONYMOUS_ROLE, array(
       'access comments' => TRUE,
@@ -1732,7 +1732,7 @@ class CommentApprovalTest extends CommentHelperCase {
   /**
    * Tests comment approval functionality through the node interface.
    */
-  function testApprovalNodeInterface() {
+  public function testApprovalNodeInterface() {
     // Set anonymous comments to require approval.
     user_role_change_permissions(BACKDROP_ANONYMOUS_ROLE, array(
       'access comments' => TRUE,
@@ -1777,7 +1777,7 @@ class CommentApprovalTest extends CommentHelperCase {
  * Tests the Comment module blocks.
  */
 class CommentBlockFunctionalTest extends CommentHelperCase {
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     parent::setUp(array('block'));
 
     $admin_user_role = $this->admin_user->roles[count($this->admin_user->roles) - 1];
@@ -1787,7 +1787,7 @@ class CommentBlockFunctionalTest extends CommentHelperCase {
   /**
    * Tests the recent comments block.
    */
-  function testRecentCommentBlock() {
+  public function testRecentCommentBlock() {
     $this->backdropLogin($this->admin_user);
     $this->setCommentSubject(COMMENT_TITLE_CUSTOM);
 
@@ -1876,7 +1876,7 @@ class CommentRSSUnitTest extends CommentHelperCase {
   /**
    * Tests comments as part of an RSS feed.
    */
-  function testCommentRSS() {
+  public function testCommentRSS() {
     // Find comment in RSS feed.
     $this->backdropLogin($this->web_user);
     $comment = $this->postComment($this->node, $this->randomName(), $this->randomName());
@@ -1900,7 +1900,7 @@ class CommentContentRebuild extends CommentHelperCase {
   /**
    * Tests the rebuilding of comment's content arrays on calling comment_view().
    */
-  function testCommentRebuild() {
+  public function testCommentRebuild() {
     // Update the comment settings so preview isn't required.
     $this->backdropLogin($this->admin_user);
     $this->setCommentSubject(COMMENT_TITLE_CUSTOM);
@@ -1931,7 +1931,7 @@ class CommentTokenReplaceTestCase extends CommentHelperCase {
   /**
    * Creates a comment, then tests the tokens generated from it.
    */
-  function testCommentTokenReplacement() {
+  public function testCommentTokenReplacement() {
     global $language;
     $url_options = array(
       'absolute' => TRUE,
@@ -2025,7 +2025,7 @@ class CommentActionsTestCase extends CommentHelperCase {
   /**
    * Tests comment publish and unpublish actions.
    */
-  function testCommentPublishUnpublishActions() {
+  public function testCommentPublishUnpublishActions() {
     $this->backdropLogin($this->web_user);
     $comment_text = $this->randomName();
     $subject = $this->randomName();
@@ -2044,7 +2044,7 @@ class CommentActionsTestCase extends CommentHelperCase {
  * Tests fields on comments.
  */
 class CommentFieldsTest extends CommentHelperCase {
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     parent::setUp(array('field_ui'));
   }
 
@@ -2093,7 +2093,7 @@ class CommentFieldsTest extends CommentHelperCase {
   /**
    * Tests that the default 'comment_body' field is correctly added.
    */
-  function testCommentDefaultFields() {
+  public function testCommentDefaultFields() {
     // Do not make assumptions on default node types created by the test
     // installation profile, and create our own.
     $this->backdropCreateContentType(array('type' => 'test_node_type'));
@@ -2126,7 +2126,7 @@ class CommentFieldsTest extends CommentHelperCase {
   /**
    * Tests that comment module works when enabled after a content module.
    */
-  function testCommentEnable() {
+  public function testCommentEnable() {
     // Create a user to do module administration.
     $this->admin_user = $this->backdropCreateUser(array('access administration pages', 'administer modules'));
     $this->backdropLogin($this->admin_user);
@@ -2167,7 +2167,7 @@ class CommentFieldsTest extends CommentHelperCase {
   /**
    * Tests that comment module works correctly with plain text format.
    */
-  function testCommentFormat() {
+  public function testCommentFormat() {
     // Disable text processing for comments.
     $this->backdropLogin($this->admin_user);
     $edit = array('instance[settings][text_processing]' => 0);
@@ -2188,7 +2188,7 @@ class CommentThreadingTestCase extends CommentHelperCase {
   /**
    * Tests the comment threading.
    */
-  function testCommentThreading() {
+  public function testCommentThreading() {
     $langcode = LANGUAGE_NONE;
     // Set comments to have a title with preview disabled.
     $this->backdropLogin($this->admin_user);
@@ -2275,7 +2275,7 @@ class CommentNodeChangesTestCase extends CommentHelperCase {
   /**
    * Tests that comments are deleted with the node.
    */
-  function testNodeDeletion() {
+  public function testNodeDeletion() {
     $this->backdropLogin($this->web_user);
     $comment = $this->postComment($this->node, $this->randomName(), '');
     $this->assertTrue(comment_load($comment->id), 'The comment could be loaded.');
@@ -2286,7 +2286,7 @@ class CommentNodeChangesTestCase extends CommentHelperCase {
   /**
    * Tests opening, closing, and hiding comments.
    */
-  function testNodeCommentSettings() {
+  public function testNodeCommentSettings() {
     $this->backdropLogin($this->admin_user);
 
     // Check that the comment settings only include "Open" and "Closed" if
@@ -2332,7 +2332,7 @@ class CommentNodeAutoCloserTestCase extends CommentHelperCase {
   /**
    * Tests the auto closer node type setting and the override setting on individual nodes.
    */
-  function testNodeCommentAutoCloserSettings() {
+  public function testNodeCommentAutoCloserSettings() {
     $this->backdropLogin($this->admin_user);
 
     $this->backdropGet('node/' . $this->node->nid . '/edit');

--- a/core/modules/comment/tests/comment_views_handler_argument_user_uid.test
+++ b/core/modules/comment/tests/comment_views_handler_argument_user_uid.test
@@ -86,7 +86,7 @@ class CommentViewsHandlerArgumentUserUidTest extends ViewsSqlTest {
     $this->postComment($this->node_user_commented);
   }
 
-  function testCommentUserUidTest() {
+  public function testCommentUserUidTest() {
     $view = $this->view_comment_user_uid();
 
 
@@ -104,7 +104,7 @@ class CommentViewsHandlerArgumentUserUidTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function view_comment_user_uid() {
+  private function view_comment_user_uid() {
     $view = new view;
     $view->name = 'test_comment_user_uid';
     $view->description = '';

--- a/core/modules/comment/tests/comment_views_handler_filter_user_uid.test
+++ b/core/modules/comment/tests/comment_views_handler_filter_user_uid.test
@@ -16,7 +16,7 @@ class CommentViewsHandlerFilterUserUidTest extends CommentViewsHandlerArgumentUs
    * Override the view from the argument test case to remove the argument and
    * add filter with the uid as the value.
    */
-  function view_comment_user_uid() {
+  private function view_comment_user_uid() {
     $view = parent::view_comment_user_uid();
     // Remove the argument.
     $view->set_item('default', 'argument', 'uid_touch', NULL);

--- a/core/modules/config/tests/config.test
+++ b/core/modules/config/tests/config.test
@@ -268,7 +268,7 @@ class ConfigurationUITest extends BackdropWebTestCase {
    */
   protected $webUser;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('config_test'));
 
     $this->webUser = $this->backdropCreateUser(array('synchronize configuration'));
@@ -278,7 +278,7 @@ class ConfigurationUITest extends BackdropWebTestCase {
   /**
    * Tests importing configuration.
    */
-  function testImport() {
+  public function testImport() {
     $name = 'config_test.simple';
     $dynamic_name = 'config_test.dynamic.new';
     $staging_storage = new ConfigFileStorage(config_get_config_directory('staging'));
@@ -355,7 +355,7 @@ class ConfigurationUITest extends BackdropWebTestCase {
   /**
    * Tests the screen that shows differences between active and staging.
    */
-  function testDiff() {
+  public function testDiff() {
     $staging_storage = new ConfigFileStorage(config_get_config_directory('staging'));
 
     $config_name = 'config_test.simple';
@@ -395,7 +395,7 @@ class ConfigurationUITest extends BackdropWebTestCase {
   /**
    * Tests export of configuration.
    */
-  function testExport() {
+  public function testExport() {
     // Verify the export page with export submit button is available.
     $this->backdropGet('admin/config/development/configuration/full/export');
     $this->assertFieldById('edit-submit', t('Export'));
@@ -438,7 +438,7 @@ class ConfigurationUITest extends BackdropWebTestCase {
   /**
    * Test full import validation.
    */
-  function testFullImportValidation() {
+  public function testFullImportValidation() {
     // Enable all non-test core modules to populate all default config files.
     $core_modules = db_query("SELECT name FROM {system} WHERE type = 'module' AND filename LIKE 'core/modules%' AND filename NOT LIKE '%/tests/%'")->fetchCol();
     module_enable($core_modules);

--- a/core/modules/contact/tests/contact.test
+++ b/core/modules/contact/tests/contact.test
@@ -15,7 +15,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('contact');
 
     // Create and login administrative user.
@@ -26,7 +26,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
   /**
    * Tests configuration options and the site-wide contact form.
    */
-  function testSiteWideContact() {
+  public function testSiteWideContact() {
     $flood_limit = 3;
     $edit = array(
       'contact_threshold_limit' => $flood_limit,
@@ -186,7 +186,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
   /**
   * Tests auto-reply on the site-wide contact form.
   */
-  function testAutoReply() {
+  public function testAutoReply() {
     // Set up three categories, 2 with an auto-reply and one without.
     $foo_autoreply = $this->randomName(40);
     $bar_autoreply = $this->randomName(40);
@@ -233,7 +233,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
    * @param boolean $selected
    *   Boolean indicating whether the category should be selected by default.
    */
-  function addCategory($category, $recipients, $reply, $selected) {
+  protected function addCategory($category, $recipients, $reply, $selected) {
     $edit = array();
     $edit['category'] = $category;
     $edit['recipients'] = $recipients;
@@ -255,7 +255,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
    * @param boolean $selected
    *   Boolean indicating whether the category should be selected by default.
    */
-  function updateCategory($categories, $category, $recipients, $reply, $selected) {
+  protected function updateCategory($categories, $category, $recipients, $reply, $selected) {
     $category_id = $categories[array_rand($categories)];
     $edit = array();
     $edit['category'] = $category;
@@ -280,7 +280,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
    * @param string $message
    *   The message body.
    */
-  function submitContact($name, $mail, $subject, $cid, $message) {
+  protected function submitContact($name, $mail, $subject, $cid, $message) {
     $edit = array();
     $edit['name'] = $name;
     $edit['mail'] = $mail;
@@ -293,7 +293,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
   /**
    * Deletes all categories.
    */
-  function deleteCategories() {
+  protected function deleteCategories() {
     $category_ids = $this->getCategories();
     foreach ($category_ids as $cid) {
       $category = contact_load($cid);
@@ -309,7 +309,7 @@ class ContactSitewideTestCase extends BackdropWebTestCase {
    * @return array
    *   A list of the category IDs.
    */
-  function getCategories() {
+  protected function getCategories() {
     $config_data = contact_config_data();
     $categories = $config_data['categories'];
     foreach ($categories as $cat) {
@@ -329,7 +329,7 @@ class ContactPersonalTestCase extends BackdropWebTestCase {
   private $web_user;
   private $contact_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('contact');
 
     // Create an admin user.
@@ -345,7 +345,7 @@ class ContactPersonalTestCase extends BackdropWebTestCase {
   /**
    * Tests access to the personal contact form.
    */
-  function testPersonalContactAccess() {
+  public function testPersonalContactAccess() {
     // Test allowed access to user with contact form enabled.
     $this->backdropLogin($this->web_user);
     $this->backdropGet('user/' . $this->contact_user->uid . '/contact');
@@ -431,7 +431,7 @@ class ContactPersonalTestCase extends BackdropWebTestCase {
   /**
    * Tests the personal contact form flood protection.
    */
-  function testPersonalContactFlood() {
+  public function testPersonalContactFlood() {
     $flood_limit = 3;
     $config = config('contact.settings');
     $config->set('contact_threshold_limit', $flood_limit);

--- a/core/modules/contextual/tests/contextual.test
+++ b/core/modules/contextual/tests/contextual.test
@@ -10,7 +10,7 @@
 class ContextualDynamicContextTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('contextual', 'node'));
     $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
     $this->backdropCreateContentType(array('type' => 'post', 'name' => 'Post'));
@@ -21,7 +21,7 @@ class ContextualDynamicContextTestCase extends BackdropWebTestCase {
   /**
    * Tests contextual links on node lists with different permissions.
    */
-  function testNodeLinks() {
+  public function testNodeLinks() {
     // Create three nodes in the following order:
     // - An post, which should be user-editable.
     // - A page, which should not be user-editable.

--- a/core/modules/dashboard/tests/dashboard.test
+++ b/core/modules/dashboard/tests/dashboard.test
@@ -11,7 +11,7 @@ class DashboardTest extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('layout', 'layout_test', 'taxonomy', 'comment', 'node', 'dashboard', 'menu'));
 
     $this->backdropCreateContentType(array(
@@ -76,7 +76,7 @@ class DashboardTest extends BackdropWebTestCase {
   /**
    * Test the dashboard layout.
    */
-  function testDashboardLayout() {
+  public function testDashboardLayout() {
     $this->backdropGet('admin/dashboard');
 
     // The welcome to Backdrop block was found.

--- a/core/modules/date/tests/date.test
+++ b/core/modules/date/tests/date.test
@@ -47,7 +47,7 @@ class DateUITestCase extends DateFieldBasic {
     $this->deleteDateField($label);
   }
 
-  function dateForm($options) {
+  protected function dateForm($options) {
     // Tests that date field functions properly.
     $edit = array();
     $edit['title'] = $this->randomName(8);

--- a/core/modules/date/tests/date_api.test
+++ b/core/modules/date/tests/date_api.test
@@ -5,7 +5,7 @@
  */
 
 class DateAPITestCase extends BackdropUnitTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     require_once(BACKDROP_ROOT . '/core/includes/date.inc');
     require_once(BACKDROP_ROOT . '/core/includes/date.class.inc');

--- a/core/modules/date/tests/date_validation.test
+++ b/core/modules/date/tests/date_validation.test
@@ -3,7 +3,7 @@
  * @file
  * Date validation tests.
  */
- 
+
 require_once BACKDROP_ROOT . '/core/modules/date/tests/date_field.test';
 
 class DateValidationTestCase extends DateFieldBasic {
@@ -47,7 +47,7 @@ class DateValidationTestCase extends DateFieldBasic {
   /**
    * Attempt to create a node with a malformed date and ensure it fails.
    */
-  function malFormedDate($field_name, $field_type, $widget_type) {
+  protected function malFormedDate($field_name, $field_type, $widget_type) {
     // Tests that date field filters improper dates.
     $edit = array();
     $edit['title'] = $this->randomName(8);

--- a/core/modules/date/tests/date_views.test
+++ b/core/modules/date/tests/date_views.test
@@ -132,7 +132,7 @@ class DateViewsTestCase extends DateFieldBasic {
   /**
    * Clear all views caches and static caches which are required for the patch.
    */
-  function clearViewsCaches() {
+  protected function clearViewsCaches() {
     // Reset views data cache.
     backdrop_static_reset('_views_fetch_data_cache');
     backdrop_static_reset('_views_fetch_data_recursion_protected');

--- a/core/modules/dblog/tests/dblog.test
+++ b/core/modules/dblog/tests/dblog.test
@@ -26,7 +26,7 @@ class DBLogTestCase extends BackdropWebTestCase {
   /**
    * Enable modules and create users with specific permissions.
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp('dblog', 'book');
     // Create users.
     $this->big_user = $this->backdropCreateUser(array('administer site configuration', 'access administration pages', 'access site reports', 'administer users'));
@@ -40,7 +40,7 @@ class DBLogTestCase extends BackdropWebTestCase {
    * Database Logging module functionality through both the admin and user
    * interfaces.
    */
-  function testDBLog() {
+  public function testDBLog() {
     // Login the admin user.
     $this->backdropLogin($this->big_user);
 

--- a/core/modules/email/tests/email.test
+++ b/core/modules/email/tests/email.test
@@ -8,7 +8,7 @@ class EmailFieldTestCase extends BackdropWebTestCase {
   protected $field;
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('field_test', 'email'));
 
     $this->web_user = $this->backdropCreateUser(array(
@@ -22,7 +22,7 @@ class EmailFieldTestCase extends BackdropWebTestCase {
   /**
    * Tests email field.
    */
-  function testEmailField() {
+  public function testEmailField() {
     // Create a field with settings to validate.
     $this->field = array(
       'field_name' => backdrop_strtolower($this->randomName()),

--- a/core/modules/entity/tests/entity.test
+++ b/core/modules/entity/tests/entity.test
@@ -8,14 +8,14 @@
  * Tests the basic Entity API.
  */
 class EntityAPITestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('entity', 'entity_test');
   }
 
   /**
    * Tests basic CRUD functionality of the Entity API.
    */
-  function testCRUD() {
+  public function testCRUD() {
     $user1 = $this->backdropCreateUser();
 
     // Create some test entities.
@@ -59,7 +59,7 @@ class EntityAPITestCase extends BackdropWebTestCase {
   /**
    * Tests caching (and not caching) of entities in the Entity API.
    */
-  function testCaching() {
+  public function testCaching() {
     module_enable(array('entity_caching_test'));
 
     $user1 = $this->backdropCreateUser();
@@ -100,7 +100,7 @@ class EntityAPITestCase extends BackdropWebTestCase {
   /**
    * Tests basic View functionality of the Entity API.
    */
-  function testEntityView() {
+  public function testEntityView() {
     $user1 = $this->backdropCreateUser();
 
     // Create a test entity.
@@ -121,7 +121,7 @@ class EntityAPIInfoTestCase extends BackdropWebTestCase  {
   /**
    * Ensures entity info cache is updated after changes.
    */
-  function testEntityInfoChanges() {
+  public function testEntityInfoChanges() {
     module_enable(array('entity_cache_test'));
     $entity_info = entity_get_info();
     $this->assertTrue(isset($entity_info['entity_cache_test']), 'Test entity type found.');
@@ -144,7 +144,7 @@ class EntityAPIInfoTestCase extends BackdropWebTestCase  {
    *
    * @see entity_cache_test_watchdog()
    */
-  function testEntityInfoCacheWatchdog() {
+  public function testEntityInfoCacheWatchdog() {
     module_enable(array('entity_cache_test'));
     $info = state_get('entity_cache_test');
     $this->assertEqual($info['label'], 'Entity Cache Test', 'Entity info label is correct.');

--- a/core/modules/entity/tests/entity_query.test
+++ b/core/modules/entity/tests/entity_query.test
@@ -19,7 +19,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
    */
   protected $field_names;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node', 'field_test', 'entity_query_access_test', 'node_access_test'));
 
     field_test_create_bundle('bundle1');
@@ -161,7 +161,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests EntityFieldQuery.
    */
-  function testEntityFieldQuery() {
+  public function testEntityFieldQuery() {
     $query = new EntityFieldQuery();
     $query
       ->entityCondition('entity_type', 'test_entity_bundle')
@@ -1051,7 +1051,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests querying translatable fields.
    */
-  function testEntityFieldQueryTranslatable() {
+  public function testEntityFieldQueryTranslatable() {
 
     // Make a test field translatable AND cardinality one.
     $this->fields[0]['translatable'] = TRUE;
@@ -1090,7 +1090,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests field meta conditions.
    */
-  function testEntityFieldQueryMetaConditions() {
+  public function testEntityFieldQueryMetaConditions() {
     // Make a test field translatable.
     $this->fields[0]['translatable'] = TRUE;
     field_update_field($this->fields[0]);
@@ -1216,7 +1216,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests the routing feature of EntityFieldQuery.
    */
-  function testEntityFieldQueryRouting() {
+  public function testEntityFieldQueryRouting() {
     // Entity-only query.
     $query = new EntityFieldQuery();
     $query->entityCondition('entity_type', 'test_entity_bundle_key');
@@ -1270,7 +1270,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests the pager integration of EntityFieldQuery.
    */
-  function testEntityFieldQueryPager() {
+  public function testEntityFieldQueryPager() {
     // Test pager in propertyQuery
     $_GET['page'] = '0,1';
     $query = new EntityFieldQuery();
@@ -1325,7 +1325,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests the disabling the pager in EntityFieldQuery.
    */
-  function testEntityFieldQueryDisablePager() {
+  public function testEntityFieldQueryDisablePager() {
     // Test enabling a pager and then disabling it.
     $query = new EntityFieldQuery();
     $query
@@ -1346,7 +1346,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests the TableSort integration of EntityFieldQuery.
    */
-  function testEntityFieldQueryTableSort() {
+  public function testEntityFieldQueryTableSort() {
     // Test TableSort in propertyQuery
     $_GET['sort'] = 'asc';
     $_GET['order'] = 'Id';
@@ -1523,7 +1523,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
   /**
    * Tests EntityFieldQuery access on non-node entities.
    */
-  function testEntityFieldQueryAccess() {
+  public function testEntityFieldQueryAccess() {
     // Test as a user with ability to bypass node access.
     $privileged_user = $this->backdropCreateUser(array('bypass node access', 'access content'));
     $this->backdropLogin($privileged_user);
@@ -1555,7 +1555,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
    *   $intended_results even if the order is not the same. If TRUE then order
    *   should match too.
    */
-  function assertEntityFieldQuery($query, $intended_results, $message, $ordered = FALSE) {
+  protected function assertEntityFieldQuery($query, $intended_results, $message, $ordered = FALSE) {
     $results = array();
     try {
       foreach ($query->execute() as $entity_type => $entity_ids) {
@@ -1579,7 +1579,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
    *
    * @see field_test_query_efq_table_prefixing_test_alter()
    */
-  function testTablePrefixing() {
+  public function testTablePrefixing() {
     $query = new EntityFieldQuery();
     $query = $query
       ->entityCondition('entity_type', 'test_entity')

--- a/core/modules/field/modules/field_sql_storage/tests/field_sql_storage.test
+++ b/core/modules/field/modules/field_sql_storage/tests/field_sql_storage.test
@@ -37,7 +37,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
    */
   protected $revision_table;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_sql_storage', 'field', 'field_test', 'text');
     $this->field_name = strtolower($this->randomName());
     $this->field = array('field_name' => $this->field_name, 'type' => 'test_field', 'cardinality' => 4);
@@ -57,7 +57,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
    * Uses the mysql tables and records to verify
    * field_load_revision works correctly.
    */
-  function testFieldAttachLoad() {
+  public function testFieldAttachLoad() {
     $entity_type = 'test_entity';
     $eid = 0;
     $langcode = LANGUAGE_NONE;
@@ -125,7 +125,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
    * Reads mysql to verify correct data is
    * written when using insert and update.
    */
-  function testFieldAttachInsertAndUpdate() {
+  public function testFieldAttachInsertAndUpdate() {
     $entity_type = 'test_entity';
     $entity = field_test_create_entity(0, 0, $this->instance['bundle']);
     $langcode = LANGUAGE_NONE;
@@ -206,7 +206,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
   /**
    * Tests insert and update with missing or NULL fields.
    */
-  function testFieldAttachSaveMissingData() {
+  public function testFieldAttachSaveMissingData() {
     $entity_type = 'test_entity';
     $entity = field_test_create_entity(0, 0, $this->instance['bundle']);
     $langcode = LANGUAGE_NONE;
@@ -301,7 +301,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
   /**
    * Test trying to update a field with data.
    */
-  function testUpdateFieldSchemaWithData() {
+  public function testUpdateFieldSchemaWithData() {
     // Create a decimal 5.2 field and add some data.
     $field = array('field_name' => 'decimal52', 'type' => 'number_decimal', 'settings' => array('precision' => 5, 'scale' => 2));
     $field = field_create_field($field);
@@ -325,7 +325,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
   /**
    * Test that failure to create fields is handled gracefully.
    */
-  function testFieldUpdateFailure() {
+  public function testFieldUpdateFailure() {
     // Create a text field.
     $field = array('field_name' => 'test_text', 'type' => 'text', 'settings' => array('max_length' => 255));
     $field = field_create_field($field);
@@ -350,7 +350,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
   /**
    * Test the storage details.
    */
-  function testFieldStorageDetails() {
+  public function testFieldStorageDetails() {
     $current = _field_sql_storage_tablename($this->field);
     $revision = _field_sql_storage_revision_tablename($this->field);
 
@@ -378,7 +378,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
   /**
    * Test foreign key support.
    */
-  function testFieldSqlStorageForeignKeys() {
+  public function testFieldSqlStorageForeignKeys() {
     // Create a decimal field.
     $field_name = 'test_field';
     $field = array(
@@ -409,7 +409,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
    *
    * Tests both the result and the complexity of the query.
    */
-  function testFieldSqlStorageMultipleConditionsSameColumn() {
+  public function testFieldSqlStorageMultipleConditionsSameColumn() {
     $entity = field_test_create_entity(NULL, NULL);
     $entity->{$this->field_name}[LANGUAGE_NONE][0] = array('value' => 1);
     field_test_entity_save($entity);
@@ -450,7 +450,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
    *
    * Tests both the result and the complexity of the query.
    */
-  function testFieldSqlStorageMultipleConditionsDifferentColumns() {
+  public function testFieldSqlStorageMultipleConditionsDifferentColumns() {
     // Create the multi-column shape field
     $field_name = strtolower($this->randomName());
     $field = array('field_name' => $field_name, 'type' => 'shape', 'cardinality' => 4);
@@ -502,7 +502,7 @@ class FieldSqlStorageTestCase extends BackdropWebTestCase {
    *
    * Tests both the result and the complexity of the query.
    */
-  function testFieldSqlStorageMultipleConditionsDifferentColumnsMultipleLanguages() {
+  public function testFieldSqlStorageMultipleConditionsDifferentColumnsMultipleLanguages() {
     field_test_entity_info_translatable('test_entity', TRUE);
 
     // Create the multi-column shape field

--- a/core/modules/field/modules/list/tests/list.test
+++ b/core/modules/field/modules/list/tests/list.test
@@ -26,7 +26,7 @@ class ListFieldTestCase extends FieldTestCase {
    */
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $this->field_name = 'test_list';
@@ -54,7 +54,7 @@ class ListFieldTestCase extends FieldTestCase {
   /**
    * Test that allowed values can be updated.
    */
-  function testUpdateAllowedValues() {
+  public function testUpdateAllowedValues() {
     $langcode = LANGUAGE_NONE;
 
     // All three options appear.
@@ -152,7 +152,7 @@ class ListDynamicValuesTestCase extends FieldTestCase {
    */
   protected $entity;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('list', 'field_test', 'list_test'));
 
     $this->field_name = 'test_list';
@@ -193,7 +193,7 @@ class ListDynamicValuesValidationTestCase extends ListDynamicValuesTestCase {
   /**
    * Test that allowed values function gets the entity.
    */
-  function testDynamicAllowedValues() {
+  public function testDynamicAllowedValues() {
     // Verify that the test passes against every value we had.
     state_set('list_test_dynamic_values', backdrop_map_assoc($this->test));
     foreach ($this->test as $key => $value) {
@@ -247,7 +247,7 @@ class ListFieldUITestCase extends FieldTestCase {
    */
   protected $admin_path;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test', 'field_ui');
 
     // Create test user.
@@ -265,7 +265,7 @@ class ListFieldUITestCase extends FieldTestCase {
   /**
    * List (integer) : test 'allowed values' input.
    */
-  function testListAllowedValuesInteger() {
+  public function testListAllowedValuesInteger() {
     $this->field_name = 'field_list_integer';
     $this->createListField('list_integer');
 
@@ -316,7 +316,7 @@ class ListFieldUITestCase extends FieldTestCase {
   /**
    * List (float) : test 'allowed values' input.
    */
-  function testListAllowedValuesFloat() {
+  public function testListAllowedValuesFloat() {
     $this->field_name = 'field_list_float';
     $this->createListField('list_float');
 
@@ -366,7 +366,7 @@ class ListFieldUITestCase extends FieldTestCase {
   /**
    * List (text) : test 'allowed values' input.
    */
-  function testListAllowedValuesText() {
+  public function testListAllowedValuesText() {
     $this->field_name = 'field_list_text';
     $this->createListField('list_text');
 
@@ -425,7 +425,7 @@ class ListFieldUITestCase extends FieldTestCase {
   /**
    * List (boolean) : test 'On/Off' values input.
    */
-  function testListAllowedValuesBoolean() {
+  public function testListAllowedValuesBoolean() {
     $this->field_name = 'field_list_boolean';
     $this->createListField('list_boolean');
 
@@ -484,7 +484,7 @@ class ListFieldUITestCase extends FieldTestCase {
    * @param $message
    *   Message to display.
    */
-  function assertAllowedValuesInput($input_string, $result, $message) {
+  protected function assertAllowedValuesInput($input_string, $result, $message) {
     $edit = array('field[settings][allowed_values][options_field]' => $input_string);
     $this->backdropPost($this->admin_path, $edit, t('Save settings'));
 
@@ -524,7 +524,7 @@ class ListFieldDisplayTestCase extends FieldTestCase {
    */
   protected $field_name;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test', 'field_ui');
 
     // Create test user.
@@ -565,7 +565,7 @@ class ListFieldDisplayTestCase extends FieldTestCase {
   /**
    * List (boolean) : test 'On/Off' values input.
    */
-  function testListDisplayFormatterBoolean() {
+  public function testListDisplayFormatterBoolean() {
     $this->field_name = 'field_list_boolean';
     $this->createListField('list_boolean');
 

--- a/core/modules/field/modules/number/tests/number.test
+++ b/core/modules/field/modules/number/tests/number.test
@@ -14,7 +14,7 @@ class NumberFieldTestCase extends BackdropWebTestCase {
   protected $instance;
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
     $this->web_user = $this->backdropCreateUser(array('access field_test content', 'administer field_test content', 'administer content types', 'administer fields'));
     $this->backdropLogin($this->web_user);
@@ -23,7 +23,7 @@ class NumberFieldTestCase extends BackdropWebTestCase {
   /**
    * Test number_decimal field.
    */
-  function testNumberDecimalField() {
+  public function testNumberDecimalField() {
     // Create a field with settings to validate.
     $this->field = array(
       'field_name' => backdrop_strtolower($this->randomName()),
@@ -164,7 +164,7 @@ class NumberFieldTestCase extends BackdropWebTestCase {
   /**
    * Test number_integer field.
    */
-  function testNumberIntegerField() {
+  public function testNumberIntegerField() {
     // Display the "Add content type" form.
     $this->backdropGet('admin/structure/types/add');
 
@@ -201,7 +201,7 @@ class NumberFieldTestCase extends BackdropWebTestCase {
   /**
    * Test number_float field.
    */
-  function testNumberFloatField() {
+  public function testNumberFloatField() {
     $this->field = array(
       'field_name' => backdrop_strtolower($this->randomName()),
       'type' => 'number_float',
@@ -246,7 +246,7 @@ class NumberFieldTestCase extends BackdropWebTestCase {
   /**
    * Test empty value submission.
    */
-  function testNumberFieldEmpty() {
+  public function testNumberFieldEmpty() {
     // Add a content type.
     $this->backdropGet('admin/structure/types/add');
     $name = $this->randomName();

--- a/core/modules/field/modules/options/tests/options.test
+++ b/core/modules/field/modules/options/tests/options.test
@@ -29,7 +29,7 @@ class OptionsWidgetsTestCase extends FieldTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test', 'list_test');
 
     // Field with cardinality 1.
@@ -92,7 +92,7 @@ class OptionsWidgetsTestCase extends FieldTestCase {
   /**
    * Tests the 'options_buttons' widget (single select).
    */
-  function testRadioButtons() {
+  public function testRadioButtons() {
     // Create an instance of the 'single value' field.
     $instance = array(
       'field_name' => $this->card_1['field_name'],
@@ -146,7 +146,7 @@ class OptionsWidgetsTestCase extends FieldTestCase {
   /**
    * Tests the 'options_buttons' widget (multiple select).
    */
-  function testCheckBoxes() {
+  public function testCheckBoxes() {
     // Create an instance of the 'multiple values' field.
     $instance = array(
       'field_name' => $this->card_2['field_name'],
@@ -233,7 +233,7 @@ class OptionsWidgetsTestCase extends FieldTestCase {
   /**
    * Tests the 'options_select' widget (single select).
    */
-  function testSelectListSingle() {
+  public function testSelectListSingle() {
     // Create an instance of the 'single value' field.
     $instance = array(
       'field_name' => $this->card_1['field_name'],
@@ -331,7 +331,7 @@ class OptionsWidgetsTestCase extends FieldTestCase {
   /**
    * Tests the 'options_select' widget (multiple select).
    */
-  function testSelectListMultiple() {
+  public function testSelectListMultiple() {
     // Create an instance of the 'multiple values' field.
     $instance = array(
       'field_name' => $this->card_2['field_name'],
@@ -448,7 +448,7 @@ class OptionsWidgetsTestCase extends FieldTestCase {
   /**
    * Tests the 'options_onoff' widget.
    */
-  function testOnOffCheckbox() {
+  public function testOnOffCheckbox() {
     // Create an instance of the 'boolean' field.
     $instance = array(
       'field_name' => $this->bool['field_name'],
@@ -555,7 +555,7 @@ class OptionsSelectDynamicValuesTestCase extends ListDynamicValuesTestCase {
   /**
    * Tests the 'options_select' widget (single select).
    */
-  function testSelectListDynamic() {
+  public function testSelectListDynamic() {
     // Create an entity.
     $this->entity->is_new = TRUE;
     field_test_entity_save($this->entity);

--- a/core/modules/field/modules/text/tests/text.test
+++ b/core/modules/field/modules/text/tests/text.test
@@ -19,7 +19,7 @@ class TextFieldTestCase extends BackdropWebTestCase {
    */
   protected $field_name;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $this->admin_user = $this->backdropCreateUser(array('administer filters'));
@@ -32,7 +32,7 @@ class TextFieldTestCase extends BackdropWebTestCase {
   /**
    * Test text field validation.
    */
-  function testTextFieldValidation() {
+  public function testTextFieldValidation() {
     // Create a field with settings to validate.
     $max_length = 3;
     $this->field = array(
@@ -75,7 +75,7 @@ class TextFieldTestCase extends BackdropWebTestCase {
   /**
    * Test widgets.
    */
-  function testTextfieldWidgets() {
+  public function testTextfieldWidgets() {
     $this->_testTextfieldWidgets('text', 'text_textfield');
     $this->_testTextfieldWidgets('text_long', 'text_textarea');
   }
@@ -83,7 +83,7 @@ class TextFieldTestCase extends BackdropWebTestCase {
   /**
    * Helper function for testTextfieldWidgets().
    */
-  function _testTextfieldWidgets($field_type, $widget_type) {
+  private function _testTextfieldWidgets($field_type, $widget_type) {
     // Setup a field and instance
     $entity_type = 'test_entity';
     $field_name = backdrop_strtolower($this->randomName());
@@ -137,7 +137,7 @@ class TextFieldTestCase extends BackdropWebTestCase {
   /**
    * Test widgets + 'formatted_text' setting.
    */
-  function testTextfieldWidgetsFormatted() {
+  public function testTextfieldWidgetsFormatted() {
     $this->_testTextfieldWidgetsFormatted('text', 'text_textfield');
     $this->_testTextfieldWidgetsFormatted('text_long', 'text_textarea');
   }
@@ -145,7 +145,7 @@ class TextFieldTestCase extends BackdropWebTestCase {
   /**
    * Helper function for testTextfieldWidgetsFormatted().
    */
-  function _testTextfieldWidgetsFormatted($field_type, $widget_type) {
+  private function _testTextfieldWidgetsFormatted($field_type, $widget_type) {
     // Setup a field and instance
     $entity_type = 'test_entity';
     $this->field_name = backdrop_strtolower($this->randomName());
@@ -387,7 +387,7 @@ class TextSummaryTestCase extends BackdropWebTestCase {
    */
   protected $post_creator;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->post_creator = $this->backdropCreateUser(array('create post content', 'edit own post content'));
   }
@@ -397,7 +397,7 @@ class TextSummaryTestCase extends BackdropWebTestCase {
    * subsequent sentences are not. This edge case is documented at
    * http://drupal.org/node/180425.
    */
-  function testFirstSentenceQuestion() {
+  public function testFirstSentenceQuestion() {
     $text = 'A question? A sentence. Another sentence.';
     $expected = 'A question? A sentence.';
     $this->assertTextSummary($text, $expected, NULL, 30);
@@ -406,7 +406,7 @@ class TextSummaryTestCase extends BackdropWebTestCase {
   /**
    * Test summary with long example.
    */
-  function testLongSentence() {
+  public function testLongSentence() {
     $text = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' . // 125
             'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ' . // 108
             'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ' . // 103
@@ -421,7 +421,7 @@ class TextSummaryTestCase extends BackdropWebTestCase {
   /**
    * Test various summary length edge cases.
    */
-  function testLength() {
+  public function testLength() {
     // This string tests a number of edge cases.
     $text = "<p>\nHi\n</p>\n<p>\nfolks\n<br />\n!\n</p>";
 
@@ -521,7 +521,7 @@ class TextSummaryTestCase extends BackdropWebTestCase {
   /**
    * Calls text_summary() and asserts that the expected teaser is returned.
    */
-  function assertTextSummary($text, $expected, $format = NULL, $size = NULL) {
+  protected function assertTextSummary($text, $expected, $format = NULL, $size = NULL) {
     $summary = text_summary($text, $format, $size);
     $this->assertIdentical($summary, $expected, format_string('Generated @format summary "@summary" matches expected "@expected".', array('@format' => $format, '@summary' => str_replace("\n", '\n', $summary), '@expected' => str_replace("\n", '\n', $expected))));
   }
@@ -529,7 +529,7 @@ class TextSummaryTestCase extends BackdropWebTestCase {
   /**
    * Test sending only summary.
    */
-  function testOnlyTextSummary() {
+  public function testOnlyTextSummary() {
     // Login as post creator.
     $this->backdropLogin($this->post_creator);
     // Create post with summary but empty body.
@@ -562,7 +562,7 @@ class TextTranslationTestCase extends BackdropWebTestCase {
    */
   protected $translator;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'translation');
 
     $full_html_format = filter_format_load('full_html');
@@ -591,7 +591,7 @@ class TextTranslationTestCase extends BackdropWebTestCase {
   /**
    * Test that a plaintext textfield widget is correctly populated.
    */
-  function testTextField() {
+  public function testTextField() {
     // Disable text processing for body.
     $edit = array('instance[settings][text_processing]' => 0);
     $this->backdropPost('admin/structure/types/manage/post/fields/body', $edit, t('Save settings'));
@@ -620,7 +620,7 @@ class TextTranslationTestCase extends BackdropWebTestCase {
    * Check that user that does not have access the field format cannot see the
    * source value when creating a translation.
    */
-  function testTextFieldFormatted() {
+  public function testTextFieldFormatted() {
     // Make node body multiple.
     $edit = array('field[cardinality]' => -1);
     $this->backdropPost('admin/structure/types/manage/post/fields/body', $edit, t('Save settings'));

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -16,7 +16,7 @@ class FieldTestCase extends BackdropWebTestCase {
    * @return array
    *  An array of random values, in the format expected for field values.
    */
-  private function _generateTestFieldValues($cardinality) {
+  protected function _generateTestFieldValues($cardinality) {
     $values = array();
     for ($i = 0; $i < $cardinality; $i++) {
       // field_test fields treat 0 as 'empty value'.

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -1561,7 +1561,7 @@ class FieldFormTestCase extends FieldTestCase {
     $this->assertRaw(t('!name field is required.', array('!name' => $this->instance['label'])), 'Required field with no value fails validation');
   }
 
-//  function testFieldFormMultiple() {
+//  public function testFieldFormMultiple() {
 //    $this->field = $this->field_multiple;
 //    $this->field_name = $this->field['field_name'];
 //    $this->instance['field_name'] = $this->field_name;

--- a/core/modules/field/tests/field.test
+++ b/core/modules/field/tests/field.test
@@ -16,7 +16,7 @@ class FieldTestCase extends BackdropWebTestCase {
    * @return array
    *  An array of random values, in the format expected for field values.
    */
-  function _generateTestFieldValues($cardinality) {
+  private function _generateTestFieldValues($cardinality) {
     $values = array();
     for ($i = 0; $i < $cardinality; $i++) {
       // field_test fields treat 0 as 'empty value'.
@@ -41,7 +41,7 @@ class FieldTestCase extends BackdropWebTestCase {
    * @param $column
    *   (Optional) the name of the column to check.
    */
-  function assertFieldValues($entity, $field_name, $langcode, $expected_values, $column = 'value') {
+  protected function assertFieldValues($entity, $field_name, $langcode, $expected_values, $column = 'value') {
     $e = clone $entity;
     field_attach_load('test_entity', array($e->ftid => $e));
     $values = isset($e->{$field_name}[$langcode]) ? $e->{$field_name}[$langcode] : array();
@@ -57,7 +57,7 @@ class FieldAttachTestCase extends FieldTestCase {
   protected $field;
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     // Since this is a base class for many test cases, support the same
     // flexibility that BackdropWebTestCase::setUp() has for the modules to be
     // passed in as either an array or a variable number of string arguments.
@@ -80,7 +80,7 @@ class FieldAttachTestCase extends FieldTestCase {
    *   (optional) A string that should only contain characters that are valid in
    *   PHP variable names as well.
    */
-  function createFieldWithInstance($suffix = '') {
+  protected function createFieldWithInstance($suffix = '') {
     $field_name = 'field_name' . $suffix;
     $field = 'field' . $suffix;
     $instance = 'instance' . $suffix;
@@ -123,7 +123,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
    * Works independently of the underlying field storage backend. Inserts or
    * updates random field data and then loads and verifies the data.
    */
-  function testFieldAttachSaveLoad() {
+  public function testFieldAttachSaveLoad() {
     // Configure the instance so that we test hook_field_load() (see
     // field_test_field_load() in field_test.module).
     $this->instance['settings']['test_hook_field_load'] = TRUE;
@@ -185,7 +185,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test the 'multiple' load feature.
    */
-  function testFieldAttachLoadMultiple() {
+  public function testFieldAttachLoadMultiple() {
     $entity_type = 'test_entity';
     $langcode = LANGUAGE_NONE;
 
@@ -264,7 +264,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test saving and loading fields using different storage backends.
    */
-  function testFieldAttachSaveLoadDifferentStorage() {
+  public function testFieldAttachSaveLoadDifferentStorage() {
     $entity_type = 'test_entity';
     $langcode = LANGUAGE_NONE;
 
@@ -317,7 +317,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
    *
    * @see field_test_storage_details_alter()
    */
-  function testFieldStorageDetailsAlter() {
+  public function testFieldStorageDetailsAlter() {
     $field_name = 'field_test_change_my_details';
     $field = array(
       'field_name' => $field_name,
@@ -356,7 +356,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Tests insert and update with missing or NULL fields.
    */
-  function testFieldAttachSaveMissingData() {
+  public function testFieldAttachSaveMissingData() {
     $entity_type = 'test_entity';
     $entity_init = field_test_create_entity();
     $langcode = LANGUAGE_NONE;
@@ -434,7 +434,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test insert with missing or NULL fields, with default value.
    */
-  function testFieldAttachSaveMissingDataDefaultValue() {
+  public function testFieldAttachSaveMissingDataDefaultValue() {
     // Add a default value function.
     $this->instance['default_value_function'] = 'field_test_default_value';
     field_update_instance($this->instance);
@@ -466,7 +466,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test field_has_data().
    */
-  function testFieldHasData() {
+  public function testFieldHasData() {
     $entity_type = 'test_entity';
     $langcode = LANGUAGE_NONE;
 
@@ -511,7 +511,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test field_attach_delete().
    */
-  function testFieldAttachDelete() {
+  public function testFieldAttachDelete() {
     $entity_type = 'test_entity';
     $langcode = LANGUAGE_NONE;
     $rev[0] = field_test_create_entity(0, 0, $this->instance['bundle']);
@@ -566,7 +566,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test field_attach_create_bundle() and field_attach_rename_bundle().
    */
-  function testFieldAttachCreateRenameBundle() {
+  public function testFieldAttachCreateRenameBundle() {
     // Create a new bundle. This has to be initiated by the module so that its
     // hook_entity_info() is consistent.
     $new_bundle = 'test_bundle_' . backdrop_strtolower($this->randomName());
@@ -607,7 +607,7 @@ class FieldAttachStorageTestCase extends FieldAttachTestCase {
   /**
    * Test field_attach_delete_bundle().
    */
-  function testFieldAttachDeleteBundle() {
+  public function testFieldAttachDeleteBundle() {
     // Create a new bundle. This has to be initiated by the module so that its
     // hook_entity_info() is consistent.
     $new_bundle = 'test_bundle_' . backdrop_strtolower($this->randomName());
@@ -676,7 +676,7 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
   /**
    * Test field_attach_view() and field_attach_prepare_view().
    */
-  function testFieldAttachView() {
+  public function testFieldAttachView() {
     $this->createFieldWithInstance('_2');
 
     $entity_type = 'test_entity';
@@ -838,7 +838,7 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
   /**
    * Tests the 'multiple entity' behavior of field_attach_prepare_view().
    */
-  function testFieldAttachPrepareViewMultiple() {
+  public function testFieldAttachPrepareViewMultiple() {
     $entity_type = 'test_entity';
     $langcode = LANGUAGE_NONE;
 
@@ -887,7 +887,7 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
   /**
    * Test field cache.
    */
-  function testFieldAttachCache() {
+  public function testFieldAttachCache() {
     // Initialize random values and a test entity.
     $entity_init = field_test_create_entity(1, 1, $this->instance['bundle']);
     $langcode = LANGUAGE_NONE;
@@ -977,7 +977,7 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
    * Verify that field_attach_validate() invokes the correct
    * hook_field_validate.
    */
-  function testFieldAttachValidate() {
+  public function testFieldAttachValidate() {
     $this->createFieldWithInstance('_2');
 
     $entity_type = 'test_entity';
@@ -1070,7 +1070,7 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
    * This could be much more thorough, but it does verify that the correct
    * widgets show up.
    */
-  function testFieldAttachForm() {
+  public function testFieldAttachForm() {
     $this->createFieldWithInstance('_2');
 
     $entity_type = 'test_entity';
@@ -1110,7 +1110,7 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
   /**
    * Test field_attach_submit().
    */
-  function testFieldAttachSubmit() {
+  public function testFieldAttachSubmit() {
     $this->createFieldWithInstance('_2');
 
     $entity_type = 'test_entity';
@@ -1194,14 +1194,14 @@ class FieldAttachOtherTestCase extends FieldAttachTestCase {
 }
 
 class FieldInfoTestCase extends FieldTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
   }
 
   /**
    * Test that field types and field definitions are correctly cached.
    */
-  function testFieldInfo() {
+  public function testFieldInfo() {
     // Test that field_test module's fields, widgets, and formatters show up.
 
     $field_test_info = field_test_field_info();
@@ -1317,7 +1317,7 @@ class FieldInfoTestCase extends FieldTestCase {
   /**
    * Test that cached field definitions are ready for current runtime context.
    */
-  function testFieldPrepare() {
+  public function testFieldPrepare() {
     $field_definition = array(
       'field_name' => 'field',
       'type' => 'test_field',
@@ -1344,7 +1344,7 @@ class FieldInfoTestCase extends FieldTestCase {
   /**
    * Test that cached instance definitions are ready for current runtime context.
    */
-  function testInstancePrepare() {
+  public function testInstancePrepare() {
     $field_definition = array(
       'field_name' => 'field',
       'type' => 'test_field',
@@ -1394,7 +1394,7 @@ class FieldInfoTestCase extends FieldTestCase {
   /**
    * Test that instances on disabled entity types are filtered out.
    */
-  function testInstanceDisabledEntityType() {
+  public function testInstanceDisabledEntityType() {
     // For this test the field type and the entity type must be exposed by
     // different modules.
     $field_definition = array(
@@ -1417,7 +1417,7 @@ class FieldInfoTestCase extends FieldTestCase {
   /**
    * Test that the field_info settings convenience functions work.
    */
-  function testSettingsInfo() {
+  public function testSettingsInfo() {
     $info = field_test_field_info();
     // We need to account for the existence of user_field_info_alter().
     foreach (array_keys($info) as $name) {
@@ -1448,7 +1448,7 @@ class FieldFormTestCase extends FieldTestCase {
   protected $field_multiple;
   protected $field_unlimited;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $web_user = $this->backdropCreateUser(array('access field_test content', 'administer field_test content'));
@@ -1477,7 +1477,7 @@ class FieldFormTestCase extends FieldTestCase {
     );
   }
 
-  function testFieldFormSingle() {
+  public function testFieldFormSingle() {
     $this->field = $this->field_single;
     $this->field_name = $this->field['field_name'];
     $this->instance['field_name'] = $this->field_name;
@@ -1530,7 +1530,7 @@ class FieldFormTestCase extends FieldTestCase {
 
   }
 
-  function testFieldFormSingleRequired() {
+  public function testFieldFormSingleRequired() {
     $this->field = $this->field_single;
     $this->field_name = $this->field['field_name'];
     $this->instance['field_name'] = $this->field_name;
@@ -1569,7 +1569,7 @@ class FieldFormTestCase extends FieldTestCase {
 //    field_create_instance($this->instance);
 //  }
 
-  function testFieldFormUnlimited() {
+  public function testFieldFormUnlimited() {
     $this->field = $this->field_unlimited;
     $this->field_name = $this->field['field_name'];
     $this->instance['field_name'] = $this->field_name;
@@ -1674,7 +1674,7 @@ class FieldFormTestCase extends FieldTestCase {
   /**
    * Tests widget handling of multiple required radios.
    */
-  function testFieldFormMultivalueWithRequiredRadio() {
+  public function testFieldFormMultivalueWithRequiredRadio() {
     // Create a multivalue test field.
     $this->field = $this->field_unlimited;
     $this->field_name = $this->field['field_name'];
@@ -1716,7 +1716,7 @@ class FieldFormTestCase extends FieldTestCase {
     $this->assertNoField("{$this->field_name}[$langcode][2][value]", 'No extraneous widget is displayed');
   }
 
-  function testFieldFormJSAddMore() {
+  public function testFieldFormJSAddMore() {
     $this->field = $this->field_unlimited;
     $this->field_name = $this->field['field_name'];
     $this->instance['field_name'] = $this->field_name;
@@ -1773,7 +1773,7 @@ class FieldFormTestCase extends FieldTestCase {
   /**
    * Tests widgets handling multiple values.
    */
-  function testFieldFormMultipleWidget() {
+  public function testFieldFormMultipleWidget() {
     // Create a field with fixed cardinality and an instance using a multiple
     // widget.
     $this->field = $this->field_multiple;
@@ -1813,7 +1813,7 @@ class FieldFormTestCase extends FieldTestCase {
   /**
    * Tests fields with no 'edit' access.
    */
-  function testFieldFormAccess() {
+  public function testFieldFormAccess() {
     // Create a "regular" field.
     $field = $this->field_single;
     $field_name = $field['field_name'];
@@ -1884,7 +1884,7 @@ class FieldFormTestCase extends FieldTestCase {
   /**
    * Tests Field API form integration within a subform.
    */
-  function testNestedFieldForm() {
+  public function testNestedFieldForm() {
     // Add two instances on the 'test_bundle'
     field_create_field($this->field_single);
     field_create_field($this->field_unlimited);
@@ -2002,7 +2002,7 @@ class FieldDisplayAPITestCase extends FieldTestCase {
   protected $values;
   protected $entity;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     // Create a field and instance.
@@ -2049,7 +2049,7 @@ class FieldDisplayAPITestCase extends FieldTestCase {
   /**
    * Test the field_view_field() function.
    */
-  function testFieldViewField() {
+  public function testFieldViewField() {
     // No display settings: check that default display settings are used.
     $output = field_view_field('test_entity', $this->entity, $this->field_name);
     $this->backdropSetContent(backdrop_render($output));
@@ -2122,7 +2122,7 @@ class FieldDisplayAPITestCase extends FieldTestCase {
   /**
    * Test the field_view_value() function.
    */
-  function testFieldViewValue() {
+  public function testFieldViewValue() {
     // No display settings: check that default display settings are used.
     $settings = field_info_formatter_settings('field_test_default');
     $setting = $settings['test_formatter_setting'];
@@ -2189,7 +2189,7 @@ class FieldCrudTestCase extends FieldTestCase {
   protected $field;
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     // field_update_field() tests use number.module
     parent::setUp('field_test', 'number');
   }
@@ -2202,7 +2202,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test the creation of a field.
    */
-  function testCreateField() {
+  public function testCreateField() {
     $field_definition = array(
       'field_name' => 'field_2',
       'type' => 'test_field',
@@ -2320,7 +2320,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test failure to create a field.
    */
-  function testCreateFieldFail() {
+  public function testCreateFieldFail() {
     $field_name = 'duplicate';
     $field_definition = array('field_name' => $field_name, 'type' => 'test_field', 'storage' => array('type' => 'field_test_storage_failure'));
 
@@ -2345,7 +2345,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test reading back a field definition.
    */
-  function testReadField() {
+  public function testReadField() {
     $field_definition = array(
       'field_name' => 'field_1',
       'type' => 'test_field',
@@ -2360,7 +2360,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test the deletion of a field.
    */
-  function testDeleteField() {
+  public function testDeleteField() {
     // TODO: Also test deletion of the data stored in the field ?
 
     // Create two fields (so we can test that only one is deleted).
@@ -2440,7 +2440,7 @@ class FieldCrudTestCase extends FieldTestCase {
     $this->assertFalse($field, 'Field is deleted after a batch run.');
   }
 
-  function testUpdateNonExistentField() {
+  public function testUpdateNonExistentField() {
     $test_field = array('field_name' => 'does_not_exist', 'type' => 'number_decimal');
     try {
       field_update_field($test_field);
@@ -2451,7 +2451,7 @@ class FieldCrudTestCase extends FieldTestCase {
     }
   }
 
-  function testUpdateFieldType() {
+  public function testUpdateFieldType() {
     $field = array('field_name' => 'field_type', 'type' => 'number_decimal');
     field_create_field($field);
 
@@ -2468,7 +2468,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test updating a field.
    */
-  function testUpdateField() {
+  public function testUpdateField() {
     // Create a field with a defined cardinality, so that we can ensure it's
     // respected. Since cardinality enforcement is consistent across database
     // systems, it makes a good test case.
@@ -2513,7 +2513,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test field type modules forbidding an update.
    */
-  function testUpdateFieldForbid() {
+  public function testUpdateFieldForbid() {
     $field = array('field_name' => 'forbidden', 'type' => 'test_field', 'settings' => array('changeable' => 0, 'unchangeable' => 0));
     $field = field_create_field($field);
     $field['settings']['changeable']++;
@@ -2537,7 +2537,7 @@ class FieldCrudTestCase extends FieldTestCase {
   /**
    * Test that fields are properly marked active or inactive.
    */
-  function testActive() {
+  public function testActive() {
     $field_definition = array(
       'field_name' => 'field_1',
       'type' => 'test_field',
@@ -2569,7 +2569,7 @@ class FieldCrudTestCase extends FieldTestCase {
    *   An array of module names. The field will be tested to be inactive as long
    *   as any of those modules is disabled.
    */
-  function _testActiveHelper($field_definition, $modules) {
+  private function _testActiveHelper($field_definition, $modules) {
     $field_name = $field_definition['field_name'];
 
     // Read the field.
@@ -2603,7 +2603,7 @@ class FieldCrudTestCase extends FieldTestCase {
  */
 class FieldSchemaAlterTestCase extends FieldTestCase {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test', 'field_test_schema_alter');
   }
 
@@ -2612,7 +2612,7 @@ class FieldSchemaAlterTestCase extends FieldTestCase {
    *
    * @see field_test_schema_alter_field_schema_alter()
    */
-  function testImageFieldSchemaAlter() {
+  public function testImageFieldSchemaAlter() {
     $test_field = array(
       'field_name' => backdrop_strtolower($this->randomName()),
       'type' => 'test_field',
@@ -2638,7 +2638,7 @@ class FieldInstanceCrudTestCase extends FieldTestCase {
   protected $field;
   protected $instance_definition;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $this->field = array(
@@ -2662,7 +2662,7 @@ class FieldInstanceCrudTestCase extends FieldTestCase {
   /**
    * Test the creation of a field instance.
    */
-  function testCreateFieldInstance() {
+  public function testCreateFieldInstance() {
     field_create_instance($this->instance_definition);
 
     // Read the raw record from the config
@@ -2746,7 +2746,7 @@ class FieldInstanceCrudTestCase extends FieldTestCase {
   /**
    * Test reading back an instance definition.
    */
-  function testReadFieldInstance() {
+  public function testReadFieldInstance() {
     field_create_instance($this->instance_definition);
 
     // Read the instance back.
@@ -2757,7 +2757,7 @@ class FieldInstanceCrudTestCase extends FieldTestCase {
   /**
    * Test the update of a field instance.
    */
-  function testUpdateFieldInstance() {
+  public function testUpdateFieldInstance() {
     field_create_instance($this->instance_definition);
     $field_type = field_info_field_types($this->field['type']);
 
@@ -2815,7 +2815,7 @@ class FieldInstanceCrudTestCase extends FieldTestCase {
   /**
    * Test the deletion of a field instance.
    */
-  function testDeleteFieldInstance() {
+  public function testDeleteFieldInstance() {
     // TODO: Test deletion of the data stored in the field also.
     // Need to check that data for a 'deleted' field / instance doesn't get loaded
     // Need to check data marked deleted is cleaned on cron (not implemented yet...)
@@ -2864,7 +2864,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   protected $instance;
   protected $entity_type;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'field_test');
 
     $this->field_name = backdrop_strtolower($this->randomName() . '_field_name');
@@ -2902,7 +2902,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   /**
    * Ensures that only valid values are returned by field_available_languages().
    */
-  function testFieldAvailableLanguages() {
+  public function testFieldAvailableLanguages() {
     // Test 'translatable' fieldable info.
     field_test_entity_info_translatable('test_entity', FALSE);
     $field = $this->field;
@@ -2933,7 +2933,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   /**
    * Test the multilanguage logic of _field_invoke().
    */
-  function testFieldInvoke() {
+  public function testFieldInvoke() {
     // Enable field translations for the entity.
     field_test_entity_info_translatable('test_entity', TRUE);
 
@@ -2971,7 +2971,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   /**
    * Test the multilanguage logic of _field_invoke_multiple().
    */
-  function testFieldInvokeMultiple() {
+  public function testFieldInvokeMultiple() {
     // Enable field translations for the entity.
     field_test_entity_info_translatable('test_entity', TRUE);
 
@@ -3045,7 +3045,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   /**
    * Test translatable fields storage/retrieval.
    */
-  function testTranslatableFieldSaveLoad() {
+  public function testTranslatableFieldSaveLoad() {
     // Enable field translations for nodes.
     field_test_entity_info_translatable('node', TRUE);
     $entity_info = entity_get_info('node');
@@ -3082,7 +3082,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   /**
    * Tests display language logic for translatable fields.
    */
-  function testFieldDisplayLanguage() {
+  public function testFieldDisplayLanguage() {
     $field_name = backdrop_strtolower($this->randomName() . '_field_name');
     $entity_type = 'test_entity';
 
@@ -3163,7 +3163,7 @@ class FieldTranslationsTestCase extends FieldTestCase {
   /**
    * Tests field translations when creating a new revision.
    */
-  function testFieldFormTranslationRevisions() {
+  public function testFieldFormTranslationRevisions() {
     $web_user = $this->backdropCreateUser(array('access field_test content', 'administer field_test content'));
     $this->backdropLogin($web_user);
 
@@ -3249,7 +3249,7 @@ class FieldBulkDeleteTestCase extends FieldTestCase {
    * @param $actual_hooks
    *   The array of actual hook invocations recorded by field_test_memorize().
    */
-  function checkHooksInvocations($expected_hooks, $actual_hooks) {
+  protected function checkHooksInvocations($expected_hooks, $actual_hooks) {
     foreach ($expected_hooks as $hook => $invocations) {
       $actual_invocations = $actual_hooks[$hook];
 
@@ -3270,7 +3270,7 @@ class FieldBulkDeleteTestCase extends FieldTestCase {
     }
   }
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $this->fields = array();
@@ -3331,7 +3331,7 @@ class FieldBulkDeleteTestCase extends FieldTestCase {
    * field_delete_instance() and could be moved to FieldCrudTestCase,
    * but depends on this class's setUp().
    */
-  function testDeleteFieldInstance() {
+  public function testDeleteFieldInstance() {
     $bundle = reset($this->bundles);
     $field = reset($this->fields);
 
@@ -3383,7 +3383,7 @@ class FieldBulkDeleteTestCase extends FieldTestCase {
    * Verify that field data items and instances are purged when an
    * instance is deleted.
    */
-  function testPurgeInstance() {
+  public function testPurgeInstance() {
     // Start recording hook invocations.
     field_test_memorize();
 
@@ -3442,7 +3442,7 @@ class FieldBulkDeleteTestCase extends FieldTestCase {
    * Verify that fields are preserved and purged correctly as multiple
    * instances are deleted and purged.
    */
-  function testPurgeField() {
+  public function testPurgeField() {
     // Start recording hook invocations.
     field_test_memorize();
 
@@ -3506,7 +3506,7 @@ class FieldBlockTestCase extends FieldTestCase {
   protected $admin_user;
   protected $node;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node', 'field', 'field_test'));
 
     $this->content_type = $this->backdropCreateContentType(array(
@@ -3541,7 +3541,7 @@ class FieldBlockTestCase extends FieldTestCase {
   /**
    * Check special conditions around the main content block.
    */
-  function testFieldBlock() {
+  public function testFieldBlock() {
     $this->backdropLogin($this->admin_user);
 
     // Override the node/% path to test the availability of the field blocks.
@@ -3659,7 +3659,7 @@ class FieldGetValueTestCase extends FieldTestCase {
    */
   protected $value_email2;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node', 'field', 'field_test', 'email'));
 
     $this->content_type = $this->backdropCreateContentType(array(
@@ -3720,7 +3720,7 @@ class FieldGetValueTestCase extends FieldTestCase {
   /**
    * Test field_get_value().
    */
-  function testFieldGetValue() {
+  public function testFieldGetValue() {
     // Test single 'value' return.
     $single_value = field_get_value($this->node, $this->test_field_name);
     $this->assertEqual($this->value1, $single_value, 'The first value in test_field is returned.');
@@ -3777,7 +3777,7 @@ class FieldTokenTestCase extends FieldTestCase {
    */
   protected $content_type;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node', 'field', 'field_ui', 'field_test', 'date', 'path'));
 
     // Create test user.
@@ -3886,7 +3886,7 @@ class FieldTokenTestCase extends FieldTestCase {
   /**
    * Test fields in token display mode.
    */
-  function testFieldToken() {
+  public function testFieldToken() {
     $edit = array();
     $edit['title'] = $this->randomName(8);
     $edit[$this->test_field_name . '[und][0][value]'] = 'foo';

--- a/core/modules/field/tests/field_views.test
+++ b/core/modules/field/tests/field_views.test
@@ -61,7 +61,7 @@ class FieldViewsTestHelper extends ViewsSqlTest {
     return $account;
   }
 
-  function setUpFields($amount = 3) {
+  protected function setUpFields($amount = 3) {
     // Create three fields.
     $field_names = array();
     for ($i = 0; $i < $amount; $i++) {
@@ -73,7 +73,7 @@ class FieldViewsTestHelper extends ViewsSqlTest {
     return $field_names;
   }
 
-  function setUpInstances($bundle = 'page') {
+  protected function setUpInstances($bundle = 'page') {
     foreach ($this->fields as $key => $field) {
       $instance = array(
         'field_name' => $field['field_name'],
@@ -87,7 +87,7 @@ class FieldViewsTestHelper extends ViewsSqlTest {
   /**
    * Clear all views caches and static caches which are required for the patch.
    */
-  function clearViewsCaches() {
+  protected function clearViewsCaches() {
     // Reset views data cache.
     backdrop_static_reset('_views_fetch_data_cache');
     backdrop_static_reset('_views_fetch_data_recursion_protected');
@@ -177,7 +177,7 @@ class FieldViewsDataTest extends FieldViewsTestHelper {
    *
    * We check data structure for both node and node revision tables.
    */
-  function testViewsData() {
+  public function testViewsData() {
     $data = views_fetch_data();
 
     // Check the table and the joins of the first field.

--- a/core/modules/field_ui/tests/field_ui.test
+++ b/core/modules/field_ui/tests/field_ui.test
@@ -11,7 +11,7 @@ class FieldUITestCase extends BackdropWebTestCase {
   protected $type;
   protected $hyphen_type;
 
-  function setUp() {
+  public function setUp() {
     // Since this is a base class for many test cases, support the same
     // flexibility that BackdropWebTestCase::setUp() has for the modules to be
     // passed in as either an array or a variable number of string arguments.
@@ -52,7 +52,7 @@ class FieldUITestCase extends BackdropWebTestCase {
    *   $edit parameter for backdropPost() on the third step ('Instance settings'
    *   form).
    */
-  function fieldUIAddNewField($bundle_path, $initial_edit, $field_edit = array(), $instance_edit = array()) {
+  protected function fieldUIAddNewField($bundle_path, $initial_edit, $field_edit = array(), $instance_edit = array()) {
     // Use 'test_field' field type by default.
     $initial_edit += array(
       'fields[_add_new_field][type]' => 'test_field',
@@ -96,7 +96,7 @@ class FieldUITestCase extends BackdropWebTestCase {
    *   $edit parameter for backdropPost() on the second step ('Instance settings'
    *   form).
    */
-  function fieldUIAddExistingField($bundle_path, $initial_edit, $instance_edit = array()) {
+  protected function fieldUIAddExistingField($bundle_path, $initial_edit, $instance_edit = array()) {
     // Use 'test_field_widget' by default.
     $initial_edit += array(
       'fields[_add_existing_field][widget_type]' => 'test_field_widget',
@@ -127,7 +127,7 @@ class FieldUITestCase extends BackdropWebTestCase {
    * @param $bundle_label
    *   The label of the bundle.
    */
-  function fieldUIDeleteField($bundle_path, $field_name, $label, $bundle_label) {
+  protected function fieldUIDeleteField($bundle_path, $field_name, $label, $bundle_label) {
     // Display confirmation form.
     $this->backdropGet("$bundle_path/fields/$field_name/delete");
     $this->assertRaw(t('Are you sure you want to delete the field %label', array('%label' => $label)), 'Delete confirmation was found.');
@@ -150,7 +150,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   protected $field_name_input;
   protected $field_name;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create random field name.
@@ -190,7 +190,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
    * In order to act on the same fields, and not create the fields over and over
    * again the following tests create, update and delete the same fields.
    */
-  function testCRUDFields() {
+  public function testCRUDFields() {
     $this->manageFieldsPage();
     $this->createField();
     $this->updateField();
@@ -203,7 +203,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
    * This test creates a field but in one fewer step because the field has
    * no global field settings.
    */
-  function testCreateFieldNoSettings() {
+  public function testCreateFieldNoSettings() {
     // This setting is checked in field_test_field_settings_form().
     state_get('field_ui_test_field_settings', FALSE);
     $this->createField();
@@ -212,7 +212,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests the manage fields page.
    */
-  function manageFieldsPage() {
+  protected function manageFieldsPage() {
     $this->backdropGet('admin/structure/types/manage/' . $this->hyphen_type . '/fields');
     // Check all table columns.
     $table_headers = array(
@@ -240,7 +240,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
    * @todo Assert properties can bet set in the form and read back in $field and
    * $instances.
    */
-  function createField() {
+  protected function createField() {
     // Create a test field.
     $edit = array(
       'fields[_add_new_field][label]' => $this->field_label,
@@ -258,7 +258,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests editing an existing field.
    */
-  function updateField() {
+  protected function updateField() {
     // Go to the field edit page.
     $this->backdropGet('admin/structure/types/manage/' . $this->hyphen_type . '/fields/' . $this->field_name);
 
@@ -281,7 +281,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests adding an existing field in another content type.
    */
-  function addExistingField() {
+  protected function addExistingField() {
     // Check "Add existing field" appears.
     $this->backdropGet('admin/structure/types/manage/page/fields');
     $this->assertRaw(t('Add existing field'), '"Add existing field" was found.');
@@ -305,7 +305,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
    * We do not test if the number can be submitted with anything else than a
    * numeric value. That is tested already in FormsTestCase::testNumber().
    */
-  function testCardinalitySettings() {
+  public function testCardinalitySettings() {
     $this->createField();
     $field_edit_path = 'admin/structure/types/manage/' . $this->hyphen_type . '/fields/' . $this->field_name;
 
@@ -352,7 +352,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
    * @param $entity_type
    *   The entity type for the instance.
    */
-  function assertFieldSettings($bundle, $field_name, $string = 'dummy test string', $entity_type = 'node') {
+  protected function assertFieldSettings($bundle, $field_name, $string = 'dummy test string', $entity_type = 'node') {
     // Reset the fields info.
     _field_info_collate_fields_reset();
     // Assert field settings.
@@ -368,7 +368,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests that default value is correctly validated and saved.
    */
-  function testDefaultValue() {
+  public function testDefaultValue() {
     // Create a test field and instance.
     $field_name = 'test';
     $field = array(
@@ -418,7 +418,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests that deletion removes fields and instances as expected.
    */
-  function testDeleteField() {
+  public function testDeleteField() {
     // Create a new field.
     $bundle_path1 = 'admin/structure/types/manage/' . $this->hyphen_type;
     $edit1 = array(
@@ -469,7 +469,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests that Field UI respects the 'no_ui' option in hook_field_info().
    */
-  function testHiddenFields() {
+  public function testHiddenFields() {
     $bundle_path = 'admin/structure/types/manage/' . $this->hyphen_type . '/fields';
 
     // Check that the field type is not available in the 'add new field' row.
@@ -504,7 +504,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests renaming a bundle.
    */
-  function testRenameBundle() {
+  public function testRenameBundle() {
     $type2 = strtolower($this->randomName(8)) . '_' .'test';
     $hyphen_type2 = str_replace('_', '-', $type2);
 
@@ -519,7 +519,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests that a duplicate field name is caught by validation.
    */
-  function testDuplicateFieldName() {
+  public function testDuplicateFieldName() {
     // field_tags already exists, so we're expecting an error when trying to
     // create a new field with the same name.
     $edit = array(
@@ -538,7 +538,7 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
   /**
    * Tests that external URLs in the 'destinations' query parameter are blocked.
    */
-  function testExternalDestinations() {
+  public function testExternalDestinations() {
     $path = 'admin/structure/types/manage/post/fields/field_tags/field-settings';
     $options = array(
       'query' => array('destinations' => array('http://example.com')),
@@ -553,14 +553,14 @@ class FieldUIManageFieldsTestCase extends FieldUITestCase {
  * Tests the functionality of the 'Manage displays' screens.
  */
 class FieldUIManageDisplayTestCase extends FieldUITestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('search', 'field_test'));
   }
 
   /**
    * Tests formatter settings.
    */
-  function testFormatterUI() {
+  public function testFormatterUI() {
     $manage_fields = 'admin/structure/types/manage/' . $this->hyphen_type;
     $manage_display = $manage_fields . '/display/default';
 
@@ -625,7 +625,7 @@ class FieldUIManageDisplayTestCase extends FieldUITestCase {
   /**
    * Tests switching display modes to use custom or 'default' settings'.
    */
-  function testViewModeCustom() {
+  public function testViewModeCustom() {
     // Create a field, and a node with some data for the field.
     $edit = array(
       'fields[_add_new_field][label]' => 'Test field',
@@ -706,7 +706,7 @@ class FieldUIManageDisplayTestCase extends FieldUITestCase {
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertNodeViewText(Node $node, $view_mode, $text, $message) {
+  protected function assertNodeViewText(Node $node, $view_mode, $text, $message) {
     return $this->assertNodeViewTextHelper($node, $view_mode, $text, $message, FALSE);
   }
 
@@ -724,7 +724,7 @@ class FieldUIManageDisplayTestCase extends FieldUITestCase {
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertNodeViewNoText(Node $node, $view_mode, $text, $message) {
+  protected function assertNodeViewNoText(Node $node, $view_mode, $text, $message) {
     return $this->assertNodeViewTextHelper($node, $view_mode, $text, $message, TRUE);
   }
 
@@ -749,7 +749,7 @@ class FieldUIManageDisplayTestCase extends FieldUITestCase {
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertNodeViewTextHelper(Node $node, $view_mode, $text, $message, $not_exists) {
+  protected function assertNodeViewTextHelper(Node $node, $view_mode, $text, $message, $not_exists) {
     // Make sure caches on the tester side are refreshed after changes
     // submitted on the tested side.
     field_info_cache_clear();
@@ -779,7 +779,7 @@ class FieldUIManageDisplayTestCase extends FieldUITestCase {
  * Tests custom widget hooks and callbacks on the field administration pages.
  */
 class FieldUIAlterTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('field_test'));
 
     // Create test user.
@@ -794,7 +794,7 @@ class FieldUIAlterTestCase extends BackdropWebTestCase {
    * @see field_test_field_widget_properties_user_alter()
    * @see field_test_field_widget_form_alter()
    */
-  function testDefaultWidgetPropertiesAlter() {
+  public function testDefaultWidgetPropertiesAlter() {
     // Create the alter_test_text field and an instance on post nodes.
     field_create_field(array(
       'field_name' => 'alter_test_text',

--- a/core/modules/file/tests/file.test
+++ b/core/modules/file/tests/file.test
@@ -167,7 +167,7 @@ class FileTestHelper extends BackdropWebTestCase {
    *   File size.
    * @return EntityInterface
    */
-  function getTestFile($type_name, $size = NULL) {
+  protected function getTestFile($type_name, $size = NULL) {
     // Get a file to upload.
     $file = current($this->backdropGetTestFiles($type_name, $size));
 
@@ -183,7 +183,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @return int
    *   File fid.
    */
-  function getLastFileId() {
+  protected function getLastFileId() {
     return (int) db_query('SELECT MAX(fid) FROM {file_managed}')->fetchField();
   }
 
@@ -201,7 +201,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param array $widget_settings
    *   A list of widget settings that will be added to the widget defaults.
    */
-  function createFileField($name, $type_name, $field_settings = array(), $instance_settings = array(), $widget_settings = array()) {
+  protected function createFileField($name, $type_name, $field_settings = array(), $instance_settings = array(), $widget_settings = array()) {
     $cardinality = 1;
     if (isset($field_settings['cardinality'])) {
       $cardinality = $field_settings['cardinality'];
@@ -232,7 +232,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param array $widget_settings
    *   A list of widget settings that will be added to the widget defaults.
    */
-  function attachFileField($name, $entity_type, $bundle, $instance_settings = array(), $widget_settings = array()) {
+  protected function attachFileField($name, $entity_type, $bundle, $instance_settings = array(), $widget_settings = array()) {
     $instance = array(
       'field_name' => $name,
       'label' => $name,
@@ -262,7 +262,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param array $widget_settings
    *   A list of widget settings that will be added to the widget defaults.
    */
-  function updateFileField($name, $type_name, $instance_settings = array(), $widget_settings = array()) {
+  protected function updateFileField($name, $type_name, $instance_settings = array(), $widget_settings = array()) {
     $instance = field_info_instance('node', $name, $type_name);
     $instance['settings'] = array_merge($instance['settings'], $instance_settings);
     $instance['widget']['settings'] = array_merge($instance['widget']['settings'], $widget_settings);
@@ -287,7 +287,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @return int
    *   Node ID.
    */
-  function uploadNodeFile($file, $field_name, $nid_or_type, $new_revision = TRUE, $extras = array()) {
+  protected function uploadNodeFile($file, $field_name, $nid_or_type, $new_revision = TRUE, $extras = array()) {
     $langcode = LANGUAGE_NONE;
     $edit = array(
       "title" => $this->randomName(),
@@ -325,7 +325,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param bool $new_revision
    *   If TRUE, create a new revision.
    */
-  function removeNodeFile($nid, $new_revision = TRUE) {
+  protected function removeNodeFile($nid, $new_revision = TRUE) {
     $edit = array(
       'revision' => (string) (int) $new_revision,
     );
@@ -346,7 +346,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param bool $new_revision
    *   If TRUE, create a new revision.
    */
-  function replaceNodeFile($file, $field_name, $nid, $new_revision = TRUE) {
+  protected function replaceNodeFile($file, $field_name, $nid, $new_revision = TRUE) {
     $edit = array(
       'files[' . $field_name . '_' . LANGUAGE_NONE . '_0]' => backdrop_realpath($file->uri),
       'revision' => (string) (int) $new_revision,
@@ -364,7 +364,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param string $message
    *   Message to display.
    */
-  function assertFileExists($file, $message = NULL) {
+  protected function assertFileExists($file, $message = NULL) {
     $message = isset($message) ? $message : format_string('File %file exists on the disk.', array('%file' => $file->uri));
     $this->assertTrue(is_file($file->uri), $message);
   }
@@ -377,7 +377,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param string $message
    *   Message to display.
    */
-  function assertFileEntryExists($file, $message = NULL) {
+  protected function assertFileEntryExists($file, $message = NULL) {
     entity_get_controller('file')->resetCache();
     $db_file = file_load($file->fid);
     $message = isset($message) ? $message : format_string('File %file exists in database at the correct path.', array('%file' => $file->uri));
@@ -392,7 +392,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param string $message
    *   Message to display.
    */
-  function assertFileNotExists($file, $message = NULL) {
+  protected function assertFileNotExists($file, $message = NULL) {
     $message = isset($message) ? $message : format_string('File %file exists on the disk.', array('%file' => $file->uri));
     $this->assertFalse(is_file($file->uri), $message);
   }
@@ -405,7 +405,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param string $message
    *   Message to display.
    */
-  function assertFileEntryNotExists($file, $message) {
+  protected function assertFileEntryNotExists($file, $message) {
     entity_get_controller('file')->resetCache();
     $message = isset($message) ? $message : format_string('File %file exists in database at the correct path.', array('%file' => $file->uri));
     $this->assertFalse(file_load($file->fid), $message);
@@ -419,7 +419,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @param string $message
    *   Message to display.
    */
-  function assertFileIsPermanent($file, $message = NULL) {
+  protected function assertFileIsPermanent($file, $message = NULL) {
     $message = isset($message) ? $message : format_string('File %file is permanent.', array('%file' => $file->uri));
     $this->assertTrue($file->status == FILE_STATUS_PERMANENT, $message);
   }
@@ -435,7 +435,7 @@ class FileTestHelper extends BackdropWebTestCase {
    * @return File
    *   A file object, or FALSE on error.
    */
-  function createTemporaryFile($data, $uid = NULL) {
+  protected function createTemporaryFile($data, $uid = NULL) {
     $file = file_save_data($data);
 
     if ($file) {
@@ -592,7 +592,7 @@ class FileManagedFileElementTestCase extends FileTestHelper {
   /**
    * Tests the managed_file element type.
    */
-  function testManagedFile() {
+  public function testManagedFile() {
     // Check that $element['#size'] is passed to the child upload element.
     $this->backdropGet('file/test');
     $this->assertFieldByXpath('//input[@name="files[nested_file]" and @size="13"]', NULL, 'The custom #size attribute is passed to the child upload element.');
@@ -682,7 +682,7 @@ class FileManagedFileElementTestCase extends FileTestHelper {
   /**
    * Tests file_ajax_upload() parents_hash.
    */
-  function testManagedFileParentsHash() {
+  public function testManagedFileParentsHash() {
     // Perform the tests with all permutations of $form['#tree'] and
     // $element['#extended'].
     foreach (array(0, 1) as $tree) {
@@ -759,7 +759,7 @@ class FileFieldWidgetTestCase extends FileTestHelper {
   /**
    * Tests upload and remove buttons for a single-valued File field.
    */
-  function testSingleValuedWidget() {
+  public function testSingleValuedWidget() {
     // Use 'page' instead of 'post', so that the 'post' image field does
     // not conflict with this test. If in the future the 'page' type gets its
     // own default file or image field, this test can be made more robust by
@@ -816,7 +816,7 @@ class FileFieldWidgetTestCase extends FileTestHelper {
   /**
    * Tests exploiting the temporary file removal of another user using fid.
    */
-  function testTemporaryFileRemovalExploit() {
+  public function testTemporaryFileRemovalExploit() {
     // Create a victim user.
     $victim_user = $this->backdropCreateUser();
 
@@ -862,7 +862,7 @@ class FileFieldWidgetTestCase extends FileTestHelper {
   /**
    * Tests validation with the Upload button.
    */
-  function testWidgetValidation() {
+  public function testWidgetValidation() {
     $type_name = 'post';
     $field_name = strtolower($this->randomName());
     $this->createFileField($field_name, $type_name);
@@ -979,7 +979,7 @@ class FileFieldWidgetTestCase extends FileTestHelper {
   /**
    * Tests upload and remove buttons for multiple multi-valued File fields.
    */
-  function testMultiValuedWidget() {
+  public function testMultiValuedWidget() {
     // Use 'page' instead of 'post', so that the 'post' image field does
     // not conflict with this test. If in the future the 'page' type gets its
     // own default file or image field, this test can be made more robust by
@@ -1104,7 +1104,7 @@ class FileFieldWidgetTestCase extends FileTestHelper {
   /**
    * Tests a file field with a "Private files" upload destination setting.
    */
-  function testPrivateFileSetting() {
+  public function testPrivateFileSetting() {
     // Use 'page' instead of 'post', so that the 'post' image field does
     // not conflict with this test. If in the future the 'page' type gets its
     // own default file or image field, this test can be made more robust by
@@ -1143,7 +1143,7 @@ class FileFieldWidgetTestCase extends FileTestHelper {
   /**
    * Tests that download restrictions on private files work on comments.
    */
-  function testPrivateFileComment() {
+  public function testPrivateFileComment() {
     $user = $this->backdropCreateUser(array('access comments'));
 
     // Remove access comments permission from anonymous user.
@@ -1231,7 +1231,7 @@ class FileFieldRevisionTestCase extends FileTestHelper {
    *  - When the last revision that uses a file is deleted, the original file
    *    should be deleted also.
    */
-  function testRevisions() {
+  public function testRevisions() {
     $type_name = 'post';
     $field_name = strtolower($this->randomName());
     $this->createFileField($field_name, $type_name);
@@ -1349,7 +1349,7 @@ class FileFieldDisplayTestCase extends FileTestHelper {
   /**
    * Tests normal formatter display on node display.
    */
-  function testNodeDisplay() {
+  public function testNodeDisplay() {
     $field_name = strtolower($this->randomName());
     $type_name = 'post';
     $field_settings = array(
@@ -1411,7 +1411,7 @@ class FileFieldValidateTestCase extends FileTestHelper {
   /**
    * Tests the required property on file fields.
    */
-  function testRequired() {
+  public function testRequired() {
     $type_name = 'post';
     $field_name = strtolower($this->randomName());
     $this->createFileField($field_name, $type_name, array(), array('required' => '1'));
@@ -1460,7 +1460,7 @@ class FileFieldValidateTestCase extends FileTestHelper {
   /**
    * Tests the max file size validator.
    */
-  function testFileMaxSize() {
+  public function testFileMaxSize() {
     $type_name = 'post';
     $field_name = strtolower($this->randomName());
     $this->createFileField($field_name, $type_name, array(), array('required' => '1'));
@@ -1512,7 +1512,7 @@ class FileFieldValidateTestCase extends FileTestHelper {
   /**
    * Tests file extension checking.
    */
-  function testFileExtension() {
+  public function testFileExtension() {
     $type_name = 'post';
     $field_name = strtolower($this->randomName());
     $this->createFileField($field_name, $type_name);
@@ -1557,7 +1557,7 @@ class FileFieldValidateTestCase extends FileTestHelper {
   /**
    * Tests default display of File Field.
    */
-  function testDefaultFileFieldDisplay() {
+  public function testDefaultFileFieldDisplay() {
     $field_name = strtolower($this->randomName());
     $type_name = 'post';
     $field_settings = array(
@@ -1590,7 +1590,7 @@ class FileFieldPathTestCase extends FileTestHelper {
   /**
    * Tests the normal formatter display on node display.
    */
-  function testUploadPath() {
+  public function testUploadPath() {
     $field_name = strtolower($this->randomName());
     $type_name = 'post';
     $field = $this->createFileField($field_name, $type_name);
@@ -1643,7 +1643,7 @@ class FileFieldPathTestCase extends FileTestHelper {
    * @param $message
    *   The message to display with this assertion.
    */
-  function assertPathMatch($expected_path, $actual_path, $message) {
+  protected function assertPathMatch($expected_path, $actual_path, $message) {
     // Strip off the extension of the expected path to allow for _0, _1, etc.
     // suffixes when the file hits a duplicate name.
     $pos = strrpos($expected_path, '.');
@@ -1662,7 +1662,7 @@ class FileTokenReplaceTestCase extends FileTestHelper {
   /**
    * Creates a file, then tests the tokens generated from it.
    */
-  function testFileTokenReplacement() {
+  public function testFileTokenReplacement() {
     global $language;
 
     // Create file field.
@@ -1723,7 +1723,7 @@ class FileTokenReplaceTestCase extends FileTestHelper {
  * Tests file access on private nodes.
  */
 class FilePrivateTestCase extends FileTestHelper {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node_access_test', 'field_test'));
     node_access_rebuild();
     state_set('node_access_test_private', TRUE);
@@ -1735,7 +1735,7 @@ class FilePrivateTestCase extends FileTestHelper {
   /**
    * Tests file access for file uploaded to a private node.
    */
-  function testPrivateFile() {
+  public function testPrivateFile() {
     // Use 'page' instead of 'post', so that the 'post' image field does
     // not conflict with this test. If in the future the 'page' type gets its
     // own default file or image field, this test can be made more robust by
@@ -1859,7 +1859,7 @@ class FilePrivateTestCase extends FileTestHelper {
   /**
    * Tests file access for private nodes when file download access is granted.
    */
-  function testPrivateFileDownloadAccessGranted() {
+  public function testPrivateFileDownloadAccessGranted() {
     // Tell file_module_test to attempt to grant access to all private files,
     // and ensure that it is doing so correctly.
     $test_file = $this->getTestFile('text');
@@ -2105,14 +2105,14 @@ class FileFieldAnonymousSubmission extends FileTestHelper {
  */
 class FileFileTypeClassificationTestCase extends BackdropWebTestCase {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
   }
 
   /**
    * Test that existing files are properly classified by file type.
    */
-  function testFileTypeClassification() {
+  public function testFileTypeClassification() {
     // Get test text and image files.
     $file = current($this->backdropGetTestFiles('text'));
     $text_file =  new File((array) $file);
@@ -2140,7 +2140,7 @@ class FileFileTypeClassificationTestCase extends BackdropWebTestCase {
    * @return
    *   The file's file type as a string.
    */
-  function getFileType($file) {
+  protected function getFileType($file) {
     $type = db_select('file_managed', 'fm')
       ->fields('fm', array('type'))
       ->condition('fid', $file->fid, '=')
@@ -2159,7 +2159,7 @@ class FileUnitTestCase extends FileTestHelper {
   /**
    * Regression tests for core issue https://www.drupal.org/node/1239376.
    */
-  function testMimeTypeMappings() {
+  public function testMimeTypeMappings() {
     $tests = array(
       'public://test.ogg' => 'audio/ogg',
       'public://test.mkv' => 'video/x-m4v',
@@ -2175,7 +2175,7 @@ class FileUnitTestCase extends FileTestHelper {
   /**
    * Tests basic file entity properties.
    */
-  function testFile() {
+  public function testFile() {
     // Save a raw file, turning it into a file entity.
     $file = $this->getTestFile('text');
     $file->uid = 1;
@@ -2195,7 +2195,7 @@ class FileUnitTestCase extends FileTestHelper {
   /**
    * Tests storing image height and width as file metadata.
    */
-  function testImageDimensions() {
+  public function testImageDimensions() {
     // Test hook_file_insert().
     $file = current($this->backdropGetTestFiles('image'));
     $image_file = new File((array) $file);
@@ -2257,7 +2257,7 @@ class FileEditTestCase extends FileTestHelper {
   protected $web_user;
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // todo use web_user but need to fix perms on the file overview View
@@ -2268,7 +2268,7 @@ class FileEditTestCase extends FileTestHelper {
   /**
    * Check file edit functionality.
    */
-  function testFileEdit() {
+  public function testFileEdit() {
     $this->backdropLogin($this->web_user);
     $name_key = "filename";
 
@@ -2308,7 +2308,7 @@ class FileEditTestCase extends FileTestHelper {
  */
 class FileUploadWizardTestCase extends FileTestHelper {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->private_files_directory = config_get('system.core', 'file_private_path');
@@ -2328,7 +2328,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
   /**
    * Test the basic file upload wizard functionality.
    */
-  function testFileUploadWizardBasic() {
+  public function testFileUploadWizardBasic() {
     $test_file = $this->getTestFile('text');
 
     // Step 1: Upload a basic document file.
@@ -2348,7 +2348,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
   /**
    * Test the file upload wizard type step.
    */
-  function testFileUploadWizardTypes() {
+  public function testFileUploadWizardTypes() {
     $test_file = $this->getTestFile('text');
 
     // Create multiple file types with the same mime types.
@@ -2377,7 +2377,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
   /**
    * Test the file upload wizard scheme step.
    */
-  function testFileUploadWizardSchemes() {
+  public function testFileUploadWizardSchemes() {
     $test_file = $this->getTestFile('text');
 
     // Enable the private file system.
@@ -2405,7 +2405,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
   /**
    * Test the file upload wizard when uploading a private file fails.
    */
-  function testFileUploadWizardPrivateFailure() {
+  public function testFileUploadWizardPrivateFailure() {
     $test_file = $this->getTestFile('text');
 
     // Record the last saved file ID.
@@ -2457,7 +2457,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
   /**
    * Test the file upload wizard field step.
    */
-  function testFileUploadWizardFields() {
+  public function testFileUploadWizardFields() {
     $test_file = $this->getTestFile('image');
     $filename = $this->randomName();
     $alt = $this->randomName();
@@ -2516,7 +2516,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
   /**
    * Test skipping each of the file upload wizard steps.
    */
-  function testFileUploadWizardStepSkipping() {
+  public function testFileUploadWizardStepSkipping() {
     $test_file = $this->getTestFile('image');
     $filename = $this->randomName();
 
@@ -2629,7 +2629,7 @@ class FileUploadWizardTestCase extends FileTestHelper {
  */
 class FileUploadSvgTestCase extends FileTestHelper {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->private_files_directory = config_get('system.core', 'file_private_path');
@@ -2774,7 +2774,7 @@ class FileAdminTestCase extends FileTestHelper {
    */
   protected $base_user_3;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Remove the "view files" permission which is set
@@ -2798,7 +2798,7 @@ class FileAdminTestCase extends FileTestHelper {
   /**
    * Tests that the table sorting works on the files admin pages.
    */
-  function testFilesAdminSort() {
+  public function testFilesAdminSort() {
     $this->backdropLogin($this->admin_user);
     $i = 0;
     foreach (array('dd', 'aa', 'DD', 'bb', 'cc', 'CC', 'AA', 'BB') as $prefix) {
@@ -2839,7 +2839,7 @@ class FileAdminTestCase extends FileTestHelper {
   /**
    * Tests file overview with different user permissions.
    */
-  function testFileAdminPages() {
+  public function testFileAdminPages() {
     $this->backdropLogin($this->admin_user);
 
     // Create a file field to add files.
@@ -2984,7 +2984,7 @@ class FileAdminTestCase extends FileTestHelper {
  */
 class FileUsageTestCase extends FileTestHelper {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $web_user = $this->backdropCreateUser(array('create files', 'bypass file access', 'edit own post content'));
@@ -2994,7 +2994,7 @@ class FileUsageTestCase extends FileTestHelper {
   /**
    * Create a file and verify its usage information.
    */
-  function testFileUsagePage() {
+  public function testFileUsagePage() {
     $image_field = 'field_image';
     $image = $this->getTestFile('image');
 
@@ -3064,7 +3064,7 @@ class FileUsageTestCase extends FileTestHelper {
  */
 class FileChangeSchemeTestCase extends FileTestHelper {
 
-  function testChangeScheme() {
+  public function testChangeScheme() {
     // Select the first text test file to use.
     $file = $this->createFile(array('type' => 'document'));
     $this->assertEqual(file_uri_scheme($file->uri), 'public', 'File is public.');
@@ -3095,7 +3095,7 @@ class FileChangeSchemeTestCase extends FileTestHelper {
  */
 class FileReplaceTestCase extends FileTestHelper {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->backdropLogin($this->admin_user);
   }
@@ -3104,7 +3104,7 @@ class FileReplaceTestCase extends FileTestHelper {
    * @todo Test image dimensions for an image field are reset when a file is replaced.
    * @todo Test image styles are cleared when an image is updated.
    */
-  function testReplaceFile() {
+  public function testReplaceFile() {
     // Select the first text test file to use.
     $file = $this->createFile(array('type' => 'document'));
 
@@ -3173,14 +3173,14 @@ class FileReplaceTestCase extends FileTestHelper {
  */
 class FileTypeTestCase extends FileTestHelper {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
   }
 
   /**
    * Test admin pages access and functionality.
    */
-  function testAdminPages() {
+  public function testAdminPages() {
     // Create a user with file type administration access.
     $user = $this->backdropCreateUser(array('administer file types'));
     $this->backdropLogin($user);
@@ -3192,7 +3192,7 @@ class FileTypeTestCase extends FileTestHelper {
   /**
    * Test creating a new type. Basic CRUD.
    */
-  function testCreate() {
+  public function testCreate() {
     $type_machine_type = 'foo';
     $type_machine_label = 'foobar';
     $type = $this->createFileType(array('type' => $type_machine_type, 'name' => $type_machine_label));
@@ -3203,7 +3203,7 @@ class FileTypeTestCase extends FileTestHelper {
   /**
    * Test file types CRUD UI.
    */
-  function testTypesCrudUi() {
+  public function testTypesCrudUi() {
     $this->backdropGet('admin/structure/file-types');
     $this->assertResponse(403, 'File types UI page is not accessible to unauthorized users.');
 
@@ -3310,7 +3310,7 @@ class FileTypeTestCase extends FileTestHelper {
    *   The page content that results from clicking on the link, or FALSE on
    *   failure. Failure also results in a failed assertion.
    */
-  function clickFileTypeOperationLink($label, $unique_href_part) {
+  protected function clickFileTypeOperationLink($label, $unique_href_part) {
     $links = $this->xpath('//a[normalize-space(text())=:label]', array(':label' => $label));
     foreach ($links as $link_index => $link) {
       $position = strpos($link['href'], $unique_href_part);
@@ -3334,7 +3334,7 @@ class FileTypeTestCase extends FileTestHelper {
  */
 class FileAccessTestCase extends FileTestHelper {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Remove the "view files" permission which is set by default for all users
@@ -3348,7 +3348,7 @@ class FileAccessTestCase extends FileTestHelper {
   /**
    * Runs basic tests for file_access function.
    */
-  function testFileAccess() {
+  public function testFileAccess() {
     $file = $this->createFile(array('type' => 'image'));
 
     // Ensures user with 'bypass file access' permission can do everything.
@@ -3429,7 +3429,7 @@ class FileAccessTestCase extends FileTestHelper {
    *  file/%/usage
    *  file/%/delete
    */
-  function testFilePageAccess() {
+  public function testFilePageAccess() {
     // Test creating files without permission.
     $web_user = $this->backdropCreateUser();
     $this->backdropLogin($web_user);
@@ -3560,7 +3560,7 @@ class FileAccessTestCase extends FileTestHelper {
   /**
    * Test to see if we have access to download private files when granted the permissions.
    */
-  function testFilePrivateDownloadAccess() {
+  public function testFilePrivateDownloadAccess() {
     foreach ($this->getPrivateDownloadAccessCases() as $case) {
       // Create users and login only if non-anonymous.
       $authenticated_user = !is_null($case['permissions']);
@@ -3594,7 +3594,7 @@ class FileAccessTestCase extends FileTestHelper {
   /**
    * Asserts file_access correctly grants or denies access.
    */
-  function assertFileAccess($ops, $file, $account) {
+  protected function assertFileAccess($ops, $file, $account) {
     backdrop_static_reset('file_access');
     backdrop_static_reset('user_access');
     foreach ($ops as $op => $result) {
@@ -3615,7 +3615,7 @@ class FileAccessTestCase extends FileTestHelper {
    *   - "expect" expected HTTP response code.
    *   - "owner" Optional boolean indicating if the user is a file owner.
    */
-  function getPrivateDownloadAccessCases() {
+  protected function getPrivateDownloadAccessCases() {
     return array(
       array(
         'message' => "File owners cannot download their own files unless they are granted the 'view own private files' permission.",
@@ -3764,7 +3764,7 @@ class FileAttributeOverrideTestCase extends FileTestHelper {
   /**
    * Test to see if file attributes can be overridden.
    */
-  function testFileFileAttributeOverrides() {
+  public function testFileFileAttributeOverrides() {
     $overrides = array(
       'width' => 40,
       'height' => 20,

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -189,7 +189,7 @@ class FilterAdminTestCase extends BackdropWebTestCase {
      *   The page content that results from clicking on the link, or FALSE on
      *   failure. Failure also results in a failed assertion.
      */
-    function clickTextFormatOperationLink($label, $unique_href_part) {
+    protected function clickTextFormatOperationLink($label, $unique_href_part) {
       $links = $this->xpath('//a[normalize-space(text())=:label]', array(':label' => $label));
       foreach ($links as $link_index => $link) {
         $position = strpos($link['href'], $unique_href_part);

--- a/core/modules/filter/tests/filter.test
+++ b/core/modules/filter/tests/filter.test
@@ -8,14 +8,14 @@
  * Tests for text format and filter CRUD operations.
  */
 class FilterCRUDTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('filter_test');
   }
 
   /**
    * Tests CRUD operations for text formats and filters.
    */
-  function testTextFormatCRUD() {
+  public function testTextFormatCRUD() {
     // Add a text format with minimum data only.
     $format = new stdClass();
     $format->format = 'empty_format';
@@ -79,7 +79,7 @@ class FilterCRUDTestCase extends BackdropWebTestCase {
   /**
    * Verifies that a text format is properly stored.
    */
-  function verifyTextFormat($format) {
+  protected function verifyTextFormat($format) {
     $t_args = array('%format' => $format->name);
     // Verify text format database record.
     $config_format = (object) config_get('filter.format.' . $format->format);
@@ -112,7 +112,7 @@ class FilterCRUDTestCase extends BackdropWebTestCase {
   /**
    * Verifies that filters are properly stored for a text format.
    */
-  function verifyFilters($format) {
+  protected function verifyFilters($format) {
     // Verify filter database records.
     $config_filters = (object) config_get('filter.format.' . $format->format, 'filters');
     $format_filters = $format->filters;
@@ -154,7 +154,7 @@ class FilterAdminTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create users.
@@ -210,7 +210,7 @@ class FilterAdminTestCase extends BackdropWebTestCase {
   /**
    * Tests the format administration functionality.
    */
-  function testFormatAdmin() {
+  public function testFormatAdmin() {
     // Add text format.
     $this->backdropGet('admin/config/content/formats');
     $this->clickLink('Add text format');
@@ -295,7 +295,7 @@ class FilterAdminTestCase extends BackdropWebTestCase {
   /**
    * Tests filter administration functionality.
    */
-  function testFilterAdmin() {
+  public function testFilterAdmin() {
     // URL filter.
     $first_filter = 'filter_url';
     // Line filter.
@@ -494,7 +494,7 @@ class FilterAdminTestCase extends BackdropWebTestCase {
   /**
    * Tests the URL filter settings form is properly validated.
    */
-  function testUrlFilterAdmin() {
+  public function testUrlFilterAdmin() {
     // The form does not save with an invalid filter URL length.
     $edit = array(
       'filter_url_length' => $this->randomName(4),
@@ -570,7 +570,7 @@ class FilterFormatAccessTestCase extends BackdropWebTestCase {
    */
   protected $disallowed_format;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create a user who can administer text formats, but does not have
@@ -616,7 +616,7 @@ class FilterFormatAccessTestCase extends BackdropWebTestCase {
   /**
    * Tests the Filter format access permissions functionality.
    */
-  function testFormatPermissions() {
+  public function testFormatPermissions() {
     // Make sure that a regular user only has access to the text format they
     // were granted access to, as well to the fallback format.
     $this->assertTrue(filter_access($this->allowed_format, $this->web_user), 'A regular user has access to a text format they were granted access to.');
@@ -676,7 +676,7 @@ class FilterFormatAccessTestCase extends BackdropWebTestCase {
   /**
    * Tests if text format is available to a role.
    */
-  function testFormatRoles() {
+  public function testFormatRoles() {
     // Get the role name assigned to the regular user.
     $roles = array_diff($this->web_user->roles, array(BACKDROP_AUTHENTICATED_ROLE));
     $role_name = reset($roles);
@@ -706,7 +706,7 @@ class FilterFormatAccessTestCase extends BackdropWebTestCase {
    * be edited by administrators only, but that the administrator is forced to
    * choose a new format before saving the page.
    */
-  function testFormatWidgetPermissions() {
+  public function testFormatWidgetPermissions() {
     config_set('path.settings', 'node_pattern', '');
     config_set('path.settings', 'node_page_pattern', '');
 
@@ -817,7 +817,7 @@ class FilterFormatAccessTestCase extends BackdropWebTestCase {
   /**
    * Tests loading of disabled formats.
    */
-  function testFormatDisabledAccess() {
+  public function testFormatDisabledAccess() {
     // Check filter_formats() in sequence loading both enabled and all formats.
     filter_format_disable($this->disallowed_format);
     $this->resetFilterCaches();
@@ -851,7 +851,7 @@ class FilterDefaultFormatTestCase extends BackdropWebTestCase {
   /**
    * Tests if the default text format is accessible to users.
    */
-  function testDefaultTextFormats() {
+  public function testDefaultTextFormats() {
     // Create two text formats, and two users. The first user has access to
     // both formats, but the second user only has access to the second one.
     $admin_user = $this->backdropCreateUser(array('administer filters'));
@@ -911,7 +911,7 @@ class FilterNoFormatTestCase extends BackdropWebTestCase {
    * Tests if text with no format is filtered the same way as text in the
    * fallback format.
    */
-  function testCheckMarkupNoFormat() {
+  public function testCheckMarkupNoFormat() {
     // Create some text. Include some HTML and line breaks, so we get a good
     // test of the filtering that is applied to it.
     $text = "<strong>" . $this->randomName(32) . "</strong>\n\n<div>" . $this->randomName(32) . "</div>";
@@ -932,7 +932,7 @@ class FilterSecurityTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('filter_test');
     $this->admin_user = $this->backdropCreateUser(array('administer modules', 'administer filters', 'administer site configuration'));
     $this->backdropLogin($this->admin_user);
@@ -944,7 +944,7 @@ class FilterSecurityTestCase extends BackdropWebTestCase {
    * Tests that filtered content is emptied when an actively used filter module
    * is disabled.
    */
-  function testDisableFilterModule() {
+  public function testDisableFilterModule() {
     // Create a new node.
     $node = $this->backdropCreateNode(array('promote' => 1));
     $body_raw = $node->body[LANGUAGE_NONE][0]['value'];
@@ -987,7 +987,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests the line break filter.
    */
-  function testLineBreakFilter() {
+  public function testLineBreakFilter() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->callback = '_filter_autop';
@@ -1095,7 +1095,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
    * - CVE-2002-1806, ~CVE-2005-0682, ~CVE-2005-2106, CVE-2005-3973,
    *   CVE-2006-1226 (= rev. 1.112?), CVE-2008-0273, CVE-2008-3740.
    */
-  function testFilterXSS() {
+  public function testFilterXSS() {
     // Tag stripping, different ways to work around removal of HTML tags.
     $f = filter_xss('<script>alert(0)</script>');
     $this->assertNoNormalized($f, 'script', 'HTML tag stripping -- simple script without special characters.');
@@ -1282,7 +1282,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
    * @todo Class, id, name and xmlns should be added to disallowed attributes,
    *   or better, an allowed attributes approach should be used for that too.
    */
-  function testHtmlFilter() {
+  public function testHtmlFilter() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->settings = array(
@@ -1331,7 +1331,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests the spam deterrent.
    */
-  function testNoFollowFilter() {
+  public function testNoFollowFilter() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->settings = array(
@@ -1362,7 +1362,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests the loose, admin HTML filter.
    */
-  function testFilterXSSAdmin() {
+  public function testFilterXSSAdmin() {
     // DRUPAL-SA-2008-044
     $f = filter_xss_admin('<object />');
     $this->assertNoNormalized($f, 'object', 'Admin HTML filter -- should not allow object tag.');
@@ -1379,7 +1379,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
    *
    * check_plain() is not tested here.
    */
-  function testHtmlEscapeFilter() {
+  public function testHtmlEscapeFilter() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->callback = '_filter_html_escape';
@@ -1397,7 +1397,7 @@ class FilterUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests the URL filter.
    */
-  function testUrlFilter() {
+  public function testUrlFilter() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->callback = '_filter_url';
@@ -1718,7 +1718,7 @@ www.example.com with a newline in comments -->
    * This means that after passing 'Input string' through the given filter, we
    * should find '<p>Input string</p>' in the output, but not 'Input string<br'.
    */
-  function assertFilteredString($filter, $tests) {
+  protected function assertFilteredString($filter, $tests) {
     foreach ($tests as $source => $tasks) {
       $function = $filter->callback;
       $result = $function($source, $filter);
@@ -1764,7 +1764,7 @@ www.example.com with a newline in comments -->
    * - Empty HTML tags (BR, IMG).
    * - Mix of absolute and partial URLs, and email addresses in one content.
    */
-  function testUrlFilterContent() {
+  public function testUrlFilterContent() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->settings = array(
@@ -1781,7 +1781,7 @@ www.example.com with a newline in comments -->
   /**
    * Tests the Image alignment filter (data-align).
    */
-  function testImageAlignFilter() {
+  public function testImageAlignFilter() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->callback = '_filter_image_align';
@@ -1829,7 +1829,7 @@ EOF;
   /**
    * Tests the Image caption filter (data-caption).
    */
-  function testImageAlignCaption() {
+  public function testImageAlignCaption() {
     // Set up dummy filter object.
     $filter = new stdClass();
     $filter->callback = '_filter_image_caption';
@@ -1858,7 +1858,7 @@ EOF;
    *
    * @todo This test could really use some validity checking function.
    */
-  function testHtmlCorrectorFilter() {
+  public function testHtmlCorrectorFilter() {
     // Tag closing.
     $f = _filter_htmlcorrector('<p>text');
     $this->assertEqual($f, '<p>text</p>', 'HTML corrector -- tag closing at the end of input.');
@@ -2066,7 +2066,7 @@ body {color:red}
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertNormalized($haystack, $needle, $message = '', $group = 'Other') {
+  protected function assertNormalized($haystack, $needle, $message = '', $group = 'Other') {
     return $this->assertTrue(strpos(strtolower(decode_entities($haystack)), $needle) !== FALSE, $message, $group);
   }
 
@@ -2090,7 +2090,7 @@ body {color:red}
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertNoNormalized($haystack, $needle, $message = '', $group = 'Other') {
+  protected function assertNoNormalized($haystack, $needle, $message = '', $group = 'Other') {
     return $this->assertTrue(strpos(strtolower(decode_entities($haystack)), $needle) === FALSE, $message, $group);
   }
 }
@@ -2099,7 +2099,7 @@ body {color:red}
  * Tests for Filter's hook invocations.
  */
 class FilterHooksTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('block', 'filter_test');
     $admin_user = $this->backdropCreateUser(array('administer filters', 'administer blocks'));
     $this->backdropLogin($admin_user);
@@ -2111,7 +2111,7 @@ class FilterHooksTestCase extends BackdropWebTestCase {
    * Tests that hooks run correctly on creating, editing, and deleting a text
    * format.
    */
-  function testFilterHooks() {
+  public function testFilterHooks() {
     // Add a text format.
     $name = $this->randomName();
     $edit = array();
@@ -2167,7 +2167,7 @@ class FilterSettingsTestCase extends BackdropWebTestCase {
   /**
    * Tests explicit and implicit default settings for filters.
    */
-  function testFilterDefaults() {
+  public function testFilterDefaults() {
     $filter_info = filter_filter_info();
     $filters = array_fill_keys(array_keys($filter_info), array());
 
@@ -2215,7 +2215,7 @@ class FilterFileUsageTest extends BackdropWebTestCase {
   /**
    * Tests file usages are tracked in creating, updating, and deleting content.
    */
-  function testFilterEntityHooks() {
+  public function testFilterEntityHooks() {
     $image = entity_create('file', array());
     $image->uri = 'core/misc/favicon.ico';
     $image->filename = 'favicon.ico';
@@ -2282,7 +2282,7 @@ class FilterDOMSerializeTestCase extends BackdropWebTestCase {
   /**
    * Tests empty DOMDocument object.
    */
-  function testFilterEmptyDOMSerialization() {
+  public function testFilterEmptyDOMSerialization() {
     $document = new DOMDocument();
     $result = filter_dom_serialize($document);
     $this->assertEqual('', $result);
@@ -2295,7 +2295,7 @@ class FilterDOMSerializeTestCase extends BackdropWebTestCase {
 class FilterEditorAccessTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('file'));
 
     $filtered_html_format = array(
@@ -2316,7 +2316,7 @@ class FilterEditorAccessTestCase extends BackdropWebTestCase {
   /**
    * Checks access to editor dialogs for adding images and links.
    */
-  function testDialogAccess() {
+  public function testDialogAccess() {
     // Check that the dialog for filtered HTML is not directly accessible.
     $this->backdropGet('editor/dialog/image/filtered_html');
     $this->assertResponse(403, 'Access denied on image dialog without token.');

--- a/core/modules/image/tests/token.test
+++ b/core/modules/image/tests/token.test
@@ -12,7 +12,7 @@ class ImageStyleTokenTests extends BackdropWebTestCase {
   /**
    * {@inheritdoc}
    */
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     parent::setUp($modules);
 
     // Create an admin user and log them in.
@@ -31,7 +31,7 @@ class ImageStyleTokenTests extends BackdropWebTestCase {
   /**
    * Test that the image style tokens exist.
    */
-  function testTokens() {
+  public function testTokens() {
     $bundle_label = 'Post';
     $node_title = 'Test post';
 
@@ -98,7 +98,7 @@ class ImageStyleTokenTests extends BackdropWebTestCase {
    * @return stdClass
    *   A file object.
    */
-  function getTestImage() {
+  protected function getTestImage() {
     // Get a file to upload.
     $file = current($this->backdropGetTestFiles('image'));
 

--- a/core/modules/installer/tests/installer.test
+++ b/core/modules/installer/tests/installer.test
@@ -239,7 +239,7 @@ class InstallerTestUploadCase extends BackdropWebTestCase {
   /**
    * Ensures that archiver extensions are properly merged in the UI.
    */
-  function testFileNameExtensionMerging() {
+  public function testFileNameExtensionMerging() {
     $this->backdropGet('admin/installer/manual');
     // Make sure the bogus extension supported by installer_test.module is there.
     $this->assertPattern('/file extensions are supported:.*installer-test-extension/', "Found 'installer-test-extension' extension");
@@ -250,7 +250,7 @@ class InstallerTestUploadCase extends BackdropWebTestCase {
   /**
    * Checks the messages on Update Manager pages when missing a security update.
    */
-  function testUpdateManagerCoreSecurityUpdateMessages() {
+  public function testUpdateManagerCoreSecurityUpdateMessages() {
     $config = config('update.settings');
     $setting = array(
       '#all' => array(

--- a/core/modules/language/tests/language.test
+++ b/core/modules/language/tests/language.test
@@ -11,14 +11,14 @@
  * Functional tests for the language list configuration forms.
  */
 class LanguageListTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('language');
   }
 
   /**
    * Functional tests for adding, configuring, and deleting languages.
    */
-  function testLanguageList() {
+  public function testLanguageList() {
     global $base_url;
 
     // User to add and remove language.

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -16,7 +16,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   protected $test_node2;
   protected $orphaned_blocks = FALSE;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('layout_test');
 
     // Create and login admin user.
@@ -57,7 +57,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test the support for contexts within conditions and blocks.
    */
-  function testRelationships() {
+  public function testRelationships() {
     // Make a new layout that creates a custom path with wildcards.
     $layout_title = $this->randomName();
     $layout_name = strtolower($layout_title);
@@ -139,7 +139,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test that layout templates may be enabled and disabled.
    */
-  function testLayoutTemplates() {
+  public function testLayoutTemplates() {
     // Attempt to disable the 1 column layout (should fail).
     $this->backdropGet('admin/structure/layouts/settings');
     $edit = array(
@@ -196,7 +196,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test the path view page link.
    */
-  function testViewPageLink() {
+  public function testViewPageLink() {
     $this->backdropGet('admin/structure/layouts');
     $this->clickLink(t('Add layout'));
 
@@ -246,7 +246,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Add and remove blocks from a custom layout path.
    */
-  function testBlockBasics() {
+  public function testBlockBasics() {
     $this->backdropGet('admin/structure/layouts');
     $this->clickLink(t('Add layout'));
 
@@ -566,7 +566,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test block path and type conditions.
    */
-  function testBlockPathTypeConditions() {
+  public function testBlockPathTypeConditions() {
     // Create a new layout overriding node/%.
     $layout_title = $this->randomName();
     $layout_name = strtolower($layout_title);
@@ -662,7 +662,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test block entity ID conditions.
    */
-  function testBlockEntityIDConditions() {
+  public function testBlockEntityIDConditions() {
     // Create a new layout overriding node/%.
     $layout_title = $this->randomName();
     $layout_name = strtolower($layout_title);
@@ -745,7 +745,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Tests user account comparison condition.
    */
-  function testBlockUserCompareConditions() {
+  public function testBlockUserCompareConditions() {
     // Create a new layout overriding user/%.
     $layout_title = $this->randomName();
     $layout_name = strtolower($layout_title);
@@ -919,7 +919,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test the support for contexts within conditions and blocks.
    */
-  function testContexts() {
+  public function testContexts() {
     // Make a new layout that creates a custom path with placeholders.
     $layout_title = $this->randomName();
     $layout_name = strtolower($layout_title);
@@ -1257,7 +1257,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test the overriding of paths.
    */
-  function testOverriddenPaths() {
+  public function testOverriddenPaths() {
     // Make a new layout that creates a custom path with placeholders.
     $layout_name = 'node';
     $layout_title = 'Generic Node';
@@ -1367,7 +1367,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Check special conditions around the main content block.
    */
-  function testMainContentBlock() {
+  public function testMainContentBlock() {
     // Make a new layout that overrides an existing path.
     $layout_title = $this->randomName();
     $layout_name = strtolower($layout_title);
@@ -1474,7 +1474,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Tests conditions and menu item navigation.
    */
-  function testLayoutMenuItems() {
+  public function testLayoutMenuItems() {
     $layout_name = strtolower($this->randomName());
     $layout_path = $layout_name . '/' . strtolower($this->randomName());
     $edit = array(
@@ -1648,7 +1648,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Test region styles.
    */
-  function testRegionStyles() {
+  public function testRegionStyles() {
     $this->backdropGet('admin/structure/layouts/manage/default/configure-region/editor/header');
     $edit = array(
       'element' => 'aside',
@@ -1666,7 +1666,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Ensure that reassignment of menu items works when deleting layouts.
    */
-  function testMenuItemReassignment() {
+  public function testMenuItemReassignment() {
     // Create a layout that will generate a menu item automatically.
     $layout_name = strtolower($this->randomName());
     $layout_path = $layout_name;
@@ -1739,7 +1739,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Tests switching between different layouts, ensuring block copying.
    */
-  function testLayoutChange() {
+  public function testLayoutChange() {
     // Add blocks to the default layout for checking.
     $default_layout = layout_load('default');
     $default_layout->addBlock('layout_test', 'foo', 'content');
@@ -1806,7 +1806,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Tests current user custom field block
    */
-  function testCurrentUser() {
+  public function testCurrentUser() {
     $field_name = 'field_field1';
 
     $field_info = array('field_name' => $field_name, 'type' => 'text');
@@ -1863,7 +1863,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Tests Taxonomy contexts within layouts.
    */
-  function testTaxonomyContext() {
+  public function testTaxonomyContext() {
     module_enable(array('taxonomy'));
 
     // Create a default vocabulary named "Tags", enabled for the 'post' content type.
@@ -1971,7 +1971,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
   /**
    * Tests layout_modules_uninstalled().
    */
-  function testBlockUninstall() {
+  public function testBlockUninstall() {
     $this->backdropGet('admin/structure/layouts');
     $this->clickLink(t('Add layout'));
 
@@ -2061,7 +2061,7 @@ class LayoutBlockTest extends BackdropWebTestCase {
   /**
    * Test Custom Text blocks.
    */
-  function testCustomTextBlocks() {
+  public function testCustomTextBlocks() {
     $this->backdropGet('admin/structure/layouts/manage/default');
     $block_title_1 = 'Title of block one';
     $block_content_1 = 'Content of block one';
@@ -2164,7 +2164,7 @@ class LayoutBlockTest extends BackdropWebTestCase {
   /**
    * Test Hero blocks.
    */
-  function testHeroBlocks() {
+  public function testHeroBlocks() {
     $hero_title_1 = 'Wonder Woman';
     $hero_content_1 = 'Youth is your greatest weapon, your greatest tool.';
     $hero_title_2 = 'Black Widow';
@@ -2285,7 +2285,7 @@ class LayoutBlockTest extends BackdropWebTestCase {
   /**
    * Test Page component blocks.
    */
-  function testPageComponentBlocks() {
+  public function testPageComponentBlocks() {
     // Create a node page.
     $page_node = $this->backdropCreateNode(array(
       'type' => 'page',
@@ -2491,7 +2491,7 @@ class LayoutSelectionTest extends BackdropWebTestCase {
   protected $web_user;
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('layout'));
     config_set('system.core', 'node_admin_theme', TRUE);
 
@@ -2519,7 +2519,7 @@ class LayoutSelectionTest extends BackdropWebTestCase {
   /**
    * Tests the correct layout is used on 404 and 403 pages.
    */
-  function testPages() {
+  public function testPages() {
     // Check that a known page is using the admin (one-column) layout.
     $this->backdropGet('admin/config/content/formats/plain_text');
     $this->assertIsAdminLayout();
@@ -2561,7 +2561,7 @@ class LayoutSelectionTest extends BackdropWebTestCase {
   /**
    * Test role-based selection of layouts.
    */
-  function testRoleSelection() {
+  public function testRoleSelection() {
     // Create and login admin user.
     $admin_user = $this->backdropCreateUser(array(
       'access administration pages',
@@ -2663,7 +2663,7 @@ class LayoutBlockTextTest extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('layout', 'block'));
     // Create and login admin user.
     $this->admin_user = $this->backdropCreateUser(array(
@@ -2678,7 +2678,7 @@ class LayoutBlockTextTest extends BackdropWebTestCase {
   /**
    * Tests the BlockText class functionality.
    */
-  function testBlockText() {
+  public function testBlockText() {
     // Save a file to test file usage saving.
     $files = $this->backdropGetTestFiles('image');
     $file_info = (array) array_pop($files);
@@ -2745,7 +2745,7 @@ class LayoutCloneTest extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('layout', 'layout_test'));
     // Create and login admin user.
     $this->admin_user = $this->backdropCreateUser(array(
@@ -2757,7 +2757,7 @@ class LayoutCloneTest extends BackdropWebTestCase {
     $this->backdropLogin($this->admin_user);
   }
 
-  function testLayoutClone() {
+  public function testLayoutClone() {
     // Create a new layout using the UI.
     $edit = array(
       'title' => 'Test layout 1',
@@ -2955,7 +2955,7 @@ class LayoutHookTestCase extends BackdropWebTestCase {
   protected $admin_user;
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('layout', 'layout_test');
 
     // Create and login admin user.
@@ -3093,7 +3093,7 @@ class LayoutBlockUsageTestCase extends BackdropWebTestCase {
   protected $admin_user;
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('layout', 'menu');
 
     // Create and login admin user.
@@ -3194,7 +3194,7 @@ class LayoutRendererTest extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('layout', 'layout_test'));
 
     // Create and login admin user.
@@ -3209,7 +3209,7 @@ class LayoutRendererTest extends BackdropWebTestCase {
   /**
    * Test that the correct renderer is used
    */
-  function testRendererSelection() {
+  public function testRendererSelection() {
     // Create a new layout at a new path.
     $this->backdropGet('admin/structure/layouts');
     $this->clickLink(t('Add layout'));
@@ -3274,7 +3274,7 @@ class LayoutFlexibleTemplateTest extends BackdropWebTestCase {
    */
   protected $no_flex_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('layout', 'layout_test');
 
     // Create and login admin user.
@@ -3290,7 +3290,7 @@ class LayoutFlexibleTemplateTest extends BackdropWebTestCase {
   /**
    * Test that layout templates may be enabled and disabled.
    */
-  function testLayoutFlexibleTemplates() {
+  public function testLayoutFlexibleTemplates() {
     $this->backdropGet('admin/structure/layouts/settings');
     $this->clickLink(t('Add flexible layout template'));
 

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -2039,24 +2039,24 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
  * Tests the blocks title, content, and display settings.
  */
 class LayoutBlockTest extends BackdropWebTestCase {
-    protected $profile = 'minimal';
-    protected $admin_user;
+  protected $profile = 'minimal';
+  protected $admin_user;
 
-    function setUp() {
-      parent::setUp(array('file', 'block'));
-      // Create content types for testing.
-      $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
+  public function setUp() {
+    parent::setUp(array('file', 'block'));
+    // Create content types for testing.
+    $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
 
-      // Create and login admin user.
-      $this->admin_user = $this->backdropCreateUser(array(
-        'access administration pages',
-        'administer layouts',
-        'access user profiles',
-        'edit any page content',
-        'administer nodes',
-      ));
-      $this->backdropLogin($this->admin_user);
-    }
+    // Create and login admin user.
+    $this->admin_user = $this->backdropCreateUser(array(
+      'access administration pages',
+      'administer layouts',
+      'access user profiles',
+      'edit any page content',
+      'administer nodes',
+    ));
+    $this->backdropLogin($this->admin_user);
+  }
 
   /**
    * Test Custom Text blocks.

--- a/core/modules/link/tests/link.attribute.test
+++ b/core/modules/link/tests/link.attribute.test
@@ -10,7 +10,7 @@ class LinkAttributeCrudTest extends LinkBaseTestClass {
   private $zebra;
   protected $field_name;
 
-  function setup() {
+  public function setUp() {
     parent::setup();
     $this->zebra = 0;
   }
@@ -45,7 +45,7 @@ class LinkAttributeCrudTest extends LinkBaseTestClass {
   /**
    * Test the link_plain formatter and it's output.
    */
-  function testFormatters() {
+  public function testFormatters() {
     $this->field_name = $this->createLinkField();
 
     // Test the plain formatter.

--- a/core/modules/link/tests/link.test
+++ b/core/modules/link/tests/link.test
@@ -27,7 +27,7 @@ class LinkBaseTestClass extends BackdropWebTestCase {
     'create page content',
   );
 
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     $modules[] = 'node';
     $modules[] = 'field_ui';

--- a/core/modules/link/tests/link.token.test
+++ b/core/modules/link/tests/link.token.test
@@ -14,7 +14,7 @@ class LinkTokenTest extends LinkBaseTestClass {
    * Creates a link field with a required title enabled for user-entered tokens.
    * Creates a node with a token in the link title and checks the value.
    */
-  function testUserTokenLinkCreate() {
+  public function testUserTokenLinkCreate() {
     $settings = array(
       'instance[settings][enable_tokens]' => 1,
     );
@@ -42,7 +42,7 @@ class LinkTokenTest extends LinkBaseTestClass {
    * Creates a link field with a static title and an admin-entered token.
    * Creates a node with a link and checks the title value.
    */
-  function testStaticTokenLinkCreate() {
+  public function testStaticTokenLinkCreate() {
     $name = $this->randomName();
     $settings = array(
       'instance[settings][title]' => 'value',
@@ -70,7 +70,7 @@ class LinkTokenTest extends LinkBaseTestClass {
    * Test that if you have a title and no URL on a field which does not have
    * tokens enabled, that the title is sanitized once.
    */
-  function testTitleOnlyTitleNoLink() {
+  public function testTitleOnlyTitleNoLink() {
     $settings = array(
       'instance[settings][url]' => 1,
       'instance[settings][enable_tokens]' => 0,

--- a/core/modules/link/tests/link.ui.test
+++ b/core/modules/link/tests/link.ui.test
@@ -29,7 +29,7 @@ class LinkUITest extends LinkBaseTestClass {
   /**
    * Creates a link field for the "page" type and creates a page with a link.
    */
-  function testLinkCreate() {
+  public function testLinkCreate() {
     $name = strtolower($this->randomName());
     $edit = array(
       'fields[_add_new_field][label]' => $name,
@@ -143,7 +143,7 @@ class LinkUITest extends LinkBaseTestClass {
   /**
    * Tests if <strong> is used in a static title that the markup is retained.
    */
-  function testStaticLinkCreate() {
+  public function testStaticLinkCreate() {
     $name = strtolower($this->randomName());
     $field_name = 'field_' . $name;
     $edit = array(
@@ -177,7 +177,7 @@ class LinkUITest extends LinkBaseTestClass {
   /**
    * Tests that if a field has a title but no URL, the title is not sanitized twice.
    */
-  function testCRUDTitleOnlyTitleNoLink() {
+  public function testCRUDTitleOnlyTitleNoLink() {
     $name = strtolower($this->randomName());
     $field_name = 'field_' . $name;
     $edit = array(
@@ -212,7 +212,7 @@ class LinkUITest extends LinkBaseTestClass {
   /**
    * Creates a field with all the default values and check expected values.
    */
-  function testCRUDCreateFieldDefaults() {
+  public function testCRUDCreateFieldDefaults() {
     $name = strtolower($this->randomName());
     $edit = array(
       'fields[_add_new_field][label]' => $name,
@@ -242,7 +242,7 @@ class LinkUITest extends LinkBaseTestClass {
   /**
    * Tests adding custom classes (single and multiple) to link fields.
    */
-  function testCRUDCreateFieldWithClasses() {
+  public function testCRUDCreateFieldWithClasses() {
     // Disable the page cache for this test.
     config_set('system.core', 'cache', 0);
     $name = strtolower($this->randomName());
@@ -304,7 +304,7 @@ class LinkUITest extends LinkBaseTestClass {
   /**
    * Tests the link type: "internal", "external", and "both" settings.
    */
-  function testCRUDCreateFieldWithLinkType() {
+  public function testCRUDCreateFieldWithLinkType() {
     $name = strtolower($this->randomName());
     $edit = array(
       'fields[_add_new_field][label]' => $name,

--- a/core/modules/link/tests/link.validate.test
+++ b/core/modules/link/tests/link.validate.test
@@ -9,7 +9,7 @@ require_once(__DIR__ . '/link.test');
 class LinkValidateTest extends LinkBaseTestClass {
   protected $field_name;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->field_name = $this->createLinkField();
   }
@@ -54,7 +54,7 @@ class LinkValidateTest extends LinkBaseTestClass {
    * Each of these tests creates a new node and ensures that the value of the
    * URL is stored properly in the database.
    */
-  function testUrls() {
+  public function testUrls() {
     $this->validateUrl('http://www.example.com');
     $this->validateUrl('<front>');
     $this->validateUrl('node/32');
@@ -76,7 +76,7 @@ class LinkValidateTest extends LinkBaseTestClass {
   /**
    * Test if we can post a bad URL if the validation is expressly turned off.
    */
-  function testBadUrlValidationOff() {
+  public function testBadUrlValidationOff() {
     // Disable validation.
     $edit = array(
       'instance[settings][validate_url]' => FALSE,
@@ -95,7 +95,7 @@ class LinkValidateTest extends LinkBaseTestClass {
   /**
    * Test if a bad URL will display if validation is disabled.
    */
-  function testXss() {
+  public function testXss() {
     // Disable validation.
     $edit = array(
       'instance[settings][validate_url]' => FALSE,
@@ -138,43 +138,43 @@ class LinkValidateTest extends LinkBaseTestClass {
  * Validation is guided by the rules in http://tools.ietf.org/html/rfc1738!
  */
 class LinkValidateUnitTest extends BackdropUnitTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     backdrop_load('module', 'link');
   }
 
   // Make sure that a link labelled <front> works.
-  function testValidateFrontLink() {
+  public function testValidateFrontLink() {
     $valid = link_validate_url('<front>');
     $this->assertEqual(LINK_FRONT, $valid, 'Make sure that front link is verified and identified');
   }
 
-  function testValidateEmailLink() {
+  public function testValidateEmailLink() {
     $valid = link_validate_url('mailto:bob@example.com');
     $this->assertEqual(LINK_EMAIL, $valid, "Make sure a basic mailto is verified and identified");
   }
 
-  function testValidateEmailLinkBad() {
+  public function testValidateEmailLinkBad() {
     $valid = link_validate_url(':bob@example.com');
     $this->assertEqual(FALSE, $valid, 'Make sure just a bad address is correctly failed');
   }
 
-  function testValidateNewsgroupLink() {
+  public function testValidateNewsgroupLink() {
     $valid = link_validate_url('news:comp.info-systems.www.misc');
     $this->assertEqual(LINK_NEWS, $valid, 'Make sure link to newsgroup validates as news.');
   }
 
-  function testValidateNewsArticleLink() {
+  public function testValidateNewsArticleLink() {
     $valid = link_validate_url('news:hj0db8$vrm$1@news.eternal-september.org');
     $this->assertEqual(LINK_NEWS, $valid, 'Make sure link to specific article validates as news.');
   }
 
-  function testValidateBadNewsgroupLink() {
+  public function testValidateBadNewsgroupLink() {
     $valid = link_validate_url('news:comp.bad_name.misc');
     $this->assertEqual(FALSE, $valid, 'newsgroup names can\'t contain underscores, so it should come back as invalid.');
   }
 
-  function testValidateInternalLinks() {
+  public function testValidateInternalLinks() {
     $links = array(
       'node/5',
       'feeds/rss.xml',
@@ -188,7 +188,7 @@ class LinkValidateUnitTest extends BackdropUnitTestCase {
     }
   }
 
-  function testValidateExternalLinks() {
+  public function testValidateExternalLinks() {
     $links = array(
       'http://localhost:8080/',
       'www.example.com',
@@ -232,7 +232,7 @@ class LinkValidateUnitTest extends BackdropUnitTestCase {
     }
   }
 
-  function testInvalidExternalLinks() {
+  public function testInvalidExternalLinks() {
     $links = array(
       'http://www.ex ample.com/',
       'http://@www.example.com/',

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -8,14 +8,14 @@
  * Functional tests for language configuration's effect on negotiation setup.
  */
 class LocaleConfigurationTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
   }
 
   /**
    * Functional tests for adding, editing and deleting languages.
    */
-  function testLanguageConfiguration() {
+  public function testLanguageConfiguration() {
     global $base_url;
 
     // User to add and remove language.
@@ -68,7 +68,7 @@ class LocaleConfigurationTest extends BackdropWebTestCase {
  * Currently, only the jQuery datepicker is localized using Backdrop translations.
  */
 class LocaleLibraryInfoAlterTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
   }
 
@@ -88,11 +88,11 @@ class LocaleLibraryInfoAlterTest extends BackdropWebTestCase {
  * Functional tests for JavaScript parsing for translatable strings.
  */
 class LocaleJavascriptTranslationTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
   }
 
-  function testFileParsing() {
+  public function testFileParsing() {
 
     $filename = backdrop_get_path('module', 'locale_test') . '/locale_test.js';
 
@@ -173,14 +173,14 @@ class LocaleJavascriptTranslationTest extends BackdropWebTestCase {
  * Functional test for string translation and validation.
  */
 class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
   }
 
   /**
    * Adds a language and tests string translation by users with the appropriate permissions.
    */
-  function testStringTranslation() {
+  public function testStringTranslation() {
     global $base_url;
 
     // User to add and remove language.
@@ -338,7 +338,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
    * Adds a language and checks that the JavaScript translation files are
    * properly created and rebuilt on deletion.
    */
-  function testJavaScriptTranslation() {
+  public function testJavaScriptTranslation() {
     $user = $this->backdropCreateUser(array('translate interface', 'administer languages', 'access administration pages'));
     $this->backdropLogin($user);
 
@@ -390,7 +390,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the validation of the translation input.
    */
-  function testStringValidation() {
+  public function testStringValidation() {
     global $base_url;
 
     // User to add language and strings.
@@ -451,7 +451,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests translation search form.
    */
-  function testStringSearch() {
+  public function testStringSearch() {
     global $base_url;
 
     // User to add and remove language.
@@ -606,7 +606,7 @@ class LocaleTranslationFunctionalTest extends BackdropWebTestCase {
  * Tests plural index computation functionality.
  */
 class LocalePluralFormatTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
 
     $admin_user = $this->backdropCreateUser(array('administer languages', 'translate interface', 'access administration pages'));
@@ -616,7 +616,7 @@ class LocalePluralFormatTest extends BackdropWebTestCase {
   /**
    * Tests locale_get_plural() functionality.
    */
-  function testGetPluralFormat() {
+  public function testGetPluralFormat() {
     // Import some .po files with formulas to set up the environment.
     // These will also add the languages to the system and enable them.
     $this->importPoFile($this->getPoFileWithSimplePlural(), array(
@@ -670,7 +670,7 @@ class LocalePluralFormatTest extends BackdropWebTestCase {
    * @param $options
    *   Additional options to pass to the translation import form.
    */
-  function importPoFile($contents, array $options = array()) {
+  protected function importPoFile($contents, array $options = array()) {
     $name = backdrop_tempnam('temporary://', "po_") . '.po';
     file_put_contents($name, $contents);
     $options['files[file]'] = $name;
@@ -682,7 +682,7 @@ class LocalePluralFormatTest extends BackdropWebTestCase {
   /**
    * Returns a .po file with a simple plural formula.
    */
-  function getPoFileWithSimplePlural() {
+  protected function getPoFileWithSimplePlural() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -705,7 +705,7 @@ EOF;
   /**
    * Returns a .po file with a complex plural formula.
    */
-  function getPoFileWithComplexPlural() {
+  protected function getPoFileWithComplexPlural() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -729,7 +729,7 @@ EOF;
   /**
    * Returns a .po file with a missing plural formula.
    */
-  function getPoFileWithMissingPlural() {
+  protected function getPoFileWithMissingPlural() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -746,7 +746,7 @@ EOF;
   /**
    * Returns a .po file with a broken plural formula.
    */
-  function getPoFileWithBrokenPlural() {
+  protected function getPoFileWithBrokenPlural() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -771,7 +771,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
    */
   protected $admin_user = NULL;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
 
     // Set the translation file directory.
@@ -789,7 +789,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
   /**
    * Test import of standalone .po files.
    */
-  function testStandalonePoFile() {
+  public function testStandalonePoFile() {
     // Try importing a .po file.
     $this->importPoFile($this->getPoFile(), array(
       'langcode' => 'fr',
@@ -877,7 +877,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
   /**
    * Test automatic import of a module's translation files.
    */
-  function testAutomaticModuleTranslationImportLanguageEnable() {
+  public function testAutomaticModuleTranslationImportLanguageEnable() {
     // Code for the language - manually set to match the test translation file.
     $langcode = 'xx';
     // The English name for the language.
@@ -910,7 +910,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
   /**
    * Test msgctxt context support.
    */
-  function testLanguageContext() {
+  public function testLanguageContext() {
     // Try importing a .po file.
     $this->importPoFile($this->getPoFileWithContext(), array(
       'langcode' => 'hr',
@@ -923,7 +923,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
   /**
    * Test empty msgstr at end of .po file see #611786.
    */
-  function testEmptyMsgstr() {
+  public function testEmptyMsgstr() {
     $langcode = 'hu';
 
     // Try importing a .po file.
@@ -964,7 +964,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
    * @param $options
    *   Additional options to pass to the translation import form.
    */
-  function importPoFile($contents, array $options = array()) {
+  protected function importPoFile($contents, array $options = array()) {
     $name = backdrop_tempnam('temporary://', "po_") . '.po';
     file_put_contents($name, $contents);
     $options['files[file]'] = $name;
@@ -975,7 +975,7 @@ class LocaleImportFunctionalTest extends BackdropWebTestCase {
   /**
    * Helper function that returns a proper .po file.
    */
-  function getPoFile() {
+  protected function getPoFile() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -1016,7 +1016,7 @@ EOF;
   /**
    * Helper function that returns a bad .po file.
    */
-  function getBadPoFile() {
+  protected function getBadPoFile() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -1041,7 +1041,7 @@ EOF;
   /**
    * Helper function that returns a proper .po file for testing.
    */
-  function getOverwritePoFile() {
+  protected function getOverwritePoFile() {
     // cspell:disable
     return <<< EOF
 msgid ""
@@ -1064,7 +1064,7 @@ EOF;
   /**
    * Helper function that returns a .po file with context.
    */
-  function getPoFileWithContext() {
+  protected function getPoFileWithContext() {
     // Croatian (code hr) is one the the languages that have a different
     // form for the full name and the abbreviated name for the month May.
     return <<< EOF
@@ -1088,7 +1088,7 @@ EOF;
   /**
    * Helper function that returns a .po file with an empty last item.
    */
-  function getPoFileWithEmptyMsgstr() {
+  protected function getPoFileWithEmptyMsgstr() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -1106,7 +1106,7 @@ EOF;
   /**
    * Helper function that returns a .po file with an empty last item.
    */
-  function getPoFileWithMsgstr() {
+  protected function getPoFileWithMsgstr() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -1136,7 +1136,7 @@ class LocaleExportFunctionalTest extends BackdropWebTestCase {
    */
   protected $admin_user = NULL;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
 
     $this->admin_user = $this->backdropCreateUser(array('administer languages', 'translate interface', 'access administration pages'));
@@ -1146,7 +1146,7 @@ class LocaleExportFunctionalTest extends BackdropWebTestCase {
   /**
    * Test exportation of translations.
    */
-  function testExportTranslation() {
+  public function testExportTranslation() {
     // First import some known translations.
     // This will also automatically enable the 'fr' language.
     $name = backdrop_tempnam('temporary://', "po_") . '.po';
@@ -1171,7 +1171,7 @@ class LocaleExportFunctionalTest extends BackdropWebTestCase {
   /**
    * Test exportation of translation template file.
    */
-  function testExportTranslationTemplateFile() {
+  public function testExportTranslationTemplateFile() {
     // Get the translation template file.
     // There are two 'Export' buttons on this page, but it somehow works.  It'd
     // be better if we could use the submit button id like documented but that
@@ -1184,7 +1184,7 @@ class LocaleExportFunctionalTest extends BackdropWebTestCase {
   /**
    * Helper function that returns a proper .po file.
    */
-  function getPoFile() {
+  protected function getPoFile() {
     return <<< EOF
 msgid ""
 msgstr ""
@@ -1205,7 +1205,7 @@ EOF;
  * Tests for the st() function.
  */
 class LocaleInstallTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
 
     // st() lives in install.inc, so ensure that it is loaded for all tests.
@@ -1215,7 +1215,7 @@ class LocaleInstallTest extends BackdropWebTestCase {
   /**
    * Verify that function signatures of t() and st() are equal.
    */
-  function testFunctionSignatures() {
+  public function testFunctionSignatures() {
     $reflector_t = new ReflectionFunction('t');
     $reflector_st = new ReflectionFunction('st');
     $this->assertEqual($reflector_t->getParameters(), $reflector_st->getParameters(), 'Function signatures of t() and st() are equal.');
@@ -1232,7 +1232,7 @@ class LocaleUninstallFunctionalTest extends BackdropWebTestCase {
    */
   protected $langcode;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
     $this->langcode = 'en';
   }
@@ -1240,7 +1240,7 @@ class LocaleUninstallFunctionalTest extends BackdropWebTestCase {
   /**
    * Check if the values of the Locale variables are correct after uninstall.
    */
-  function testUninstallProcess() {
+  public function testUninstallProcess() {
     $locale_module = array('locale', 'language');
 
     // Add a new language and optionally set it as default.
@@ -1347,7 +1347,7 @@ class LocaleUninstallFunctionalTest extends BackdropWebTestCase {
  * to test with this new language.
  */
 class LocaleUninstallFrenchFunctionalTest extends LocaleUninstallFunctionalTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->langcode = 'fr';
   }
@@ -1357,7 +1357,7 @@ class LocaleUninstallFrenchFunctionalTest extends LocaleUninstallFunctionalTest 
  * Functional tests for the language switching feature.
  */
 class LocaleLanguageSwitchingFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
 
     // Create and login user.
@@ -1368,7 +1368,7 @@ class LocaleLanguageSwitchingFunctionalTest extends BackdropWebTestCase {
   /**
    * Functional tests for the language switcher block.
    */
-  function testLanguageBlock() {
+  public function testLanguageBlock() {
     // Enable the language switching block.
     $language_type = LANGUAGE_TYPE_INTERFACE;
     $layout = layout_load('default');
@@ -1428,7 +1428,7 @@ class LocaleBrowserDetectionTest extends BackdropUnitTestCase {
   /**
    * Unit tests for the locale_language_from_browser() function.
    */
-  function testLanguageFromBrowser() {
+  public function testLanguageFromBrowser() {
     // Load the required functions.
     require_once BACKDROP_ROOT . '/core/includes/locale.inc';
 
@@ -1536,14 +1536,14 @@ class LocaleBrowserDetectionTest extends BackdropUnitTestCase {
  * Functional tests for a user's ability to change their default language.
  */
 class LocaleUserLanguageFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
   }
 
   /**
    * Test if user can change their default language.
    */
-  function testUserLanguageConfiguration() {
+  public function testUserLanguageConfiguration() {
     global $base_url;
 
     // User to add and remove language.
@@ -1617,7 +1617,7 @@ class LocaleUserLanguageFunctionalTest extends BackdropWebTestCase {
  * Functional test for language handling during user creation.
  */
 class LocaleUserCreationTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
     config_set('system.core', 'user_register', USER_REGISTER_VISITORS);
   }
@@ -1625,7 +1625,7 @@ class LocaleUserCreationTest extends BackdropWebTestCase {
   /**
    * Functional test for language handling during user creation.
    */
-  function testLocalUserCreation() {
+  public function testLocalUserCreation() {
     // User to add and remove language and create new users.
     $admin_user = $this->backdropCreateUser(array('administer languages', 'access administration pages', 'administer users'));
     $this->backdropLogin($admin_user);
@@ -1709,14 +1709,14 @@ class LocaleUserCreationTest extends BackdropWebTestCase {
  * Functional tests for configuring a different URL alias per language.
  */
 class LocalePathFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'path');
   }
 
   /**
    * Test if a language can be associated with a URL alias.
    */
-  function testPathLanguageConfiguration() {
+  public function testPathLanguageConfiguration() {
     global $base_url;
 
     // User to add and remove language.
@@ -1838,14 +1838,14 @@ class LocalePathFunctionalTest extends BackdropWebTestCase {
  * Functional tests for multilingual support on nodes.
  */
 class LocaleContentFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
   }
 
   /**
    * Verifies that machine name fields are always LTR.
    */
-  function testMachineNameLTR() {
+  public function testMachineNameLTR() {
     // User to add and remove language.
     $admin_user = $this->backdropCreateUser(array('administer languages', 'administer content types', 'access administration pages'));
 
@@ -1873,7 +1873,7 @@ class LocaleContentFunctionalTest extends BackdropWebTestCase {
   /**
    * Test if a content type can be set to multilingual and language is present.
    */
-  function testContentTypeLanguageConfiguration() {
+  public function testContentTypeLanguageConfiguration() {
     global $base_url;
 
     // User to add and remove language.
@@ -1969,7 +1969,7 @@ class LocaleContentFunctionalTest extends BackdropWebTestCase {
   /**
    * Test if a dir and lang tags exist in node's attributes.
    */
-  function testContentTypeDirLang() {
+  public function testContentTypeDirLang() {
     // User to add and remove language.
     $admin_user = $this->backdropCreateUser(array('administer languages', 'administer content types', 'access administration pages'));
     // User to create a node.
@@ -2075,7 +2075,7 @@ class LocaleContentFunctionalTest extends BackdropWebTestCase {
  *          UI language in Chinese
  */
 class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
     require_once BACKDROP_ROOT . '/core/includes/language.inc';
     backdrop_load('module', 'locale');
@@ -2086,7 +2086,7 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
   /**
    * Tests for language switching by URL path.
    */
-  function testUILanguageNegotiation() {
+  public function testUILanguageNegotiation() {
     // A few languages to switch to.
     // This one is unknown, should get the default lang version.
     $langcode_unknown = 'blah-blah';
@@ -2261,7 +2261,7 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
   /**
    * Test URL language detection when the requested URL has no language.
    */
-  function testUrlLanguageFallback() {
+  public function testUrlLanguageFallback() {
     // Add the Italian language.
     $langcode_browser_fallback = 'it';
     $language = (object) array(
@@ -2314,7 +2314,7 @@ class LocaleUILanguageNegotiationTest extends BackdropWebTestCase {
   /**
    * Tests url() when separate domains are used for multiple languages.
    */
-  function testLanguageDomain() {
+  public function testLanguageDomain() {
     // Add the Italian language.
     $langcode = 'it';
     $language = (object) array(
@@ -2376,7 +2376,7 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
 
     // Create and login user.
@@ -2410,7 +2410,7 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
   /**
    * Check that disabled or non-installed languages are not considered.
    */
-  function testUrlRewritingEdgeCases() {
+  public function testUrlRewritingEdgeCases() {
     // Check URL rewriting with a disabled language.
     $languages = language_list();
     $this->checkUrl($languages['it'], 'Path language is ignored if language is disabled.', 'URL language negotiation does not work with disabled languages');
@@ -2458,7 +2458,7 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
   /**
    * Check URL rewriting when using a domain name and a non-standard port.
    */
-  function testDomainNameNegotiationPort() {
+  public function testDomainNameNegotiationPort() {
     $edit = array(
       // Enable domain configuration.
       'language_negotiation_url_part' => LANGUAGE_NEGOTIATION_URL_DOMAIN,
@@ -2516,7 +2516,7 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
  * Functional test for multilingual fields.
  */
 class LocaleMultilingualFieldsFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
     // Setup users.
     $admin_user = $this->backdropCreateUser(array('administer languages', 'administer content types', 'access administration pages', 'create page content', 'edit own page content'));
@@ -2550,7 +2550,7 @@ class LocaleMultilingualFieldsFunctionalTest extends BackdropWebTestCase {
   /**
    * Test if field languages are correctly set through the node form.
    */
-  function testMultilingualNodeForm() {
+  public function testMultilingualNodeForm() {
     // Create "Page" content.
     $langcode = LANGUAGE_NONE;
     $title_key = "title";
@@ -2599,7 +2599,7 @@ class LocaleMultilingualFieldsFunctionalTest extends BackdropWebTestCase {
   /*
    * Test multilingual field display settings.
    */
-  function testMultilingualDisplaySettings() {
+  public function testMultilingualDisplaySettings() {
     // Create "Page" content.
     $langcode = LANGUAGE_NONE;
     $title_key = "title";
@@ -2629,7 +2629,7 @@ class LocaleMultilingualFieldsFunctionalTest extends BackdropWebTestCase {
  * Functional tests for comment language.
  */
 class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale', 'locale_test');
 
     // Create and login user.
@@ -2667,7 +2667,7 @@ class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
   /**
    * Test that comment language is properly set.
    */
-  function testCommentLanguage() {
+  public function testCommentLanguage() {
     backdrop_static_reset('language_list');
 
     // Create two nodes, one for english and one for french, and comment each
@@ -2714,7 +2714,7 @@ class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
  * Functional tests for localizing date formats.
  */
 class LocaleDateFormatsFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
 
     // Make sure we're using UTC
@@ -2738,7 +2738,7 @@ class LocaleDateFormatsFunctionalTest extends BackdropWebTestCase {
   /**
    * Functional tests for localizing date formats.
    */
-  function testLocalizeDateFormats() {
+  public function testLocalizeDateFormats() {
     // Add language.
     $edit = array(
       'predefined_langcode' => 'fr',
@@ -2802,7 +2802,7 @@ class LocaleDateFormatsFunctionalTest extends BackdropWebTestCase {
  * Functional test for language types/negotiation info.
  */
 class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
     require_once BACKDROP_ROOT .'/core/includes/language.inc';
     $admin_user = $this->backdropCreateUser(array('administer languages', 'access administration pages', 'view the administration theme'));
@@ -2813,7 +2813,7 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests alterations to language types/negotiation info.
    */
-  function testInfoAlterations() {
+  public function testInfoAlterations() {
     // Enable language type/negotiation info alterations.
     state_set('locale_test_language_types', TRUE);
     state_set('locale_test_language_negotiation_info', TRUE);
@@ -2925,7 +2925,7 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends BackdropWebTestCase {
  * Tests locale translation safe string handling.
  */
 class LocaleStringIsSafeTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
   }
 

--- a/core/modules/menu/tests/menu.test
+++ b/core/modules/menu/tests/menu.test
@@ -10,7 +10,7 @@ class MenuTestCase extends BackdropWebTestCase {
   protected $menu;
   protected $items;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('menu');
     // Create users.
     $this->big_user = $this->backdropCreateUser(array('access administration pages', 'administer blocks', 'administer menu', 'create post content'));
@@ -33,7 +33,7 @@ class MenuTestCase extends BackdropWebTestCase {
   /**
    * Login users, add menus and menu links, and test menu functionality through the admin and user interfaces.
    */
-  function testMenu() {
+  public function testMenu() {
     // Login the user.
     $this->backdropLogin($this->big_user);
     $this->items = array();
@@ -100,7 +100,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * Test standard menu functionality using main-menu menu.
    *
    */
-  function doStandardMenuTests() {
+  protected function doStandardMenuTests() {
     $this->doMenuTests();
     $this->addInvalidMenuLink();
   }
@@ -109,7 +109,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * Test custom menu functionality using main-menu menu.
    *
    */
-  function doCustomMenuTests() {
+  protected function doCustomMenuTests() {
     $this->menu = $this->addCustomMenu();
     $this->doMenuTests($this->menu['menu_name']);
     $this->addInvalidMenuLink($this->menu['menu_name']);
@@ -119,7 +119,7 @@ class MenuTestCase extends BackdropWebTestCase {
   /**
    * Add custom menu using CRUD functions.
    */
-  function addCustomMenuCRUD() {
+  protected function addCustomMenuCRUD() {
     // Add a new custom menu.
     $menu_name = substr(hash('sha256', $this->randomName(16)), 0, MENU_MAX_MENU_NAME_LENGTH_UI);
     $title = $this->randomName(16);
@@ -146,7 +146,7 @@ class MenuTestCase extends BackdropWebTestCase {
   /**
    * Add custom menu.
    */
-  function addCustomMenu() {
+  protected function addCustomMenu() {
     // Add custom menu.
 
     // Try adding a menu using a menu_name that is too long.
@@ -198,7 +198,7 @@ class MenuTestCase extends BackdropWebTestCase {
    *
    * @param string $menu_name Custom menu name.
    */
-  function deleteCustomMenu($menu) {
+  protected function deleteCustomMenu($menu) {
     $menu_name = $this->menu['menu_name'];
     $title = $this->menu['title'];
 
@@ -215,7 +215,7 @@ class MenuTestCase extends BackdropWebTestCase {
   /**
    * Test menu functionality using main-menu menu.
    */
-  function doMenuTests($menu_name = 'main-menu') {
+  protected function doMenuTests($menu_name = 'main-menu') {
     // Add nodes to use as links for menu links.
     $node1 = $this->backdropCreateNode(array('type' => 'post'));
     $node2 = $this->backdropCreateNode(array('type' => 'post'));
@@ -305,7 +305,7 @@ class MenuTestCase extends BackdropWebTestCase {
   /**
    * Add and remove a menu link with a query string and fragment.
    */
-  function testMenuQueryAndFragment() {
+  public function testMenuQueryAndFragment() {
     $this->backdropLogin($this->big_user);
 
     // Make a path with query and fragment on.
@@ -337,7 +337,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @return array
    *   Menu link created.
    */
-  function addMenuLink($plid = 0, $link = '<front>', $menu_name = 'main-menu', $expanded = TRUE, $weight = 0) {
+  protected function addMenuLink($plid = 0, $link = '<front>', $menu_name = 'main-menu', $expanded = TRUE, $weight = 0) {
     // View add menu link page.
     $this->backdropGet("admin/structure/menu/manage/$menu_name/add");
     $this->assertResponse(200);
@@ -377,7 +377,7 @@ class MenuTestCase extends BackdropWebTestCase {
    *
    * @param string $menu_name Menu name.
    */
-  function addInvalidMenuLink($menu_name = 'main-menu') {
+  protected function addInvalidMenuLink($menu_name = 'main-menu') {
     foreach (array('-&-', 'admin/config/people/permissions', '#') as $link_path) {
       $edit = array(
         'link_path' => $link_path,
@@ -396,7 +396,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @param array $parent Parent menu link.
    * @param object $parent_node Parent menu link content node.
    */
-  function verifyMenuLink($item, $item_node, $parent = NULL, $parent_node = NULL) {
+  protected function verifyMenuLink($item, $item_node, $parent = NULL, $parent_node = NULL) {
     // View user page.
     $this->backdropGet('user');
     $this->assertResponse(200);
@@ -426,7 +426,7 @@ class MenuTestCase extends BackdropWebTestCase {
   /**
    * Change the parent of a menu link using the menu module UI.
    */
-  function moveMenuLink($item, $plid, $menu_name) {
+  protected function moveMenuLink($item, $plid, $menu_name) {
     $mlid = $item['mlid'];
 
     $edit = array(
@@ -441,7 +441,7 @@ class MenuTestCase extends BackdropWebTestCase {
    *
    * @param array $item Menu link passed by reference.
    */
-  function modifyMenuLink(&$item) {
+  protected function modifyMenuLink(&$item) {
     $item['link_title'] = $this->randomName(16);
 
     $mlid = $item['mlid'];
@@ -465,7 +465,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @param array $item Menu link.
    * @param string $old_title Original title for menu link.
    */
-  function resetMenuLink($item, $old_title) {
+  protected function resetMenuLink($item, $old_title) {
     $mlid = $item['mlid'];
     $title = $item['link_title'];
 
@@ -485,7 +485,7 @@ class MenuTestCase extends BackdropWebTestCase {
    *
    * @param array $item Menu link.
    */
-  function deleteMenuLink($item) {
+  protected function deleteMenuLink($item) {
     $mlid = $item['mlid'];
     $title = $item['link_title'];
 
@@ -505,7 +505,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @param $item
    *   Menu link.
    */
-  function toggleMenuLink($item) {
+  protected function toggleMenuLink($item) {
     $this->disableMenuLink($item);
     // Verify menu link is absent.
     $this->backdropGet('user');
@@ -523,7 +523,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @param $item
    *   Menu link.
    */
-  function disableMenuLink($item) {
+  protected function disableMenuLink($item) {
     $mlid = $item['mlid'];
     $edit['enabled'] = FALSE;
     $this->backdropPost("admin/structure/menu/item/$mlid/edit", $edit, t('Save'));
@@ -539,7 +539,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @param $item
    *   Menu link.
    */
-  function enableMenuLink($item) {
+  protected function enableMenuLink($item) {
     $mlid = $item['mlid'];
     $edit['enabled'] = TRUE;
     $this->backdropPost("admin/structure/menu/item/$mlid/edit", $edit, t('Save'));
@@ -557,7 +557,7 @@ class MenuTestCase extends BackdropWebTestCase {
    * @param $item
    *   Array containing properties to verify.
    */
-  function assertMenuLink($mlid, array $expected_item) {
+  protected function assertMenuLink($mlid, array $expected_item) {
     // Retrieve menu link.
     $item = db_query('SELECT * FROM {menu_links} WHERE mlid = :mlid', array(':mlid' => $mlid))->fetchAssoc();
     $options = unserialize($item['options']);
@@ -663,7 +663,7 @@ class MenuNodeTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('menu');
 
     $this->admin_user = $this->backdropCreateUser(array(
@@ -680,7 +680,7 @@ class MenuNodeTestCase extends BackdropWebTestCase {
   /**
    * Test creating, editing, deleting menu links via node form widget.
    */
-  function testMenuNodeFormWidget() {
+  public function testMenuNodeFormWidget() {
     // Enable Main menu as available menu.
     $edit = array(
       'menu_options[main-menu]' => 1,

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -8,7 +8,7 @@
  * Defines a base class for testing the Node module.
  */
 class NodeWebTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -30,7 +30,7 @@ class NodeWebTestCase extends BackdropWebTestCase {
 class NodeLoadMultipleUnitTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create content types for testing.
@@ -45,7 +45,7 @@ class NodeLoadMultipleUnitTest extends BackdropWebTestCase {
   /**
    * Creates four nodes and ensures that they are loaded correctly.
    */
-  function testNodeMultipleLoad() {
+  public function testNodeMultipleLoad() {
     $node1 = $this->backdropCreateNode(array('type' => 'post', 'promote' => 1));
     $node2 = $this->backdropCreateNode(array('type' => 'post', 'promote' => 1));
     $node3 = $this->backdropCreateNode(array('type' => 'post', 'promote' => 0));
@@ -109,7 +109,7 @@ class NodeLoadMultipleUnitTest extends BackdropWebTestCase {
 class NodeLoadHooksTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node_test');
     // Create content types for testing.
     $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
@@ -119,7 +119,7 @@ class NodeLoadHooksTestCase extends BackdropWebTestCase {
   /**
    * Tests that hook_node_load() is invoked correctly.
    */
-  function testHookNodeLoad() {
+  public function testHookNodeLoad() {
     // Create some sample posts and pages.
     $node1 = $this->backdropCreateNode(array('type' => 'post', 'status' => NODE_PUBLISHED));
     $node2 = $this->backdropCreateNode(array('type' => 'post', 'status' => NODE_PUBLISHED));
@@ -163,7 +163,7 @@ class NodeRevisionsTestCase extends BackdropWebTestCase {
    */
   protected $logs;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Make sure we're using UTC
@@ -214,7 +214,7 @@ class NodeRevisionsTestCase extends BackdropWebTestCase {
   /**
    * Checks node revision related operations.
    */
-  function testRevisions() {
+  public function testRevisions() {
     $nodes = $this->nodes;
     $logs = $this->logs;
 
@@ -304,7 +304,7 @@ class NodeRevisionsTestCase extends BackdropWebTestCase {
   /**
    * Checks that revisions are correctly saved without log messages.
    */
-  function testNodeRevisionWithoutLogMessage() {
+  public function testNodeRevisionWithoutLogMessage() {
     // Create a node with an initial log message.
     $log = $this->randomName(10);
     $node = $this->backdropCreateNode(array('log' => $log));
@@ -365,7 +365,7 @@ class PageEditTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->web_user = $this->backdropCreateUser(array('edit own page content', 'create page content'));
@@ -375,7 +375,7 @@ class PageEditTestCase extends BackdropWebTestCase {
   /**
    * Checks node edit functionality.
    */
-  function testPageEdit() {
+  public function testPageEdit() {
     $this->backdropLogin($this->web_user);
 
     $langcode = LANGUAGE_NONE;
@@ -442,7 +442,7 @@ class PageEditTestCase extends BackdropWebTestCase {
   /**
    * Tests changing a node's "authored by" field.
    */
-  function testPageAuthoredBy() {
+  public function testPageAuthoredBy() {
     $this->backdropLogin($this->admin_user);
 
     // Create node to edit.
@@ -504,7 +504,7 @@ class PagePreviewTestCase extends BackdropWebTestCase {
    */
   protected $term;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('taxonomy', 'node', 'email'));
 
     $web_user = $this->backdropCreateUser(array(
@@ -595,7 +595,7 @@ class PagePreviewTestCase extends BackdropWebTestCase {
   /**
    * Checks the node preview functionality.
    */
-  function testPagePreview() {
+  public function testPagePreview() {
     $langcode = LANGUAGE_NONE;
     $title_key = "title";
     $body_key = "body[$langcode][0][value]";
@@ -1091,7 +1091,7 @@ class NodeLayoutRevisionTestCase extends BackdropWebTestCase {
  * Tests creating and saving a node.
  */
 class NodeCreationTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     // Enable dummy module that implements hook_node_insert for exceptions.
     parent::setUp('node_test_exception');
 
@@ -1102,7 +1102,7 @@ class NodeCreationTestCase extends BackdropWebTestCase {
   /**
    * Creates a "Page" node and verifies its consistency in the database.
    */
-  function testNodeCreation() {
+  public function testNodeCreation() {
     // Create a node.
     $edit = array();
     $langcode = LANGUAGE_NONE;
@@ -1121,7 +1121,7 @@ class NodeCreationTestCase extends BackdropWebTestCase {
   /**
    * Verifies that a transaction rolls back the failed creation.
    */
-  function testFailedPageCreation() {
+  public function testFailedPageCreation() {
     // Create a node.
     $edit = array(
       'uid'      => $this->loggedInUser->uid,
@@ -1171,7 +1171,7 @@ class NodeCreationTestCase extends BackdropWebTestCase {
   /**
    * Create an unpublished node and confirm correct redirect behavior.
    */
-  function testUnpublishedNodeCreation() {
+  public function testUnpublishedNodeCreation() {
     // Set "Page" content type to be unpublished by default.
     $node_type = node_type_get_type('page');
     $node_type->settings['status_default'] = 0;
@@ -1198,7 +1198,7 @@ class PageViewTestCase extends BackdropWebTestCase {
   /**
    * Tests an anonymous and unpermissioned user attempting to edit the node.
    */
-  function testPageView() {
+  public function testPageView() {
     // Create a node to view.
     $node = $this->backdropCreateNode();
     $this->assertTrue(node_load($node->nid), 'Node created.');
@@ -1233,7 +1233,7 @@ class SummaryLengthTestCase extends BackdropWebTestCase {
   /**
    * Tests the node summary length functionality.
    */
-  function testSummaryLength() {
+  public function testSummaryLength() {
     // Create a node to view.
     $settings = array(
       'body' => array(LANGUAGE_NONE => array(array('value' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vitae arcu at leo cursus laoreet. Curabitur dui tortor, adipiscing malesuada tempor in, bibendum ac diam. Cras non tellus a libero pellentesque condimentum. What is a foobar? Suspendisse ac lacus libero. Ut non est vel nisl faucibus interdum nec sed leo. Pellentesque sem risus, vulputate eu semper eget, auctor in libero. Ut fermentum est vitae metus convallis scelerisque. Phasellus pellentesque rhoncus tellus, eu dignissim purus posuere id. Quisque eu fringilla ligula. Morbi ullamcorper, lorem et mattis egestas, tortor neque pretium velit, eget eleifend odio turpis eu purus. Donec vitae metus quis leo pretium tincidunt a pulvinar sem. Morbi adipiscing laoreet mauris vel placerat. Nullam elementum, nisl sit amet scelerisque malesuada, dolor nunc hendrerit quam, eu ultrices erat est in orci. Curabitur feugiat egestas nisl sed accumsan.'))),
@@ -1270,7 +1270,7 @@ class NodeTitleXSSTestCase extends BackdropWebTestCase {
   /**
    * Tests XSS functionality with a node entity.
    */
-  function testNodeTitleXSS() {
+  public function testNodeTitleXSS() {
     // Prepare a user to do the stuff.
     $web_user = $this->backdropCreateUser(array('create page content', 'edit any page content'));
     $this->backdropLogin($web_user);
@@ -1296,7 +1296,7 @@ class NodeTitleXSSTestCase extends BackdropWebTestCase {
  * Tests the availability of the syndicate block.
  */
 class NodeBlockTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('node_test');
 
     // Create and login user
@@ -1307,7 +1307,7 @@ class NodeBlockTestCase extends BackdropWebTestCase {
   /**
    * Tests the "Syndicate" block settings.
    */
-  function testSyndicateBlock() {
+  public function testSyndicateBlock() {
     // Test default promoted nodes feed shown if default block settings.
     $layout = layout_load('home');
     $layout->addBlock('node', 'syndicate', 'footer');
@@ -1368,7 +1368,7 @@ class NodeBlockTestCase extends BackdropWebTestCase {
  * Checks that the post information displays when enabled for a content type.
  */
 class NodePostSettingsTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Use Stark for expected markup checking.
@@ -1382,7 +1382,7 @@ class NodePostSettingsTestCase extends BackdropWebTestCase {
   /**
    * Confirms "Page" content type and post information is on a new node.
    */
-  function testPagePostInfo() {
+  public function testPagePostInfo() {
 
     // Set "Page" content type to display post information.
     $edit = array();
@@ -1404,7 +1404,7 @@ class NodePostSettingsTestCase extends BackdropWebTestCase {
   /**
    * Confirms absence of post information on a new node.
    */
-  function testPageNotPostInfo() {
+  public function testPageNotPostInfo() {
 
     // Set "Page" content type to display post information.
     $edit = array();
@@ -1434,7 +1434,7 @@ class NodePostSettingsTestCase extends BackdropWebTestCase {
 class NodeRSSContentTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     // Enable dummy module that implements hook_node_view.
     parent::setUp('node_test');
     module_disable(array('views'));
@@ -1450,7 +1450,7 @@ class NodeRSSContentTestCase extends BackdropWebTestCase {
   /**
    * Ensures that a new node includes the custom data when added to an RSS feed.
    */
-  function testNodeRSSContent() {
+  public function testNodeRSSContent() {
     // Create a node.
     $node = $this->backdropCreateNode(array('type' => 'post', 'promote' => 1));
 
@@ -1502,14 +1502,14 @@ class NodeAccessUnitTest extends BackdropWebTestCase {
   /**
    * Asserts node_access() correctly grants or denies access.
    */
-  function assertNodeAccess($ops, $node, $account) {
+  protected function assertNodeAccess($ops, $node, $account) {
     foreach ($ops as $op => $result) {
       $msg = format_string("node_access returns @result with operation '@op'.", array('@result' => $result ? 'true' : 'false', '@op' => $op));
       $this->assertEqual($result, node_access($op, $node, $account), $msg);
     }
   }
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create content types for testing.
@@ -1525,7 +1525,7 @@ class NodeAccessUnitTest extends BackdropWebTestCase {
   /**
    * Runs basic tests for node_access function.
    */
-  function testNodeAccess() {
+  public function testNodeAccess() {
     // Ensures user without 'access content' permission can do nothing.
     $web_user1 = $this->backdropCreateUser(array('create page content', 'edit any page content', 'delete any page content'));
     $node1 = $this->backdropCreateNode(array('type' => 'page'));
@@ -1571,7 +1571,7 @@ class NodeAccessUnitTest extends BackdropWebTestCase {
 class NodeAccessRecordsUnitTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     // Enable dummy module that implements hook_node_grants(),
     // hook_node_access_records(), hook_node_grants_alter() and
     // hook_node_access_records_alter().
@@ -1585,7 +1585,7 @@ class NodeAccessRecordsUnitTest extends BackdropWebTestCase {
   /**
    * Creates a node and tests the creation of node access rules.
    */
-  function testNodeAccessRecords() {
+  public function testNodeAccessRecords() {
     // Create a post node.
     $node1 = $this->backdropCreateNode(array('type' => 'post'));
     $this->assertTrue(node_load($node1->nid), 'Post node created.');
@@ -1699,7 +1699,7 @@ class NodeAccessBaseTableTestCase extends BackdropWebTestCase {
    * - Test that user 4 can view all content created above.
    * - Test that user 4 can view all content on taxonomy listing.
    */
-  function testNodeAccessBasic() {
+  public function testNodeAccessBasic() {
     $num_simple_users = 2;
     $simple_users = array();
 
@@ -1833,7 +1833,7 @@ class NodeSaveTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node_test');
     $this->backdropCreateContentType(array('type' => 'post', 'name' => 'Post'));
     // Create a user that is allowed to post; we'll use this to test the submission.
@@ -1850,7 +1850,7 @@ class NodeSaveTestCase extends BackdropWebTestCase {
    *  - save the content
    *  - check if node exists
    */
-  function testImport() {
+  public function testImport() {
     // Node ID must be a number that is not in the database.
     $max_nid = db_query('SELECT MAX(nid) FROM {node}')->fetchField();
     $test_nid = $max_nid + mt_rand(1000, 1000000);
@@ -1880,7 +1880,7 @@ class NodeSaveTestCase extends BackdropWebTestCase {
   /**
    * Verifies accuracy of the "created" and "changed" timestamp functionality.
    */
-  function testTimestamps() {
+  public function testTimestamps() {
     // Use the default timestamps.
     $edit = array(
       'uid' => $this->web_user->uid,
@@ -1937,7 +1937,7 @@ class NodeSaveTestCase extends BackdropWebTestCase {
    * Tests determining changes in hook_node_presave() and verifies the static
    * node load cache is cleared upon save.
    */
-  function testDeterminingChanges() {
+  public function testDeterminingChanges() {
     // Initial creation.
     $node = entity_create('node', array(
       'uid' => $this->web_user->uid,
@@ -1972,7 +1972,7 @@ class NodeSaveTestCase extends BackdropWebTestCase {
    *
    * @see node_test_node_insert()
    */
-  function testNodeSaveOnInsert() {
+  public function testNodeSaveOnInsert() {
     // node_test_node_insert() triggers a save on insert if the title equals
     // 'new'.
     $node = $this->backdropCreateNode(array('title' => 'new'));
@@ -1987,7 +1987,7 @@ class NodeTypeTestCase extends BackdropWebTestCase {
   /**
    * Tests creating a content type programmatically and via a form.
    */
-  function testNodeTypeCreation() {
+  public function testNodeTypeCreation() {
     // Ensure node type functions (node_type_get_*) work correctly.
     $node_types = node_type_get_types();
     $node_names = node_type_get_names();
@@ -2079,7 +2079,7 @@ class NodeTypeTestCase extends BackdropWebTestCase {
   /**
    * Tests editing a node type using the UI.
    */
-  function testNodeTypeEditing() {
+  public function testNodeTypeEditing() {
     $web_user = $this->backdropCreateUser(array('bypass node access', 'administer content types', 'administer fields'));
     $this->backdropLogin($web_user);
 
@@ -2132,7 +2132,7 @@ class NodeTypeTestCase extends BackdropWebTestCase {
   /**
    * Tests that node types permissions are correctly set from the Node Type UI.
    */
-  function testNodeTypePermissions() {
+  public function testNodeTypePermissions() {
     // Create admin user.
     $admin_user = $this->backdropCreateUser(array(
       'bypass node access',
@@ -2194,7 +2194,7 @@ class NodeTypeTestCase extends BackdropWebTestCase {
   /**
    * Tests that node types correctly handle the 'disabled' flag.
    */
-  function testNodeTypeStatus() {
+  public function testNodeTypeStatus() {
     // Enable all core node modules, and all types should be active.
     module_enable(array('book'), FALSE);
     $types = node_type_get_types();
@@ -2226,7 +2226,7 @@ class NodeTypeTestCase extends BackdropWebTestCase {
    * Add new node type and test function returns correct result with and
    * without content present.
    */
-  function testNodeTypeHasContent() {
+  public function testNodeTypeHasContent() {
     // Delete the two default nodes.
     node_delete_multiple(array(1, 2));
 
@@ -2252,7 +2252,7 @@ class NodeTypePersistenceTestCase extends BackdropWebTestCase {
   /**
    * Tests that node type customizations persist through disable and uninstall.
    */
-  function testNodeTypeCustomizationPersistence() {
+  public function testNodeTypeCustomizationPersistence() {
     $web_user = $this->backdropCreateUser(array('bypass node access', 'administer content types', 'administer modules'));
     $this->backdropLogin($web_user);
 
@@ -2317,7 +2317,7 @@ class NodeAccessRebuildTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $web_user = $this->backdropCreateUser(array('administer site configuration', 'access administration pages', 'access site reports'));
@@ -2328,7 +2328,7 @@ class NodeAccessRebuildTestCase extends BackdropWebTestCase {
   /**
    * Tests rebuilding the node access permissions table.
    */
-  function testNodeAccessRebuild() {
+  public function testNodeAccessRebuild() {
     $this->backdropGet('admin/reports/status');
     $this->clickLink(t('Rebuild permissions'));
     $this->backdropPost(NULL, array(), t('Rebuild permissions'));
@@ -2367,7 +2367,7 @@ class NodeAdminTestCase extends BackdropWebTestCase {
    */
   protected $base_user_4;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create content types for testing.
@@ -2394,7 +2394,7 @@ class NodeAdminTestCase extends BackdropWebTestCase {
   /**
    * Tests that the table sorting works on the content admin pages.
    */
-  function testContentAdminSort() {
+  public function testContentAdminSort() {
     $this->backdropLogin($this->admin_user);
     foreach (array('dd', 'aa', 'DD', 'bb', 'cc', 'CC', 'AA', 'BB') as $index => $prefix) {
       $node = $this->backdropCreateNode(array('title' => $prefix . $this->randomName(6)));
@@ -2443,7 +2443,7 @@ class NodeAdminTestCase extends BackdropWebTestCase {
    *
    * @see TaxonomyNodeFilterTestCase
    */
-  function testContentAdminPages() {
+  public function testContentAdminPages() {
     // Do not use any patterns for nodes in this test.
     config_set('path.settings', 'node_pattern', '');
     config_set('path.settings', 'node_page_pattern', '');
@@ -2560,7 +2560,7 @@ class NodeTitleTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Use Stark for expected markup checking.
@@ -2580,7 +2580,7 @@ class NodeTitleTestCase extends BackdropWebTestCase {
   /**
    *  Creates one node and tests if the node title has the correct value.
    */
-  function testNodeTitle() {
+  public function testNodeTitle() {
     // Create "Page" content with title.
     // Add the node to the frontpage so we can test if teaser links are clickable.
     $settings = array(
@@ -2643,7 +2643,7 @@ class NodeFeedTestCase extends BackdropWebTestCase {
   /**
    * Ensures that node_feed() accepts and prints extra channel elements.
    */
-  function testNodeFeedExtraChannelElements() {
+  public function testNodeFeedExtraChannelElements() {
     ob_start();
     node_feed(array(), array('copyright' => 'Copyright Backdrop CMS.'));
     $output = ob_get_clean();
@@ -2662,7 +2662,7 @@ class NodeFrontPageCallback extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node', 'system');
 
     $this->admin_user = $this->backdropCreateUser(
@@ -2676,7 +2676,7 @@ class NodeFrontPageCallback extends BackdropWebTestCase {
     $this->backdropLogin($this->admin_user);
   }
 
-  function testCustomFrontPage() {
+  public function testCustomFrontPage() {
     $settings = array(
       'title' => $this->randomName(8),
       'promote' => 0,
@@ -2712,7 +2712,7 @@ class NodeBlockFunctionalTest extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node', 'block');
 
     // Create users and test node.
@@ -2732,7 +2732,7 @@ class NodeBlockFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the recent content block.
    */
-  function testRecentNodeBlock() {
+  public function testRecentNodeBlock() {
     $this->backdropLogin($this->admin_user);
 
     // Disallow anonymous users to view content.
@@ -2851,7 +2851,7 @@ class NodeBlockFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the Existing content block.
    */
-  function testNodeBlock() {
+  public function testNodeBlock() {
     $this->backdropLogin($this->admin_user);
 
     // Add some test nodes.
@@ -2936,7 +2936,7 @@ class NodeBlockFunctionalTest extends BackdropWebTestCase {
  */
 class NodeTranslateBlockFunctionalTest extends BackdropWebTestCase {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node', 'block', 'locale', 'language', 'translation');
 
     // Create users and test node.
@@ -2958,7 +2958,7 @@ class NodeTranslateBlockFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the Existing content block.
    */
-  function testNodeTranslateBlock() {
+  public function testNodeTranslateBlock() {
     $this->backdropLogin($this->admin_user);
 
     $langcode = 'es';
@@ -3038,7 +3038,7 @@ class NodeBuildContent extends BackdropWebTestCase {
  /**
   * Ensures that content array is rebuilt on every call to node_build_content().
   */
-  function testNodeRebuildContent() {
+  public function testNodeRebuildContent() {
     $node = $this->backdropCreateNode();
 
     // Set a property in the content array so we can test for its existence later on.
@@ -3075,7 +3075,7 @@ class NodeQueryAlter extends BackdropWebTestCase {
    */
   protected $noAccessUser2;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node_access_test');
 
     node_access_rebuild();
@@ -3096,7 +3096,7 @@ class NodeQueryAlter extends BackdropWebTestCase {
   /**
    * Tests that node access permissions are followed.
    */
-  function testNodeQueryAlterWithUI() {
+  public function testNodeQueryAlterWithUI() {
     // Verify that a user with access permission can see at least one node.
     $this->backdropLogin($this->accessUser);
     $this->backdropGet('node_access_test_page');
@@ -3124,7 +3124,7 @@ class NodeQueryAlter extends BackdropWebTestCase {
    * Verifies that a non-standard table alias can be used, and that a user with
    * node access can view the nodes.
    */
-  function testNodeQueryAlterLowLevelWithAccess() {
+  public function testNodeQueryAlterLowLevelWithAccess() {
     // User with access should be able to view 4 nodes.
     try {
       $query = db_select('node', 'mytab')
@@ -3147,7 +3147,7 @@ class NodeQueryAlter extends BackdropWebTestCase {
    * Verifies that a non-standard table alias can be used, and that a user
    * without node access cannot view the nodes.
    */
-  function testNodeQueryAlterLowLevelNoAccess() {
+  public function testNodeQueryAlterLowLevelNoAccess() {
     // User without access should be able to view 0 nodes.
     try {
       $query = db_select('node', 'mytab')
@@ -3170,7 +3170,7 @@ class NodeQueryAlter extends BackdropWebTestCase {
    * Verifies that a non-standard table alias can be used, and that a user with
    * view-only node access cannot edit the nodes.
    */
-  function testNodeQueryAlterLowLevelEditAccess() {
+  public function testNodeQueryAlterLowLevelEditAccess() {
     // User with view-only access should not be able to edit nodes.
     try {
       $query = db_select('node', 'mytab')
@@ -3198,7 +3198,7 @@ class NodeQueryAlter extends BackdropWebTestCase {
    * add a record to {node_access} paired with a corresponding privilege in
    * hook_node_grants().
    */
-  function testNodeQueryAlterOverride() {
+  public function testNodeQueryAlterOverride() {
     $record = array(
       'nid' => 0,
       'gid' => 0,
@@ -3270,7 +3270,7 @@ class NodeEntityFieldQueryAlter extends BackdropWebTestCase {
    */
   protected $noAccessUser;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node_access_test');
     node_access_rebuild();
 
@@ -3296,7 +3296,7 @@ class NodeEntityFieldQueryAlter extends BackdropWebTestCase {
   /**
    * Tests that node access permissions are followed.
    */
-  function testNodeQueryAlterWithUI() {
+  public function testNodeQueryAlterWithUI() {
     // Verify that a user with access permission can see at least one node.
     $this->backdropLogin($this->accessUser);
     $this->backdropGet('node_access_entity_test_page');
@@ -3318,7 +3318,7 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Creates a node, then tests the tokens generated from it.
    */
-  function testNodeTokenReplacement() {
+  public function testNodeTokenReplacement() {
     global $language;
     $url_options = array(
       'absolute' => TRUE,
@@ -3439,7 +3439,7 @@ class NodeRevisionPermissionsTestCase extends BackdropWebTestCase {
     'delete' => 'delete revisions',
   );
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create a node with several revisions.
@@ -3485,7 +3485,7 @@ class NodeRevisionPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Tests the _node_revision_access() function.
    */
-  function testNodeRevisionAccess() {
+  public function testNodeRevisionAccess() {
     $revision = $this->node_revisions[1];
 
     $parameters = array(
@@ -3617,7 +3617,7 @@ class NodeAccessFieldTestCase extends NodeWebTestCase {
   /**
    * Tests administering fields when node access is restricted.
    */
-  function testNodeAccessAdministerField() {
+  public function testNodeAccessAdministerField() {
     // Create a page node.
     $langcode = LANGUAGE_NONE;
     $field_data = array();
@@ -3661,14 +3661,14 @@ class NodeAccessFieldTestCase extends NodeWebTestCase {
  * Tests changing display modes for nodes.
  */
 class NodeEntityViewModeAlterTest extends NodeWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node_test'));
   }
 
   /**
    * Create a "Page" node and verify its consistency in the database.
    */
-  function testNodeViewModeChange() {
+  public function testNodeViewModeChange() {
     $web_user = $this->backdropCreateUser(array('create page content', 'edit own page content'));
     $this->backdropLogin($web_user);
 
@@ -3699,7 +3699,7 @@ class NodeEntityViewModeAlterTest extends NodeWebTestCase {
   /**
    * Tests fields that were previously hidden when the display mode is changed.
    */
-  function testNodeViewModeChangeHiddenField() {
+  public function testNodeViewModeChangeHiddenField() {
     // Hide the tags field on the default display
     $instance = field_info_instance('node', 'field_tags', 'post');
     $instance['display']['default']['type'] = 'hidden';
@@ -3747,7 +3747,7 @@ class NodePageCacheTest extends NodeWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     config_set('system.core', 'cache', 1);
@@ -3908,7 +3908,7 @@ class NodePublishScheduling extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function testNodeTypeCreateDefaultDraft() {
+  public function testNodeTypeCreateDefaultDraft() {
     // Create a content type of foobar via the user interface.
     $this->admin_user = $this->backdropCreateUser(array('bypass node access', 'administer nodes'));
     $web_user = $this->backdropCreateUser(array('bypass node access', 'administer content types', 'administer nodes'));

--- a/core/modules/node/tests/node_views_revision_relations.test
+++ b/core/modules/node/tests/node_views_revision_relations.test
@@ -13,7 +13,7 @@ class NodeViewsRevisionRelationsTestCase extends ViewsSqlTest {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     parent::setUp($modules);
 
     // Create content type for testing.
@@ -68,7 +68,7 @@ class NodeViewsRevisionRelationsTestCase extends ViewsSqlTest {
   /**
    * Test view with default join on node.nid.
    */
-  function test_view_node_revision_nid() {
+  public function test_view_node_revision_nid() {
     $view = new view();
     $view->name = 'test_node_revision_nid';
     $view->description = '';
@@ -129,7 +129,7 @@ class NodeViewsRevisionRelationsTestCase extends ViewsSqlTest {
   /**
    * Test view with default join on node.vid.
    */
-  function test_view_node_revision_vid() {
+  public function test_view_node_revision_vid() {
     $view = new view();
     $view->name = 'test_node_revision_vid';
     $view->description = '';

--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -10,7 +10,7 @@
 class PathTestCase extends BackdropWebTestCase {
   protected $profile = 'minimal';
 
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     $modules[] = 'path';
     parent::setUp($modules);
 
@@ -30,7 +30,7 @@ class PathTestCase extends BackdropWebTestCase {
   /**
    * Tests the path cache.
    */
-  function testPathCache() {
+  public function testPathCache() {
     // Create test node.
     $node1 = $this->backdropCreateNode();
 
@@ -57,7 +57,7 @@ class PathTestCase extends BackdropWebTestCase {
   /**
    * Tests alias functionality through the admin interfaces.
    */
-  function testAdminAlias() {
+  public function testAdminAlias() {
     // Create test node.
     $node1 = $this->backdropCreateNode();
 
@@ -144,7 +144,7 @@ class PathTestCase extends BackdropWebTestCase {
   /**
    * Tests alias functionality through the node interfaces.
    */
-  function testNodeAlias() {
+  public function testNodeAlias() {
     // Create test node.
     $node1 = $this->backdropCreateNode();
 
@@ -205,14 +205,14 @@ class PathTestCase extends BackdropWebTestCase {
    * @return int
    *   Integer representing the path ID.
    */
-  function getPID($alias) {
+  protected function getPID($alias) {
     return db_query("SELECT pid FROM {url_alias} WHERE alias = :alias", array(':alias' => $alias))->fetchField();
   }
 
   /**
    * Tests that tries to create a duplicate alias are caught by validation.
    */
-  function testDuplicateNodeAlias() {
+  public function testDuplicateNodeAlias() {
     // Create one node with a random alias.
     $node_one = $this->backdropCreateNode();
     $edit = array();
@@ -232,7 +232,7 @@ class PathTestCase extends BackdropWebTestCase {
  * Tests URL aliases for taxonomy terms.
  */
 class PathTaxonomyTermTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('path', 'taxonomy');
 
     // Redirect module is not tested with aliases in these tests. Redirect does
@@ -248,7 +248,7 @@ class PathTaxonomyTermTestCase extends BackdropWebTestCase {
   /**
    * Tests alias functionality through the admin interfaces.
    */
-  function testTermAlias() {
+  public function testTermAlias() {
     // Create a term in the default 'Tags' vocabulary with URL alias.
     $vocabulary = taxonomy_vocabulary_load('tags');
     $description = $this->randomName();
@@ -304,7 +304,7 @@ class PathLanguageTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     $modules[] = 'node';
     $modules[] = 'path';
     $modules[] = 'locale';
@@ -334,7 +334,7 @@ class PathLanguageTestCase extends BackdropWebTestCase {
   /**
    * Test alias functionality through the admin interfaces.
    */
-  function testAliasTranslation() {
+  public function testAliasTranslation() {
     // Set 'page' content type to enable translation.
     $node_type = node_type_load('page');
     $node_type->settings['language'] = TRANSLATION_ENABLED;
@@ -454,7 +454,7 @@ class PathLanguageTestCase extends BackdropWebTestCase {
 class PathLanguageUITestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('path', 'locale');
 
     // Create the content type.
@@ -481,7 +481,7 @@ class PathLanguageUITestCase extends BackdropWebTestCase {
   /**
    * Tests that a language-neutral URL alias works.
    */
-  function testLanguageNeutralURLs() {
+  public function testLanguageNeutralURLs() {
     $name = $this->randomName(8);
     $edit = array();
     $edit['source'] = 'admin/config/urls/path';
@@ -495,7 +495,7 @@ class PathLanguageUITestCase extends BackdropWebTestCase {
   /**
    * Tests that a default language URL alias works.
    */
-  function testDefaultLanguageURLs() {
+  public function testDefaultLanguageURLs() {
     $name = $this->randomName(8);
     $edit = array();
     $edit['source'] = 'admin/config/urls/path';
@@ -510,7 +510,7 @@ class PathLanguageUITestCase extends BackdropWebTestCase {
   /**
    * Tests that a non-default language URL alias works.
    */
-  function testNonDefaultURLs() {
+  public function testNonDefaultURLs() {
     $name = $this->randomName(8);
     $edit = array();
     $edit['source'] = 'admin/config/urls/path';
@@ -530,7 +530,7 @@ class PathLanguageUITestCase extends BackdropWebTestCase {
 class PathMonolingualTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('path', 'locale', 'translation');
 
     // Create and login user.
@@ -567,7 +567,7 @@ class PathMonolingualTestCase extends BackdropWebTestCase {
   /**
    * Verifies that links do not have language prefixes in them.
    */
-  function testPageLinks() {
+  public function testPageLinks() {
     // Navigate to 'admin/config' path.
     $this->backdropGet('admin/config');
 
@@ -587,7 +587,7 @@ class PathMonolingualTestCase extends BackdropWebTestCase {
 class PathHooksTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node', 'path', 'path_test'));
     // Disable default path patterns for nodes.
     config_set('path.settings', 'node_pattern', '');
@@ -601,7 +601,7 @@ class PathHooksTestCase extends BackdropWebTestCase {
     $this->backdropLogin($web_user);
   }
 
-  function testPathHooks() {
+  public function testPathHooks() {
     // Create test node.
     $node1 = $this->backdropCreateNode();
 

--- a/core/modules/path/tests/path_pattern.test
+++ b/core/modules/path/tests/path_pattern.test
@@ -10,7 +10,7 @@
 class PathPatternTestHelper extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     $modules[] = 'path';
     $modules[] = 'taxonomy';
     parent::setUp($modules);
@@ -29,13 +29,13 @@ class PathPatternTestHelper extends BackdropWebTestCase {
       ->save();
   }
 
-  function assertToken($type, $object, $token, $expected) {
+  protected function assertToken($type, $object, $token, $expected) {
     $tokens = token_generate($type, array($token => $token), array($type => $object));
     $tokens += array($token => '');
     $this->assertIdentical($tokens[$token], $expected, format_string("Token value for [@type:@token] was '@actual', expected value '@expected'.", array('@type' => $type, '@token' => $token, '@actual' => $tokens[$token], '@expected' => $expected)));
   }
 
-  function saveAlias($source, $alias, $langcode = LANGUAGE_NONE) {
+  protected function saveAlias($source, $alias, $langcode = LANGUAGE_NONE) {
     $alias = array(
       'source' => $source,
       'alias' => $alias,
@@ -45,54 +45,54 @@ class PathPatternTestHelper extends BackdropWebTestCase {
     return $alias;
   }
 
-  function saveEntityAlias($entity_type, $entity, $alias, $language = LANGUAGE_NONE) {
+  protected function saveEntityAlias($entity_type, $entity, $alias, $language = LANGUAGE_NONE) {
     $uri = entity_uri($entity_type, $entity);
     return $this->saveAlias($uri['path'], $alias, $language);
   }
 
-  function assertEntityAlias($entity_type, $entity, $expected_alias, $language = LANGUAGE_NONE) {
+  protected function assertEntityAlias($entity_type, $entity, $expected_alias, $language = LANGUAGE_NONE) {
     $uri = entity_uri($entity_type, $entity);
     $this->assertAlias($uri['path'], $expected_alias, $language);
   }
 
-  function assertEntityAliasExists($entity_type, $entity) {
+  protected function assertEntityAliasExists($entity_type, $entity) {
     $uri = entity_uri($entity_type, $entity);
     return $this->assertAliasExists(array('source' => $uri['path']));
   }
 
-  function assertNoEntityAlias($entity_type, $entity, $language = LANGUAGE_NONE) {
+  protected function assertNoEntityAlias($entity_type, $entity, $language = LANGUAGE_NONE) {
     $uri = entity_uri($entity_type, $entity);
     $this->assertEntityAlias($entity_type, $entity, $uri['path'], $language);
   }
 
-  function assertNoEntityAliasExists($entity_type, $entity) {
+  protected function assertNoEntityAliasExists($entity_type, $entity) {
     $uri = entity_uri($entity_type, $entity);
     $this->assertNoAliasExists(array('source' => $uri['path']));
   }
 
-  function assertAlias($source, $expected_alias, $langcode = LANGUAGE_NONE) {
+  protected function assertAlias($source, $expected_alias, $langcode = LANGUAGE_NONE) {
     backdrop_clear_path_cache($source);
     $alias = backdrop_get_path_alias($source, $langcode);
     $this->assertIdentical($alias, $expected_alias, format_string("Alias for %source with language '@language' was %actual, expected %expected.", array('%source' => $source, '%actual' => $alias, '%expected' => $expected_alias, '@language' => $langcode)));
   }
 
-  function assertAliasExists($conditions) {
+  protected function assertAliasExists($conditions) {
     $path = path_load($conditions);
     $this->assertTrue($path, format_string('Alias with conditions @conditions found.', array('@conditions' => var_export($conditions, TRUE))));
     return $path;
   }
 
-  function assertNoAliasExists($conditions) {
+  protected function assertNoAliasExists($conditions) {
     $alias = path_load($conditions);
     $this->assertFalse($alias, format_string('Alias with conditions @conditions not found.', array('@conditions' => var_export($conditions, TRUE))));
   }
 
-  function deleteAllAliases() {
+  protected function deleteAllAliases() {
     db_delete('url_alias')->execute();
     backdrop_clear_path_cache();
   }
 
-  function addVocabulary(array $vocabulary = array()) {
+  protected function addVocabulary(array $vocabulary = array()) {
     $name = backdrop_strtolower($this->randomName(5));
     $vocabulary += array(
       'name' => $name,
@@ -103,7 +103,7 @@ class PathPatternTestHelper extends BackdropWebTestCase {
     return $vocabulary;
   }
 
-  function addTerm(TaxonomyVocabulary $vocabulary, array $term = array()) {
+  protected function addTerm(TaxonomyVocabulary $vocabulary, array $term = array()) {
     $term += array(
       'name' => backdrop_strtolower($this->randomName(5)),
       'vocabulary' => $vocabulary->machine_name,
@@ -114,14 +114,14 @@ class PathPatternTestHelper extends BackdropWebTestCase {
     return $term;
   }
 
-  function assertEntityPattern($entity_type, $bundle, $langcode, $expected) {
+  protected function assertEntityPattern($entity_type, $bundle, $langcode, $expected) {
     backdrop_static_reset('path_get_pattern_by_entity_type');
     $this->refreshVariables();
     $pattern = path_get_pattern_by_entity_type($entity_type, $bundle, $langcode);
     $this->assertIdentical($expected, $pattern);
   }
 
-  function backdropGetTermByName($name, $reset = FALSE) {
+  protected function backdropGetTermByName($name, $reset = FALSE) {
     $terms = entity_load('taxonomy_term', array(), array('name' => $name), $reset);
     return !empty($terms) ? reset($terms) : FALSE;
   }
@@ -131,7 +131,7 @@ class PathPatternTestHelper extends BackdropWebTestCase {
  * Unit tests for Path pattern functions.
  */
 class PathPatternUnitTestCase extends PathPatternTestHelper {
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     parent::setUp($modules);
     module_load_include('inc', 'path');
   }
@@ -139,14 +139,14 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
   /**
    * Test _path_get_schema_alias_maxlength().
    */
-  function testGetSchemaAliasMaxLength() {
+  public function testGetSchemaAliasMaxLength() {
     $this->assertIdentical(_path_get_schema_alias_maxlength(), 255);
   }
 
   /**
    * Test path_get_pattern_by_entity_type().
    */
-  function testPatternLoadByEntity() {
+  public function testPatternLoadByEntity() {
     $config = config('path.settings');
     $config->set('node_story_en_pattern', 'story/en/[node:title] ');
     $config->set('node_story_pattern', 'story/[node:title]');
@@ -171,7 +171,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
   /**
    * Test path_clean_string().
    */
-  function testCleanString() {
+  public function testCleanString() {
     $config = config('path.settings');
     $tests = array();
     $config->set('ignore_words', ', a, in, is,that, the  , this, with, ');
@@ -225,7 +225,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
   /**
    * Test path_clean_alias().
    */
-  function testCleanAlias() {
+  public function testCleanAlias() {
     $tests = array();
     $tests['one/two/three'] = 'one/two/three';
     $tests['/one/two/three/'] = 'one/two/three';
@@ -241,7 +241,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
   /**
    * Test path_delete_multiple().
    */
-  function testPathDeleteMultiple() {
+  public function testPathDeleteMultiple() {
     $this->saveAlias('node/1', 'node-1-alias');
     $this->saveAlias('node/1/view', 'node-1-alias/view');
     $this->saveAlias('node/1', 'node-1-alias-en', 'en');
@@ -257,7 +257,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
   /**
    * Test the different update actions in path_save_automatic_alias().
    */
-  function testUpdateActions() {
+  public function testUpdateActions() {
     $config = config('path.settings');
     // Test PATH_UPDATE_ACTION_NO_NEW with a new inserted, unaliased node.
     $config->set('update_action', PATH_UPDATE_ACTION_NO_NEW);
@@ -320,7 +320,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
    * Test that path_save_automatic_alias() will not create a URL alias for a
    * pattern that does not get any tokens replaced.
    */
-  function testNoTokensNoAlias() {
+  public function testNoTokensNoAlias() {
     $node = $this->backdropCreateNode(array('title' => ''));
     $this->assertNoEntityAliasExists('node', $node);
 
@@ -340,7 +340,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
   /**
    * Test the handling of path vs non-path tokens in path_clean_token_values().
    */
-  function testPathTokens() {
+  public function testPathTokens() {
     $config = config('path.settings');
     $config->set('taxonomy_term_pattern', '[term:parent:url:path]/[term:name]');
     $config->save();
@@ -357,7 +357,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
     $this->assertEntityAlias('taxonomy_term', $term2, 'My Crazy/Alias/child-term');
   }
 
-  function testEntityBundleRenamingDeleting() {
+  public function testEntityBundleRenamingDeleting() {
     $config = config('path.settings');
     // Create a vocabulary and test that it's pattern variable works.
     $vocab = $this->addVocabulary(array('machine_name' => 'old_name'));
@@ -380,7 +380,7 @@ class PathPatternUnitTestCase extends PathPatternTestHelper {
     $this->assertEntityPattern('taxonomy_term', 'new_name', LANGUAGE_NONE, 'base');
   }
 
-  function testNoExistingPathAliases() {
+  public function testNoExistingPathAliases() {
     $config = config('path.settings');
     $config->set('node_page_pattern', '[node:title]');
     $config->set('punctuation_period', PATH_PUNCTUATION_DO_NOTHING);
@@ -415,7 +415,7 @@ class PathPatternFunctionalTestHelper extends PathPatternTestHelper {
   protected $admin_user;
   protected $config;
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     parent::setUp($modules);
     $config = config('path.settings');
 
@@ -456,7 +456,7 @@ class PathPatternFunctionalTestHelper extends PathPatternTestHelper {
 class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   protected $profile = 'standard';
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     parent::setUp($modules);
 
     // Delete all default content.
@@ -467,7 +467,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Create a new content type with new path pattern.
    */
-  function testNodeTypeCreate() {
+  public function testNodeTypeCreate() {
     // Create a user with more permissions.
     $permissions = array(
       'administer path patterns',
@@ -508,7 +508,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Basic functional testing of node Path patterns.
    */
-  function testNodeEditing() {
+  public function testNodeEditing() {
     $config = config('path.settings');
     // Delete the default node pattern. Only the page content type will have a pattern.
     $config->set('node_pattern', '');
@@ -611,7 +611,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Test node operations.
    */
-  function testNodeOperations() {
+  public function testNodeOperations() {
     $node1 = $this->backdropCreateNode(array('title' => 'node1'));
     $node2 = $this->backdropCreateNode(array('title' => 'node2'));
 
@@ -632,7 +632,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Basic functional testing of Path automatic aliases with taxonomy terms.
    */
-  function testTermEditing() {
+  public function testTermEditing() {
     $this->backdropGet('admin/structure');
     $this->backdropGet('admin/structure/taxonomy');
 
@@ -682,7 +682,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Basic functional testing of Path automatic aliases with users.
    */
-  function testUserEditing() {
+  public function testUserEditing() {
     // There should be no auto checkbox on user forms.
     $this->backdropGet('user/' . $this->admin_user->uid . '/edit');
     $this->assertNoFieldById('edit-path-auto');
@@ -691,7 +691,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Test user operations.
    */
-  function testUserOperations() {
+  public function testUserOperations() {
     $account = $this->backdropCreateUser();
 
     // Delete all current URL aliases.
@@ -713,7 +713,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
     $this->assertEntityAlias('user', $this->admin_user, 'user/' . $this->admin_user->uid);
   }
 
-  function testConfigurationUserInterfaces() {
+  public function testConfigurationUserInterfaces() {
     // Test validation.
     $edit = array();
     $edit['max_length'] = 'abc';
@@ -800,7 +800,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
     $this->assertFieldByName('user_pattern', 'accounts/[user:name]/foo', 'URL alias pattern set with user account settings appears on path config page.');
   }
 
-  function testPatternsValidation() {
+  public function testPatternsValidation() {
     $edit = array();
     $edit['node_pattern'] = '[node:title]/[user:name]/[term:name]';
     $edit['node_page_pattern'] = 'page';
@@ -819,7 +819,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Test programmatic entity creation for aliases.
    */
-  function testProgrammaticEntityCreation() {
+  public function testProgrammaticEntityCreation() {
     $node = $this->backdropCreateNode(array('title' => 'Test node', 'path' => array('auto' => TRUE)));
     $this->assertEntityAlias('node', $node, 'content/test-node');
 
@@ -840,7 +840,7 @@ class PathPatternFunctionalTestCase extends PathPatternFunctionalTestHelper {
 
 class PathPatternLocaleTestCase extends PathPatternFunctionalTestHelper {
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     $modules[] = 'language';
     $modules[] = 'locale';
     $modules[] = 'translation';
@@ -866,7 +866,7 @@ class PathPatternLocaleTestCase extends PathPatternFunctionalTestHelper {
    * Test that when an English node is updated, its old English URL alias is
    * updated and its newer French URL alias is left intact.
    */
-  function testLanguageAliases() {
+  public function testLanguageAliases() {
     $node = array(
       'title' => 'English node',
       'langcode' => 'en',
@@ -940,7 +940,7 @@ class PathPatternBulkUpdateTestCase extends PathPatternFunctionalTestHelper {
   private $terms;
   private $users;
 
-  function testBulkUpdate() {
+  public function testBulkUpdate() {
     $this->nodes = array();
     $this->terms = array();
     $user1 = user_load(1, TRUE);
@@ -1131,7 +1131,7 @@ class PathPatternBulkUpdateTestCase extends PathPatternFunctionalTestHelper {
  */
 class PathPatternTokenTestCase extends PathPatternFunctionalTestHelper {
 
-  function testPathPatternTokens() {
+  public function testPathPatternTokens() {
     $array = array(
       'test first arg',
       'The Array / value',
@@ -1153,7 +1153,7 @@ class PathPatternTokenTestCase extends PathPatternFunctionalTestHelper {
   /**
    * Function copied from TokenTestHelper::assertTokens().
    */
-  function assertTokens($type, array $data, array $tokens, array $options = array()) {
+  protected function assertTokens($type, array $data, array $tokens, array $options = array()) {
     $input = $this->mapTokenNames($type, array_keys($tokens));
     $replacements = token_generate($type, $input, $data, $options);
     foreach ($tokens as $name => $expected) {
@@ -1175,7 +1175,7 @@ class PathPatternTokenTestCase extends PathPatternFunctionalTestHelper {
     return $replacements;
   }
 
-  function mapTokenNames($type, array $tokens = array()) {
+  protected function mapTokenNames($type, array $tokens = array()) {
     $return = array();
     foreach ($tokens as $token) {
       $return[$token] = "[$type:$token]";

--- a/core/modules/redirect/tests/redirect.test
+++ b/core/modules/redirect/tests/redirect.test
@@ -7,7 +7,7 @@
 class RedirectTestHelper extends BackdropWebTestCase {
   protected $profile = 'minimal';
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     $modules[] = 'node';
     $modules[] = 'path';
     $modules[] = 'redirect';
@@ -100,7 +100,7 @@ class RedirectUnitTest extends BackdropUnitTestCase {
   /**
    * Test the redirect_compare_array_recursive() function.
    */
-  function testCompareArrayRecursive() {
+  public function testCompareArrayRecursive() {
     backdrop_load('module', 'redirect');
     $haystack = array('a' => 'aa', 'b' => 'bb', 'c' => array('c1' => 'cc1', 'c2' => 'cc2'));
     $cases = array(
@@ -120,7 +120,7 @@ class RedirectUnitTest extends BackdropUnitTestCase {
   /**
    * Test redirect_sort_recursive().
    */
-  function testSortRecursive() {
+  public function testSortRecursive() {
     $test_cases = array(
       array(
         'input' => array('b' => 'aa', 'c' => array('c2' => 'aa', 'c1' => 'aa'), 'a' => 'aa'),
@@ -139,7 +139,7 @@ class RedirectUnitTest extends BackdropUnitTestCase {
 class RedirectFunctionalTest extends RedirectTestHelper {
   protected $admin_user;
 
-  function setUp(array $modules = array()) {
+  public function setUp(array $modules = array()) {
     parent::setUp($modules);
 
     $this->backdropCreateContentType(array('type' => 'post', 'name' => 'Post'));
@@ -150,7 +150,7 @@ class RedirectFunctionalTest extends RedirectTestHelper {
   /**
    * Tests the links added to 404 pages for creating redirects.
    */
-  function test404Interface() {
+  public function test404Interface() {
     // Check that 404 pages do get "Add URL redirect" links for admin users.
     $this->backdropGet('invalid-path1');
     $this->backdropGet('invalid-path2');
@@ -173,7 +173,7 @@ class RedirectFunctionalTest extends RedirectTestHelper {
   /**
    * Tests the links added to 404 pages for creating URL redirects.
    */
-  function testPageCache() {
+  public function testPageCache() {
     // Set up cache variables.
     config_set('system.core', 'cache', 1);
     $edit = array(
@@ -218,7 +218,7 @@ class RedirectFunctionalTest extends RedirectTestHelper {
   /**
    * Tests renaming automatic aliases in a circular loop.
    */
-  function testPathChangeRedirects() {
+  public function testPathChangeRedirects() {
     // Create an initial post node with a URL alias.
     $node = $this->backdropCreateNode(array('type' => 'post', 'path' => array('alias' => 'first-alias')));
     $node_path = 'node/' . $node->nid;
@@ -277,7 +277,7 @@ class RedirectFunctionalTest extends RedirectTestHelper {
   /**
    * Tests presence or absence of Redirect elements on node edit forms.
    */
-  function testNodeRedirectForm() {
+  public function testNodeRedirectForm() {
     // Ensure that the redirect form is not present on node/add
     $this->backdropGet('node/add');
     $this->assertNoLink('Add URL redirect to this node');

--- a/core/modules/search/tests/search.test
+++ b/core/modules/search/tests/search.test
@@ -17,14 +17,14 @@ class SearchMatchTestCase extends BackdropWebTestCase {
   /**
    * Implementation setUp().
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
   }
 
   /**
    * Test search indexing.
    */
-  function testMatching() {
+  public function testMatching() {
     $this->_setup();
     $this->_testQueries();
   }
@@ -32,7 +32,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
   /**
    * Set up a small index of items to test against.
    */
-  function _setup() {
+  private function _setup() {
     config_set('search.settings', 'search_minimum_word_size', 3);
 
     for ($i = 1; $i <= 7; ++$i) {
@@ -64,7 +64,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
    *   6  enim am minim veniam es cillum
    *   7  am minim veniam es cillum dolore eu
    */
-  function getText($n) {
+  protected function getText($n) {
     $words = explode(' ', "Ipsum dolore sit am. Ut enim am minim veniam. Es cillum dolore eu.");
     return implode(' ', array_slice($words, $n - 1, $n));
   }
@@ -79,7 +79,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
    *   11 came over from germany
    *   12 over from germany swimming
    */
-  function getText2($n) {
+  protected function getText2($n) {
     $words = explode(' ', "Dear King Philip came over from Germany swimming.");
     return implode(' ', array_slice($words, $n - 1, $n));
   }
@@ -87,7 +87,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
   /**
    * Run predefine queries looking for indexed terms.
    */
-  function _testQueries() {
+  private function _testQueries() {
     /*
       Note: OR queries that include short words in OR groups are only accepted
       if the ORed terms are ANDed with at least one long word in the rest of the query.
@@ -199,7 +199,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
    *
    * Verify if a query produces the correct results.
    */
-  function _testQueryMatching($query, $set, $results) {
+  private function _testQueryMatching($query, $set, $results) {
     // Get result IDs.
     $found = array();
     foreach ($set as $item) {
@@ -217,7 +217,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
    *
    * Verify if a query produces normalized, monotonous scores.
    */
-  function _testQueryScores($query, $set, $results) {
+  private function _testQueryScores($query, $set, $results) {
     // Get result scores.
     $scores = array();
     foreach ($set as $item) {
@@ -240,7 +240,7 @@ class SearchMatchTestCase extends BackdropWebTestCase {
 class SearchPageText extends BackdropWebTestCase {
   protected $searching_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
 
     // Create user.
@@ -250,7 +250,7 @@ class SearchPageText extends BackdropWebTestCase {
   /**
    * Tests the failed search text, and various other text on the search page.
    */
-  function testSearchText() {
+  public function testSearchText() {
     $this->backdropLogin($this->searching_user);
     $this->backdropGet('search/node');
     $this->assertText(t('Enter your keywords'));
@@ -299,7 +299,7 @@ class SearchPageText extends BackdropWebTestCase {
 class SearchAdvancedSearchForm extends BackdropWebTestCase {
   protected $node;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
     // Create and login user.
     $test_user = $this->backdropCreateUser(array('access content', 'search content', 'use advanced search', 'administer nodes'));
@@ -322,7 +322,7 @@ class SearchAdvancedSearchForm extends BackdropWebTestCase {
    * Test using the search form with GET and POST queries.
    * Test using the advanced search form to limit search to nodes of type "Page".
    */
-  function testNodeType() {
+  public function testNodeType() {
     $this->assertTrue($this->node->type == 'page', 'Node type is Page.');
 
     // Assert that the dummy title doesn't equal the real title.
@@ -358,11 +358,11 @@ class SearchRankingTestCase extends BackdropWebTestCase {
   /**
    * Implementation setUp().
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'comment');
   }
 
-  function testRankings() {
+  public function testRankings() {
     // Login with sufficient privileges.
     $this->backdropLogin($this->backdropCreateUser(array('skip comment approval', 'create page content')));
 
@@ -428,7 +428,7 @@ class SearchRankingTestCase extends BackdropWebTestCase {
   /**
    * Test rankings of HTML tags.
    */
-  function testHTMLRankings() {
+  public function testHTMLRankings() {
     // Login with sufficient privileges.
     $this->backdropLogin($this->backdropCreateUser(array('create page content')));
 
@@ -512,7 +512,7 @@ class SearchRankingTestCase extends BackdropWebTestCase {
    *
    * See issue http://drupal.org/node/771596
    */
-  function testDoubleRankings() {
+  public function testDoubleRankings() {
     // Login with sufficient privileges.
     $this->backdropLogin($this->backdropCreateUser(array('skip comment approval', 'create page content')));
 
@@ -551,7 +551,7 @@ class SearchRankingTestCase extends BackdropWebTestCase {
  * Tests the rendering of the search block.
  */
 class SearchBlockTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
 
     // Create and log user in.
@@ -562,7 +562,7 @@ class SearchBlockTestCase extends BackdropWebTestCase {
   /**
    * Test that the search block form works correctly.
    */
-  function testBlock() {
+  public function testBlock() {
     // Add the search block to the default layout.
     $layout = layout_load('default');
     $layout->addBlock('search', 'form', 'content');
@@ -623,14 +623,14 @@ class SearchBlockTestCase extends BackdropWebTestCase {
  * Tests that searching for a phrase gets the correct page count.
  */
 class SearchExactTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
   }
 
   /**
    * Tests that the correct number of pager links are found for both keywords and phrases.
    */
-  function testExactQuery() {
+  public function testExactQuery() {
     // Login with sufficient privileges.
     $this->backdropLogin($this->backdropCreateUser(array('create page content', 'search content')));
 
@@ -694,7 +694,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
    */
   protected $node;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('comment', 'search');
 
     // Disable cache.
@@ -755,7 +755,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
   /**
    * Verify that comments are rendered using proper format in search results.
    */
-  function testSearchResultsComment() {
+  public function testSearchResultsComment() {
     $comment_body = 'Test comment body';
 
     // Allow anonymous users to search content.
@@ -817,7 +817,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
   /**
    * Verify access rules for comment indexing with different permissions.
    */
-  function testSearchResultsCommentAccess() {
+  public function testSearchResultsCommentAccess() {
     $comment_body = 'Test comment body';
     $this->comment_subject = 'Test comment subject';
     $roles = array_diff($this->admin_user->roles, array(BACKDROP_AUTHENTICATED_ROLE));
@@ -874,7 +874,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
   /**
    * Set permissions for role.
    */
-  function setRolePermissions($role_name, $access_comments = FALSE, $search_content = TRUE) {
+  protected function setRolePermissions($role_name, $access_comments = FALSE, $search_content = TRUE) {
     $permissions = array(
       'access comments' => $access_comments,
       'search content' => $search_content,
@@ -885,7 +885,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
   /**
    * Update search index and search for comment.
    */
-  function assertCommentAccess($message, $assume_access = FALSE) {
+  protected function assertCommentAccess($message, $assume_access = FALSE) {
     // Invoke search index update.
     search_touch_node($this->node->nid);
     $this->cronRun();
@@ -904,7 +904,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
   /**
    * Verify that 'Add comment' does not appear in search results or index.
    */
-  function testAddNewComment() {
+  public function testAddNewComment() {
     // Create a node with a short body.
     $settings = array(
       'type' => 'post',
@@ -945,7 +945,7 @@ class SearchCommentTestCase extends BackdropWebTestCase {
  * @see http://drupal.org/node/419388 (issue)
  */
 class SearchExpressionInsertExtractTestCase extends BackdropUnitTestCase {
-  function setUp() {
+  public function setUp() {
     backdrop_load('module', 'search');
     parent::setUp();
   }
@@ -953,7 +953,7 @@ class SearchExpressionInsertExtractTestCase extends BackdropUnitTestCase {
   /**
    * Tests search_expression_insert() and search_expression_extract().
    */
-  function testInsertExtract() {
+  public function testInsertExtract() {
     $base_expression = "mykeyword";
     // Build an array of option, value, what should be in the expression, what
     // should be retrieved from expression.
@@ -1006,7 +1006,7 @@ class SearchCommentCountToggleTestCase extends BackdropWebTestCase {
   protected $searching_user;
   protected $searchable_nodes;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
 
     // Create searching user.
@@ -1048,7 +1048,7 @@ class SearchCommentCountToggleTestCase extends BackdropWebTestCase {
    * Verify that comment count displays correctly based on comment status of
    * node.
    */
-  function testSearchCommentCountToggle() {
+  public function testSearchCommentCountToggle() {
     // Search for the nodes by string in the node body.
     $edit = array(
       'search_block_form' => "'SearchCommentToggleTestCase'",
@@ -1088,7 +1088,7 @@ class SearchSimplifyTestCase extends BackdropWebTestCase {
   /**
    * Tests that all Unicode characters simplify correctly.
    */
-  function testSearchSimplifyUnicode() {
+  public function testSearchSimplifyUnicode() {
     // This test uses a file that was constructed so that the even lines are
     // boundary characters, and the odd lines are valid word characters. (It
     // was generated as a sequence of all the Unicode characters, and then the
@@ -1140,7 +1140,7 @@ class SearchSimplifyTestCase extends BackdropWebTestCase {
   /**
    * Tests that search_simplify() does the right thing with punctuation.
    */
-  function testSearchSimplifyPunctuation() {
+  public function testSearchSimplifyPunctuation() {
     $cases = array(
       array('20.03/94-28,876', '20039428876', 'Punctuation removed from numbers'),
       array('great...backdrop--module', 'great backdrop module', 'Multiple dot and dashes are word boundaries'),
@@ -1166,7 +1166,7 @@ class SearchKeywordsConditions extends BackdropWebTestCase {
    */
   protected $searching_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'search_extra_type');
     // Create searching user.
     $this->searching_user = $this->backdropCreateUser(array('search content', 'access content', 'access comments', 'skip comment approval'));
@@ -1180,7 +1180,7 @@ class SearchKeywordsConditions extends BackdropWebTestCase {
   /**
    * Verify the keywords are captured and conditions respected.
    */
-  function testSearchKeywordsConditions() {
+  public function testSearchKeywordsConditions() {
     // No keys, not conditions - no results.
     $this->backdropGet('search/dummy_path');
     $this->assertNoText('Dummy search snippet to display');
@@ -1212,7 +1212,7 @@ class SearchNumbersTestCase extends BackdropWebTestCase {
   protected $numbers;
   protected $nodes;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
 
     $this->test_user = $this->backdropCreateUser(array('search content', 'access content', 'administer nodes', 'access site reports'));
@@ -1257,7 +1257,7 @@ class SearchNumbersTestCase extends BackdropWebTestCase {
   /**
    * Tests that all the numbers can be searched.
    */
-  function testNumberSearching() {
+  public function testNumberSearching() {
     $types = array_keys($this->numbers);
 
     foreach ($types as $type) {
@@ -1292,7 +1292,7 @@ class SearchNumberMatchingTestCase extends BackdropWebTestCase {
   protected $numbers;
   protected $nodes;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
 
     $this->test_user = $this->backdropCreateUser(array('search content', 'access content', 'administer nodes', 'access site reports'));
@@ -1330,7 +1330,7 @@ class SearchNumberMatchingTestCase extends BackdropWebTestCase {
   /**
    * Tests that all the numbers can be searched.
    */
-  function testNumberSearching() {
+  public function testNumberSearching() {
     for ($i = 0; $i < count($this->numbers); $i++) {
       $node = $this->nodes[$i];
 
@@ -1366,7 +1366,7 @@ class SearchConfigSettingsForm extends BackdropWebTestCase {
   public $search_user;
   public $search_node;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'search_extra_type');
 
     // Login as a user that can create and search content.
@@ -1399,7 +1399,7 @@ class SearchConfigSettingsForm extends BackdropWebTestCase {
   /**
    * Verify the search settings form.
    */
-  function testSearchSettingsPage() {
+  public function testSearchSettingsPage() {
 
     // Test that the settings form displays the correct count of items left to index.
     $this->backdropGet('admin/config/search/settings');
@@ -1460,7 +1460,7 @@ class SearchConfigSettingsForm extends BackdropWebTestCase {
   /**
    * Verify that you can disable individual search modules.
    */
-  function testSearchModuleDisabling() {
+  public function testSearchModuleDisabling() {
     // Array of search modules to test: 'path' is the search path, 'title' is
     // the tab title, 'keys' are the keywords to search for, and 'text' is
     // the text to assert is on the results page.
@@ -1549,7 +1549,7 @@ class SearchConfigSettingsForm extends BackdropWebTestCase {
   /**
    * Verify enabling/disabling of certain node types.
    */
-  function testSearchNodeTypes() {
+  public function testSearchNodeTypes() {
     $new_type1 = $this->backdropCreateContentType();
     $new_type2 = $this->backdropCreateContentType();
     $new_type3 = $this->backdropCreateContentType();
@@ -1623,7 +1623,7 @@ class SearchConfigSettingsForm extends BackdropWebTestCase {
  * Tests the search_excerpt() function.
  */
 class SearchExcerptTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
   }
 
@@ -1636,7 +1636,7 @@ class SearchExcerptTestCase extends BackdropWebTestCase {
    * contains either highlighted keywords or the original marked
    * up string if no keywords matched the string.
    */
-  function testSearchExcerpt() {
+  public function testSearchExcerpt() {
     // Make some text with entities and tags.
     $text = 'The <strong>quick</strong> <a href="#">brown</a> fox &amp; jumps <h2>over</h2> the lazy dog';
     // Note: The search_excerpt() function adds some extra spaces -- not
@@ -1671,7 +1671,7 @@ class SearchExcerptTestCase extends BackdropWebTestCase {
    * search_simplify(). This test passes keywords that match simplified words
    * and compares them with strings that contain the original unsimplified word.
    */
-  function testSearchExcerptSimplified() {
+  public function testSearchExcerptSimplified() {
     $lorem1 = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vitae arcu at leo cursus laoreet. Curabitur dui tortor, adipiscing malesuada tempor in, bibendum ac diam. Cras non tellus a libero pellentesque condimentum. What is a foobar? Suspendisse ac lacus libero. Ut non est vel nisl faucibus interdum nec sed leo. Pellentesque sem risus, vulputate eu semper eget, auctor in libero.';
     $lorem2 = 'Ut fermentum est vitae metus convallis scelerisque. Phasellus pellentesque rhoncus tellus, eu dignissim purus posuere id. Quisque eu fringilla ligula. Morbi ullamcorper, lorem et mattis egestas, tortor neque pretium velit, eget eleifend odio turpis eu purus. Donec vitae metus quis leo pretium tincidunt a pulvinar sem. Morbi adipiscing laoreet mauris vel placerat. Nullam elementum, nisl sit amet scelerisque malesuada, dolor nunc hendrerit quam, eu ultrices erat est in orci.';
 
@@ -1718,7 +1718,7 @@ class SearchExcerptTestCase extends BackdropWebTestCase {
  * Test the CJK tokenizer.
  */
 class SearchTokenizerTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
   }
 
@@ -1730,7 +1730,7 @@ class SearchTokenizerTestCase extends BackdropWebTestCase {
    * character classes are tokenized properly. See PREG_CLASS_CKJ for more
    * information.
    */
-  function testTokenizer() {
+  public function testTokenizer() {
     // Set the minimum word size to 1 (to split all CJK characters) and make
     // sure CJK tokenizing is turned on.
     config('search.settings')
@@ -1818,7 +1818,7 @@ class SearchTokenizerTestCase extends BackdropWebTestCase {
    * This is just a sanity check - it verifies that strings of letters are
    * not tokenized.
    */
-  function testNoTokenizer() {
+  public function testNoTokenizer() {
     // Set the minimum word size to 1 (to split all CJK characters) and make
     // sure CJK tokenizing is turned on.
     config('search.settings')
@@ -1840,7 +1840,7 @@ class SearchTokenizerTestCase extends BackdropWebTestCase {
    * converts a number to the corresponding unicode character. Adapted from
    * functions supplied in comments on several functions on php.net.
    */
-  function code2utf($num) {
+  protected function code2utf($num) {
     if ($num < 128) {
       return chr($num);
     }
@@ -1875,7 +1875,7 @@ class SearchEmbedForm extends BackdropWebTestCase {
    */
   public $submit_count = 0;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'search_embedded_form');
 
     // Create a user and a node, and update the search index.
@@ -1895,7 +1895,7 @@ class SearchEmbedForm extends BackdropWebTestCase {
   /**
    * Tests that the embedded form appears and can be submitted.
    */
-  function testEmbeddedForm() {
+  public function testEmbeddedForm() {
     // First verify we can submit the form from the module's page.
     $this->backdropPost('search_embedded_form',
       array('name' => 'John'),'Send away');
@@ -1932,7 +1932,7 @@ class SearchEmbedForm extends BackdropWebTestCase {
 class SearchPageOverride extends BackdropWebTestCase {
   public $search_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'search_extra_type');
 
     // Login as a user that can create and search content.
@@ -1944,7 +1944,7 @@ class SearchPageOverride extends BackdropWebTestCase {
     menu_rebuild();
   }
 
-  function testSearchPageHook() {
+  public function testSearchPageHook() {
     $keys = 'bike shed ' . $this->randomName();
     $this->backdropGet("search/dummy_path/{$keys}");
     $this->assertText('Dummy search snippet', 'Dummy search snippet is shown');
@@ -1959,7 +1959,7 @@ class SearchLanguageTestCase extends BackdropWebTestCase {
   /**
    * Implementation setUp().
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'locale');
 
     // Create and login user.
@@ -1967,7 +1967,7 @@ class SearchLanguageTestCase extends BackdropWebTestCase {
     $this->backdropLogin($test_user);
   }
 
-  function testLanguages() {
+  public function testLanguages() {
     // Check that there are initially no languages displayed.
     $this->backdropGet('search/node');
     $this->assertNoText(t('Languages'), 'No languages to choose from.');
@@ -2015,7 +2015,7 @@ class SearchLanguageTestCase extends BackdropWebTestCase {
 class SearchNodeAccessTest extends BackdropWebTestCase {
   public $test_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('search', 'node_access_test');
     node_access_rebuild();
 
@@ -2027,7 +2027,7 @@ class SearchNodeAccessTest extends BackdropWebTestCase {
   /**
    * Tests that search works with punctuation and HTML entities.
    */
-  function testPhraseSearchPunctuation() {
+  public function testPhraseSearchPunctuation() {
     $node = $this->backdropCreateNode(array('body' => array(LANGUAGE_NONE => array(array('value' => "The bunny's ears were fuzzy.")))));
     $node2 = $this->backdropCreateNode(array('body' => array(LANGUAGE_NONE => array(array('value' => 'Dignissim Aliquam &amp; Quieligo meus natu quae quia te. Damnum&copy; erat&mdash; neo pneum. Facilisi feugiat ibidem ratis.')))));
 
@@ -2060,7 +2060,7 @@ class SearchNodeAccessTest extends BackdropWebTestCase {
  * Tests searching with locale values set.
  */
 class SearchSetLocaleTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('search');
 
     // Create a simple node so something will be put in the index.

--- a/core/modules/simpletest/tests/actions.test
+++ b/core/modules/simpletest/tests/actions.test
@@ -10,14 +10,14 @@
 class ActionLoopTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('dblog', 'actions_loop_test');
   }
 
   /**
    * Set up a loop with 3 - 12 recursions, and see if it aborts properly.
    */
-  function testActionLoop() {
+  public function testActionLoop() {
     // Delete any existing watchdog messages to clear the plethora of
     // "Action added" messages from when Backdrop was installed.
     db_delete('watchdog')->execute();

--- a/core/modules/simpletest/tests/ajax.test
+++ b/core/modules/simpletest/tests/ajax.test
@@ -8,7 +8,7 @@
  * Ajax Test.
  */
 class AJAXTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -75,7 +75,7 @@ class AJAXFrameworkTestCase extends AJAXTestCase {
    *   and JavaScript files to be loaded by the page. See
    *   http://drupal.org/node/561858.
    */
-  function testAJAXRender() {
+  public function testAJAXRender() {
     $commands = $this->backdropGetAJAX('ajax-test/render');
 
     // Verify that there is a command to load settings added with
@@ -90,7 +90,7 @@ class AJAXFrameworkTestCase extends AJAXTestCase {
   /**
    * Test behavior of ajax_render_error().
    */
-  function testAJAXRenderError() {
+  public function testAJAXRenderError() {
     // Verify default error message.
     $commands = $this->backdropGetAJAX('ajax-test/render-error');
     $expected = array(
@@ -114,7 +114,7 @@ class AJAXFrameworkTestCase extends AJAXTestCase {
   /**
    * Test that new JavaScript and CSS files added during an AJAX request are returned.
    */
-  function testLazyLoad() {
+  public function testLazyLoad() {
     $expected = array(
       'setting_name' => 'ajax_forms_test_lazy_load_form_submit',
       'setting_value' => 'executed',
@@ -183,7 +183,7 @@ class AJAXFrameworkTestCase extends AJAXTestCase {
   /**
    * Tests that overridden CSS files are not added during lazy load.
    */
-  function testLazyLoadOverriddenCSS() {
+  public function testLazyLoadOverriddenCSS() {
     // The test theme overrides system.css without an implementation,
     // thereby removing it.
     theme_enable(array('test_theme'));
@@ -209,7 +209,7 @@ class AJAXCommandsTestCase extends AJAXTestCase {
   /**
    * Test the various Ajax Commands.
    */
-  function testAJAXCommands() {
+  public function testAJAXCommands() {
     $form_path = 'ajax_forms_test_ajax_commands_form';
     $web_user = $this->backdropCreateUser(array('access content'));
     $this->backdropLogin($web_user);
@@ -365,7 +365,7 @@ class AJAXFormValuesTestCase extends AJAXTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->web_user = $this->backdropCreateUser(array('access content'));
@@ -375,7 +375,7 @@ class AJAXFormValuesTestCase extends AJAXTestCase {
   /**
    * Create a simple form, then POST to system/ajax to change to it.
    */
-  function testSimpleAJAXFormValue() {
+  public function testSimpleAJAXFormValue() {
     // Verify form values of a select element.
     foreach (array('red', 'green', 'blue') as $item) {
       $edit = array(
@@ -414,7 +414,7 @@ class AJAXMultiFormTestCase extends AJAXTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('form_test'));
 
     // Create a multi-valued field for 'page' nodes to use for Ajax testing.
@@ -440,7 +440,7 @@ class AJAXMultiFormTestCase extends AJAXTestCase {
   /**
    * Test that a page with the 'page_node_form' included twice works correctly.
    */
-  function testMultiForm() {
+  public function testMultiForm() {
     // HTML IDs for elements within the field are potentially modified with
     // each Ajax submission, but these variables are stable and help target the
     // desired elements.
@@ -561,7 +561,7 @@ class AJAXElementValidation extends AJAXTestCase {
    * filled in, and we want to see if the activation of the "driver_text"
    * Ajax-enabled field fails due to the required field being empty.
    */
-  function testAJAXElementValidation() {
+  public function testAJAXElementValidation() {
     $web_user = $this->backdropCreateUser();
     $edit = array('driver_text' => t('some dumb text'));
 
@@ -584,7 +584,7 @@ class AJAXDialogTest extends AJAXTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->web_user = $this->backdropCreateUser(array('access content'));
@@ -594,7 +594,7 @@ class AJAXDialogTest extends AJAXTestCase {
   /**
    * Test sending non-JS and AJAX requests to open and manipulate modals.
    */
-  function testDialog() {
+  public function testDialog() {
     // Ensure the elements render without notices or exceptions.
     $this->backdropGet('ajax-test/dialog');
 

--- a/core/modules/simpletest/tests/batch.test
+++ b/core/modules/simpletest/tests/batch.test
@@ -10,14 +10,14 @@
 class BatchProcessingTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('batch_test');
   }
 
   /**
    * Test batches triggered outside of form submission.
    */
-  function testBatchNoForm() {
+  public function testBatchNoForm() {
     // Displaying the page triggers batch 1.
     $this->backdropGet('batch-test/no-form');
     $this->assertBatchMessages($this->_resultMessages(1), t('Batch for step 2 performed successfully.'));
@@ -28,7 +28,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Test batches defined in a form submit handler.
    */
-  function testBatchForm() {
+  public function testBatchForm() {
     // Batch 0: no operation.
     $edit = array('batch' => 'batch_0');
     $this->backdropPost('batch-test/simple', $edit, 'Submit');
@@ -67,7 +67,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Test batches defined in a multistep form.
    */
-  function testBatchFormMultistep() {
+  public function testBatchFormMultistep() {
     $this->backdropGet('batch-test/multistep');
     $this->assertText('step 1', t('Form is displayed in step 1.'));
 
@@ -87,7 +87,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Test batches defined in different submit handlers on the same form.
    */
-  function testBatchFormMultipleBatches() {
+  public function testBatchFormMultipleBatches() {
     // Batches 1, 2 and 3 are triggered in sequence by different submit
     // handlers. Each submit handler modify the submitted 'value'.
     $value = 'sample-value';
@@ -109,7 +109,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Test batches defined in a programmatically submitted form.
    */
-  function testBatchFormProgrammatic() {
+  public function testBatchFormProgrammatic() {
     // Batches 1, 2 and 3 are triggered in sequence by different submit
     // handlers. Each submit handler modify the submitted 'value'.
     $value = 'sample-value-from-menu';
@@ -125,7 +125,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Test that backdrop_form_submit() can run within a batch operation.
    */
-  function testBackdropFormSubmitInBatch() {
+  public function testBackdropFormSubmitInBatch() {
     // Displaying the page triggers a batch that programmatically submits a
     // form.
     $value = 'sample-value-from-menu';
@@ -137,7 +137,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
    * Test batches that return $context['finished'] > 1 do in fact complete.
    * See http://drupal.org/node/600836
    */
-  function testBatchLargePercentage() {
+  public function testBatchLargePercentage() {
     // Displaying the page triggers batch 5.
     $this->backdropGet('batch-test/large-percentage');
     $this->assertBatchMessages($this->_resultMessages(1), t('Batch for step 2 performed successfully.'));
@@ -156,7 +156,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertBatchMessages($texts, $message) {
+  protected function assertBatchMessages($texts, $message) {
     $pattern = '|' . implode('.*', $texts) .'|s';
     return $this->assertPattern($pattern, $message);
   }
@@ -164,7 +164,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Helper function: return expected execution stacks for the test batches.
    */
-  function _resultStack($id, $value = 0) {
+  private function _resultStack($id, $value = 0) {
     $stack = array();
     switch ($id) {
       case 'batch_1':
@@ -231,7 +231,7 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
   /**
    * Helper function: return expected result messages for the test batches.
    */
-  function _resultMessages($id) {
+  private function _resultMessages($id) {
     $messages = array();
 
     switch ($id) {
@@ -276,14 +276,14 @@ class BatchProcessingTestCase extends BackdropWebTestCase {
 class BatchPageTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('batch_test');
   }
 
   /**
    * Tests that the batch API progress page uses the correct theme.
    */
-  function testBatchProgressPageTheme() {
+  public function testBatchProgressPageTheme() {
     // Make sure that the page which starts the batch (an administrative page)
     // is using a different theme than would normally be used by the batch API.
     config_set('system.core', 'theme_default', 'bartik');
@@ -310,7 +310,7 @@ class BatchPercentagesUnitTestCase extends BackdropUnitTestCase {
   protected $profile = 'testing';
   protected $testCases = array();
 
-  function setUp() {
+  public function setUp() {
     // Set up an array of test cases, where the expected values are the keys,
     // and the values are arrays with the keys 'total' and 'current',
     // corresponding with the function parameters of _batch_api_percentage().
@@ -367,7 +367,7 @@ class BatchPercentagesUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test the _batch_api_percentage() function.
    */
-  function testBatchPercentages() {
+  public function testBatchPercentages() {
     foreach ($this->testCases as $expected_result => $arguments) {
       // PHP sometimes casts numeric strings that are array keys to integers,
       // cast them back here.

--- a/core/modules/simpletest/tests/boot.test
+++ b/core/modules/simpletest/tests/boot.test
@@ -3,7 +3,7 @@
  * Perform early bootstrap tests.
  */
 class EarlyBootstrapTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('boot_test_1', 'boot_test_2');
   }
 

--- a/core/modules/simpletest/tests/bootstrap.test
+++ b/core/modules/simpletest/tests/bootstrap.test
@@ -38,7 +38,7 @@ class BootstrapIPAddressTestCase extends BackdropWebTestCase {
    */
   protected $untrusted_ip;
 
-  function setUp() {
+  public function setUp() {
     $this->oldserver = $_SERVER;
 
     $this->remote_ip = '127.0.0.1';
@@ -57,7 +57,7 @@ class BootstrapIPAddressTestCase extends BackdropWebTestCase {
     parent::setUp();
   }
 
-  function tearDown() {
+  protected function tearDown() {
     $_SERVER = $this->oldserver;
     backdrop_static_reset('ip_address');
     parent::tearDown();
@@ -66,7 +66,7 @@ class BootstrapIPAddressTestCase extends BackdropWebTestCase {
   /**
    * test IP Address and hostname
    */
-  function testIPAddressHost() {
+  public function testIPAddressHost() {
     // Test the normal IP address.
     $this->assertTrue(
       ip_address() == $this->remote_ip,
@@ -142,14 +142,14 @@ class BootstrapIPAddressTestCase extends BackdropWebTestCase {
 class BootstrapPageCacheTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
   }
 
   /**
    * Test support for requests containing If-Modified-Since and If-None-Match headers.
    */
-  function testConditionalRequests() {
+  public function testConditionalRequests() {
     config_set('system.core', 'cache', 1);
     config_set('system.core', 'page_cache_background_fetch', 0);
     config_set('system.core', 'page_cache_maximum_age', 300);
@@ -192,7 +192,7 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
   /**
    * Test cache headers.
    */
-  function testPageCache() {
+  public function testPageCache() {
     config_set('system.core', 'cache', 1);
     config_set('system.core', 'page_cache_background_fetch', 0);
     config_set('system.core', 'page_cache_maximum_age', 300);
@@ -358,7 +358,7 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
    * .htaccess or similar, or if compression is done outside PHP, e.g. by the
    * mod_deflate Apache module.
    */
-  function testPageCompression() {
+  public function testPageCompression() {
     config_set('system.core', 'cache', 1);
     config_set('system.core', 'page_cache_background_fetch', 0);
     config_set('system.core', 'page_cache_maximum_age', 300);
@@ -402,14 +402,14 @@ class BootstrapPageCacheTestCase extends BackdropWebTestCase {
 class BootstrapVariableTestCase extends BackdropWebTestCase {
   protected $profile = 'minimal';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
   }
 
   /**
    * testVariable
    */
-  function testVariable() {
+  public function testVariable() {
     // Setting and retrieving values.
     $variable = $this->randomName();
     variable_set('simpletest_bootstrap_variable_test', $variable);
@@ -429,7 +429,7 @@ class BootstrapVariableTestCase extends BackdropWebTestCase {
   /**
    * Makes sure that the default variable parameter is passed through okay.
    */
-  function testVariableDefaults() {
+  public function testVariableDefaults() {
     // Tests passing nothing through to the default.
     $this->assertIdentical(NULL, state_get('simpletest_bootstrap_variable_test'), 'Variables are correctly defaulting to NULL.');
 
@@ -445,14 +445,14 @@ class BootstrapVariableTestCase extends BackdropWebTestCase {
 class HookBootExitTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test', 'dblog');
   }
 
   /**
    * Test calling of hook_boot() and hook_exit().
    */
-  function testHookBootExit() {
+  public function testHookBootExit() {
     // Test with cache disabled. Boot and exit should always fire.
     config_set('system.core', 'cache', 0);
 
@@ -499,7 +499,7 @@ class BootstrapGetFilenameTestCase extends BackdropUnitTestCase {
   /**
    * Test that backdrop_get_filename() works correctly when the file is not found in the database.
    */
-  function testBackdropGetFilename() {
+  public function testBackdropGetFilename() {
     // Reset the static cache so we can test the "db is not active" code of
     // backdrop_get_filename().
     backdrop_static_reset('backdrop_get_filename');
@@ -537,7 +537,7 @@ class BootstrapTimerTestCase extends BackdropUnitTestCase {
    * started and stopped multiple times.
    * @return
    */
-  function testTimer() {
+  public function testTimer() {
     timer_start('test');
     sleep(1);
     $this->assertTrue(timer_read('test') >= 1000, 'Timer measured 1 second of sleeping while running.');
@@ -562,7 +562,7 @@ class BootstrapResettableStaticTestCase extends BackdropUnitTestCase {
    * Test that a variable reference returned by backdrop_static() gets reset when
    * backdrop_static_reset() is called.
    */
-  function testBackdropStatic() {
+  public function testBackdropStatic() {
     $name = __CLASS__ . '_' . __METHOD__;
     $var = &backdrop_static($name, 'foo');
     $this->assertEqual($var, 'foo', 'Variable returned by backdrop_static() was set to its default.');
@@ -591,7 +591,7 @@ class BootstrapMiscTestCase extends BackdropUnitTestCase {
   /**
    * Test miscellaneous functions in bootstrap.inc.
    */
-  function testMisc() {
+  public function testMisc() {
     // Test backdrop_array_merge_deep().
     $link_options_1 = array('fragment' => 'x', 'attributes' => array('title' => 'X', 'class' => array('a', 'b')), 'language' => 'en');
     $link_options_2 = array('fragment' => 'y', 'attributes' => array('title' => 'Y', 'class' => array('c', 'd')), 'html' => TRUE);
@@ -607,7 +607,7 @@ class BootstrapOverrideServerVariablesTestCase extends BackdropUnitTestCase {
   /**
    * Test providing a direct URL to to backdrop_override_server_variables().
    */
-  function testBackdropOverrideServerVariablesProvidedURL() {
+  public function testBackdropOverrideServerVariablesProvidedURL() {
     $tests = array(
       'http://example.com' => array(
         'HTTP_HOST' => 'example.com',
@@ -640,7 +640,7 @@ class BootstrapOverrideServerVariablesTestCase extends BackdropUnitTestCase {
   /**
    * Test that settings.php variables can be overridden by the server.
    */
-  function testBackdropSettingsOverride() {
+  public function testBackdropSettingsOverride() {
     // This test only runs when the "BACKDROP_SETTINGS" environment variable is
     // set. This usually is done through a Apache VirtualHost setting.
     // See backdrop_settings_initialize().
@@ -667,7 +667,7 @@ class BootstrapOverrideServerVariablesTestCase extends BackdropUnitTestCase {
   /**
    * Tests that the backdrop_check_memory_limit() function works as expected.
    */
-  function testCheckMemoryLimit() {
+  public function testCheckMemoryLimit() {
     // Test that a very reasonable amount of memory is available.
     $this->assertTrue(backdrop_check_memory_limit('30MB'), '30MB of memory tested available.');
 
@@ -690,7 +690,7 @@ class BootstrapOverrideServerVariablesTestCase extends BackdropUnitTestCase {
 class BootstrapDestinationTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
   }
 
@@ -788,7 +788,7 @@ class WatchdogTestCase extends BackdropWebTestCase {
    * @param $link
    *   A link to associate with the message.
    */
-  function assertLogMessage($type, $message, $variables = array(), $severity = WATCHDOG_NOTICE, $link = '') {
+  protected function assertLogMessage($type, $message, $variables = array(), $severity = WATCHDOG_NOTICE, $link = '') {
     $count = db_select('watchdog', 'w')
       ->condition('type', $type)
       ->condition('message', $message)
@@ -822,7 +822,7 @@ class WatchdogTestCase extends BackdropWebTestCase {
    * @param $link
    *   A link to associate with the message.
    */
-  function assertNoLogMessage($type, $message, $variables = array(), $severity = WATCHDOG_NOTICE, $link = '') {
+  protected function assertNoLogMessage($type, $message, $variables = array(), $severity = WATCHDOG_NOTICE, $link = '') {
     $count = db_select('watchdog', 'w')
       ->condition('type', $type)
       ->condition('message', $message)
@@ -837,7 +837,7 @@ class WatchdogTestCase extends BackdropWebTestCase {
 }
 
 class BootstrapWatchdogTestCase extends WatchdogTestCase {
-  function testWatchdogLogging() {
+  public function testWatchdogLogging() {
     // Check the basic watchdog calls work.
     watchdog('testing', 'test @severity message', array('@severity' => 'notice'), WATCHDOG_NOTICE, 'http://example.org');
     $this->assertLogMessage('testing', 'test @severity message', array('@severity' => 'notice'), WATCHDOG_NOTICE, 'http://example.org');

--- a/core/modules/simpletest/tests/cache.test
+++ b/core/modules/simpletest/tests/cache.test
@@ -63,7 +63,7 @@ class CacheTestCase extends BackdropWebTestCase {
    * @param $bin
    *   The bin the cache item was stored in.
    */
-  function assertCacheRemoved($message, $cid = NULL, $bin = NULL) {
+  protected function assertCacheRemoved($message, $cid = NULL, $bin = NULL) {
     if ($bin == NULL) {
       $bin = $this->default_bin;
     }
@@ -93,35 +93,35 @@ class CacheSavingCase extends CacheTestCase {
   /**
    * Test the saving and restoring of a string.
    */
-  function testString() {
+  public function testString() {
     $this->checkVariable($this->randomName(100));
   }
 
   /**
    * Test the saving and restoring of an integer.
    */
-  function testInteger() {
+  public function testInteger() {
     $this->checkVariable(100);
   }
 
   /**
    * Test the saving and restoring of a double.
    */
-  function testDouble() {
+  public function testDouble() {
     $this->checkVariable(1.29);
   }
 
   /**
    * Test the saving and restoring of an array.
    */
-  function testArray() {
+  public function testArray() {
     $this->checkVariable(array('backdrop1', 'backdrop2' => 'backdrop3', 'backdrop4' => array('backdrop5', 'backdrop6')));
   }
 
   /**
    * Test the saving and restoring of an object.
    */
-  function testObject() {
+  public function testObject() {
     $test_object = new stdClass();
     $test_object->test1 = $this->randomName(100);
     $test_object->test2 = 100;
@@ -136,7 +136,7 @@ class CacheSavingCase extends CacheTestCase {
   /**
    * Check or a variable is stored and restored properly.
    */
-  function checkVariable($var) {
+  protected function checkVariable($var) {
     cache()->set('test_var', $var);
     $cached = cache()->get('test_var');
     $this->assertTrue(isset($cached->data) && $cached->data === $var, format_string('@type is saved and restored properly.', array('@type' => ucfirst(gettype($var)))));
@@ -145,7 +145,7 @@ class CacheSavingCase extends CacheTestCase {
   /**
    * Test no empty cids are written in cache table.
    */
-  function testNoEmptyCids() {
+  public function testNoEmptyCids() {
     $this->backdropGet('user/register');
     $this->assertFalse(cache()->get(''), 'No cache entry is written with an empty cid.');
   }
@@ -155,7 +155,7 @@ class CacheSavingCase extends CacheTestCase {
  * Test getMultiple().
  */
 class CacheGetMultipleUnitTest extends CacheTestCase {
-  function setUp() {
+  public function setUp() {
     $this->default_bin = 'page';
     parent::setUp();
   }
@@ -163,7 +163,7 @@ class CacheGetMultipleUnitTest extends CacheTestCase {
   /**
    * Test getMultiple().
    */
-  function testCacheMultiple() {
+  public function testCacheMultiple() {
     $item1 = $this->randomName(10);
     $item2 = $this->randomName(10);
     $cache = cache($this->default_bin);
@@ -194,7 +194,7 @@ class CacheGetMultipleUnitTest extends CacheTestCase {
  * Test cache clearing methods.
  */
 class CacheClearCase extends CacheTestCase {
-  function setUp() {
+  public function setUp() {
     $this->default_bin = 'page';
     $this->default_value = $this->randomName(10);
 
@@ -204,7 +204,7 @@ class CacheClearCase extends CacheTestCase {
   /**
    * Test clearing using a cid.
    */
-  function testClearCid() {
+  public function testClearCid() {
     $cache = cache($this->default_bin);
     $cache->set('test_cid_clear', $this->default_value);
 
@@ -217,7 +217,7 @@ class CacheClearCase extends CacheTestCase {
   /**
    * Test clearing using wildcard.
    */
-  function testClearWildcard() {
+  public function testClearWildcard() {
     $cache = cache($this->default_bin);
     $cache->set('test_cid_clear1', $this->default_value);
     $cache->set('test_cid_clear2', $this->default_value);
@@ -243,7 +243,7 @@ class CacheClearCase extends CacheTestCase {
   /**
    * Test clearing using an array.
    */
-  function testClearArray() {
+  public function testClearArray() {
     // Create three cache entries.
     $cache = cache($this->default_bin);
     $cache->set('test_cid_clear1', $this->default_value);
@@ -279,7 +279,7 @@ class CacheClearCase extends CacheTestCase {
   /**
    * Test backdrop_flush_all_caches().
    */
-  function testFlushAllCaches() {
+  public function testFlushAllCaches() {
     // Create cache entries for each flushed cache bin.
     $bins = array('cache', 'filter', 'page', 'bootstrap', 'path');
     $bins = array_merge(module_invoke_all('flush_caches'), $bins);
@@ -302,7 +302,7 @@ class CacheClearCase extends CacheTestCase {
  * Test isEmpty() method.
  */
 class CacheIsEmptyCase extends CacheTestCase {
-  function setUp() {
+  public function setUp() {
     $this->default_bin = 'page';
     $this->default_value = $this->randomName(10);
 
@@ -312,7 +312,7 @@ class CacheIsEmptyCase extends CacheTestCase {
   /**
    * Test clearing using a cid.
    */
-  function testIsEmpty() {
+  public function testIsEmpty() {
     // Clear the cache bin.
     $cache = cache($this->default_bin);
     $cache->flush();

--- a/core/modules/simpletest/tests/color.test
+++ b/core/modules/simpletest/tests/color.test
@@ -5,11 +5,11 @@
  * Tests color conversion functions.
  */
 class ColorTest extends BackdropUnitTestCase {
-  
+
   /**
    * Tests Color::hexToRgb().
    */
-  function testHexToRgb() {
+  public function testHexToRgb() {
     // Any invalid arguments should throw an exception.
     $values = array('', '-1', '1', '12', '12345', '1234567', '123456789', '123456789a', 'foo');
     // Duplicate all invalid value tests with additional '#' prefix.
@@ -58,7 +58,7 @@ class ColorTest extends BackdropUnitTestCase {
   /**
    * Tests Color::rgbToHex().
    */
-  function testRgbToHex() {
+  public function testRgbToHex() {
     $tests = array(
       '#000000' => array('red' => 0, 'green' => 0, 'blue' => 0),
       '#ffffff' => array('red' => 255, 'green' => 255, 'blue' => 255),

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -325,32 +325,32 @@ class CommonURLUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test backdrop_get_bare_domain().
    */
-   function testBackdropGetBareDomain() {
-     // Input => Expected Output.
-     $tests = array(
-       'http://www.example.com/path-to-page' => 'example.com',
-       'http://example.com/path-to-page' => 'example.com',
-       'http://beta.example.com/path-to-page' => 'example.com',
-       'https://www.beta.example.co.uk/path-to-page' => 'example.co.uk',
-       'http://example.co.uk/path-to-page' => 'example.co.uk',
-       'http://beta.example.co.uk/path-to-page' => 'example.co.uk',
-       '//example.co.uk/path-to-page' => 'example.co.uk',
+  public function testBackdropGetBareDomain() {
+    // Input => Expected Output.
+    $tests = array(
+     'http://www.example.com/path-to-page' => 'example.com',
+     'http://example.com/path-to-page' => 'example.com',
+     'http://beta.example.com/path-to-page' => 'example.com',
+     'https://www.beta.example.co.uk/path-to-page' => 'example.co.uk',
+     'http://example.co.uk/path-to-page' => 'example.co.uk',
+     'http://beta.example.co.uk/path-to-page' => 'example.co.uk',
+     '//example.co.uk/path-to-page' => 'example.co.uk',
 
-       'example.co.uk' => 'example.co.uk',
-       'example.com' => 'example.com',
-       'beta.example.com' => 'example.com',
-       'alpha.beta.example.com' => 'example.com',
-       'bbc.co.uk' => 'bbc.co.uk',
-       'foo.bbc.co.uk' => 'bbc.co.uk',
-       'bar.foo.bbc.co.uk' => 'bbc.co.uk',
-       'bar.foo.abc.com' => 'abc.com',
-       'lb.cm' => 'lb.cm',
-     );
+     'example.co.uk' => 'example.co.uk',
+     'example.com' => 'example.com',
+     'beta.example.com' => 'example.com',
+     'alpha.beta.example.com' => 'example.com',
+     'bbc.co.uk' => 'bbc.co.uk',
+     'foo.bbc.co.uk' => 'bbc.co.uk',
+     'bar.foo.bbc.co.uk' => 'bbc.co.uk',
+     'bar.foo.abc.com' => 'abc.com',
+     'lb.cm' => 'lb.cm',
+    );
 
-     foreach ($tests as $input => $expected_output) {
-       $this->assertIdentical($expected_output, backdrop_get_bare_domain($input));
-     }
-   }
+    foreach ($tests as $input => $expected_output) {
+     $this->assertIdentical($expected_output, backdrop_get_bare_domain($input));
+    }
+  }
 
   /**
    * Test backdrop_parse_url().

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -8,11 +8,11 @@
  * Tests for URL generation functions.
  */
 class CommonBackdropAlterTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('common_test');
   }
 
-  function testBackdropAlter() {
+  public function testBackdropAlter() {
     // This test depends on Bartik, so make sure that it is always the current
     // active theme.
     global $theme, $base_theme_info;
@@ -70,7 +70,7 @@ class CommonURLWebTestCase extends BackdropWebTestCase {
   /**
    * Confirm that invalid text given as $path is filtered.
    */
-  function testLXSS() {
+  public function testLXSS() {
     $text = $this->randomName();
     $path = "<SCRIPT>alert('XSS')</SCRIPT>";
     $link = l($text, $path);
@@ -101,7 +101,7 @@ class CommonURLWebTestCase extends BackdropWebTestCase {
   /*
    * Tests for active class in l() function.
    */
-  function testLActiveClass() {
+  public function testLActiveClass() {
     $link = l($this->randomName(), $_GET['q']);
     $this->assertTrue($this->hasClass($link, 'active'), format_string('Class @class is present on link to the current page', array('@class' => 'active')));
   }
@@ -109,7 +109,7 @@ class CommonURLWebTestCase extends BackdropWebTestCase {
   /**
    * Tests for custom class in l() function.
    */
-  function testLCustomClass() {
+  public function testLCustomClass() {
     $class = $this->randomName();
     $link = l($this->randomName(), $_GET['q'], array('attributes' => array('class' => array($class))));
     $this->assertTrue($this->hasClass($link, $class), format_string('Custom class @class is present on link when requested', array('@class' => $class)));
@@ -124,7 +124,7 @@ class CommonURLWebTestCase extends BackdropWebTestCase {
    * Test url() with/without query, with/without fragment, absolute on/off and
    * assert all that works when clean URLs are on and off.
    */
-  function testUrl() {
+  public function testUrl() {
     global $base_url;
 
     foreach (array(FALSE, TRUE) as $absolute) {
@@ -201,7 +201,7 @@ class CommonURLWebTestCase extends BackdropWebTestCase {
   /**
    * Test external URL handling.
    */
-  function testExternalUrls() {
+  public function testExternalUrls() {
     $test_url = 'https://backdropcms.org/';
 
     // Verify external URL can contain a fragment.
@@ -247,7 +247,7 @@ class CommonURLWebTestCase extends BackdropWebTestCase {
   /**
    * Tests the url() function on internal paths which mimic external URLs.
    */
-  function testInternalPathMimicsExternal() {
+  public function testInternalPathMimicsExternal() {
     module_enable(array('common_test'));
     // Ensure that calling url(current_path()) on "/http://example.com" (an
     // internal path which mimics an external URL) always links to the internal
@@ -268,7 +268,7 @@ class CommonURLUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test backdrop_get_query_parameters().
    */
-  function testBackdropGetQueryParameters() {
+  public function testBackdropGetQueryParameters() {
     $original = array(
       'a' => 1,
       'b' => array(
@@ -315,7 +315,7 @@ class CommonURLUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test backdrop_http_build_query().
    */
-  function testBackdropHttpBuildQuery() {
+  public function testBackdropHttpBuildQuery() {
     $this->assertEqual(backdrop_http_build_query(array('a' => ' &#//+%20@۞')), 'a=%20%26%23//%2B%2520%40%DB%9E', 'Value was properly encoded.');
     $this->assertEqual(backdrop_http_build_query(array(' &#//+%20@۞' => 'a')), '%20%26%23//%2B%2520%40%DB%9E=a', 'Key was properly encoded.');
     $this->assertEqual(backdrop_http_build_query(array('a' => '1', 'b' => '2', 'c' => '3')), 'a=1&b=2&c=3', 'Multiple values were properly concatenated.');
@@ -355,7 +355,7 @@ class CommonURLUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test backdrop_parse_url().
    */
-  function testBackdropParseUrl() {
+  public function testBackdropParseUrl() {
     // Relative URL.
     $url = 'foo/bar?foo=bar&bar=baz&baz#foo';
     $result = array(
@@ -438,7 +438,7 @@ class UrlIsExternalUnitTest extends BackdropUnitTestCase {
   /**
    * Tests if each URL is external or not.
    */
-  function testUrlIsExternal() {
+  public function testUrlIsExternal() {
     foreach ($this->examples() as $path => $expected) {
       $this->assertIdentical(url_is_external($path), $expected, $path);
     }
@@ -488,7 +488,7 @@ class CommonXssUnitTestCase extends BackdropUnitTestCase {
   /**
    * Check that invalid multi-byte sequences are rejected.
    */
-  function testInvalidMultiByte() {
+  public function testInvalidMultiByte() {
      // Ignore PHP 8.0+ null deprecations.
      $text = check_plain(NULL);
      $this->assertEqual($text, '', 'check_plain() casts null to string');
@@ -513,7 +513,7 @@ class CommonXssUnitTestCase extends BackdropUnitTestCase {
   /**
    * Check that special characters are escaped.
    */
-  function testEscaping() {
+  public function testEscaping() {
      $text = check_plain("<script>");
      $this->assertEqual($text, '&lt;script&gt;', 'check_plain() escapes &lt;script&gt;');
      $text = check_plain('<>&"\'');
@@ -523,7 +523,7 @@ class CommonXssUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test t() and format_string() replacement functionality.
    */
-  function testFormatStringAndT() {
+  public function testFormatStringAndT() {
     foreach (array('format_string', 't') as $function) {
       $text = $function('Simple text');
       $this->assertEqual($text, 'Simple text', $function . ' leaves simple text alone.');
@@ -539,7 +539,7 @@ class CommonXssUnitTestCase extends BackdropUnitTestCase {
   /**
    * Check that harmful protocols are stripped.
    */
-  function testBadProtocolStripping() {
+  public function testBadProtocolStripping() {
     // Ensure that check_url() strips out harmful protocols, and encodes for
     // HTML. Ensure backdrop_strip_dangerous_protocols() can be used to return a
     // plain-text string stripped of harmful protocols.
@@ -558,7 +558,7 @@ class CommonSizeUnitTestCase extends BackdropUnitTestCase {
   protected $exact_test_cases;
   protected $rounded_test_cases;
 
-  function setUp() {
+  public function setUp() {
     $kb = BACKDROP_KILOBYTE;
     $this->exact_test_cases = array(
       '1 byte' => 1,
@@ -584,7 +584,7 @@ class CommonSizeUnitTestCase extends BackdropUnitTestCase {
   /**
    * Check that format_size() returns the expected string.
    */
-  function testCommonFormatSize() {
+  public function testCommonFormatSize() {
     foreach (array($this->exact_test_cases, $this->rounded_test_cases) as $test_cases) {
       foreach ($test_cases as $expected => $input) {
         $this->assertEqual(
@@ -599,7 +599,7 @@ class CommonSizeUnitTestCase extends BackdropUnitTestCase {
   /**
    * Check that parse_size() returns the proper byte sizes.
    */
-  function testCommonParseSize() {
+  public function testCommonParseSize() {
     foreach ($this->exact_test_cases as $string => $size) {
       $this->assertEqual(
         $parsed_size = parse_size($string),
@@ -632,7 +632,7 @@ class CommonSizeUnitTestCase extends BackdropUnitTestCase {
   /**
    * Cross-test parse_size() and format_size().
    */
-  function testCommonParseSizeFormatSize() {
+  public function testCommonParseSizeFormatSize() {
     foreach ($this->exact_test_cases as $size) {
       $this->assertEqual(
         $size,
@@ -657,7 +657,7 @@ class CommonAutocompleteTagsTestCase extends BackdropUnitTestCase {
   /**
    * Explode a series of tags.
    */
-  function testBackdropExplodeTags() {
+  public function testBackdropExplodeTags() {
     $string = implode(', ', array_keys($this->validTags));
     $tags = backdrop_explode_tags($string);
     $this->assertTags($tags);
@@ -666,7 +666,7 @@ class CommonAutocompleteTagsTestCase extends BackdropUnitTestCase {
   /**
    * Implode a series of tags.
    */
-  function testBackdropImplodeTags() {
+  public function testBackdropImplodeTags() {
     $tags = array_values($this->validTags);
     // Let's explode and implode to our heart's content.
     for ($i = 0; $i < 10; $i++) {
@@ -679,7 +679,7 @@ class CommonAutocompleteTagsTestCase extends BackdropUnitTestCase {
   /**
    * Helper function: asserts that the ending array of tags is what we wanted.
    */
-  function assertTags($tags) {
+  protected function assertTags($tags) {
     $original = $this->validTags;
     foreach ($tags as $tag) {
       $key = array_search($tag, $original);
@@ -698,7 +698,7 @@ class CommonAutocompleteTagsTestCase extends BackdropUnitTestCase {
 class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('language', 'common_test');
     // Reset backdrop_add_css() before each test.
     backdrop_static_reset('backdrop_add_css');
@@ -707,14 +707,14 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Check default stylesheets as empty.
    */
-  function testDefault() {
+  public function testDefault() {
     $this->assertEqual(array(), backdrop_add_css(), 'Default CSS is empty.');
   }
 
   /**
    * Test that stylesheets in module .info files are loaded.
    */
-  function testModuleInfo() {
+  public function testModuleInfo() {
     $this->backdropGet('');
 
     // Verify common_test.css in a STYLE media="all" tag.
@@ -735,7 +735,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests adding a file stylesheet.
    */
-  function testAddFile() {
+  public function testAddFile() {
     $path = backdrop_get_path('module', 'simpletest') . '/css/simpletest.css';
     $css = backdrop_add_css($path);
     $this->assertEqual($css[$path]['data'], $path, 'Adding a CSS file caches it properly.');
@@ -744,7 +744,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests adding an external stylesheet.
    */
-  function testAddExternal() {
+  public function testAddExternal() {
     $path = 'http://example.com/style.css';
     $css = backdrop_add_css($path, 'external');
     $this->assertEqual($css[$path]['type'], 'external', 'Adding an external CSS file caches it properly.');
@@ -753,7 +753,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Makes sure that resetting the CSS empties the cache.
    */
-  function testReset() {
+  public function testReset() {
     backdrop_static_reset('backdrop_add_css');
     $this->assertEqual(array(), backdrop_add_css(), 'Resetting the CSS empties the cache.');
   }
@@ -761,7 +761,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests rendering the stylesheets.
    */
-  function testRenderFile() {
+  public function testRenderFile() {
     $css = backdrop_get_path('module', 'simpletest') . '/css/simpletest.css';
     backdrop_add_css($css);
     $styles = backdrop_get_css();
@@ -775,7 +775,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests rendering an external stylesheet.
    */
-  function testRenderExternal() {
+  public function testRenderExternal() {
     $css = 'http://example.com/style.css';
     backdrop_add_css($css, 'external');
     $styles = backdrop_get_css();
@@ -787,7 +787,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests rendering inline stylesheets with preprocessing on.
    */
-  function testRenderInlinePreprocess() {
+  public function testRenderInlinePreprocess() {
     $css = 'body { padding: 0px; }';
     $css_preprocessed = '<style media="all">' . backdrop_load_stylesheet_content($css, TRUE) . '</style>';
     backdrop_add_css($css, array('type' => 'inline'));
@@ -798,7 +798,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests removing charset when rendering stylesheets with preprocessing on.
    */
-  function testRenderRemoveCharsetPreprocess() {
+  public function testRenderRemoveCharsetPreprocess() {
     $cases = array(
       array(
         'asset' => '@charset "UTF-8";html{font-family:"sans-serif";}',
@@ -823,7 +823,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Tests rendering inline stylesheets with preprocessing off.
    */
-  function testRenderInlineNoPreprocess() {
+  public function testRenderInlineNoPreprocess() {
     $css = 'body { padding: 0px; }';
     backdrop_add_css($css, array('type' => 'inline', 'preprocess' => FALSE));
     $styles = backdrop_get_css();
@@ -835,7 +835,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
    *
    * @see common_test_render_inline_full_page()
    */
-  function testRenderInlineFullPage() {
+  public function testRenderInlineFullPage() {
     // Inline CSS is minified unless 'preprocess' => FALSE is passed as a
     // backdrop_add_css() option.
     $expected = 'body{font-size:254px;}';
@@ -848,7 +848,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Test CSS ordering.
    */
-  function testRenderOrder() {
+  public function testRenderOrder() {
     // A module CSS file.
     backdrop_add_css(backdrop_get_path('module', 'simpletest') . '/css/simpletest.css');
     // A few system CSS files, ordered in a strange way.
@@ -878,7 +878,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Test CSS override.
    */
-  function testRenderOverride() {
+  public function testRenderOverride() {
     $system = backdrop_get_path('module', 'system');
     $simpletest = backdrop_get_path('module', 'simpletest');
 
@@ -903,7 +903,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
   /**
    * Test CSS Styles with attributes rendering.
    */
-  function testRenderStylesAttributes() {
+  public function testRenderStylesAttributes() {
     // Disable aggregation.
     config_set('system.core', 'preprocess_css', 0);
 
@@ -928,7 +928,7 @@ class CommonCascadingStylesheetsTestCase extends BackdropWebTestCase {
    * Tests that the query string remains intact when adding CSS files that have
    * query string parameters.
    */
-  function testAddCssFileWithQueryString() {
+  public function testAddCssFileWithQueryString() {
     $this->backdropGet('common-test/query-string');
     $query_string = state_get('css_js_query_string', '0');
     $this->assertRaw(backdrop_get_path('module', 'node') . '/css/node.admin.css?' . $query_string, 'Query string was appended correctly to css.');
@@ -943,7 +943,7 @@ class CommonHTMLIdentifierTestCase extends BackdropUnitTestCase {
   /**
    * Tests that backdrop_clean_css_identifier() cleans the identifier properly.
    */
-  function testBackdropCleanCSSIdentifier() {
+  public function testBackdropCleanCSSIdentifier() {
     // Verify that no valid ASCII characters are stripped from the identifier.
     $identifier = 'abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789';
     $this->assertIdentical(backdrop_clean_css_identifier($identifier, array()), $identifier, 'Verify valid ASCII characters pass through.');
@@ -959,7 +959,7 @@ class CommonHTMLIdentifierTestCase extends BackdropUnitTestCase {
   /**
    * Tests that backdrop_html_class() cleans the class name properly.
    */
-  function testBackdropHTMLClass() {
+  public function testBackdropHTMLClass() {
     // Verify Backdrop coding standards are enforced.
     $this->assertIdentical(backdrop_html_class('CLASS NAME_[Ü]'), 'class-name--ü', 'Enforce Backdrop coding standards.');
   }
@@ -967,7 +967,7 @@ class CommonHTMLIdentifierTestCase extends BackdropUnitTestCase {
   /**
    * Tests that backdrop_html_id() cleans the ID properly.
    */
-  function testBackdropHTMLId() {
+  public function testBackdropHTMLId() {
     // Verify that letters, digits, and hyphens are not stripped from the ID.
     $id = 'abcdefghijklmnopqrstuvwxyz-0123456789';
     $this->assertIdentical(backdrop_html_id($id), $id, 'Verify valid characters pass through.');
@@ -1003,7 +1003,7 @@ class CommonCascadingStylesheetsUnitTestCase extends BackdropUnitTestCase {
    * - Support semicolons in import statements.
    *   (https://github.com/backdrop/backdrop-issues/issues/6337)
    */
-  function testLoadCssBasic() {
+  public function testLoadCssBasic() {
     // Array of files to test living in 'simpletest/files/css_test_files/'.
     // - Original: name.css
     // - Unoptimized expected content: name.css.unoptimized.css
@@ -1043,11 +1043,11 @@ class CommonCascadingStylesheetsUnitTestCase extends BackdropUnitTestCase {
  * Test backdrop_http_request().
  */
 class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test', 'locale');
   }
 
-  function testBackdropHTTPRequest() {
+  public function testBackdropHTTPRequest() {
     global $is_https;
 
     // Parse URL schema.
@@ -1097,7 +1097,7 @@ class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
     }
   }
 
-  function testBackdropHTTPRequestBasicAuth() {
+  public function testBackdropHTTPRequestBasicAuth() {
     $username = $this->randomName();
     $password = $this->randomName();
     $url = url('system-test/auth', array('absolute' => TRUE));
@@ -1110,7 +1110,7 @@ class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
     $this->assertRaw($password, 'Password is passed correctly.');
   }
 
-  function testBackdropHTTPRequestRedirect() {
+  public function testBackdropHTTPRequestRedirect() {
     $redirect_301 = backdrop_http_request(url('system-test/redirect/301', array('absolute' => TRUE)), array('max_redirects' => 1));
     $this->assertEqual($redirect_301->redirect_code, 301, 'backdrop_http_request follows the 301 redirect.');
 
@@ -1156,7 +1156,7 @@ class CommonBackdropHTTPRequestTestCase extends BackdropWebTestCase {
   /**
    * Tests Content-language headers generated by Backdrop.
    */
-  function testBackdropHTTPRequestHeaders() {
+  public function testBackdropHTTPRequestHeaders() {
     // Check the default header.
     $request = backdrop_http_request(url('<front>', array('absolute' => TRUE)));
     $this->assertEqual($request->headers['content-language'], 'en', t('Content-Language HTTP header is English.'));
@@ -1282,14 +1282,14 @@ class CommonBackdropHTTPResponseStatusLineTest extends BackdropUnitTestCase {
  * Tests backdrop_goto() and hook_backdrop_goto_alter().
  */
 class CommonBackdropGotoTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('common_test');
   }
 
   /**
    * Test backdrop_goto().
    */
-  function testBackdropGoto() {
+  public function testBackdropGoto() {
     $this->backdropGet('common-test/backdrop_goto/redirect');
     $headers = $this->backdropGetHeaders(TRUE);
     list(, $status) = explode(' ', $headers[0][':status'], 3);
@@ -1325,7 +1325,7 @@ class CommonBackdropGotoTestCase extends BackdropWebTestCase {
   /**
    * Test hook_backdrop_goto_alter().
    */
-  function testBackdropGotoAlter() {
+  public function testBackdropGotoAlter() {
     $this->backdropGet('common-test/backdrop_goto/redirect_fail');
 
     $this->assertNoText(t("Backdrop goto failed to stop program"), 'Backdrop goto stopped program.');
@@ -1335,7 +1335,7 @@ class CommonBackdropGotoTestCase extends BackdropWebTestCase {
   /**
    * Test backdrop_get_destination().
    */
-  function testBackdropGetDestination() {
+  public function testBackdropGetDestination() {
     $query = $this->randomName(10);
 
     // Verify that a 'destination' query string is used as destination.
@@ -1359,7 +1359,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    */
   protected $preprocess_js = NULL;
 
-  function setUp() {
+  public function setUp() {
     // Enable Locale and SimpleTest in the test environment.
     parent::setUp('locale', 'simpletest', 'common_test');
 
@@ -1372,7 +1372,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     backdrop_static_reset('backdrop_add_library');
   }
 
-  function tearDown() {
+  protected function tearDown() {
     // Restore configured value for JavaScript preprocessing.
     config_set('system.core', 'preprocess_js', $this->preprocess_js);
     parent::tearDown();
@@ -1381,14 +1381,14 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test default JavaScript is empty.
    */
-  function testDefault() {
+  public function testDefault() {
     $this->assertEqual(array(), backdrop_add_js(), 'Default JavaScript is empty.');
   }
 
   /**
    * Test adding a JavaScript file.
    */
-  function testAddFile() {
+  public function testAddFile() {
     $javascript = backdrop_add_js('core/misc/collapse.js');
     $this->assertTrue(array_key_exists('core/misc/jquery.js', $javascript), 'jQuery is added when a file is added.');
     $this->assertTrue(array_key_exists('core/misc/backdrop.js', $javascript), 'Backdrop.js is added when file is added.');
@@ -1401,7 +1401,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test adding settings.
    */
-  function testAddSetting() {
+  public function testAddSetting() {
     $javascript = backdrop_add_js(array('backdrop' => 'rocks', 'v1.0.0' => 1421394600), 'setting');
     $this->assertEqual(1421394600, $javascript['settings']['data'][2]['v1.0.0'], 'JavaScript setting is set correctly.');
     $this->assertEqual('rocks', $javascript['settings']['data'][2]['backdrop'], 'The other JavaScript setting is set correctly.');
@@ -1410,7 +1410,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Tests adding an external JavaScript File.
    */
-  function testAddExternal() {
+  public function testAddExternal() {
     $path = 'http://example.com/script.js';
     $javascript = backdrop_add_js($path, 'external');
     $this->assertTrue(array_key_exists('http://example.com/script.js', $javascript), 'Added an external JavaScript file.');
@@ -1419,7 +1419,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test backdrop_get_js() for JavaScript settings.
    */
-  function testHeaderSetting() {
+  public function testHeaderSetting() {
     // Only the second of these two entries should appear in Backdrop.settings.
     backdrop_add_js(array('commonTest' => 'commonTestShouldNotAppear'), 'setting');
     backdrop_add_js(array('commonTest' => 'commonTestShouldAppear'), 'setting');
@@ -1454,7 +1454,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test to see if resetting the JavaScript empties the cache.
    */
-  function testReset() {
+  public function testReset() {
     backdrop_add_js('core/misc/collapse.js');
     backdrop_static_reset('backdrop_add_js');
     $this->assertEqual(array(), backdrop_add_js(), 'Resetting the JavaScript correctly empties the cache.');
@@ -1463,7 +1463,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test adding inline scripts.
    */
-  function testAddInline() {
+  public function testAddInline() {
     $inline = 'jQuery(function () { });';
     $javascript = backdrop_add_js($inline, array('type' => 'inline', 'scope' => 'footer'));
     $this->assertTrue(array_key_exists('core/misc/jquery.js', $javascript), 'jQuery is added when inline scripts are added.');
@@ -1474,7 +1474,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test rendering an external JavaScript file.
    */
-  function testRenderExternal() {
+  public function testRenderExternal() {
     $external = 'http://example.com/example.js';
     backdrop_add_js($external, 'external');
     $javascript = backdrop_get_js();
@@ -1485,7 +1485,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test backdrop_get_js() with a footer scope.
    */
-  function testFooterHTML() {
+  public function testFooterHTML() {
     $inline = 'jQuery(function () { });';
     backdrop_add_js($inline, array('type' => 'inline', 'scope' => 'footer'));
     $javascript = backdrop_get_js('footer');
@@ -1495,7 +1495,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test backdrop_add_js() sets preprocess to false when cache is set to false.
    */
-  function testNoCache() {
+  public function testNoCache() {
     $javascript = backdrop_add_js('core/misc/collapse.js', array('cache' => FALSE));
     $this->assertFalse($javascript['core/misc/collapse.js']['preprocess'], 'Setting cache to FALSE sets preprocess to FALSE when adding JavaScript.');
   }
@@ -1503,7 +1503,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test adding a JavaScript file with a different group.
    */
-  function testDifferentGroup() {
+  public function testDifferentGroup() {
     $javascript = backdrop_add_js('core/misc/collapse.js', array('group' => JS_THEME));
     $this->assertEqual($javascript['core/misc/collapse.js']['group'], JS_THEME, 'Adding a JavaScript file with a different group caches the given group.');
   }
@@ -1511,7 +1511,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test adding a JavaScript file with a different weight.
    */
-  function testDifferentWeight() {
+  public function testDifferentWeight() {
     $javascript = backdrop_add_js('core/misc/collapse.js', array('weight' => 2));
     $this->assertEqual($javascript['core/misc/collapse.js']['weight'], 2, 'Adding a JavaScript file with a different weight caches the given weight.');
   }
@@ -1527,7 +1527,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    *
    * @see backdrop_pre_render_conditional_comments()
    */
-  function testDeprecatedBrowserConditionalComments() {
+  public function testDeprecatedBrowserConditionalComments() {
     $default_query_string = state_get('css_js_query_string', '0');
 
     backdrop_add_js('core/misc/collapse.js', array('browsers' => array('IE' => 'lte IE 8', '!IE' => FALSE)));
@@ -1546,7 +1546,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test JavaScript versioning.
    */
-  function testVersionQueryString() {
+  public function testVersionQueryString() {
     backdrop_add_js('core/misc/collapse.js', array('version' => 'foo'));
     backdrop_add_js('core/misc/ajax.js', array('version' => 'bar'));
     $javascript = backdrop_get_js();
@@ -1556,7 +1556,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test JavaScript grouping and aggregation.
    */
-  function testAggregation() {
+  public function testAggregation() {
     $default_query_string = state_get('css_js_query_string', '0');
 
     // To optimize aggregation, items with the 'every_page' option are ordered
@@ -1596,7 +1596,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Tests JavaScript aggregation when files are added to a different scope.
    */
-  function testAggregationOrder() {
+  public function testAggregationOrder() {
     // Enable JavaScript aggregation.
     config_set('system.core', 'preprocess_js', 1);
     backdrop_static_reset('backdrop_add_js');
@@ -1638,7 +1638,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test JavaScript ordering.
    */
-  function testRenderOrder() {
+  public function testRenderOrder() {
     // Add a bunch of JavaScript in strange ordering.
     backdrop_add_js('(function($){alert("Weight 5 #1");})(jQuery);', array('type' => 'inline', 'scope' => 'footer', 'weight' => 5));
     backdrop_add_js('(function($){alert("Weight 0 #1");})(jQuery);', array('type' => 'inline', 'scope' => 'footer'));
@@ -1680,7 +1680,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Test rendering the JavaScript with a file's weight above jQuery's.
    */
-  function testRenderDifferentWeight() {
+  public function testRenderDifferentWeight() {
     // JavaScript files are sorted first by group, then by the 'every_page'
     // flag, then by weight (see backdrop_sort_css_js()), so to test the effect of
     // weight, we need the other two options to be the same.
@@ -1842,7 +1842,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    *
    * @see simpletest_js_alter()
    */
-  function testAlter() {
+  public function testAlter() {
     // Add both tableselect.js and simpletest.js, with a larger weight on SimpleTest.
     backdrop_add_js('core/misc/tableselect.js');
     backdrop_add_js(backdrop_get_path('module', 'simpletest') . '/js/simpletest.js', array('weight' => 9999));
@@ -1857,7 +1857,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Adds a library to the page and tests for both its JavaScript and its CSS.
    */
-  function testLibraryRender() {
+  public function testLibraryRender() {
     $result = backdrop_add_library('system', 'farbtastic');
     $this->assertTrue($result !== FALSE, t('Library was added without errors.'));
     $scripts = backdrop_get_js();
@@ -1871,7 +1871,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    *
    * @see common_test_library_info_alter()
    */
-  function testLibraryAlter() {
+  public function testLibraryAlter() {
     // Verify that common_test altered the title of Farbtastic.
     $library = backdrop_get_library('system', 'farbtastic');
     $this->assertEqual($library['title'], 'Farbtastic: Altered Library', 'Registered libraries were altered.');
@@ -1887,7 +1887,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    *
    * @see common_test_library_info()
    */
-  function testLibraryNameConflicts() {
+  public function testLibraryNameConflicts() {
     $farbtastic = backdrop_get_library('common_test', 'farbtastic');
     $this->assertEqual($farbtastic['title'], 'Custom Farbtastic Library', 'Alternative libraries can be added to the page.');
   }
@@ -1895,7 +1895,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Tests non-existing libraries.
    */
-  function testLibraryUnknown() {
+  public function testLibraryUnknown() {
     $result = backdrop_get_library('unknown', 'unknown');
     $this->assertFalse($result, 'Unknown library returned FALSE.');
     backdrop_static_reset('backdrop_get_library');
@@ -1909,7 +1909,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Tests the addition of libraries through the #attached['library'] property.
    */
-  function testAttachedLibrary() {
+  public function testAttachedLibrary() {
     $element['#attached']['library'][] = array('system', 'farbtastic');
     backdrop_render($element);
     $scripts = backdrop_get_js();
@@ -1919,7 +1919,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   /**
    * Tests retrieval of libraries via backdrop_get_library().
    */
-  function testGetLibrary() {
+  public function testGetLibrary() {
     // Retrieve all libraries registered by a module.
     $libraries = backdrop_get_library('common_test');
     $this->assertTrue(isset($libraries['farbtastic']), 'Retrieved all module libraries.');
@@ -1940,7 +1940,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    * Tests that the query string remains intact when adding JavaScript files
    *  that have query string parameters.
    */
-  function testAddJsFileWithQueryString() {
+  public function testAddJsFileWithQueryString() {
     $this->backdropGet('common-test/query-string');
     $query_string = state_get('css_js_query_string', '0');
     $this->assertRaw(backdrop_get_path('module', 'node') . '/js/node.js?' . $query_string, 'Query string was appended correctly to js.');
@@ -1953,14 +1953,14 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
 class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('common_test');
   }
 
   /**
    * Tests the output backdrop_render() for some elementary input values.
    */
-  function testBackdropRenderBasics() {
+  public function testBackdropRenderBasics() {
     $types = array(
       array(
         'name' => 'null',
@@ -2014,7 +2014,7 @@ class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   /**
    * Test sorting by weight.
    */
-  function testBackdropRenderSorting() {
+  public function testBackdropRenderSorting() {
     $first = $this->randomName();
     $second = $this->randomName();
     // Build an array with '#weight' set for each element.
@@ -2065,7 +2065,7 @@ class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   /**
    * Test #attached functionality in children elements.
    */
-  function testBackdropRenderChildrenAttached() {
+  public function testBackdropRenderChildrenAttached() {
     // The cache system is turned off for POST requests.
     $request_method = $_SERVER['REQUEST_METHOD'];
     $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -2116,7 +2116,7 @@ class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   /**
    * Test passing arguments to the theme function.
    */
-  function testBackdropRenderThemeArguments() {
+  public function testBackdropRenderThemeArguments() {
     $element = array(
       '#theme' => 'common_test_foo',
     );
@@ -2134,7 +2134,7 @@ class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   /**
    * Test rendering form elements without passing through form_builder().
    */
-  function testBackdropRenderFormElements() {
+  public function testBackdropRenderFormElements() {
     // Define a series of form elements.
     $element = array(
       '#type' => 'button',
@@ -2244,7 +2244,7 @@ class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   /**
    * Test rendering elements with invalid keys.
    */
-  function testBackdropRenderInvalidKeys() {
+  public function testBackdropRenderInvalidKeys() {
     $error = array(
       '%type' => 'User error',
       '!message' => '"child" is an invalid render array key',
@@ -2277,7 +2277,7 @@ class CommonBackdropRenderTestCase extends BackdropWebTestCase {
   /**
    * Tests caching of render items.
    */
-  function testBackdropRenderCache() {
+  public function testBackdropRenderCache() {
     // Force a request via GET.
     $request_method = $_SERVER['REQUEST_METHOD'];
     $_SERVER['REQUEST_METHOD'] = 'GET';
@@ -2366,7 +2366,7 @@ class CommonValidUrlUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test valid absolute URLs.
    */
-  function testValidAbsolute() {
+  public function testValidAbsolute() {
     $url_schemes = array('http', 'https', 'ftp');
     $valid_absolute_urls = array(
       // cspell:disable
@@ -2403,7 +2403,7 @@ class CommonValidUrlUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test invalid absolute URLs.
    */
-  function testInvalidAbsolute() {
+  public function testInvalidAbsolute() {
     $url_schemes = array('http', 'https', 'ftp');
     $invalid_absolute_urls = array(
       // cspell:disable
@@ -2425,7 +2425,7 @@ class CommonValidUrlUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test valid relative URLs.
    */
-  function testValidRelative() {
+  public function testValidRelative() {
     $valid_relative_urls = array(
       // cspell:disable
       'paren(the)sis',
@@ -2448,7 +2448,7 @@ class CommonValidUrlUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test invalid relative URLs.
    */
-  function testInvalidRelative() {
+  public function testInvalidRelative() {
     $invalid_relative_urls = array(
       // cspell:disable
       'ex^mple',
@@ -2474,7 +2474,7 @@ class CommonValidNumberStepUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests valid_number_step() without offset.
    */
-  function testNumberStep() {
+  public function testNumberStep() {
     // Value and step equal.
     $this->assertTrue(valid_number_step(10.3, 10.3));
 
@@ -2520,7 +2520,7 @@ class CommonValidNumberStepUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests valid_number_step() with offset.
    */
-  function testNumberStepOffset() {
+  public function testNumberStepOffset() {
     // Try obvious fits.
     $this->assertTrue(valid_number_step(11.3, 10.3, 1));
     $this->assertTrue(valid_number_step(100, 10, 50));
@@ -2541,14 +2541,14 @@ class CommonValidNumberStepUnitTestCase extends BackdropUnitTestCase {
  * Tests writing of data records with backdrop_write_record().
  */
 class CommonBackdropWriteRecordTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('database_test');
   }
 
   /**
    * Test the backdrop_write_record() API function.
    */
-  function testBackdropWriteRecord() {
+  public function testBackdropWriteRecord() {
     // Insert a record with no columns populated.
     $record = array();
     $insert_result = backdrop_write_record('test', $record);
@@ -2680,14 +2680,14 @@ class CommonSimpleTestErrorCollectorTestCase extends BackdropWebTestCase {
    */
   protected $collectedErrors = array();
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test', 'error_test');
   }
 
   /**
    * Test that simpletest collects errors from the tested site.
    */
-  function testErrorCollect() {
+  public function testErrorCollect() {
     $this->collectedErrors = array();
     $this->backdropGet('error-test/generate-warnings-with-report');
     $this->assertEqual(count($this->collectedErrors), 3, 'Three errors were collected');
@@ -2738,7 +2738,7 @@ class CommonSimpleTestErrorCollectorTestCase extends BackdropWebTestCase {
   /**
    * Assert that a collected error matches what we are expecting.
    */
-  function assertError($error, $group, $function, $file, $message = NULL) {
+  protected function assertError($error, $group, $function, $file, $message = NULL) {
     $this->assertEqual($error['group'], $group, format_string("Group was %group", array('%group' => $group)));
     $this->assertEqual($error['caller']['function'], $function, format_string("Function was %function", array('%function' => $function)));
     $this->assertEqual(backdrop_basename($error['caller']['file']), $file, format_string("File was %file", array('%file' => $file)));
@@ -2755,7 +2755,7 @@ class CommonBackdropParseInfoFileTestCase extends BackdropUnitTestCase {
   /**
    * Parse an example .info file an verify the results.
    */
-  function testParseInfoFile() {
+  public function testParseInfoFile() {
     $info_values = backdrop_parse_info_file(backdrop_get_path('module', 'simpletest') . '/tests/common_test_info.txt');
     $this->assertEqual($info_values['simple_string'], 'A simple string', 'Simple string value was parsed correctly.', 'System');
     $this->assertEqual($info_values['simple_constant'], WATCHDOG_INFO, 'Constant value was parsed correctly.', 'System');
@@ -2775,7 +2775,7 @@ class CommonBackdropSystemListingTestCase extends BackdropWebTestCase {
   /**
    * Test that files in different directories take precedence as expected.
    */
-  function testDirectoryPrecedence() {
+  public function testDirectoryPrecedence() {
     // Define the module files we will search for, and the directory precedence
     // we expect.
     $expected_directories = array(
@@ -2830,7 +2830,7 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
    */
   const LANGCODE = 'xx';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('locale');
 
     config('system.date')
@@ -2852,7 +2852,7 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
   /**
    * Test admin-defined formats in format_date().
    */
-  function testAdminDefinedFormatDate() {
+  public function testAdminDefinedFormatDate() {
     // Create an admin user.
     $this->admin_user = $this->backdropCreateUser(array('administer site configuration'));
     $this->backdropLogin($this->admin_user);
@@ -2887,7 +2887,7 @@ class CommonFormatDateTestCase extends BackdropWebTestCase {
   /**
    * Tests for the format_date() function.
    */
-  function testFormatDate() {
+  public function testFormatDate() {
     global $user, $language;
 
     $timestamp = strtotime('2007-03-26T00:00:00+00:00');
@@ -2962,7 +2962,7 @@ class CommonBackdropFormatXmlElementsUnitTestCase extends BackdropUnitTestCase {
   /**
    * Provide a sample data structure and verify the XML results.
    */
-  function testParseFormatXmlElements() {
+  public function testParseFormatXmlElements() {
     $structure = array(
       // Test normal key => value pairs.
       'key-value-pairs' => array(
@@ -3032,7 +3032,7 @@ class CommonBackdropAttributesUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests that backdrop_html_class() cleans the class name properly.
    */
-  function testBackdropAttributes() {
+  public function testBackdropAttributes() {
     // Verify that special characters are HTML encoded.
     $this->assertIdentical(backdrop_attributes(array('title' => '&"\'<>')), ' title="&amp;&quot;&#039;&lt;&gt;"', 'HTML encode attribute values.');
 
@@ -3072,7 +3072,7 @@ class CommonBackdropArrayUnitTest extends BackdropUnitTestCase {
    */
   protected $parents;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create a form structure with a nested element.
@@ -3087,7 +3087,7 @@ class CommonBackdropArrayUnitTest extends BackdropUnitTestCase {
   /**
    * Tests getting nested array values.
    */
-  function testGet() {
+  public function testGet() {
     // Verify getting a value of a nested element.
     $value = backdrop_array_get_nested_value($this->form, $this->parents);
     $this->assertEqual($value['#value'], 'Nested element', 'Nested element value found.');
@@ -3115,7 +3115,7 @@ class CommonBackdropArrayUnitTest extends BackdropUnitTestCase {
   /**
    * Tests setting nested array values.
    */
-  function testSet() {
+  public function testSet() {
     $new_value = array(
       '#value' => 'New value',
       '#required' => TRUE,
@@ -3130,7 +3130,7 @@ class CommonBackdropArrayUnitTest extends BackdropUnitTestCase {
   /**
    * Tests unsetting nested array values.
    */
-  function testUnset() {
+  public function testUnset() {
     // Verify unsetting a non-existing nested element throws no errors and the
     // non-existing key is properly reported.
     $key_existed = NULL;
@@ -3150,7 +3150,7 @@ class CommonBackdropArrayUnitTest extends BackdropUnitTestCase {
   /**
    * Tests existence of array key.
    */
-  function testKeyExists() {
+  public function testKeyExists() {
     // Verify that existing key is found.
     $this->assertIdentical(backdrop_array_nested_key_exists($this->form, $this->parents), TRUE, 'Nested key found.');
 
@@ -3168,7 +3168,7 @@ class CommonJSONUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests converting PHP variables to JSON strings and back.
    */
-  function testJSON() {
+  public function testJSON() {
     // Setup a string with the full ASCII table.
     $str = '';
     for ($i=0; $i < 128; $i++) {
@@ -3252,7 +3252,7 @@ class CommonBackdropAddFeedTestCase extends BackdropWebTestCase {
   /**
    * Test backdrop_add_feed() with paths, URLs, and titles.
    */
-  function testBasicFeedAddNoTitle() {
+  public function testBasicFeedAddNoTitle() {
     $path = $this->randomName(12);
     $external_url = 'http://' . $this->randomName(12) . '/' . $this->randomName(12);
     $fully_qualified_local_url = url($this->randomName(12), array('absolute' => TRUE));
@@ -3311,7 +3311,7 @@ class CommonBackdropAddFeedTestCase extends BackdropWebTestCase {
   /**
    * Create a pattern representing the RSS feed in the page.
    */
-  function urlToRSSLinkPattern($url, $title = '') {
+  protected function urlToRSSLinkPattern($url, $title = '') {
     // Escape any regular expression characters in the URL ('?' is the worst).
     $url = preg_replace('/([+?.*])/', '[$0]', $url);
     $generated_pattern = '%<link +rel="alternate" +type="application/rss.xml" +title="' . $title . '" +href="' . $url . '" */>%';
@@ -3331,7 +3331,7 @@ class CommonBackdropSortUnitTest extends BackdropUnitTestCase {
    */
   protected $test_array;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->test_array = array(
@@ -3449,7 +3449,7 @@ class ArrayDiffUnitTest extends BackdropUnitTestCase {
    */
   protected $array2;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->array1 = array(
@@ -3517,7 +3517,7 @@ class FeedIconTest extends BackdropWebTestCase {
   /**
    * Check that special characters are correctly escaped. Test for issue #1211668.
    */
-  function testFeedIconEscaping() {
+  public function testFeedIconEscaping() {
     $variables = array();
     $variables['url'] = 'node';
     $variables['title'] = '<>&"\'';

--- a/core/modules/simpletest/tests/config_obj.test
+++ b/core/modules/simpletest/tests/config_obj.test
@@ -4,7 +4,7 @@
  */
 class ConfigObjectTestCase extends BackdropWebTestCase {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('config_obj_test'));
   }
 

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -3763,88 +3763,87 @@ class DatabaseExtraTypesTestCase extends BackdropWebTestCase {
   /**
    * Test the date data type.
    */
-   function testDateField() {
-     try {
-       $date_table = array(
-         'fields' => array(
-           'date_field' => array(
-             'description' => t('Test Date field'),
-             'type' => 'date',
-             'not null' => FALSE,
-           ),
-         ),
-       );
-       db_create_table('date_table', $date_table);
-       $this->assertTrue(db_table_exists('date_table'), t('Created table with date field'));
+  public function testDateField() {
+    try {
+      $date_table = array(
+        'fields' => array(
+          'date_field' => array(
+            'description' => t('Test Date field'),
+            'type' => 'date',
+            'not null' => FALSE,
+          ),
+        ),
+      );
+      db_create_table('date_table', $date_table);
+      $this->assertTrue(db_table_exists('date_table'), t('Created table with date field'));
 
-       db_insert('date_table')->fields(array('date_field'))
-         ->values(array('date_field' => '2001-01-01'))
-         ->values(array('date_field' => '1856-12-31'))
-         ->values(array('date_field' => '2100-06-30'))
-         ->execute();
+      db_insert('date_table')->fields(array('date_field'))
+        ->values(array('date_field' => '2001-01-01'))
+        ->values(array('date_field' => '1856-12-31'))
+        ->values(array('date_field' => '2100-06-30'))
+        ->execute();
 
-       $num_records = (int) db_query('SELECT COUNT(*) FROM {date_table}')->fetchField();
-       $this->assertEqual($num_records, 3, t('Inserted 3 records, and counted 3 records'));
-       $res = db_query('SELECT date_field from {date_table} ORDER BY date_field');
+      $num_records = (int) db_query('SELECT COUNT(*) FROM {date_table}')->fetchField();
+      $this->assertEqual($num_records, 3, t('Inserted 3 records, and counted 3 records'));
+      $res = db_query('SELECT date_field from {date_table} ORDER BY date_field');
 
-       $date = $res->fetch()->date_field;
-       $this->assertEqual($date, '1856-12-31', t('Date retrieved in order @date', array('@date' => $date)));
-       $date = $res->fetch()->date_field;
-       $this->assertEqual($date, '2001-01-01', t('Date retrieved in order @date', array('@date' => $date)));
-       $date = $res->fetch()->date_field;
-       $this->assertEqual($date, '2100-06-30', t('Date retrieved in order @date', array('@date' => $date)));
+      $date = $res->fetch()->date_field;
+      $this->assertEqual($date, '1856-12-31', t('Date retrieved in order @date', array('@date' => $date)));
+      $date = $res->fetch()->date_field;
+      $this->assertEqual($date, '2001-01-01', t('Date retrieved in order @date', array('@date' => $date)));
+      $date = $res->fetch()->date_field;
+      $this->assertEqual($date, '2100-06-30', t('Date retrieved in order @date', array('@date' => $date)));
 
 
-       db_drop_table('date_table');
-       $this->assertFalse(db_table_exists('date_table'), t('Dropped table with date field'));
+      db_drop_table('date_table');
+      $this->assertFalse(db_table_exists('date_table'), t('Dropped table with date field'));
 
-     } catch (Exception $e) {
-       $this->fail($e->getMessage());
-     }
-
-   }
+    } catch (Exception $e) {
+      $this->fail($e->getMessage());
+    }
+  }
 
   /**
    * Test the time data type.
    */
-   function testTimeField() {
-     try {
-       $time_table = array(
-         'fields' => array(
-           'time_field' => array(
-             'description' => t('Test Time field'),
-             'type' => 'time',
-             'not null' => FALSE,
-           ),
-         ),
-       );
-       db_create_table('time_table', $time_table);
-       $this->assertTrue(db_table_exists('time_table'), t('Created table with time field'));
+  public function testTimeField() {
+    try {
+      $time_table = array(
+        'fields' => array(
+          'time_field' => array(
+            'description' => t('Test Time field'),
+            'type' => 'time',
+            'not null' => FALSE,
+          ),
+        ),
+      );
+      db_create_table('time_table', $time_table);
+      $this->assertTrue(db_table_exists('time_table'), t('Created table with time field'));
 
-       db_insert('time_table')->fields(array('time_field'))
-         ->values(array('time_field' => '12:59:00'))
-         ->values(array('time_field' => '00:01:00'))
-         ->values(array('time_field' => '23:17:00'))
-         ->execute();
+      db_insert('time_table')->fields(array('time_field'))
+        ->values(array('time_field' => '12:59:00'))
+        ->values(array('time_field' => '00:01:00'))
+        ->values(array('time_field' => '23:17:00'))
+        ->execute();
 
-       $num_records = (int) db_query('SELECT COUNT(*) FROM {time_table}')->fetchField();
-       $this->assertEqual($num_records, 3, t('Inserted 3 records, and counted 3 records'));
-       $res = db_query('SELECT time_field from {time_table} ORDER BY time_field');
+      $num_records = (int) db_query('SELECT COUNT(*) FROM {time_table}')->fetchField();
+      $this->assertEqual($num_records, 3, t('Inserted 3 records, and counted 3 records'));
+      $res = db_query('SELECT time_field from {time_table} ORDER BY time_field');
 
-       $time = $res->fetch()->time_field;
-       $this->assertEqual($time, '00:01:00', t('Time retrieved in order @time', array('@time' => $time)));
-       $time = $res->fetch()->time_field;
-       $this->assertEqual($time, '12:59:00', t('Time retrieved in order @time', array('@time' => $time)));
-       $time = $res->fetch()->time_field;
-       $this->assertEqual($time, '23:17:00', t('Time retrieved in order @time', array('@time' => $time)));
+      $time = $res->fetch()->time_field;
+      $this->assertEqual($time, '00:01:00', t('Time retrieved in order @time', array('@time' => $time)));
+      $time = $res->fetch()->time_field;
+      $this->assertEqual($time, '12:59:00', t('Time retrieved in order @time', array('@time' => $time)));
+      $time = $res->fetch()->time_field;
+      $this->assertEqual($time, '23:17:00', t('Time retrieved in order @time', array('@time' => $time)));
 
-       db_drop_table('time_table');
-       $this->assertFalse(db_table_exists('time_table'), t('Dropped table with time field'));
-     } catch (Exception $e) {
-       $this->fail($e->getMessage());
-     }
+      db_drop_table('time_table');
+      $this->assertFalse(db_table_exists('time_table'), t('Dropped table with time field'));
+    } catch (Exception $e) {
+      $this->fail($e->getMessage());
+    }
 
-  }
+ }
 
 }
 

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -29,7 +29,7 @@ class FakeRecord {
 class DatabaseTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -55,7 +55,7 @@ class DatabaseTestCase extends BackdropWebTestCase {
    * @param $schema
    *   An array of table definitions to install.
    */
-  function installTables($schema) {
+  protected function installTables($schema) {
     // This ends up being a test for table drop and create, too, which is nice.
     foreach ($schema as $name => $data) {
       if (db_table_exists($name)) {
@@ -72,7 +72,7 @@ class DatabaseTestCase extends BackdropWebTestCase {
   /**
    * Set up tables for NULL handling.
    */
-  function ensureSampleDataNull() {
+  protected function ensureSampleDataNull() {
     $schema['test_null'] = backdrop_get_schema('test_null');
     $this->installTables($schema);
 
@@ -99,7 +99,7 @@ class DatabaseTestCase extends BackdropWebTestCase {
    * These are added using db_query(), since we're not trying to test the
    * INSERT operations here, just populate.
    */
-  function addSampleData() {
+  protected function addSampleData() {
     // We need the IDs, so we can't use a multi-insert here.
     $john = db_insert('test')
       ->fields(array(
@@ -189,7 +189,7 @@ class DatabaseConnectionTestCase extends DatabaseTestCase {
   /**
    * Test that connections return appropriate connection objects.
    */
-  function testConnectionRouting() {
+  public function testConnectionRouting() {
     // Clone the primary credentials to a replica connection.
     // Note this will result in two independent connection objects that happen
     // to point to the same place.
@@ -223,7 +223,7 @@ class DatabaseConnectionTestCase extends DatabaseTestCase {
   /**
    * Test that connections return appropriate connection objects.
    */
-  function testConnectionRoutingOverride() {
+  public function testConnectionRoutingOverride() {
     // Clone the primary credentials to a replica connection.
     // Note this will result in two independent connection objects that happen
     // to point to the same place.
@@ -241,7 +241,7 @@ class DatabaseConnectionTestCase extends DatabaseTestCase {
   /**
    * Tests the closing of a database connection.
    */
-  function testConnectionClosing() {
+  public function testConnectionClosing() {
     // Open the default target so we have an object to compare.
     $db1 = Database::getConnection('default', 'default');
 
@@ -256,7 +256,7 @@ class DatabaseConnectionTestCase extends DatabaseTestCase {
   /**
    * Tests the connection options of the active database.
    */
-  function testConnectionOptions() {
+  public function testConnectionOptions() {
     $connection_info = Database::getConnectionInfo('default');
 
     // Be sure we're connected to the default database.
@@ -296,7 +296,7 @@ class DatabaseSelectCloneTest extends DatabaseTestCase {
   /**
    * Test that subqueries as value within conditions are cloned properly.
    */
-  function testSelectConditionSubQueryCloning() {
+  public function testSelectConditionSubQueryCloning() {
     $subquery = db_select('test', 't');
     $subquery->addField('t', 'id', 'id');
     $subquery->condition('age', 28, '<');
@@ -359,7 +359,7 @@ class DatabaseFetchTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can fetch a record properly in default object mode.
    */
-  function testQueryFetchDefault() {
+  public function testQueryFetchDefault() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age = :age', array(':age' => 25));
     $this->assertTrue($result instanceof DatabaseStatementInterface, 'Result set is a Backdrop statement object.');
@@ -375,7 +375,7 @@ class DatabaseFetchTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can fetch a record to an object explicitly.
    */
-  function testQueryFetchObject() {
+  public function testQueryFetchObject() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age = :age', array(':age' => 25), array('fetch' => PDO::FETCH_OBJ));
     foreach ($result as $record) {
@@ -390,7 +390,7 @@ class DatabaseFetchTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can fetch a record to an array associative explicitly.
    */
-  function testQueryFetchArray() {
+  public function testQueryFetchArray() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age = :age', array(':age' => 25), array('fetch' => PDO::FETCH_ASSOC));
     foreach ($result as $record) {
@@ -408,7 +408,7 @@ class DatabaseFetchTestCase extends DatabaseTestCase {
    *
    * @see FakeRecord
    */
-  function testQueryFetchClass() {
+  public function testQueryFetchClass() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age = :age', array(':age' => 25), array('fetch' => 'FakeRecord'));
     foreach ($result as $record) {
@@ -429,7 +429,7 @@ class DatabaseFetchTestCase extends DatabaseTestCase {
  */
 class DatabaseFetch2TestCase extends DatabaseTestCase {
   // Confirm that we can fetch a record into an indexed array explicitly.
-  function testQueryFetchNum() {
+  public function testQueryFetchNum() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age = :age', array(':age' => 25), array('fetch' => PDO::FETCH_NUM));
     foreach ($result as $record) {
@@ -445,7 +445,7 @@ class DatabaseFetch2TestCase extends DatabaseTestCase {
   /**
    * Confirm that we can fetch a record into a doubly-keyed array explicitly.
    */
-  function testQueryFetchBoth() {
+  public function testQueryFetchBoth() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age = :age', array(':age' => 25), array('fetch' => PDO::FETCH_BOTH));
     foreach ($result as $record) {
@@ -462,7 +462,7 @@ class DatabaseFetch2TestCase extends DatabaseTestCase {
   /**
    * Confirm that we can fetch an entire column of a result set at once.
    */
-  function testQueryFetchCol() {
+  public function testQueryFetchCol() {
     $records = array();
     $result = db_query('SELECT name FROM {test} WHERE age > :age', array(':age' => 25));
     $column = $result->fetchCol();
@@ -483,7 +483,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Test the very basic insert functionality.
    */
-  function testSimpleInsert() {
+  public function testSimpleInsert() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $query = db_insert('test');
@@ -502,7 +502,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Test that we can insert multiple records in one query object.
    */
-  function testMultiInsert() {
+  public function testMultiInsert() {
     $num_records_before = (int) db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $query = db_insert('test');
@@ -535,7 +535,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Test that an insert object can be reused with new data after it executes.
    */
-  function testRepeatedInsert() {
+  public function testRepeatedInsert() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $query = db_insert('test');
@@ -570,7 +570,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Test that we can specify fields without values and specify values later.
    */
-  function testInsertFieldOnlyDefinition() {
+  public function testInsertFieldOnlyDefinition() {
     // This is useful for importers, when we want to create a query and define
     // its fields once, then loop over a multi-insert execution.
     db_insert('test')
@@ -590,7 +590,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Test that inserts return the proper auto-increment ID.
    */
-  function testInsertLastInsertID() {
+  public function testInsertLastInsertID() {
     $id = db_insert('test')
       ->fields(array(
         'name' => 'Larry',
@@ -604,7 +604,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Test that the INSERT INTO ... SELECT (fields) ... syntax works.
    */
-  function testInsertSelectFields() {
+  public function testInsertSelectFields() {
     $query = db_select('test_people', 'tp');
     // The query builder will always append expressions after fields.
     // Add the expression first to test that the insert fields are correctly
@@ -630,7 +630,7 @@ class DatabaseInsertTestCase extends DatabaseTestCase {
   /**
    * Tests that the INSERT INTO ... SELECT * ... syntax works.
    */
-  function testInsertSelectAll() {
+  public function testInsertSelectAll() {
     $query = db_select('test_people', 'tp')
       ->fields('tp')
       ->condition('tp.name', 'Meredith');
@@ -656,7 +656,7 @@ class DatabaseInsertLOBTestCase extends DatabaseTestCase {
   /**
    * Test that we can insert a single blob field successfully.
    */
-  function testInsertOneBlob() {
+  public function testInsertOneBlob() {
     $data = "This is\000a test.";
     $this->assertTrue(strlen($data) === 15, 'Test data contains a NULL.');
     $id = db_insert('test_one_blob')
@@ -669,7 +669,7 @@ class DatabaseInsertLOBTestCase extends DatabaseTestCase {
   /**
    * Test that we can insert multiple blob fields in the same query.
    */
-  function testInsertMultipleBlob() {
+  public function testInsertMultipleBlob() {
     $id = db_insert('test_two_blobs')
       ->fields(array(
         'blob1' => 'This is',
@@ -688,7 +688,7 @@ class DatabaseInsertDefaultsTestCase extends DatabaseTestCase {
   /**
    * Test that we can run a query that is "default values for everything".
    */
-  function testDefaultInsert() {
+  public function testDefaultInsert() {
     $query = db_insert('test')->useDefaults(array('job'));
     $id = $query->execute();
 
@@ -701,7 +701,7 @@ class DatabaseInsertDefaultsTestCase extends DatabaseTestCase {
   /**
    * Test that no action will be preformed if no fields are specified.
    */
-  function testDefaultEmptyInsert() {
+  public function testDefaultEmptyInsert() {
     $num_records_before = (int) db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     try {
@@ -719,7 +719,7 @@ class DatabaseInsertDefaultsTestCase extends DatabaseTestCase {
   /**
    * Test that we can insert fields with values and defaults in the same query.
    */
-  function testDefaultInsertWithFields() {
+  public function testDefaultInsertWithFields() {
     $query = db_insert('test')
       ->fields(array('name' => 'Bob'))
       ->useDefaults(array('job'));
@@ -739,7 +739,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update a single record successfully.
    */
-  function testSimpleUpdate() {
+  public function testSimpleUpdate() {
     $num_updated = db_update('test')
       ->fields(array('name' => 'Tiffany'))
       ->condition('id', 1)
@@ -753,7 +753,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm updating to NULL.
    */
-  function testSimpleNullUpdate() {
+  public function testSimpleNullUpdate() {
     $this->ensureSampleDataNull();
     $num_updated = db_update('test_null')
       ->fields(array('age' => NULL))
@@ -768,7 +768,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update a multiple records successfully.
    */
-  function testMultiUpdate() {
+  public function testMultiUpdate() {
     $num_updated = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->condition('job', 'Singer')
@@ -782,7 +782,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update a multiple records with a non-equality condition.
    */
-  function testMultiGTUpdate() {
+  public function testMultiGTUpdate() {
     $num_updated = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->condition('age', 26, '>')
@@ -796,7 +796,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update a multiple records with a where call.
    */
-  function testWhereUpdate() {
+  public function testWhereUpdate() {
     $num_updated = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->where('age > :age', array(':age' => 26))
@@ -810,7 +810,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can stack condition and where calls.
    */
-  function testWhereAndConditionUpdate() {
+  public function testWhereAndConditionUpdate() {
     $update = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->where('age > :age', array(':age' => 26))
@@ -825,7 +825,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Test updating with expressions.
    */
-  function testExpressionUpdate() {
+  public function testExpressionUpdate() {
     // Ensure that expressions are handled properly. This should set every
     // record's age to a square of itself
     $num_rows = db_update('test')
@@ -837,7 +837,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Tests return value on update.
    */
-  function testUpdateAffectedRows() {
+  public function testUpdateAffectedRows() {
     // At 5am in the morning, all band members but those with a priority 1 task
     // are sleeping. So we set their tasks to 'sleep'. 5 records match the
     // condition and therefore are affected by the query, even though two of
@@ -854,7 +854,7 @@ class DatabaseUpdateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update the primary key of a record successfully.
    */
-  function testPrimaryKeyUpdate() {
+  public function testPrimaryKeyUpdate() {
     $num_updated = db_update('test')
       ->fields(array('id' => 42, 'name' => 'John'))
       ->condition('id', 1)
@@ -873,7 +873,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test updates with OR conditionals.
    */
-  function testOrConditionUpdate() {
+  public function testOrConditionUpdate() {
     $update = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->condition(db_or()
@@ -890,7 +890,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test WHERE IN clauses.
    */
-  function testInConditionUpdate() {
+  public function testInConditionUpdate() {
     $num_updated = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->condition('name', array('John', 'Paul'), 'IN')
@@ -904,7 +904,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test WHERE NOT IN clauses.
    */
-  function testNotInConditionUpdate() {
+  public function testNotInConditionUpdate() {
     // The o is lowercase in the 'NoT IN' operator, to make sure the operators
     // work in mixed case.
     $num_updated = db_update('test')
@@ -920,7 +920,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test BETWEEN conditional clauses.
    */
-  function testBetweenConditionUpdate() {
+  public function testBetweenConditionUpdate() {
     $num_updated = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->condition('age', array(25, 26), 'BETWEEN')
@@ -934,7 +934,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test LIKE conditionals.
    */
-  function testLikeConditionUpdate() {
+  public function testLikeConditionUpdate() {
     $num_updated = db_update('test')
       ->fields(array('job' => 'Musician'))
       ->condition('name', '%ge%', 'LIKE')
@@ -948,7 +948,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test update with expression values.
    */
-  function testUpdateExpression() {
+  public function testUpdateExpression() {
     $before_age = db_query('SELECT age FROM {test} WHERE name = :name', array(':name' => 'Ringo'))->fetchField();
     $GLOBALS['larry_test'] = 1;
     $num_updated = db_update('test')
@@ -971,7 +971,7 @@ class DatabaseUpdateComplexTestCase extends DatabaseTestCase {
   /**
    * Test update with only expression values.
    */
-  function testUpdateOnlyExpression() {
+  public function testUpdateOnlyExpression() {
     $before_age = db_query('SELECT age FROM {test} WHERE name = :name', array(':name' => 'Ringo'))->fetchField();
     $num_updated = db_update('test')
       ->condition('name', 'Ringo')
@@ -991,7 +991,7 @@ class DatabaseUpdateLOBTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update a blob column.
    */
-  function testUpdateOneBlob() {
+  public function testUpdateOneBlob() {
     $data = "This is\000a test.";
     $this->assertTrue(strlen($data) === 15, 'Test data contains a NULL.');
     $id = db_insert('test_one_blob')
@@ -1011,7 +1011,7 @@ class DatabaseUpdateLOBTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can update two blob columns in the same table.
    */
-  function testUpdateMultipleBlob() {
+  public function testUpdateMultipleBlob() {
     $id = db_insert('test_two_blobs')
       ->fields(array(
         'blob1' => 'This is',
@@ -1044,7 +1044,7 @@ class DatabaseDeleteTruncateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can use a subselect in a delete successfully.
    */
-  function testSubselectDelete() {
+  public function testSubselectDelete() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();
     $pid_to_delete = db_query("SELECT * FROM {test_task} WHERE task = 'sleep'")->fetchField();
 
@@ -1065,7 +1065,7 @@ class DatabaseDeleteTruncateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can delete a single record successfully.
    */
-  function testSimpleDelete() {
+  public function testSimpleDelete() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $num_deleted = db_delete('test')
@@ -1080,7 +1080,7 @@ class DatabaseDeleteTruncateTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can truncate a whole table successfully.
    */
-  function testTruncate() {
+  public function testTruncate() {
     $num_records_before = db_query("SELECT COUNT(*) FROM {test}")->fetchField();
 
     db_truncate('test')->execute();
@@ -1097,7 +1097,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can merge-insert a record successfully.
    */
-  function testMergeInsert() {
+  public function testMergeInsert() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
     $max_id_before = db_query('SELECT MAX(id) FROM {test}')->fetchField();
 
@@ -1124,7 +1124,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can merge-update a record successfully.
    */
-  function testMergeUpdate() {
+  public function testMergeUpdate() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_people}')->fetchField();
     $num_records_matched = db_query('SELECT COUNT(*) FROM {test_people} WHERE job = :job', array(':job' => 'Speaker'))->fetchField();
 
@@ -1150,7 +1150,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can merge-update a record successfully, with different insert and update.
    */
-  function testMergeUpdateExcept() {
+  public function testMergeUpdateExcept() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_people}')->fetchField();
 
     db_merge('test_people')
@@ -1171,7 +1171,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can merge-update a record successfully, with alternate replacement.
    */
-  function testMergeUpdateExplicit() {
+  public function testMergeUpdateExplicit() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_people}')->fetchField();
 
     db_merge('test_people')
@@ -1197,7 +1197,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can merge-update a record successfully, with expressions.
    */
-  function testMergeUpdateExpression() {
+  public function testMergeUpdateExpression() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_people}')->fetchField();
 
     $age_before = db_query('SELECT age FROM {test_people} WHERE job = :job', array(':job' => 'Speaker'))->fetchField();
@@ -1226,7 +1226,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Test that we can merge-insert without any update fields.
    */
-  function testMergeInsertWithoutUpdate() {
+  public function testMergeInsertWithoutUpdate() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_people}')->fetchField();
 
     db_merge('test_people')
@@ -1245,7 +1245,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can merge-update without any update fields.
    */
-  function testMergeUpdateWithoutUpdate() {
+  public function testMergeUpdateWithoutUpdate() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test_people}')->fetchField();
 
     db_merge('test_people')
@@ -1277,7 +1277,7 @@ class DatabaseMergeTestCase extends DatabaseTestCase {
   /**
    * Test that an invalid merge query throws an exception like it is supposed to.
    */
-  function testInvalidMerge() {
+  public function testInvalidMerge() {
     try {
       // This query should die because there is no key field specified.
       db_merge('test_people')
@@ -1302,7 +1302,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test rudimentary SELECT statements.
    */
-  function testSimpleSelect() {
+  public function testSimpleSelect() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -1319,7 +1319,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test rudimentary SELECT statement with a COMMENT.
    */
-  function testSimpleComment() {
+  public function testSimpleComment() {
     $query = db_select('test');
     $query->comment('Testing query comments');
     $query->addField('test', 'name');
@@ -1341,7 +1341,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test query COMMENT system against vulnerabilities.
    */
-  function testVulnerableComment() {
+  public function testVulnerableComment() {
     $query = db_select('test');
     $query->comment('Testing query comments */ SELECT nid FROM {node}; --');
     $query->addField('test', 'name');
@@ -1369,7 +1369,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Provides expected and input values for testVulnerableComment().
    */
-  function makeCommentsProvider() {
+  protected function makeCommentsProvider() {
     return array(
       array(
         '/*  */ ',
@@ -1400,7 +1400,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test basic conditionals on SELECT statements.
    */
-  function testSimpleSelectConditional() {
+  public function testSimpleSelectConditional() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -1420,7 +1420,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test SELECT statements with expressions.
    */
-  function testSimpleSelectExpression() {
+  public function testSimpleSelectExpression() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addExpression("age*2", 'double_age');
@@ -1440,7 +1440,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test SELECT statements with multiple expressions.
    */
-  function testSimpleSelectExpressionMultiple() {
+  public function testSimpleSelectExpressionMultiple() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_double_field = $query->addExpression("age*2");
@@ -1462,7 +1462,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test adding multiple fields to a select statement at the same time.
    */
-  function testSimpleSelectMultipleFields() {
+  public function testSimpleSelectMultipleFields() {
     $record = db_select('test')
       ->fields('test', array('id', 'name', 'age', 'job'))
       ->condition('age', 27)
@@ -1485,7 +1485,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test adding all fields from a given table to a select statement.
    */
-  function testSimpleSelectAllFields() {
+  public function testSimpleSelectAllFields() {
     $record = db_select('test')
       ->fields('test')
       ->condition('age', 27)
@@ -1508,7 +1508,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test that a comparison with NULL is always FALSE.
    */
-  function testNullCondition() {
+  public function testNullCondition() {
     $this->ensureSampleDataNull();
 
     $names = db_select('test_null', 'tn')
@@ -1522,7 +1522,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test that we can find a record with a NULL value.
    */
-  function testIsNullCondition() {
+  public function testIsNullCondition() {
     $this->ensureSampleDataNull();
 
     $names = db_select('test_null', 'tn')
@@ -1537,7 +1537,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test that we can find a record without a NULL value.
    */
-  function testIsNotNullCondition() {
+  public function testIsNotNullCondition() {
     $this->ensureSampleDataNull();
 
     $names = db_select('test_null', 'tn')
@@ -1555,7 +1555,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
    * Test that we can UNION multiple Select queries together. This is
    * semantically equal to UNION DISTINCT, so we don't explicitly test that.
    */
-  function testUnion() {
+  public function testUnion() {
     $query_1 = db_select('test', 't')
       ->fields('t', array('name'))
       ->condition('age', array(27, 28), 'IN');
@@ -1578,7 +1578,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test that we can UNION ALL multiple Select queries together.
    */
-  function testUnionAll() {
+  public function testUnionAll() {
     $query_1 = db_select('test', 't')
       ->fields('t', array('name'))
       ->condition('age', array(27, 28), 'IN');
@@ -1614,7 +1614,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
    * the only way this could happen is if we have successfully triggered the
    * database's random ordering functionality.
    */
-  function testRandomOrder() {
+  public function testRandomOrder() {
     // Use 52 items, so the chance that this test fails by accident will be the
     // same as the chance that a deck of cards will come out in the same order
     // after shuffling it (in other words, nearly impossible).
@@ -1664,7 +1664,7 @@ class DatabaseSelectTestCase extends DatabaseTestCase {
   /**
    * Test that aliases are renamed when duplicates.
    */
-  function testSelectDuplicateAlias() {
+  public function testSelectDuplicateAlias() {
     $query = db_select('test', 't');
     $alias1 = $query->addField('t', 'name', 'the_alias');
     $alias2 = $query->addField('t', 'age', 'the_alias');
@@ -1679,7 +1679,7 @@ class DatabaseSelectSubqueryTestCase extends DatabaseTestCase {
   /**
    * Test that we can use a subquery in a FROM clause.
    */
-  function testFromSubquerySelect() {
+  public function testFromSubquerySelect() {
     // Create a subquery, which is just a normal query object.
     $subquery = db_select('test_task', 'tt');
     $subquery->addField('tt', 'pid', 'pid');
@@ -1713,7 +1713,7 @@ class DatabaseSelectSubqueryTestCase extends DatabaseTestCase {
   /**
    * Test that we can use a subquery in a FROM clause with a limit.
    */
-  function testFromSubquerySelectWithLimit() {
+  public function testFromSubquerySelectWithLimit() {
     // Create a subquery, which is just a normal query object.
     $subquery = db_select('test_task', 'tt');
     $subquery->addField('tt', 'pid', 'pid');
@@ -1739,7 +1739,7 @@ class DatabaseSelectSubqueryTestCase extends DatabaseTestCase {
   /**
    * Test that we can use a subquery in a WHERE clause.
    */
-  function testConditionSubquerySelect() {
+  public function testConditionSubquerySelect() {
     // Create a subquery, which is just a normal query object.
     $subquery = db_select('test_task', 'tt');
     $subquery->addField('tt', 'pid', 'pid');
@@ -1775,7 +1775,7 @@ class DatabaseSelectSubqueryTestCase extends DatabaseTestCase {
   /**
    * Test that we can use a subquery in a JOIN clause.
    */
-  function testJoinSubquerySelect() {
+  public function testJoinSubquerySelect() {
     // Create a subquery, which is just a normal query object.
     $subquery = db_select('test_task', 'tt');
     $subquery->addField('tt', 'pid', 'pid');
@@ -1802,7 +1802,7 @@ class DatabaseSelectSubqueryTestCase extends DatabaseTestCase {
    * We essentially select all rows from the {test} table that have matching
    * rows in the {test_people} table based on the shared name column.
    */
-  function testExistsSubquerySelect() {
+  public function testExistsSubquerySelect() {
     // Put George into {test_people}.
     db_insert('test_people')
       ->fields(array(
@@ -1832,7 +1832,7 @@ class DatabaseSelectSubqueryTestCase extends DatabaseTestCase {
    * We essentially select all rows from the {test} table that don't have
    * matching rows in the {test_people} table based on the shared name column.
    */
-  function testNotExistsSubquerySelect() {
+  public function testNotExistsSubquerySelect() {
     // Put George into {test_people}.
     db_insert('test_people')
       ->fields(array(
@@ -1864,7 +1864,7 @@ class DatabaseSelectOrderedTestCase extends DatabaseTestCase {
   /**
    * Test basic order by.
    */
-  function testSimpleSelectOrdered() {
+  public function testSimpleSelectOrdered() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -1885,7 +1885,7 @@ class DatabaseSelectOrderedTestCase extends DatabaseTestCase {
   /**
    * Test multiple order by.
    */
-  function testSimpleSelectMultiOrdered() {
+  public function testSimpleSelectMultiOrdered() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -1916,7 +1916,7 @@ class DatabaseSelectOrderedTestCase extends DatabaseTestCase {
   /**
    * Test order by descending.
    */
-  function testSimpleSelectOrderedDesc() {
+  public function testSimpleSelectOrderedDesc() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -1937,7 +1937,7 @@ class DatabaseSelectOrderedTestCase extends DatabaseTestCase {
   /**
    * Tests that the sort direction is sanitized properly.
    */
-  function testOrderByEscaping() {
+  public function testOrderByEscaping() {
     $query = db_select('test')->orderBy('name', 'invalid direction');
     $order_bys = $query->getOrderBy();
     $this->assertEqual($order_bys['name'], 'ASC', 'Invalid order by direction is converted to ASC.');
@@ -1951,7 +1951,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test simple JOIN statements.
    */
-  function testDefaultJoin() {
+  public function testDefaultJoin() {
     $query = db_select('test_task', 't');
     $people_alias = $query->join('test', 'p', 't.pid = p.id');
     $name_field = $query->addField($people_alias, 'name', 'name');
@@ -1976,7 +1976,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test LEFT OUTER joins.
    */
-  function testLeftOuterJoin() {
+  public function testLeftOuterJoin() {
     $query = db_select('test', 'p');
     $people_alias = $query->leftJoin('test_task', 't', 't.pid = p.id');
     $name_field = $query->addField('p', 'name', 'name');
@@ -2001,7 +2001,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test GROUP BY clauses.
    */
-  function testGroupBy() {
+  public function testGroupBy() {
     $query = db_select('test_task', 't');
     $count_field = $query->addExpression('COUNT(task)', 'num');
     $task_field = $query->addField('t', 'task');
@@ -2037,7 +2037,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test GROUP BY and HAVING clauses together.
    */
-  function testGroupByAndHaving() {
+  public function testGroupByAndHaving() {
     $query = db_select('test_task', 't');
     $count_field = $query->addExpression('COUNT(task)', 'num');
     $task_field = $query->addField('t', 'task');
@@ -2071,7 +2071,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test range queries. The SQL clause varies with the database.
    */
-  function testRange() {
+  public function testRange() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -2089,7 +2089,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test distinct queries.
    */
-  function testDistinct() {
+  public function testDistinct() {
     $query = db_select('test_task');
     $task_field = $query->addField('test_task', 'task');
     $query->distinct();
@@ -2106,7 +2106,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test that we can generate a count query from a built query.
    */
-  function testCountQuery() {
+  public function testCountQuery() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -2123,7 +2123,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
     $this->assertEqual($record->$age_field, 27, 'Correct data retrieved.');
   }
 
-  function testHavingCountQuery() {
+  public function testHavingCountQuery() {
     $query = db_select('test')
       ->extend('PagerDefault')
       ->groupBy('age')
@@ -2138,7 +2138,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
    * Test that countQuery properly removes 'all_fields' statements and
    * ordering clauses.
    */
-  function testCountQueryRemovals() {
+  public function testCountQueryRemovals() {
     $query = db_select('test');
     $query->fields('test');
     $query->orderBy('name');
@@ -2166,7 +2166,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test that countQuery properly removes fields and expressions.
    */
-  function testCountQueryFieldRemovals() {
+  public function testCountQueryFieldRemovals() {
     // countQuery should remove all fields and expressions, so this can be
     // tested by adding a non-existent field and expression: if it ends
     // up in the query, an error will be thrown. If not, it will return the
@@ -2184,7 +2184,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test that we can generate a count query from a query with distinct.
    */
-  function testCountQueryDistinct() {
+  public function testCountQueryDistinct() {
     $query = db_select('test_task');
     $task_field = $query->addField('test_task', 'task');
     $query->distinct();
@@ -2197,7 +2197,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Test that we can generate a count query from a query with GROUP BY.
    */
-  function testCountQueryGroupBy() {
+  public function testCountQueryGroupBy() {
     $query = db_select('test_task');
     $pid_field = $query->addField('test_task', 'pid');
     $query->groupBy('pid');
@@ -2222,7 +2222,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Confirm that we can properly nest conditional clauses.
    */
-  function testNestedConditions() {
+  public function testNestedConditions() {
     // This query should translate to:
     // "SELECT job FROM {test} WHERE name = 'Paul' AND (age = 26 OR age = 27)"
     // That should find only one record. Yes it's a non-optimal way of writing
@@ -2239,7 +2239,7 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
   /**
    * Confirm we can join on a single table twice with a dynamic alias.
    */
-  function testJoinTwice() {
+  public function testJoinTwice() {
     $query = db_select('test')->fields('test');
     $alias = $query->join('test', 'test', 'test.job = %alias.job');
     $query->addField($alias, 'name', 'othername');
@@ -2256,14 +2256,14 @@ class DatabaseSelectComplexTestCase extends DatabaseTestCase {
  * Test more complex select statements, part 2.
  */
 class DatabaseSelectComplexTestCase2 extends DatabaseTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node_access_test'));
   }
 
   /**
    * Test that we can join on a query.
    */
-  function testJoinSubquery() {
+  public function testJoinSubquery() {
     $acct = $this->backdropCreateUser();
     $this->backdropLogin($acct);
 
@@ -2304,7 +2304,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
    * Note that we have to make an HTTP request to a test page handler
    * because the pager depends on GET parameters.
    */
-  function testEvenPagerQuery() {
+  public function testEvenPagerQuery() {
     // To keep the test from being too brittle, we determine up front
     // what the page count should be dynamically, and pass the control
     // information forward to the actual query on the other side of the
@@ -2338,7 +2338,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
    * Note that we have to make an HTTP request to a test page handler
    * because the pager depends on GET parameters.
    */
-  function testOddPagerQuery() {
+  public function testOddPagerQuery() {
     // To keep the test from being too brittle, we determine up front
     // what the page count should be dynamically, and pass the control
     // information forward to the actual query on the other side of the
@@ -2371,7 +2371,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
    *
    * This is a regression test for #467984.
    */
-  function testInnerPagerQuery() {
+  public function testInnerPagerQuery() {
     $query = db_select('test', 't')->extend('PagerDefault');
     $query
       ->fields('t', array('age'))
@@ -2392,7 +2392,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
    *
    * This is a regression test for #467984.
    */
-  function testHavingPagerQuery() {
+  public function testHavingPagerQuery() {
     $query = db_select('test', 't')->extend('PagerDefault');
     $query
       ->fields('t', array('name'))
@@ -2410,7 +2410,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
   /**
    * Confirm that every pager gets a valid non-overlapping element ID.
    */
-  function testElementNumbers() {
+  public function testElementNumbers() {
     $_GET['page'] = '3, 2, 1, 0';
 
     $query = db_select('test', 't')->extend('PagerDefault');
@@ -2453,7 +2453,7 @@ class DatabaseSelectTableSortDefaultTestCase extends DatabaseTestCase {
    * Note that we have to make an HTTP request to a test page handler
    * because the pager depends on GET parameters.
    */
-  function testTableSortQuery() {
+  public function testTableSortQuery() {
     $sorts = array(
       array('field' => t('Task ID'), 'sort' => 'desc', 'first' => 'perform at superbowl', 'last' => 'eat'),
       array('field' => t('Task ID'), 'sort' => 'asc', 'first' => 'eat', 'last' => 'perform at superbowl'),
@@ -2479,7 +2479,7 @@ class DatabaseSelectTableSortDefaultTestCase extends DatabaseTestCase {
    * Confirm that if a tablesort's orderByHeader is called before another orderBy, that the header happens first.
    *
    */
-  function testTableSortQueryFirst() {
+  public function testTableSortQueryFirst() {
     $sorts = array(
       array('field' => t('Task ID'), 'sort' => 'desc', 'first' => 'perform at superbowl', 'last' => 'eat'),
       array('field' => t('Task ID'), 'sort' => 'asc', 'first' => 'eat', 'last' => 'perform at superbowl'),
@@ -2504,7 +2504,7 @@ class DatabaseSelectTableSortDefaultTestCase extends DatabaseTestCase {
   /**
    * Confirm that if a sort is not set in a tableselect form there is no error thrown when using the default.
    */
-  function testTableSortDefaultSort() {
+  public function testTableSortDefaultSort() {
     $this->backdropGet('database_test/tablesort_default_sort');
     // Any PHP errors or notices thrown would trigger a simpletest exception, so
     // no additional assertions are needed.
@@ -2521,7 +2521,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
   /**
    * Confirm that a query has a "tag" added to it.
    */
-  function testHasTag() {
+  public function testHasTag() {
     $query = db_select('test');
     $query->addField('test', 'name');
     $query->addField('test', 'age', 'age');
@@ -2535,7 +2535,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
   /**
    * Test query tagging "has all of these tags" functionality.
    */
-  function testHasAllTags() {
+  public function testHasAllTags() {
     $query = db_select('test');
     $query->addField('test', 'name');
     $query->addField('test', 'age', 'age');
@@ -2550,7 +2550,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
   /**
    * Test query tagging "has at least one of these tags" functionality.
    */
-  function testHasAnyTag() {
+  public function testHasAnyTag() {
     $query = db_select('test');
     $query->addField('test', 'name');
     $query->addField('test', 'age', 'age');
@@ -2564,7 +2564,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
   /**
    * Confirm that an extended query has a "tag" added to it.
    */
-  function testExtenderHasTag() {
+  public function testExtenderHasTag() {
     $query = db_select('test')
       ->extend('SelectQueryExtender');
     $query->addField('test', 'name');
@@ -2579,7 +2579,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
   /**
    * Test extended query tagging "has all of these tags" functionality.
    */
-  function testExtenderHasAllTags() {
+  public function testExtenderHasAllTags() {
     $query = db_select('test')
       ->extend('SelectQueryExtender');
     $query->addField('test', 'name');
@@ -2595,7 +2595,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
   /**
    * Test extended query tagging "has at least one of these tags" functionality.
    */
-  function testExtenderHasAnyTag() {
+  public function testExtenderHasAnyTag() {
     $query = db_select('test')
       ->extend('SelectQueryExtender');
     $query->addField('test', 'name');
@@ -2612,7 +2612,7 @@ class DatabaseTaggingTestCase extends DatabaseTestCase {
    *
    * This is how we pass additional context to alter hooks.
    */
-  function testMetaData() {
+  public function testMetaData() {
     $query = db_select('test');
     $query->addField('test', 'name');
     $query->addField('test', 'age', 'age');
@@ -2641,7 +2641,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can do basic alters.
    */
-  function testSimpleAlter() {
+  public function testSimpleAlter() {
     $query = db_select('test');
     $query->addField('test', 'name');
     $query->addField('test', 'age', 'age');
@@ -2660,7 +2660,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can alter the joins on a query.
    */
-  function testAlterWithJoin() {
+  public function testAlterWithJoin() {
     $query = db_select('test_task');
     $tid_field = $query->addField('test_task', 'tid');
     $task_field = $query->addField('test_task', 'task');
@@ -2684,7 +2684,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can alter a query's conditionals.
    */
-  function testAlterChangeConditional() {
+  public function testAlterChangeConditional() {
     $query = db_select('test_task');
     $tid_field = $query->addField('test_task', 'tid');
     $pid_field = $query->addField('test_task', 'pid');
@@ -2709,7 +2709,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can alter the fields of a query.
    */
-  function testAlterChangeFields() {
+  public function testAlterChangeFields() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addField('test', 'age', 'age');
@@ -2724,7 +2724,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can alter expressions in the query.
    */
-  function testAlterExpression() {
+  public function testAlterExpression() {
     $query = db_select('test');
     $name_field = $query->addField('test', 'name');
     $age_field = $query->addExpression("age*2", 'double_age');
@@ -2742,7 +2742,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can remove a range() value from a query. This also tests hook_query_TAG_alter().
    */
-  function testAlterRemoveRange() {
+  public function testAlterRemoveRange() {
     $query = db_select('test');
     $query->addField('test', 'name');
     $query->addField('test', 'age', 'age');
@@ -2757,7 +2757,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
   /**
    * Test that we can do basic alters on subqueries.
    */
-  function testSimpleAlterSubquery() {
+  public function testSimpleAlterSubquery() {
     // Create a sub-query with an alter tag.
     $subquery = db_select('test', 'p');
     $subquery->addField('p', 'name');
@@ -2784,7 +2784,7 @@ class DatabaseAlterTestCase extends DatabaseTestCase {
  * Regression tests.
  */
 class DatabaseRegressionTestCase extends DatabaseTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node'));
   }
 
@@ -2794,7 +2794,7 @@ class DatabaseRegressionTestCase extends DatabaseTestCase {
    * Tries to insert non-ascii UTF-8 data in a database column and checks
    * if its stored properly.
    */
-  function testRegression_310447() {
+  public function testRegression_310447() {
     // That's a 255 character UTF-8 string.
     $name = str_repeat("é", 255);
     db_insert('test')
@@ -2811,7 +2811,7 @@ class DatabaseRegressionTestCase extends DatabaseTestCase {
   /**
    * Test the db_table_exists() function.
    */
-  function testDBTableExists() {
+  public function testDBTableExists() {
     $this->assertIdentical(TRUE, db_table_exists('node'), 'Returns true for existent table.');
     $this->assertIdentical(FALSE, db_table_exists('nosuchtable'), 'Returns false for nonexistent table.');
   }
@@ -2819,7 +2819,7 @@ class DatabaseRegressionTestCase extends DatabaseTestCase {
   /**
    * Test the db_field_exists() function.
    */
-  function testDBFieldExists() {
+  public function testDBFieldExists() {
     $this->assertIdentical(TRUE, db_field_exists('node', 'nid'), 'Returns true for existent column.');
     $this->assertIdentical(FALSE, db_field_exists('node', 'nosuchcolumn'), 'Returns false for nonexistent column.');
   }
@@ -2827,7 +2827,7 @@ class DatabaseRegressionTestCase extends DatabaseTestCase {
   /**
    * Test the db_index_exists() function.
    */
-  function testDBIndexExists() {
+  public function testDBIndexExists() {
     $this->assertIdentical(TRUE, db_index_exists('node', 'node_created'), 'Returns true for existent index.');
     $this->assertIdentical(FALSE, db_index_exists('node', 'nosuchindex'), 'Returns false for nonexistent index.');
   }
@@ -2840,7 +2840,7 @@ class DatabaseLoggingTestCase extends DatabaseTestCase {
   /**
    * Test that we can log the existence of a query.
    */
-  function testEnableLogging() {
+  public function testEnableLogging() {
     $log = Database::startLog('testing');
 
     db_query('SELECT name FROM {test} WHERE age > :age', array(':age' => 25))->fetchCol();
@@ -2861,7 +2861,7 @@ class DatabaseLoggingTestCase extends DatabaseTestCase {
   /**
    * Test that we can run two logs in parallel.
    */
-  function testEnableMultiLogging() {
+  public function testEnableMultiLogging() {
     Database::startLog('testing1');
 
     db_query('SELECT name FROM {test} WHERE age > :age', array(':age' => 25))->fetchCol();
@@ -2880,7 +2880,7 @@ class DatabaseLoggingTestCase extends DatabaseTestCase {
   /**
    * Test that we can log queries against multiple targets on the same connection.
    */
-  function testEnableTargetLogging() {
+  public function testEnableTargetLogging() {
     // Clone the primary credentials to a replica connection and to another fake
     // connection.
     $connection_info = Database::getConnectionInfo('default');
@@ -2906,7 +2906,7 @@ class DatabaseLoggingTestCase extends DatabaseTestCase {
    * a fake target so the query should fall back to running on the default
    * target.
    */
-  function testEnableTargetLoggingNoTarget() {
+  public function testEnableTargetLoggingNoTarget() {
     Database::startLog('testing1');
 
     db_query('SELECT name FROM {test} WHERE age > :age', array(':age' => 25))->fetchCol();
@@ -2928,7 +2928,7 @@ class DatabaseLoggingTestCase extends DatabaseTestCase {
   /**
    * Test that we can log queries separately on different connections.
    */
-  function testEnableMultiConnectionLogging() {
+  public function testEnableMultiConnectionLogging() {
     // Clone the primary credentials to a fake connection.
     // That both connections point to the same physical database is irrelevant.
     $connection_info = Database::getConnectionInfo('default');
@@ -2960,7 +2960,7 @@ class DatabaseSerializeQueryTestCase extends DatabaseTestCase {
   /**
    * Confirm that a query can be serialized and unserialized.
    */
-  function testSerializeQuery() {
+  public function testSerializeQuery() {
     $query = db_select('test');
     $query->addField('test', 'age');
     $query->condition('name', 'Ringo');
@@ -2976,14 +2976,14 @@ class DatabaseSerializeQueryTestCase extends DatabaseTestCase {
  * Range query tests.
  */
 class DatabaseRangeQueryTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('database_test');
   }
 
   /**
    * Confirm that range query work and return correct result.
    */
-  function testRangeQuery() {
+  public function testRangeQuery() {
     // Test if return correct number of rows.
     $range_rows = db_query_range("SELECT name FROM {system} ORDER BY name", 2, 3)->fetchAll();
     $this->assertEqual(count($range_rows), 3, 'Range query work and return correct number of rows.');
@@ -2999,21 +2999,21 @@ class DatabaseRangeQueryTestCase extends BackdropWebTestCase {
  * Temporary query tests.
  */
 class DatabaseTemporaryQueryTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('database_test');
   }
 
   /**
    * Return the number of rows of a table.
    */
-  function countTableRows($table_name) {
+  protected function countTableRows($table_name) {
     return db_select($table_name)->countQuery()->execute()->fetchField();
   }
 
   /**
    * Confirm that temporary tables work and are limited to one request.
    */
-  function testTemporaryQuery() {
+  public function testTemporaryQuery() {
     $this->backdropGet('database_test/db_query_temporary');
     $data = json_decode($this->backdropGetContent());
     if ($data) {
@@ -3053,7 +3053,7 @@ class DatabaseBasicSyntaxTestCase extends DatabaseTestCase {
   /**
    * Test for string concatenation.
    */
-  function testBasicConcat() {
+  public function testBasicConcat() {
     $result = db_query('SELECT CONCAT(:a1, CONCAT(:a2, CONCAT(:a3, CONCAT(:a4, :a5))))', array(
       ':a1' => 'This',
       ':a2' => ' ',
@@ -3067,7 +3067,7 @@ class DatabaseBasicSyntaxTestCase extends DatabaseTestCase {
   /**
    * Test for string concatenation with field values.
    */
-  function testFieldConcat() {
+  public function testFieldConcat() {
     $result = db_query('SELECT CONCAT(:a1, CONCAT(name, CONCAT(:a2, CONCAT(age, :a3)))) FROM {test} WHERE age = :age', array(
       ':a1' => 'The age of ',
       ':a2' => ' is ',
@@ -3080,7 +3080,7 @@ class DatabaseBasicSyntaxTestCase extends DatabaseTestCase {
   /**
    * Test escaping of LIKE wildcards.
    */
-  function testLikeEscape() {
+  public function testLikeEscape() {
     db_insert('test')
       ->fields(array(
         'name' => 'Ring_',
@@ -3106,7 +3106,7 @@ class DatabaseBasicSyntaxTestCase extends DatabaseTestCase {
   /**
    * Test LIKE query containing a backslash.
    */
-  function testLikeBackslash() {
+  public function testLikeBackslash() {
     db_insert('test')
       ->fields(array('name'))
       ->values(array(
@@ -3142,7 +3142,7 @@ class DatabaseCaseSensitivityTestCase extends DatabaseTestCase {
   /**
    * Test BINARY collation in MySQL.
    */
-  function testCaseSensitiveInsert() {
+  public function testCaseSensitiveInsert() {
     $num_records_before = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $john = db_insert('test')
@@ -3167,7 +3167,7 @@ class DatabaseInvalidDataTestCase extends DatabaseTestCase {
   /**
    * Traditional SQL database systems abort inserts when invalid data is encountered.
    */
-  function testInsertDuplicateData() {
+  public function testInsertDuplicateData() {
     // Try to insert multiple records where at least one has bad data.
     try {
       db_insert('test')
@@ -3228,7 +3228,7 @@ class DatabaseQueryTestCase extends DatabaseTestCase {
   /**
    * Test that we can specify an array of values in the query by passing in an array.
    */
-  function testArraySubstitution() {
+  public function testArraySubstitution() {
     $names = db_query('SELECT name FROM {test} WHERE age IN (:ages) ORDER BY age', array(':ages' => array(25, 26, 27)))->fetchAll();
 
     $this->assertEqual(count($names), 3, 'Correct number of names returned');
@@ -3397,7 +3397,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
    *
    * If the active connection does not support transactions, this test does nothing.
    */
-  function testTransactionRollBackSupported() {
+  public function testTransactionRollBackSupported() {
     // This test won't work right if transactions are not supported.
     if (!Database::getConnection()->supportsTransactions()) {
       return;
@@ -3423,7 +3423,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
    *
    * If the active driver supports transactions, this test does nothing.
    */
-  function testTransactionRollBackNotSupported() {
+  public function testTransactionRollBackNotSupported() {
     // This test won't work right if transactions are supported.
     if (Database::getConnection()->supportsTransactions()) {
       return;
@@ -3450,7 +3450,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
    * The behavior of this test should be identical for connections that support
    * transactions and those that do not.
    */
-  function testCommittedTransaction() {
+  public function testCommittedTransaction() {
     try {
       // Create two nested transactions. The changes should be committed.
       $this->transactionOuterLayer('A');
@@ -3469,7 +3469,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
   /**
    * Test the compatibility of transactions with DDL statements.
    */
-  function testTransactionWithDdlStatement() {
+  public function testTransactionWithDdlStatement() {
     // First, test that a commit works normally, even with DDL statements.
     $transaction = db_transaction();
     $this->insertRow('row');
@@ -3617,7 +3617,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
    * @param $message
    *   The message to log for the assertion.
    */
-  function assertRowPresent($name, $message = NULL) {
+  protected function assertRowPresent($name, $message = NULL) {
     if (!isset($message)) {
       $message = format_string('Row %name is present.', array('%name' => $name));
     }
@@ -3633,7 +3633,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
    * @param $message
    *   The message to log for the assertion.
    */
-  function assertRowAbsent($name, $message = NULL) {
+  protected function assertRowAbsent($name, $message = NULL) {
     if (!isset($message)) {
       $message = format_string('Row %name is absent.', array('%name' => $name));
     }
@@ -3644,7 +3644,7 @@ class DatabaseTransactionTestCase extends DatabaseTestCase {
   /**
    * Test transaction stacking and commit / rollback.
    */
-  function testTransactionStacking() {
+  public function testTransactionStacking() {
     // This test won't work right if transactions are not supported.
     if (!Database::getConnection()->supportsTransactions()) {
       return;
@@ -3855,7 +3855,7 @@ class DatabaseNextIdCase extends BackdropWebTestCase {
   /**
    * Test that the sequences API work.
    */
-  function testDbNextId() {
+  public function testDbNextId() {
     $first = db_next_id();
     $second = db_next_id();
     // We can test for exact increase in here because we know there is no
@@ -3874,7 +3874,7 @@ class DatabaseEmptyStatementTestCase extends BackdropWebTestCase {
   /**
    * Test that the empty result set behaves as empty.
    */
-  function testEmpty() {
+  public function testEmpty() {
     $result = new DatabaseStatementEmpty();
 
     $this->assertTrue($result instanceof DatabaseStatementInterface, 'Class implements expected interface');
@@ -3884,7 +3884,7 @@ class DatabaseEmptyStatementTestCase extends BackdropWebTestCase {
   /**
    * Test that the empty result set iterates safely.
    */
-  function testEmptyIteration() {
+  public function testEmptyIteration() {
     $result = new DatabaseStatementEmpty();
 
     foreach ($result as $record) {
@@ -3898,7 +3898,7 @@ class DatabaseEmptyStatementTestCase extends BackdropWebTestCase {
   /**
    * Test that the empty result set mass-fetches in an expected way.
    */
-  function testEmptyFetchAll() {
+  public function testEmptyFetchAll() {
     $result = new DatabaseStatementEmpty();
 
     $this->assertEqual($result->fetchAll(), array(), 'Empty array returned from empty result set.');
@@ -3926,7 +3926,7 @@ class ConnectionUnitTest extends BackdropUnitTestCase {
    */
   protected $skipTest;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->key = 'default';
@@ -4005,7 +4005,7 @@ class ConnectionUnitTest extends BackdropUnitTestCase {
    *
    * @todo getConnectionID() executes a query.
    */
-  function testOpenClose() {
+  public function testOpenClose() {
     if ($this->skipTest) {
       return;
     }
@@ -4029,7 +4029,7 @@ class ConnectionUnitTest extends BackdropUnitTestCase {
   /**
    * Tests Database::closeConnection() with a query.
    */
-  function testOpenQueryClose() {
+  public function testOpenQueryClose() {
     if ($this->skipTest) {
       return;
     }
@@ -4056,7 +4056,7 @@ class ConnectionUnitTest extends BackdropUnitTestCase {
   /**
    * Tests Database::closeConnection() with a query and custom prefetch method.
    */
-  function testOpenQueryPrefetchClose() {
+  public function testOpenQueryPrefetchClose() {
     if ($this->skipTest) {
       return;
     }
@@ -4083,7 +4083,7 @@ class ConnectionUnitTest extends BackdropUnitTestCase {
   /**
    * Tests Database::closeConnection() with a select query.
    */
-  function testOpenSelectQueryClose() {
+  public function testOpenSelectQueryClose() {
     if ($this->skipTest) {
       return;
     }

--- a/core/modules/simpletest/tests/error.test
+++ b/core/modules/simpletest/tests/error.test
@@ -4,14 +4,14 @@
  * Tests Backdrop error and exception handlers.
  */
 class BackdropErrorHandlerUnitTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('error_test');
   }
 
   /**
    * Test the error handler.
    */
-  function testErrorHandler() {
+  public function testErrorHandler() {
     $config = config('system.core');
     $error_notice = array(
       '%type' => 'Notice',
@@ -60,7 +60,7 @@ class BackdropErrorHandlerUnitTest extends BackdropWebTestCase {
   /**
    * Test the exception handler.
    */
-  function testExceptionHandler() {
+  public function testExceptionHandler() {
     $config = config('system.core');
     $error_exception = array(
       '%type' => 'Exception',
@@ -97,7 +97,7 @@ class BackdropErrorHandlerUnitTest extends BackdropWebTestCase {
   /**
    * Helper function: assert that the error message is found.
    */
-  function assertErrorMessage(array $error) {
+  protected function assertErrorMessage(array $error) {
     $message = t('%type: !message in %function (line ', $error);
     $this->assertRaw($message, format_string('Found error message: !message.', array('!message' => $message)));
   }
@@ -105,7 +105,7 @@ class BackdropErrorHandlerUnitTest extends BackdropWebTestCase {
   /**
    * Helper function: assert that the error message is not found.
    */
-  function assertNoErrorMessage(array $error) {
+  protected function assertNoErrorMessage(array $error) {
     $message = t('%type: !message in %function (line ', $error);
     $this->assertNoRaw($message, format_string('Did not find error message: !message.', array('!message' => $message)));
   }

--- a/core/modules/simpletest/tests/file.test
+++ b/core/modules/simpletest/tests/file.test
@@ -57,7 +57,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @param $after
    *   File object to compare.
    */
-  function assertFileUnchanged($before, $after) {
+  protected function assertFileUnchanged($before, $after) {
     $this->assertEqual($before->fid, $after->fid, format_string('File id is the same: %file1 == %file2.', array('%file1' => $before->fid, '%file2' => $after->fid)), 'File unchanged');
     $this->assertEqual($before->uid, $after->uid, format_string('File owner is the same: %file1 == %file2.', array('%file1' => $before->uid, '%file2' => $after->uid)), 'File unchanged');
     $this->assertEqual($before->filename, $after->filename, format_string('File name is the same: %file1 == %file2.', array('%file1' => $before->filename, '%file2' => $after->filename)), 'File unchanged');
@@ -75,7 +75,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @param $file2
    *   File object to compare.
    */
-  function assertDifferentFile($file1, $file2) {
+  protected function assertDifferentFile($file1, $file2) {
     $this->assertNotEqual($file1->fid, $file2->fid, format_string('Files have different ids: %file1 != %file2.', array('%file1' => $file1->fid, '%file2' => $file2->fid)), 'Different file');
     $this->assertNotEqual($file1->uri, $file2->uri, format_string('Files have different paths: %file1 != %file2.', array('%file1' => $file1->uri, '%file2' => $file2->uri)), 'Different file');
   }
@@ -88,7 +88,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @param $file2
    *   File object to compare.
    */
-  function assertSameFile($file1, $file2) {
+  protected function assertSameFile($file1, $file2) {
     $this->assertEqual($file1->fid, $file2->fid, format_string('Files have the same ids: %file1 == %file2.', array('%file1' => $file1->fid, '%file2-fid' => $file2->fid)), 'Same file');
     $this->assertEqual($file1->uri, $file2->uri, format_string('Files have the same path: %file1 == %file2.', array('%file1' => $file1->uri, '%file2' => $file2->uri)), 'Same file');
   }
@@ -103,7 +103,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @param $message
    *   Optional message.
    */
-  function assertFilePermissions($filepath, $expected_mode, $message = NULL) {
+  protected function assertFilePermissions($filepath, $expected_mode, $message = NULL) {
     // Clear out PHP's file stat cache to be sure we see the current value.
     clearstatcache();
 
@@ -138,7 +138,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @param $message
    *   Optional message.
    */
-  function assertDirectoryPermissions($directory, $expected_mode, $message = NULL) {
+  protected function assertDirectoryPermissions($directory, $expected_mode, $message = NULL) {
     // Clear out PHP's file stat cache to be sure we see the current value.
     clearstatcache();
 
@@ -172,7 +172,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @return
    *   The path to the directory.
    */
-  function createDirectory($path = NULL) {
+  protected function createDirectory($path = NULL) {
     // A directory to operate on.
     if (!isset($path)) {
       $path = file_default_scheme() . '://' . $this->randomName();
@@ -198,7 +198,7 @@ class FileTestCase extends BackdropWebTestCase {
    * @return File
    *   File object.
    */
-  function createFile($filepath = NULL, $contents = NULL, $scheme = NULL) {
+  protected function createFile($filepath = NULL, $contents = NULL, $scheme = NULL) {
     if (!isset($filepath)) {
       // Prefix with non-latin characters to ensure that all file-related
       // tests work with international filenames.
@@ -238,7 +238,7 @@ class FileTestCase extends BackdropWebTestCase {
  * hooks.
  */
 class FileHookTestCase extends FileTestCase {
-  function setUp() {
+  public function setUp() {
     // Install file_test module
     parent::setUp('file_test');
     // Clear out any hook calls.
@@ -253,7 +253,7 @@ class FileHookTestCase extends FileTestCase {
    *   Array with string containing with the hook name, e.g. 'load', 'save',
    *   'insert', etc.
    */
-  function assertFileHooksCalled($expected) {
+  protected function assertFileHooksCalled($expected) {
     // Determine which hooks were called.
     $actual = array_keys(array_filter(file_test_get_all_calls()));
 
@@ -286,7 +286,7 @@ class FileHookTestCase extends FileTestCase {
    * @param $message
    *   Optional translated string message.
    */
-  function assertFileHookCalled($hook, $expected_count = 1, $message = NULL) {
+  protected function assertFileHookCalled($hook, $expected_count = 1, $message = NULL) {
     $actual_count = count(file_test_get_calls($hook));
 
     if (!isset($message)) {
@@ -309,7 +309,7 @@ class FileHookTestCase extends FileTestCase {
  *  This will run tests against the file_space_used() function.
  */
 class FileSpaceUsedTest extends FileTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create records for a couple of users with different sizes.
@@ -332,7 +332,7 @@ class FileSpaceUsedTest extends FileTestCase {
   /**
    * Test different users with the default status.
    */
-  function testFileSpaceUsed() {
+  public function testFileSpaceUsed() {
     // Test different users with default status.
     $this->assertEqual(file_space_used(2), 70);
     $this->assertEqual(file_space_used(3), 300);
@@ -361,7 +361,7 @@ class FileValidatorTest extends BackdropWebTestCase {
   protected $non_image;
   protected $file;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('file'));
 
     $this->image = new File(array());
@@ -376,7 +376,7 @@ class FileValidatorTest extends BackdropWebTestCase {
   /**
    * Test the file_validate_extensions() function.
    */
-  function testFileValidateExtensions() {
+  public function testFileValidateExtensions() {
     $file = new File(array('filename' => 'asdf.txt'));
     $errors = file_validate_extensions($file, 'asdf txt pork');
     $this->assertEqual(count($errors), 0, 'Valid extension accepted.', 'File');
@@ -389,7 +389,7 @@ class FileValidatorTest extends BackdropWebTestCase {
   /**
    *  This ensures a specific file is actually an image.
    */
-  function testFileValidateIsImage() {
+  public function testFileValidateIsImage() {
     $this->assertTrue(file_exists($this->image->uri), 'The image being tested exists.', 'File');
     $errors = file_validate_is_image($this->image);
     $this->assertEqual(count($errors), 0, 'No error reported for our image file.', 'File');
@@ -403,7 +403,7 @@ class FileValidatorTest extends BackdropWebTestCase {
    *  This ensures the resolution of a specific file is within bounds.
    *  The image will be resized if it's too large.
    */
-  function testFileValidateImageResolution() {
+  public function testFileValidateImageResolution() {
     // Non-images.
     $errors = file_validate_image_resolution($this->non_image);
     $this->assertEqual(count($errors), 0, "Shouldn't get any errors for a non-image file.", 'File');
@@ -445,7 +445,7 @@ class FileValidatorTest extends BackdropWebTestCase {
   /**
    *  This will ensure the filename length is valid.
    */
-  function testFileValidateNameLength() {
+  public function testFileValidateNameLength() {
     // Create a new file entity.
     $file = new File();
 
@@ -470,7 +470,7 @@ class FileValidatorTest extends BackdropWebTestCase {
   /**
    * Test file_validate_size().
    */
-  function testFileValidateSize() {
+  public function testFileValidateSize() {
     // Create a file with a size of 1000 bytes, and quotas of only 1 byte.
     $file = new File(array('filesize' => 1000));
     $errors = file_validate_size($file, 0, 0);
@@ -493,7 +493,7 @@ class FileUnmanagedSaveDataTest extends FileTestCase {
   /**
    * Test the file_unmanaged_save_data() function.
    */
-  function testFileSaveData() {
+  public function testFileSaveData() {
     $contents = $this->randomName(8);
 
     // No filename.
@@ -515,7 +515,7 @@ class FileUnmanagedSaveDataTest extends FileTestCase {
  *  Tests the file_unmanaged_save_data() function on remote filesystems.
  */
 class RemoteFileUnmanagedSaveDataTest extends FileUnmanagedSaveDataTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -541,7 +541,7 @@ class FileSaveUploadTest extends FileHookTestCase {
    */
   protected $maxFidBefore;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $image_files = $this->backdropGetTestFiles('image');
@@ -573,7 +573,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test the file_save_upload() function.
    */
-  function testNormal() {
+  public function testNormal() {
     $max_fid_after = db_query('SELECT MAX(fid) AS fid FROM {file_managed}')->fetchField();
     $this->assertTrue($max_fid_after > $this->maxFidBefore, 'A new file was created.');
     $file1 = file_load($max_fid_after);
@@ -625,7 +625,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test extension handling.
    */
-  function testHandleExtension() {
+  public function testHandleExtension() {
     // The file being tested is a .gif which is in the default safe list
     // of extensions to allow when the extension validator isn't used. This is
     // implicitly tested at the testNormal() test. Here we tell
@@ -707,7 +707,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test dangerous file handling.
    */
-  function testHandleDangerousFile() {
+  public function testHandleDangerousFile() {
     // Allow the .php extension and make sure it gets munged and given a .txt
     // extension for safety. Also check to make sure its MIME type was changed.
     $edit = array(
@@ -784,7 +784,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test file munge handling.
    */
-  function testHandleFileMunge() {
+  public function testHandleFileMunge() {
     $original_image_uri = $this->image->uri;
     $this->image = file_move($this->image, $this->image->uri . '.foo.' . $this->image_extension);
 
@@ -938,7 +938,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test renaming when uploading over a file that already exists.
    */
-  function testExistingRename() {
+  public function testExistingRename() {
     $edit = array(
       'file_test_replace' => FILE_EXISTS_RENAME,
       'files[file_test_upload]' => backdrop_realpath($this->image->uri)
@@ -954,7 +954,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test replacement when uploading over a file that already exists.
    */
-  function testExistingReplace() {
+  public function testExistingReplace() {
     $edit = array(
       'file_test_replace' => FILE_EXISTS_REPLACE,
       'files[file_test_upload]' => backdrop_realpath($this->image->uri)
@@ -970,7 +970,7 @@ class FileSaveUploadTest extends FileHookTestCase {
   /**
    * Test for failure when uploading over a file that already exists.
    */
-  function testErrors() {
+  public function testErrors() {
     $edit = array(
       'file_test_replace' => FILE_EXISTS_ERROR,
       'files[file_test_upload]' => backdrop_realpath($this->image->uri)
@@ -995,7 +995,7 @@ class FileSaveUploadTest extends FileHookTestCase {
  * Test the file_save_upload() function on remote filesystems.
  */
 class RemoteFileSaveUploadTest extends FileSaveUploadTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1005,14 +1005,14 @@ class RemoteFileSaveUploadTest extends FileSaveUploadTest {
  * Tests transliterating files on upload and subsequent bulk updating.
  */
 class FileUploadTransliterationTest extends FileTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('file_test'));
 
     $admin_user = $this->backdropCreateUser(array('administer site configuration'));
     $this->backdropLogin($admin_user);
   }
 
-  function testTransliteration() {
+  public function testTransliteration() {
     // Make a particularly troublesome file name, starting with an umlaut and
     // containing upper-case variant characters.
     // cspell:disable-next-line.
@@ -1124,7 +1124,7 @@ class FileDirectoryTest extends FileTestCase {
   /**
    * Test directory handling functions.
    */
-  function testFileCheckDirectoryHandling() {
+  public function testFileCheckDirectoryHandling() {
     // A directory to operate on.
     $directory = file_default_scheme() . '://' . $this->randomName() . '/' . $this->randomName();
     $this->assertFalse(is_dir($directory), 'Directory does not exist prior to testing.');
@@ -1169,7 +1169,7 @@ class FileDirectoryTest extends FileTestCase {
    * This will take a directory and path, and find a valid filepath that is not
    * taken by another file.
    */
-  function testFileCreateNewFilepath() {
+  public function testFileCreateNewFilepath() {
     // First we test against an imaginary file that does not exist in a
     // directory.
     $basename = 'xyz.txt';
@@ -1209,7 +1209,7 @@ class FileDirectoryTest extends FileTestCase {
    *
    * If the file doesn't currently exist, then it will return the filepath.
    */
-  function testFileDestination() {
+  public function testFileDestination() {
     // First test for non-existent file.
     $destination = 'core/misc/xyz.txt';
     $path = file_destination($destination, FILE_EXISTS_REPLACE);
@@ -1239,7 +1239,7 @@ class FileDirectoryTest extends FileTestCase {
   /**
    * Ensure that the file_directory_temp() function always returns a value.
    */
-  function testFileDirectoryTemp() {
+  public function testFileDirectoryTemp() {
     // Start with an empty config to ensure we have a clean slate.
     config_set('system.core', 'file_temporary_path', '');
     $tmp_directory = file_directory_temp();
@@ -1257,7 +1257,7 @@ class FileDirectoryTest extends FileTestCase {
  * Directory related tests.
  */
 class RemoteFileDirectoryTest extends FileDirectoryTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1269,7 +1269,7 @@ class RemoteFileDirectoryTest extends FileDirectoryTest {
 class FileScanDirectoryTest extends FileTestCase {
   protected $path;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->path = backdrop_get_path('module', 'simpletest') . '/files';
   }
@@ -1277,7 +1277,7 @@ class FileScanDirectoryTest extends FileTestCase {
   /**
    * Check the format of the returned values.
    */
-  function testReturn() {
+  public function testReturn() {
     // Grab a listing of all the JavaScript files and check that they're
     // passed to the callback.
     $all_files = file_scan_directory($this->path, '/^javascript-/');
@@ -1302,7 +1302,7 @@ class FileScanDirectoryTest extends FileTestCase {
   /**
    * Check that the callback function is called correctly.
    */
-  function testOptionCallback() {
+  public function testOptionCallback() {
     // When nothing is matched nothing should be passed to the callback.
     $all_files = file_scan_directory($this->path, '/^NONEXISTINGFILENAME/', array('callback' => 'file_test_file_scan_callback'));
     $this->assertEqual(0, count($all_files), 'No files were found.');
@@ -1322,7 +1322,7 @@ class FileScanDirectoryTest extends FileTestCase {
   /**
    * Check that the no-mask parameter is honored.
    */
-  function testOptionNoMask() {
+  public function testOptionNoMask() {
     // Grab a listing of all the JavaScript files.
     $all_files = file_scan_directory($this->path, '/^javascript-/', array('recurse' => FALSE));
     $this->assertEqual(2, count($all_files), 'Found two, expected javascript files.');
@@ -1342,7 +1342,7 @@ class FileScanDirectoryTest extends FileTestCase {
   /**
    * Check that key parameter sets the return value's key.
    */
-  function testOptionKey() {
+  public function testOptionKey() {
     // "filename", for the path starting with $dir.
     $expected = array($this->path . '/javascript-1.txt', $this->path . '/javascript-2.script');
     $actual = array_keys(file_scan_directory($this->path, '/^javascript-/', array('key' => 'filepath')));
@@ -1371,7 +1371,7 @@ class FileScanDirectoryTest extends FileTestCase {
   /**
    * Check that the recurse option descends into subdirectories.
    */
-  function testOptionRecurse() {
+  public function testOptionRecurse() {
     $files = file_scan_directory(backdrop_get_path('module', 'simpletest'), '/^javascript-/', array('recurse' => FALSE));
     $this->assertTrue(empty($files), "Without recursion couldn't find javascript files.");
 
@@ -1384,7 +1384,7 @@ class FileScanDirectoryTest extends FileTestCase {
    * Check that the min_depth options lets us ignore files in the starting
    * directory.
    */
-  function testOptionMinDepth() {
+  public function testOptionMinDepth() {
     $files = file_scan_directory($this->path, '/^javascript-/', array('min_depth' => 0));
     $this->assertEqual(2, count($files), 'No minimum-depth gets files in current directory.');
 
@@ -1397,7 +1397,7 @@ class FileScanDirectoryTest extends FileTestCase {
  * Tests the file_scan_directory() function on remote filesystems.
  */
 class RemoteFileScanDirectoryTest extends FileScanDirectoryTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1413,7 +1413,7 @@ class FileUnmanagedDeleteTest extends FileTestCase {
   /**
    * Delete a normal file.
    */
-  function testNormal() {
+  public function testNormal() {
     // Create a file for testing
     $file = $this->createFile();
 
@@ -1425,7 +1425,7 @@ class FileUnmanagedDeleteTest extends FileTestCase {
   /**
    * Try deleting a missing file.
    */
-  function testMissing() {
+  public function testMissing() {
     // Try to delete a non-existing file
     $this->assertTrue(file_unmanaged_delete(file_default_scheme() . '/' . $this->randomName()), 'Returns true when deleting a non-existent file.');
   }
@@ -1433,7 +1433,7 @@ class FileUnmanagedDeleteTest extends FileTestCase {
   /**
    * Try deleting a directory.
    */
-  function testDirectory() {
+  public function testDirectory() {
     // A directory to operate on.
     $directory = $this->createDirectory();
 
@@ -1447,7 +1447,7 @@ class FileUnmanagedDeleteTest extends FileTestCase {
  * Deletion related tests on remote filesystems.
  */
 class RemoteFileUnmanagedDeleteTest extends FileUnmanagedDeleteTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1463,7 +1463,7 @@ class FileUnmanagedDeleteRecursiveTest extends FileTestCase {
   /**
    * Delete a normal file.
    */
-  function testSingleFile() {
+  public function testSingleFile() {
     // Create a file for testing
     $filepath = file_default_scheme() . '://' . $this->randomName();
     file_put_contents($filepath, '');
@@ -1476,7 +1476,7 @@ class FileUnmanagedDeleteRecursiveTest extends FileTestCase {
   /**
    * Try deleting an empty directory.
    */
-  function testEmptyDirectory() {
+  public function testEmptyDirectory() {
     // A directory to operate on.
     $directory = $this->createDirectory();
 
@@ -1488,7 +1488,7 @@ class FileUnmanagedDeleteRecursiveTest extends FileTestCase {
   /**
    * Try deleting a directory with some files.
    */
-  function testDirectory() {
+  public function testDirectory() {
     // A directory to operate on.
     $directory = $this->createDirectory();
     $filepathA = $directory . '/A';
@@ -1506,7 +1506,7 @@ class FileUnmanagedDeleteRecursiveTest extends FileTestCase {
   /**
    * Try deleting subdirectories with some files.
    */
-  function testSubDirectory() {
+  public function testSubDirectory() {
     // A directory to operate on.
     $directory = $this->createDirectory();
     $subdirectory = $this->createDirectory($directory . '/sub');
@@ -1528,7 +1528,7 @@ class FileUnmanagedDeleteRecursiveTest extends FileTestCase {
  * Deletion related tests on remote filesystems.
  */
 class RemoteFileUnmanagedDeleteRecursiveTest extends FileUnmanagedDeleteRecursiveTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1544,7 +1544,7 @@ class FileUnmanagedMoveTest extends FileTestCase {
   /**
    * Move a normal file.
    */
-  function testNormal() {
+  public function testNormal() {
     // Create a file for testing
     $file = $this->createFile();
 
@@ -1575,7 +1575,7 @@ class FileUnmanagedMoveTest extends FileTestCase {
   /**
    * Try to move a missing file.
    */
-  function testMissing() {
+  public function testMissing() {
     // Move non-existent file.
     $new_filepath = file_unmanaged_move($this->randomName(), $this->randomName());
     $this->assertFalse($new_filepath, 'Moving a missing file fails.');
@@ -1584,7 +1584,7 @@ class FileUnmanagedMoveTest extends FileTestCase {
   /**
    * Try to move a file onto itself.
    */
-  function testOverwriteSelf() {
+  public function testOverwriteSelf() {
     // Create a file for testing.
     $file = $this->createFile();
 
@@ -1605,7 +1605,7 @@ class FileUnmanagedMoveTest extends FileTestCase {
  * Unmanaged move related tests on remote filesystems.
  */
 class RemoteFileUnmanagedMoveTest extends FileUnmanagedMoveTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1621,7 +1621,7 @@ class FileUnmanagedCopyTest extends FileTestCase {
   /**
    * Copy a normal file.
    */
-  function testNormal() {
+  public function testNormal() {
     // Create a file for testing
     $file = $this->createFile();
 
@@ -1651,7 +1651,7 @@ class FileUnmanagedCopyTest extends FileTestCase {
   /**
    * Copy a non-existent file.
    */
-  function testNonExistent() {
+  public function testNonExistent() {
     // Copy non-existent file
     $desired_filepath = $this->randomName();
     $this->assertFalse(file_exists($desired_filepath), "Randomly named file doesn't exists.");
@@ -1662,7 +1662,7 @@ class FileUnmanagedCopyTest extends FileTestCase {
   /**
    * Copy a file onto itself.
    */
-  function testOverwriteSelf() {
+  public function testOverwriteSelf() {
     // Create a file for testing
     $file = $this->createFile();
 
@@ -1698,7 +1698,7 @@ class FileUnmanagedCopyTest extends FileTestCase {
  * Unmanaged copy related tests on remote filesystems.
  */
 class RemoteFileUnmanagedCopyTest extends FileUnmanagedCopyTest {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     config_set('system.core', 'file_default_scheme', 'dummy-remote');
   }
@@ -1711,7 +1711,7 @@ class FileDeleteTest extends FileHookTestCase {
   /**
    * Tries deleting a normal file (as opposed to a directory, symlink, etc).
    */
-  function testUnused() {
+  public function testUnused() {
     $file = $this->createFile();
 
     // Check that deletion removes the file and database record.
@@ -1725,7 +1725,7 @@ class FileDeleteTest extends FileHookTestCase {
   /**
    * Tries deleting a file that is in use.
    */
-  function testInUse() {
+  public function testInUse() {
     $file = $this->createFile();
     file_usage_add($file, 'testing', 'test', 1);
     file_usage_add($file, 'testing', 'test', 1);
@@ -1778,7 +1778,7 @@ class FileMoveTest extends FileHookTestCase {
   /**
    * Move a normal file.
    */
-  function testNormal() {
+  public function testNormal() {
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
     $desired_filepath = 'public://' . $this->randomName();
@@ -1808,7 +1808,7 @@ class FileMoveTest extends FileHookTestCase {
   /**
    * Test renaming when moving onto a file that already exists.
    */
-  function testExistingRename() {
+  public function testExistingRename() {
     // Setup a file to overwrite.
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
@@ -1843,7 +1843,7 @@ class FileMoveTest extends FileHookTestCase {
   /**
    * Test replacement when moving onto a file that already exists.
    */
-  function testExistingReplace() {
+  public function testExistingReplace() {
     // Setup a file to overwrite.
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
@@ -1875,7 +1875,7 @@ class FileMoveTest extends FileHookTestCase {
   /**
    * Test replacement when moving onto itself.
    */
-  function testExistingReplaceSelf() {
+  public function testExistingReplaceSelf() {
     // Setup a file to overwrite.
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
@@ -1898,7 +1898,7 @@ class FileMoveTest extends FileHookTestCase {
    * Test that moving onto an existing file fails when FILE_EXISTS_ERROR is
    * specified.
    */
-  function testExistingError() {
+  public function testExistingError() {
     $contents = $this->randomName(10);
     $source = $this->createFile();
     $target = $this->createFile(NULL, $contents);
@@ -1931,7 +1931,7 @@ class FileCopyTest extends FileHookTestCase {
   /**
    * Test file copying in the normal, base case.
    */
-  function testNormal() {
+  public function testNormal() {
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
     $desired_uri = 'public://' . $this->randomName();
@@ -1960,7 +1960,7 @@ class FileCopyTest extends FileHookTestCase {
   /**
    * Test renaming when copying over a file that already exists.
    */
-  function testExistingRename() {
+  public function testExistingRename() {
     // Setup a file to overwrite.
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
@@ -2000,7 +2000,7 @@ class FileCopyTest extends FileHookTestCase {
   /**
    * Test replacement when copying over a file that already exists.
    */
-  function testExistingReplace() {
+  public function testExistingReplace() {
     // Setup a file to overwrite.
     $contents = $this->randomName(10);
     $source = $this->createFile(NULL, $contents);
@@ -2039,7 +2039,7 @@ class FileCopyTest extends FileHookTestCase {
    * Test that copying over an existing file fails when FILE_EXISTS_ERROR is
    * specified.
    */
-  function testExistingError() {
+  public function testExistingError() {
     $contents = $this->randomName(10);
     $source = $this->createFile();
     $target = $this->createFile(NULL, $contents);
@@ -2069,7 +2069,7 @@ class FileLoadTest extends FileHookTestCase {
   /**
    * Try to load a non-existent file by fid.
    */
-  function testLoadMissingFid() {
+  public function testLoadMissingFid() {
     $this->assertFalse(file_load(-1), "Try to load an invalid fid fails.");
     $this->assertFileHooksCalled(array());
   }
@@ -2077,7 +2077,7 @@ class FileLoadTest extends FileHookTestCase {
   /**
    * Try to load a non-existent file by URI.
    */
-  function testLoadMissingFilepath() {
+  public function testLoadMissingFilepath() {
     $files = file_load_multiple(array(), array('uri' => 'foobar://misc/feed.png'));
     $this->assertFalse(reset($files), "Try to load a file that doesn't exist in the database fails.");
     $this->assertFileHooksCalled(array());
@@ -2086,7 +2086,7 @@ class FileLoadTest extends FileHookTestCase {
   /**
    * Try to load a non-existent file by status.
    */
-  function testLoadInvalidStatus() {
+  public function testLoadInvalidStatus() {
     $files = file_load_multiple(array(), array('status' => -99));
     $this->assertFalse(reset($files), "Trying to load a file with an invalid status fails.");
     $this->assertFileHooksCalled(array());
@@ -2095,7 +2095,7 @@ class FileLoadTest extends FileHookTestCase {
   /**
    * Load a single file and ensure that the correct values are returned.
    */
-  function testSingleValues() {
+  public function testSingleValues() {
     // Create a new file entity from scratch so we know the values.
     $file = $this->createFile('backdrop.txt', NULL, 'public');
 
@@ -2113,7 +2113,7 @@ class FileLoadTest extends FileHookTestCase {
   /**
    * This will test loading file data from the database.
    */
-  function testMultiple() {
+  public function testMultiple() {
     // Create a new file entity.
     $file = $this->createFile('backdrop.txt', NULL, 'public');
 
@@ -2145,7 +2145,7 @@ class FileLoadTest extends FileHookTestCase {
  * Tests saving files.
  */
 class FileSaveTest extends FileHookTestCase {
-  function testFileSave() {
+  public function testFileSave() {
     // Create a new file object.
     $file = new File(array(
       'uid' => 1,
@@ -2196,7 +2196,7 @@ class FileUsageTest extends FileTestCase {
   /**
    * Tests file_usage_list().
    */
-  function testGetUsage() {
+  public function testGetUsage() {
     $file = $this->createFile();
     db_insert('file_usage')
       ->fields(array(
@@ -2229,7 +2229,7 @@ class FileUsageTest extends FileTestCase {
   /**
    * Tests file_usage_add().
    */
-  function testAddUsage() {
+  public function testAddUsage() {
     $file = $this->createFile();
     file_usage_add($file, 'testing', 'foo', 1);
     // Add the file twice to ensure that the count is incremented rather than
@@ -2254,7 +2254,7 @@ class FileUsageTest extends FileTestCase {
   /**
    * Tests file_usage_delete().
    */
-  function testRemoveUsage() {
+  public function testRemoveUsage() {
     $file = $this->createFile();
     db_insert('file_usage')
       ->fields(array(
@@ -2302,7 +2302,7 @@ class FileValidateTest extends FileHookTestCase {
   /**
    * Test that the validators passed into are checked.
    */
-  function testCallerValidation() {
+  public function testCallerValidation() {
     $file = $this->createFile();
 
     // Empty validators.
@@ -2352,7 +2352,7 @@ class FileSaveDataTest extends FileHookTestCase {
   /**
    * Test the file_save_data() function when no filename is provided.
    */
-  function testWithoutFilename() {
+  public function testWithoutFilename() {
     $contents = $this->randomName(8);
 
     $result = file_save_data($contents);
@@ -2374,7 +2374,7 @@ class FileSaveDataTest extends FileHookTestCase {
   /**
    * Test the file_save_data() function when a filename is provided.
    */
-  function testWithFilename() {
+  public function testWithFilename() {
     $contents = $this->randomName(8);
 
     // Using filename with non-latin characters.
@@ -2400,7 +2400,7 @@ class FileSaveDataTest extends FileHookTestCase {
   /**
    * Test file_save_data() when renaming around an existing file.
    */
-  function testExistingRename() {
+  public function testExistingRename() {
     // Setup a file to overwrite.
     $existing = $this->createFile();
     $contents = $this->randomName(8);
@@ -2428,7 +2428,7 @@ class FileSaveDataTest extends FileHookTestCase {
   /**
    * Test file_save_data() when replacing an existing file.
    */
-  function testExistingReplace() {
+  public function testExistingReplace() {
     // Setup a file to overwrite.
     $existing = $this->createFile();
     $contents = $this->randomName(8);
@@ -2455,7 +2455,7 @@ class FileSaveDataTest extends FileHookTestCase {
   /**
    * Test that file_save_data() fails overwriting an existing file.
    */
-  function testExistingError() {
+  public function testExistingError() {
     $contents = $this->randomName(8);
     $existing = $this->createFile(NULL, $contents);
 
@@ -2476,7 +2476,7 @@ class FileSaveDataTest extends FileHookTestCase {
  * Tests for download/file transfer functions.
  */
 class FileDownloadTest extends FileTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     // Clear out any hook calls.
     file_test_reset();
@@ -2485,7 +2485,7 @@ class FileDownloadTest extends FileTestCase {
   /**
    * Test the public file transfer system.
    */
-  function testPublicFileTransfer() {
+  public function testPublicFileTransfer() {
     // Test generating an URL to a created file.
     $file = $this->createFile();
     $url = file_create_url($file->uri);
@@ -2508,7 +2508,7 @@ class FileDownloadTest extends FileTestCase {
   /**
    * Test the private file transfer system.
    */
-  function testPrivateFileTransfer() {
+  public function testPrivateFileTransfer() {
     // Set file downloads to private so handler functions get called.
 
     // Create a file.
@@ -2540,7 +2540,7 @@ class FileDownloadTest extends FileTestCase {
   /**
    * Test file_create_url().
    */
-  function testFileCreateUrl() {
+  public function testFileCreateUrl() {
     global $base_url;
 
     // Tilde (~) is excluded from this test because it is encoded by
@@ -2610,14 +2610,14 @@ class FileDownloadTest extends FileTestCase {
  * Tests for file URL rewriting.
  */
 class FileURLRewritingTest extends FileTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
   }
 
   /**
    * Test the generating of rewritten shipped file URLs.
    */
-  function testShippedFileURL()  {
+  public function testShippedFileURL()  {
     // Test generating an URL to a shipped file (i.e. a file that is part of
     // Backdrop core, a module or a theme, for example a JavaScript file).
 
@@ -2652,7 +2652,7 @@ class FileURLRewritingTest extends FileTestCase {
   /**
    * Test the generating of rewritten public created file URLs.
    */
-  function testPublicCreatedFileURL() {
+  public function testPublicCreatedFileURL() {
     // Test generating an URL to a created file.
 
     // Test alteration of file URLs to use a CDN.
@@ -2684,7 +2684,7 @@ class FileNameMungingTest extends FileTestCase {
   protected $name;
   protected $name_with_uc_ext;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->bad_extension = 'foo';
     $this->name = $this->randomName() . '.' . $this->bad_extension . '.txt';
@@ -2694,7 +2694,7 @@ class FileNameMungingTest extends FileTestCase {
   /**
    * Create a file and munge/unmunge the name.
    */
-  function testMunging() {
+  public function testMunging() {
     $munged_name = file_munge_filename($this->name, '', TRUE);
     $messages = backdrop_get_messages();
     $this->assertTrue(in_array(t('For security reasons, your upload has been renamed to %filename.', array('%filename' => $munged_name)), $messages['status']), 'Alert properly set when a file is renamed.');
@@ -2704,7 +2704,7 @@ class FileNameMungingTest extends FileTestCase {
   /**
    * Tests munging with a null byte in the filename.
    */
-  function testMungeNullByte() {
+  public function testMungeNullByte() {
     $prefix = $this->randomName();
     $filename = $prefix . '.' . $this->bad_extension . "\0.txt";
     $this->assertEqual(file_munge_filename($filename, ''), $prefix . '.' . $this->bad_extension . '_.txt', 'A filename with a null byte is correctly munged to remove the null byte.');
@@ -2714,7 +2714,7 @@ class FileNameMungingTest extends FileTestCase {
    * If the allow_insecure_uploads variable evaluates to true, the file should
    * come out untouched, no matter how evil the filename.
    */
-  function testMungeIgnoreInsecure() {
+  public function testMungeIgnoreInsecure() {
     $GLOBALS['settings']['allow_insecure_uploads'] = 1;
     $munged_name = file_munge_filename($this->name, '');
     $this->assertIdentical($munged_name, $this->name, format_string('The original filename (%original) matches the munged filename (%munged) when insecure uploads are enabled.', array('%munged' => $munged_name, '%original' => $this->name)));
@@ -2723,7 +2723,7 @@ class FileNameMungingTest extends FileTestCase {
   /**
    * Allowed extensions are ignored by file_munge_filename().
    */
-  function testMungeIgnoreAllowed() {
+  public function testMungeIgnoreAllowed() {
     // Declare our extension as allowed. The declared extensions should be case
     // insensitive so test using one with a different case.
     $munged_name = file_munge_filename($this->name_with_uc_ext, $this->bad_extension);
@@ -2748,7 +2748,7 @@ class FileNameMungingTest extends FileTestCase {
   /**
    * Ensure that unmunge gets your name back.
    */
-  function testUnMunge() {
+  public function testUnMunge() {
     $munged_name = file_munge_filename($this->name, '', FALSE);
     $unmunged_name = file_unmunge_filename($munged_name);
     $this->assertIdentical($unmunged_name, $this->name, format_string('The unmunged (%unmunged) filename matches the original (%original)', array('%unmunged' => $unmunged_name, '%original' => $this->name)));
@@ -2759,7 +2759,7 @@ class FileNameMungingTest extends FileTestCase {
  * Tests for file_get_mimetype().
  */
 class FileMimeTypeTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
   }
 
@@ -2840,12 +2840,12 @@ class StreamWrapperTest extends BackdropWebTestCase {
   protected $scheme = 'dummy';
   protected $class_name = 'BackdropDummyStreamWrapper';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('file_test');
     backdrop_static_reset('file_get_stream_wrappers');
   }
 
-  function tearDown() {
+  protected function tearDown() {
     parent::tearDown();
     stream_wrapper_unregister($this->scheme);
   }
@@ -2853,7 +2853,7 @@ class StreamWrapperTest extends BackdropWebTestCase {
   /**
    * Test the getClassName() function.
    */
-  function testGetClassName() {
+  public function testGetClassName() {
     // Check the dummy scheme.
     $this->assertEqual($this->class_name, file_stream_wrapper_get_class($this->scheme), 'Got correct class name for dummy scheme.');
     // Check core's scheme.
@@ -2863,7 +2863,7 @@ class StreamWrapperTest extends BackdropWebTestCase {
   /**
    * Test the file_stream_wrapper_get_instance_by_scheme() function.
    */
-  function testGetInstanceByScheme() {
+  public function testGetInstanceByScheme() {
     $instance = file_stream_wrapper_get_instance_by_scheme($this->scheme);
     $this->assertEqual($this->class_name, get_class($instance), 'Got correct class type for dummy scheme.');
 
@@ -2874,7 +2874,7 @@ class StreamWrapperTest extends BackdropWebTestCase {
   /**
    * Test the URI and target functions.
    */
-  function testUriFunctions() {
+  public function testUriFunctions() {
     $site_config = config('system.core');
     $instance = file_stream_wrapper_get_instance_by_uri($this->scheme . '://foo');
     $this->assertEqual($this->class_name, get_class($instance), 'Got correct class type for dummy URI.');
@@ -2898,7 +2898,7 @@ class StreamWrapperTest extends BackdropWebTestCase {
   /**
    * Test the scheme functions.
    */
-  function testGetValidStreamScheme() {
+  public function testGetValidStreamScheme() {
     $this->assertEqual('foo', file_uri_scheme('foo://pork//chops'), 'Got the correct scheme from foo://asdf');
     $this->assertTrue(file_stream_wrapper_valid_scheme(file_uri_scheme('public://asdf')), 'Got a valid stream scheme from public://asdf');
     $this->assertFalse(file_stream_wrapper_valid_scheme(file_uri_scheme('foo://asdf')), 'Did not get a valid stream scheme from foo://asdf');

--- a/core/modules/simpletest/tests/filetransfer.test
+++ b/core/modules/simpletest/tests/filetransfer.test
@@ -12,12 +12,12 @@ class FileTransferTest extends BackdropWebTestCase {
    */
   protected $testConnection;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->testConnection = TestFileTransfer::factory(BACKDROP_ROOT, array('hostname' => $this->hostname, 'username' => $this->username, 'password' => $this->password, 'port' => $this->port));
   }
 
-  function _getFakeModuleFiles() {
+  private function _getFakeModuleFiles() {
     $files = array(
       'fake.module',
       'fake.info',
@@ -31,7 +31,7 @@ class FileTransferTest extends BackdropWebTestCase {
     return $files;
   }
 
-  function _buildFakeModule() {
+  private function _buildFakeModule() {
     $location = 'temporary://fake';
     if (is_dir($location)) {
       $ret = 0;
@@ -47,7 +47,7 @@ class FileTransferTest extends BackdropWebTestCase {
     return $location;
   }
 
-  function _writeDirectory($base, $files = array()) {
+  private function _writeDirectory($base, $files = array()) {
     mkdir($base);
     foreach ($files as $key => $file) {
       if (is_array($file)) {
@@ -60,7 +60,7 @@ class FileTransferTest extends BackdropWebTestCase {
     }
   }
 
-  function testJail() {
+  public function testJail() {
     $source = $this->_buildFakeModule();
 
     // This convoluted piece of code is here because our testing framework does
@@ -100,7 +100,7 @@ class TestFileTransfer extends FileTransfer {
    */
   public $shouldIsDirectoryReturnTrue = FALSE;
 
-  function __construct($jail, $username, $password, $hostname = 'localhost', $port = 9999) {
+  private function __construct($jail, $username, $password, $hostname = 'localhost', $port = 9999) {
     parent::__construct($jail, $username, $password, $hostname, $port);
   }
 
@@ -108,13 +108,13 @@ class TestFileTransfer extends FileTransfer {
     return new TestFileTransfer($jail, $settings['username'], $settings['password'], $settings['hostname'], $settings['port']);
   }
 
-  function connect() {
+  protected function connect() {
     $connection = new MockTestConnection();
     $connection->connectionString = 'test://' . urlencode((string) $this->username) . ':' . urlencode((string) $this->password) . "@$this->host:$this->port/";
     $this->connection = $connection;
   }
 
-  function copyFileJailed($source, $destination) {
+  protected function copyFileJailed($source, $destination) {
     $this->connection->run("copyFile $source $destination");
   }
 
@@ -122,25 +122,25 @@ class TestFileTransfer extends FileTransfer {
     $this->connection->run("rmdir $directory");
   }
 
-  function createDirectoryJailed($directory) {
+  protected function createDirectoryJailed($directory) {
     $this->connection->run("mkdir $directory");
   }
 
-  function removeFileJailed($destination) {
+  protected function removeFileJailed($destination) {
     if (!ftp_delete($this->connection, $item)) {
       throw new FileTransferException('Unable to remove to file @file.', NULL, array('@file' => $item));
     }
   }
 
-  function isDirectory($path) {
+  protected function isDirectory($path) {
     return $this->shouldIsDirectoryReturnTrue;
   }
 
-  function isFile($path) {
+  protected function isFile($path) {
     return FALSE;
   }
 
-  function chmodJailed($path, $mode, $recursive) {
+  protected function chmodJailed($path, $mode, $recursive) {
     return;
   }
 }
@@ -153,11 +153,11 @@ class MockTestConnection {
   var $commandsRun = array();
   var $connectionString;
 
-  function run($cmd) {
+  protected function run($cmd) {
     $this->commandsRun[] = $cmd;
   }
 
-  function flushCommands() {
+  protected function flushCommands() {
     $out = $this->commandsRun;
     $this->commandsRun = array();
     return $out;

--- a/core/modules/simpletest/tests/form.test
+++ b/core/modules/simpletest/tests/form.test
@@ -7,7 +7,7 @@
 include_once(dirname(__FILE__) . '/system_config_test.inc');
 
 class FormsTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -608,7 +608,7 @@ class FormsTestCase extends BackdropWebTestCase {
 class FormElementTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('form_test'));
   }
 
@@ -735,7 +735,7 @@ class FormElementTestCase extends BackdropWebTestCase {
 class FormAlterTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -762,7 +762,7 @@ class FormAlterTestCase extends BackdropWebTestCase {
 class FormValidationTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -928,7 +928,7 @@ class FormValidationTestCase extends BackdropWebTestCase {
 class FormsElementsLabelsTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -1084,7 +1084,7 @@ class FormsElementsDescriptionsTestCase extends BackdropWebTestCase {
 class FormsElementsTableSelectFunctionalTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -1302,7 +1302,7 @@ class FormsElementsTableSelectFunctionalTest extends BackdropWebTestCase {
 class FormsElementsVerticalTabsFunctionalTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -1336,7 +1336,7 @@ class FormsFormStorageTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
 
     $this->web_user = $this->backdropCreateUser();
@@ -1695,7 +1695,7 @@ class FormsFormCacheTestCase extends BackdropWebTestCase {
 class FormsFormWrapperTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -1715,7 +1715,7 @@ class FormsFormWrapperTestCase extends BackdropWebTestCase {
 class FormStateValuesCleanTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -1762,7 +1762,7 @@ class FormStateValuesCleanAdvancedTestCase extends BackdropWebTestCase {
    */
   protected $image;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('file', 'form_test');
   }
 
@@ -1802,7 +1802,7 @@ class FormsRebuildTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
 
     $this->web_user = $this->backdropCreateUser();
@@ -1888,7 +1888,7 @@ class FormsRebuildTestCase extends BackdropWebTestCase {
 class FormsRedirectTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('form_test'));
   }
 
@@ -1956,7 +1956,7 @@ class FormsRedirectTestCase extends BackdropWebTestCase {
 class FormsProgrammaticTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -2062,7 +2062,7 @@ class FormsProgrammaticTestCase extends BackdropWebTestCase {
 class FormsTriggeringElementTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -2151,7 +2151,7 @@ class FormsTriggeringElementTestCase extends BackdropWebTestCase {
  * Tests rebuilding of arbitrary forms by altering them.
  */
 class FormsArbitraryRebuildTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
     // Auto-create a field for testing.
     $field = array(
@@ -2211,7 +2211,7 @@ class FormsArbitraryRebuildTestCase extends BackdropWebTestCase {
 class FormsFileInclusionTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -2238,7 +2238,7 @@ class FormsFileInclusionTestCase extends BackdropWebTestCase {
 class FormCheckboxTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -2394,7 +2394,7 @@ class FormResizableTextareaTestCase extends BackdropWebTestCase {
 class FormEmailTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -2430,7 +2430,7 @@ class FormEmailTestCase extends BackdropWebTestCase {
 class FormH5datetimeTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 
@@ -2484,7 +2484,7 @@ class FormH5datetimeTestCase extends BackdropWebTestCase {
 class HTMLIdTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('form_test');
   }
 

--- a/core/modules/simpletest/tests/graph.test
+++ b/core/modules/simpletest/tests/graph.test
@@ -8,7 +8,7 @@
  * Unit tests for the graph handling features.
  */
 class GraphUnitTest extends BackdropUnitTestCase {
-  function setUp() {
+  public function setUp() {
     require_once BACKDROP_ROOT . '/core/includes/graph.inc';
     parent::setUp();
   }
@@ -16,7 +16,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
   /**
    * Test depth-first-search features.
    */
-  function testDepthFirstSearch() {
+  public function testDepthFirstSearch() {
     // The sample graph used is:
     // 1 --> 2 --> 3     5 ---> 6
     //       |     ^     ^
@@ -81,7 +81,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
   /**
    * Return a normalized version of a graph.
    */
-  function normalizeGraph($graph) {
+  protected function normalizeGraph($graph) {
     $normalized_graph = array();
     foreach ($graph as $vertex => $edges) {
       // Create vertex even if it hasn't any edges.
@@ -101,7 +101,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
    * @param $expected_paths
    *   An associative array containing vertices with their expected paths.
    */
-  function assertPaths($graph, $expected_paths) {
+  protected function assertPaths($graph, $expected_paths) {
     foreach ($expected_paths as $vertex => $paths) {
       // Build an array with keys = $paths and values = TRUE.
       $expected = array_fill_keys($paths, TRUE);
@@ -123,7 +123,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
    *   An associative array containing vertices with their expected reverse
    *   paths.
    */
-  function assertReversePaths($graph, $expected_reverse_paths) {
+  protected function assertReversePaths($graph, $expected_reverse_paths) {
     foreach ($expected_reverse_paths as $vertex => $paths) {
       // Build an array with keys = $paths and values = TRUE.
       $expected = array_fill_keys($paths, TRUE);
@@ -144,7 +144,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
    * @param $expected_components
    *   An array containing of components defined as a list of their vertices.
    */
-  function assertComponents($graph, $expected_components) {
+  protected function assertComponents($graph, $expected_components) {
     $unassigned_vertices = array_fill_keys(array_keys($graph), TRUE);
     foreach ($expected_components as $component) {
       $result_components = array();
@@ -168,7 +168,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
    * @param $expected_orders
    *   An array containing lists of vertices in their expected order.
    */
-  function assertWeights($graph, $expected_orders) {
+  protected function assertWeights($graph, $expected_orders) {
     foreach ($expected_orders as $order) {
       $previous_vertex = array_shift($order);
       foreach ($order as $vertex) {
@@ -185,7 +185,7 @@ class GraphUnitTest extends BackdropUnitTestCase {
    * @param $keys
    *   (optional) Whether to output the keys of $paths instead of the values.
    */
-  function displayArray($paths, $keys = FALSE) {
+  protected function displayArray($paths, $keys = FALSE) {
     if (!empty($paths)) {
       return implode(', ', $keys ? array_keys($paths) : $paths);
     }

--- a/core/modules/simpletest/tests/image.test
+++ b/core/modules/simpletest/tests/image.test
@@ -12,7 +12,7 @@ class ImageToolkitTestCase extends BackdropWebTestCase {
   protected $file;
   protected $image;
 
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -47,7 +47,7 @@ class ImageToolkitTestCase extends BackdropWebTestCase {
    *   Array with string containing with the operation name, e.g. 'load',
    *   'save', 'crop', etc.
    */
-  function assertToolkitOperationsCalled(array $expected) {
+  protected function assertToolkitOperationsCalled(array $expected) {
     // Determine which operations were called.
     $actual = array_keys(array_filter(image_test_get_all_calls()));
 
@@ -79,7 +79,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
    * Check that hook_image_toolkits() is called and only available toolkits are
    * returned.
    */
-  function testGetAvailableToolkits() {
+  public function testGetAvailableToolkits() {
     $toolkits = image_get_available_toolkits();
     $this->assertTrue(isset($toolkits['test']), 'The working toolkit was returned.');
     $this->assertFalse(isset($toolkits['broken']), 'The toolkit marked unavailable was not returned');
@@ -89,7 +89,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_load() function.
    */
-  function testLoad() {
+  public function testLoad() {
     $image = image_load($this->file, $this->toolkit);
     $this->assertTrue(is_object($image), 'Returned an object.');
     $this->assertEqual($this->toolkit, $image->toolkit, 'Image had toolkit set.');
@@ -99,7 +99,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_save() function.
    */
-  function testSave() {
+  public function testSave() {
     $this->assertFalse(image_save($this->image), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('save'));
   }
@@ -107,7 +107,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_resize() function.
    */
-  function testResize() {
+  public function testResize() {
     $this->assertTrue(image_resize($this->image, 1, 2), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('resize'));
 
@@ -120,7 +120,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_scale() function.
    */
-  function testScale() {
+  public function testScale() {
   // @todo: need to test upscaling.
     $this->assertTrue(image_scale($this->image, 10, 10), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('resize'));
@@ -134,7 +134,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_scale_and_crop() function.
    */
-  function testScaleAndCrop() {
+  public function testScaleAndCrop() {
     $this->assertTrue(image_scale_and_crop($this->image, 5, 10, 'center-center'), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('resize', 'crop'));
 
@@ -150,7 +150,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_rotate() function.
    */
-  function testRotate() {
+  public function testRotate() {
     $this->assertTrue(image_rotate($this->image, 90, 1), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('rotate'));
 
@@ -163,7 +163,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_crop() function.
    */
-  function testCrop() {
+  public function testCrop() {
     $this->assertTrue(image_crop($this->image, 1, 2, 3, 4), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('crop'));
 
@@ -178,7 +178,7 @@ class ImageToolkitUnitTest extends ImageToolkitTestCase {
   /**
    * Test the image_desaturate() function.
    */
-  function testDesaturate() {
+  public function testDesaturate() {
     $this->assertTrue(image_desaturate($this->image), 'Function returned the expected value.');
     $this->assertToolkitOperationsCalled(array('desaturate'));
 
@@ -218,7 +218,7 @@ class ImageToolkitGdTestCase extends BackdropWebTestCase {
   /**
    * Function to compare two colors by RGBa.
    */
-  function colorsAreEqual($color_a, $color_b) {
+  protected function colorsAreEqual($color_a, $color_b) {
     // Fully transparent pixels are equal, regardless of RGB.
     if ($color_a[3] == 127 && $color_b[3] == 127) {
       return TRUE;
@@ -236,7 +236,7 @@ class ImageToolkitGdTestCase extends BackdropWebTestCase {
   /**
    * Function for finding a pixel's RGBa values.
    */
-  function getPixelColor($image, $x, $y) {
+  protected function getPixelColor($image, $x, $y) {
     $color_index = imagecolorat($image->resource, $x, $y);
 
     $transparent_index = imagecolortransparent($image->resource);
@@ -252,7 +252,7 @@ class ImageToolkitGdTestCase extends BackdropWebTestCase {
    * properly, build a list of expected color values for each of the corners and
    * the expected height and widths for the final images.
    */
-  function testManipulations() {
+  public function testManipulations() {
     // Typically the corner colors will be unchanged. These colors are in the
     // order of top-left, top-right, bottom-right, bottom-left.
     $default_corners = array($this->red, $this->green, $this->blue, $this->transparent);
@@ -473,7 +473,7 @@ class ImageFileMoveTest extends ImageToolkitTestCase {
   /**
    * Tests moving a randomly generated image.
    */
-  function testNormal() {
+  public function testNormal() {
     // Pick a file for testing.
     $file = entity_create('file', (array) current($this->backdropGetTestFiles('image')));
 

--- a/core/modules/simpletest/tests/installer.test
+++ b/core/modules/simpletest/tests/installer.test
@@ -10,7 +10,7 @@
 class InstallerLanguageTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Copy test translations to the active translations directory.
@@ -26,7 +26,7 @@ class InstallerLanguageTestCase extends BackdropWebTestCase {
   /**
    * Tests that the installer can find translation files.
    */
-  function testInstallerTranslationFiles() {
+  public function testInstallerTranslationFiles() {
     include_once BACKDROP_ROOT . '/core/includes/install.core.inc';
 
     // Different translation files would be found depending on which language

--- a/core/modules/simpletest/tests/lock.test
+++ b/core/modules/simpletest/tests/lock.test
@@ -6,14 +6,14 @@
 class LockFunctionalTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
   }
 
   /**
    * Confirm that we can acquire and release locks in two parallel requests.
    */
-  function testLockAcquire() {
+  public function testLockAcquire() {
     $lock_acquired = 'TRUE: Lock successfully acquired in system_test_lock_acquire()';
     $lock_not_acquired = 'FALSE: Lock not acquired in system_test_lock_acquire()';
     $this->assertTrue(lock_acquire('system_test_lock_acquire'), 'Lock acquired by this request.', 'Lock');

--- a/core/modules/simpletest/tests/mail.test
+++ b/core/modules/simpletest/tests/mail.test
@@ -12,7 +12,7 @@ class MailTestCase extends BackdropWebTestCase implements MailSystemInterface {
    */
   private static $sent_message;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('simpletest'));
 
     // Set MailTestCase (i.e. this class) as the SMTP library
@@ -22,7 +22,7 @@ class MailTestCase extends BackdropWebTestCase implements MailSystemInterface {
   /**
    * Assert that the pluggable mail system is functional.
    */
-  function testPluggableFramework() {
+  public function testPluggableFramework() {
     global $language;
 
     // Use MailTestCase for sending a message.
@@ -37,7 +37,7 @@ class MailTestCase extends BackdropWebTestCase implements MailSystemInterface {
    *
    * @see simpletest_mail_alter()
    */
-  function testCancelMessage() {
+  public function testCancelMessage() {
     global $language;
 
     // Reset the class variable holding a copy of the last sent message.
@@ -87,7 +87,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
    *   An HTML representation of the text string that, when displayed in a
    *   browser, represents the PHP source code equivalent of $text.
    */
-  function stringToHtml($text) {
+  protected function stringToHtml($text) {
     return '"' .
       str_replace(
         array("\n", ' '),
@@ -109,7 +109,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
    *   (optional) An array of allowed tags, or NULL to default to the full
    *   set of tags supported by backdrop_html_to_text().
    */
-  function assertHtmlToText($html, $text, $message, $allowed_tags = NULL) {
+  protected function assertHtmlToText($html, $text, $message, $allowed_tags = NULL) {
     preg_match_all('/<([a-z0-6]+)/', backdrop_strtolower($html), $matches);
     $tested_tags = implode(', ', array_unique($matches[1]));
     $message .= ' (' . $tested_tags . ')';
@@ -128,7 +128,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
   /**
    * Test all supported tags of backdrop_html_to_text().
    */
-  function testTags() {
+  public function testTags() {
     global $base_path, $base_url;
     $tests = array(
       // @todo Trailing linefeeds should be trimmed.
@@ -224,7 +224,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
   /**
    * Test $allowed_tags argument of backdrop_html_to_text().
    */
-  function testBackdropHtmlToTextArgs() {
+  public function testBackdropHtmlToTextArgs() {
     // The second parameter of backdrop_html_to_text() overrules the allowed tags.
     $this->assertHtmlToText(
       'Backdrop <b>Backdrop</b> Backdrop',
@@ -257,7 +257,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
   /**
    * Tests that backdrop_wrap_mail() removes trailing whitespace before newlines.
    */
-  function testBackdropHtmltoTextRemoveTrailingWhitespace() {
+  public function testBackdropHtmltoTextRemoveTrailingWhitespace() {
     $text = "Hi there! \nFoo Bar";
     $mail_lines = explode("\n", backdrop_wrap_mail($text));
     $this->assertNotEqual(" ", substr($mail_lines[0], -1), 'Trailing whitespace removed.');
@@ -269,7 +269,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
    * RFC 3676 says, "This is a special case; an (optionally quoted or quoted and
    * stuffed) line consisting of DASH DASH SP is neither fixed nor flowed."
    */
-  function testBackdropHtmltoTextUsenetSignature() {
+  public function testBackdropHtmltoTextUsenetSignature() {
     $text = "Hi there!\n-- \nFoo Bar";
     $mail_lines = explode("\n", backdrop_wrap_mail($text));
     $this->assertEqual("-- ", $mail_lines[1], 'Trailing whitespace not removed for dash-dash-space signatures.');
@@ -282,7 +282,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
   /**
    * Test that whitespace is collapsed.
    */
-  function testBackdropHtmltoTextCollapsesWhitespace() {
+  public function testBackdropHtmltoTextCollapsesWhitespace() {
     $input = "<p>Backdrop  Backdrop\n\nBackdrop<pre>Backdrop  Backdrop\n\nBackdrop</pre>Backdrop  Backdrop\n\nBackdrop</p>";
     // @todo The whitespace should be collapsed.
     $collapsed = "Backdrop  Backdrop\n\nBackdropBackdrop  Backdrop\n\nBackdropBackdrop  Backdrop\n\nBackdrop\n\n";
@@ -298,7 +298,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
    * Test that text separated by block-level tags in HTML get separated by
    * (at least) a newline in the plaintext version.
    */
-  function testBackdropHtmlToTextBlockTagToNewline() {
+  public function testBackdropHtmlToTextBlockTagToNewline() {
     $input = '[text]'
       . '<blockquote>[blockquote]</blockquote>'
       . '<br />[br]'
@@ -348,7 +348,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
   /**
    * Test that headers are properly separated from surrounding text.
    */
-  function testHeaderSeparation() {
+  public function testHeaderSeparation() {
     $html = 'Backdrop<h1>Backdrop</h1>Backdrop';
     // @todo There should be more space above the header than below it.
     $text = "Backdrop\n======== BACKDROP ============================================================\n\nBackdrop\n";
@@ -373,7 +373,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
   /**
    * Test that footnote references are properly generated.
    */
-  function testFootnoteReferences() {
+  public function testFootnoteReferences() {
     global $base_path, $base_url;
     $source = '<a href="http://www.example.com/node/1">Host and path</a>'
       . '<br /><a href="http://www.example.com">Host, no path</a>'
@@ -398,7 +398,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
    * Test that combinations of paragraph breaks, line breaks, linefeeds,
    * and spaces are properly handled.
    */
-  function testBackdropHtmlToTextParagraphs() {
+  public function testBackdropHtmlToTextParagraphs() {
     $tests = array();
     $tests[] = array(
         'html' => "<p>line 1<br />\nline 2<br />line 3\n<br />line 4</p><p>paragraph</p>",
@@ -427,7 +427,7 @@ class BackdropHtmlToTextTestCase extends BackdropWebTestCase {
    * RFC 821 says, "The maximum total length of a text line including the
    * <CRLF> is 1000 characters."
    */
-  function testVeryLongLineWrap() {
+  public function testVeryLongLineWrap() {
     $input = 'Backdrop<br /><p>' . str_repeat('x', 2100) . '</p><br />Backdrop';
     $output = backdrop_html_to_text($input);
     // This awkward construct comes from includes/mail.inc lines 8-13.

--- a/core/modules/simpletest/tests/menu.test
+++ b/core/modules/simpletest/tests/menu.test
@@ -5,7 +5,7 @@
  */
 
 class MenuWebTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -123,7 +123,7 @@ class MenuWebTestCase extends BackdropWebTestCase {
 class MenuRouterTestCase extends BackdropWebTestCase {
   protected $profile = 'minimal';
 
-  function setUp() {
+  public function setUp() {
     // Enable dummy module that implements hook_menu.
     parent::setUp('menu_test');
     // Make the tests below more robust by explicitly setting the default theme
@@ -136,7 +136,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Tests title and theme callbacks in hook_menu().
    */
-  function testMenuCallbacks() {
+  public function testMenuCallbacks() {
     // Test title callback set to FALSE.
     $this->backdropGet('node');
     $this->assertText('A title with @placeholder', 'Raw text found on the page');
@@ -224,7 +224,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
    * Test that an authenticated user hitting 'user/login' gets redirected to
    * 'user' and 'user/register' gets redirected to the user edit page.
    */
-  function testAuthUserUserLogin() {
+  public function testAuthUserUserLogin() {
     $loggedInUser = $this->backdropCreateUser(array());
     $this->backdropLogin($loggedInUser);
 
@@ -240,7 +240,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Test that hook_custom_theme() can control the theme of a page.
    */
-  function testHookCustomTheme() {
+  public function testHookCustomTheme() {
     // Trigger hook_custom_theme() to dynamically request the Stark theme for
     // the requested page.
     state_set('menu_test_hook_custom_theme_name', 'stark');
@@ -256,7 +256,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Test that the theme callback wins out over hook_custom_theme().
    */
-  function testThemeCallbackHookCustomTheme() {
+  public function testThemeCallbackHookCustomTheme() {
     // Trigger hook_custom_theme() to dynamically request the Stark theme for
     // the requested page.
     state_set('menu_test_hook_custom_theme_name', 'stark');
@@ -272,7 +272,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Tests for menu_link_maintain().
    */
-  function testMenuLinkMaintain() {
+  public function testMenuLinkMaintain() {
     $admin_user = $this->backdropCreateUser(array('administer site configuration'));
     $this->backdropLogin($admin_user);
 
@@ -318,7 +318,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Tests for menu_name parameter for hook_menu().
    */
-  function testMenuName() {
+  public function testMenuName() {
     $admin_user = $this->backdropCreateUser(array('administer site configuration'));
     $this->backdropLogin($admin_user);
 
@@ -339,7 +339,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Tests for menu hierarchy.
    */
-  function testMenuHierarchy() {
+  public function testMenuHierarchy() {
     $parent_link = db_query('SELECT * FROM {menu_links} WHERE link_path = :link_path', array(':link_path' => 'menu-test/hierarchy/parent'))->fetchAssoc();
     $child_link = db_query('SELECT * FROM {menu_links} WHERE link_path = :link_path', array(':link_path' => 'menu-test/hierarchy/parent/child'))->fetchAssoc();
     $unattached_child_link = db_query('SELECT * FROM {menu_links} WHERE link_path = :link_path', array(':link_path' => 'menu-test/hierarchy/parent/child2/child'))->fetchAssoc();
@@ -351,7 +351,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Tests menu link depth and parents of local tasks and menu callbacks.
    */
-  function testMenuHidden() {
+  public function testMenuHidden() {
     // Verify links for one dynamic argument.
     $links = db_select('menu_links', 'ml')
       ->fields('ml')
@@ -440,7 +440,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Test menu_get_item() with empty ancestors.
    */
-  function testMenuGetItemNoAncestors() {
+  public function testMenuGetItemNoAncestors() {
     state_set('menu_masks', array());
     $this->backdropGet('');
   }
@@ -448,7 +448,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Test menu_set_item().
    */
-  function testMenuSetItem() {
+  public function testMenuSetItem() {
     $item = menu_get_item('node');
 
     $this->assertEqual($item['path'], 'node', "Path from menu_get_item('node') is equal to 'node'", 'menu');
@@ -465,7 +465,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Test menu maintenance hooks.
    */
-  function testMenuItemHooks() {
+  public function testMenuItemHooks() {
     // Create an item.
     menu_link_maintain('menu_test', 'insert', 'menu_test_maintain/4', 'Menu link #4');
     $this->assertEqual(menu_test_static_variable(), 'insert', 'hook_menu_link_insert() fired correctly');
@@ -480,7 +480,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Test menu link 'options' storage and rendering.
    */
-  function testMenuLinkOptions() {
+  public function testMenuLinkOptions() {
     // Create a menu link with options.
     $menu_link = array(
       'link_title' => 'Menu link options test',
@@ -509,7 +509,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
    *
    * @see menu_test_init()
    */
-  function testMenuItemTitlesCases() {
+  public function testMenuItemTitlesCases() {
     for ($case_no = 1; $case_no <= 4; $case_no++) {
       $this->backdropGet('menu-title-test/case' . $case_no);
       $this->assertResponse(200);
@@ -528,7 +528,7 @@ class MenuRouterTestCase extends BackdropWebTestCase {
   /**
    * Tests inheritance of 'load arguments'.
    */
-  function testMenuLoadArgumentsInheritance() {
+  public function testMenuLoadArgumentsInheritance() {
     $expected = array(
       'menu-test/arguments/%/%' => array(
         2 => array('menu_test_argument_load' => array(3)),
@@ -587,7 +587,7 @@ class MenuLinksUnitTestCase extends BackdropWebTestCase {
   /**
    * Create a simple hierarchy of links.
    */
-  function createLinkHierarchy($module = 'menu_test') {
+  protected function createLinkHierarchy($module = 'menu_test') {
     // First remove all the menu links.
     db_truncate('menu_links')->execute();
 
@@ -638,7 +638,7 @@ class MenuLinksUnitTestCase extends BackdropWebTestCase {
   /**
    * Assert that at set of links is properly parented.
    */
-  function assertMenuLinkParents($links, $expected_hierarchy) {
+  protected function assertMenuLinkParents($links, $expected_hierarchy) {
     foreach ($expected_hierarchy as $child => $parent) {
       $mlid = $links[$child]['mlid'];
       $plid = $parent ? $links[$parent]['mlid'] : 0;
@@ -652,7 +652,7 @@ class MenuLinksUnitTestCase extends BackdropWebTestCase {
   /**
    * Test automatic re-parenting of menu links.
    */
-  function testMenuLinkReparenting($module = 'menu_test') {
+  public function testMenuLinkReparenting($module = 'menu_test') {
     // Check the initial hierarchy.
     $links = $this->createLinkHierarchy($module);
 
@@ -734,7 +734,7 @@ class MenuLinksUnitTestCase extends BackdropWebTestCase {
   /**
    * Test automatic reparenting of menu links derived from menu routers.
    */
-  function testMenuLinkRouterReparenting() {
+  public function testMenuLinkRouterReparenting() {
     // Run all the standard parenting tests on menu links derived from
     // menu routers.
     $this->testMenuLinkReparenting('system');
@@ -797,7 +797,7 @@ class MenuRebuildTestCase extends BackdropWebTestCase {
   /**
    * Test if the 'menu_rebuild_needed' variable triggers a menu_rebuild() call.
    */
-  function testMenuRebuildByVariable() {
+  public function testMenuRebuildByVariable() {
     // Check if 'admin' path exists.
     $admin_exists = db_query('SELECT path from {menu_router} WHERE path = :path', array(':path' => 'admin'))->fetchField();
     $this->assertEqual($admin_exists, 'admin', "The path 'admin/' exists prior to deleting.");
@@ -840,7 +840,7 @@ class MenuTreeDataTestCase extends BackdropUnitTestCase {
   /**
    * Validate the generation of a proper menu tree hierarchy.
    */
-  function testMenuTreeData() {
+  public function testMenuTreeData() {
     $tree = menu_tree_data($this->links);
 
     // Validate that parent items #1, #2, and #5 exist on the root level.
@@ -900,7 +900,7 @@ class MenuTreeOutputTestCase extends BackdropWebTestCase {
   /**
    * Validate the generation of a proper menu tree output.
    */
-  function testMenuTreeData() {
+  public function testMenuTreeData() {
     $output = menu_tree_output($this->tree_data);
 
     // Validate that the - in main-menu is changed into an underscore
@@ -924,7 +924,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
   protected $admin_user;
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -946,7 +946,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
   /**
    * Tests breadcrumbs on node and administrative paths.
    */
-  function testBreadCrumbs() {
+  public function testBreadCrumbs() {
     foreach (array('default', 'admin_default') as $layout_name) {
       $layout = layout_load($layout_name);
       // Assume that the menu block is the second block in the default layout.
@@ -1402,7 +1402,7 @@ class MenuBreadcrumbTestCase extends MenuWebTestCase {
 class MenuTrailTestCase extends MenuWebTestCase {
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     $modules = func_get_args();
     if (isset($modules[0]) && is_array($modules[0])) {
       $modules = $modules[0];
@@ -1439,7 +1439,7 @@ class MenuTrailTestCase extends MenuWebTestCase {
   /**
    * Tests active trails are properly affected by menu_tree_set_path().
    */
-  function testMenuTreeSetPath() {
+  public function testMenuTreeSetPath() {
     $home = array('<front>' => 'Home');
     $config_tree = array(
       'admin' => t('Administration'),
@@ -1502,7 +1502,7 @@ class MenuTrailTestCase extends MenuWebTestCase {
   /**
    * Tests that the active trail works correctly on custom 403 and 404 pages.
    */
-  function testCustom403And404Pages() {
+  public function testCustom403And404Pages() {
     // Set the custom 403 and 404 pages we will use.
     config('system.core')
       ->set('site_403', 'menu-test/custom-403-page')

--- a/core/modules/simpletest/tests/module.test
+++ b/core/modules/simpletest/tests/module.test
@@ -17,7 +17,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
   /**
    * The basic functionality of module_list().
    */
-  function testModuleList() {
+  public function testModuleList() {
     // Build a list of modules, sorted alphabetically.
     $profile_info = install_profile_info('standard', 'en');
     $module_list = $profile_info['dependencies'];
@@ -81,7 +81,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
   /**
    * Test module_implements() caching.
    */
-  function testModuleImplements() {
+  public function testModuleImplements() {
     // Clear the cache.
     cache('bootstrap')->delete('module_implements');
     $this->assertFalse(cache('bootstrap')->get('module_implements'), 'The module implements cache is empty.');
@@ -116,7 +116,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
   /**
    * Test that module_invoke() can load a hook defined in hook_hook_info().
    */
-  function testModuleInvoke() {
+  public function testModuleInvoke() {
     module_enable(array('module_test'), FALSE);
     $this->resetAll();
     $this->backdropGet('module-test/hook-dynamic-loading-invoke');
@@ -126,7 +126,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
   /**
    * Test that module_invoke_all() can load a hook defined in hook_hook_info().
    */
-  function testModuleInvokeAll() {
+  public function testModuleInvokeAll() {
     module_enable(array('module_test'), FALSE);
     $this->resetAll();
     $this->backdropGet('module-test/hook-dynamic-loading-invoke-all');
@@ -136,7 +136,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
   /**
    * Test dependency resolution.
    */
-  function testDependencyResolution() {
+  public function testDependencyResolution() {
     // Enable the test module, disable the second module, and make sure that
     // other modules we are testing are not already enabled. (If they were, the
     // tests below would not work correctly.)
@@ -244,7 +244,7 @@ class ModuleUnitTest extends BackdropWebTestCase {
  * Unit tests for module installation.
  */
 class ModuleInstallTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('module_test');
   }
 
@@ -260,7 +260,7 @@ class ModuleInstallTestCase extends BackdropWebTestCase {
    * that modules are fully functional while Backdrop is installing and enabling
    * them.
    */
-  function testBackdropWriteRecord() {
+  public function testBackdropWriteRecord() {
     // Check for data that was inserted using backdrop_write_record() while the
     // 'module_test' module was being installed and enabled.
     $data = db_query("SELECT data FROM {module_test}")->fetchCol();
@@ -279,14 +279,14 @@ class ModuleUninstallTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('module_test', 'user');
   }
 
   /**
    * Tests the hook_modules_uninstalled() of the user module.
    */
-  function testUserPermsUninstalled() {
+  public function testUserPermsUninstalled() {
     // Grant the test permission to the authenticate user role.
     user_role_grant_permissions(BACKDROP_AUTHENTICATED_ROLE, array('module_test perm'));
     $role = user_role_load(BACKDROP_AUTHENTICATED_ROLE);
@@ -379,7 +379,7 @@ class ModuleImplementsAlterTestCase extends BackdropWebTestCase {
   /**
    * Tests hook_module_implements_alter() adding an implementation.
    */
-  function testModuleImplementsAlter() {
+  public function testModuleImplementsAlter() {
     module_enable(array('module_test'), FALSE);
     $this->assertTrue(module_exists('module_test'), 'Test module is enabled.');
 

--- a/core/modules/simpletest/tests/pager.test
+++ b/core/modules/simpletest/tests/pager.test
@@ -15,7 +15,7 @@ class PagerFunctionalWebTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('dblog'));
 
     // Insert 300 log messages.
@@ -32,7 +32,7 @@ class PagerFunctionalWebTestCase extends BackdropWebTestCase {
   /**
    * Tests markup and CSS classes of pager links.
    */
-  function testActiveClass() {
+  public function testActiveClass() {
     // Verify first page.
     $this->backdropGet('admin/reports/dblog');
     $current_page = 0;

--- a/core/modules/simpletest/tests/password.test
+++ b/core/modules/simpletest/tests/password.test
@@ -10,7 +10,7 @@
 class PasswordHashingTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     require_once BACKDROP_ROOT . '/' . settings_get('password_inc', 'core/includes/password.inc');
     parent::setUp();
   }
@@ -18,7 +18,7 @@ class PasswordHashingTest extends BackdropWebTestCase {
   /**
    * Test password hashing.
    */
-  function testPasswordHashing() {
+  public function testPasswordHashing() {
     // Set a log2 iteration count that is deliberately out of bounds to test
     // that it is corrected to be within bounds.
     $GLOBALS['settings']['password_count_log2'] = 1;

--- a/core/modules/simpletest/tests/path.test
+++ b/core/modules/simpletest/tests/path.test
@@ -12,7 +12,7 @@
 class BackdropMatchPathTestCase extends BackdropWebTestCase {
   protected $front;
 
-  function setUp() {
+  public function setUp() {
     // Set up the database and testing environment.
     parent::setUp();
 
@@ -26,7 +26,7 @@ class BackdropMatchPathTestCase extends BackdropWebTestCase {
   /**
    * Run through our test cases, making sure each one works as expected.
    */
-  function testBackdropMatchPath() {
+  public function testBackdropMatchPath() {
     // Set up our test cases.
     $tests = $this->backdropMatchPathTests();
     foreach ($tests as $patterns => $cases) {
@@ -121,14 +121,14 @@ class BackdropMatchPathTestCase extends BackdropWebTestCase {
  * Tests hook_url_alter functions.
  */
 class UrlAlterFunctionalTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('path', 'url_alter_test');
   }
 
   /**
    * Test that URL altering works and that it occurs in the correct order.
    */
-  function testUrlAlter() {
+  public function testUrlAlter() {
     $account = $this->backdropCreateUser(array('administer url aliases'));
     // Remove the default alias if set.
     $account->path['auto'] = FALSE;
@@ -167,7 +167,7 @@ class UrlAlterFunctionalTest extends BackdropWebTestCase {
   /**
    * Test current_path() and request_path().
    */
-  function testCurrentUrlRequestedPath() {
+  public function testCurrentUrlRequestedPath() {
     $this->backdropGet('url-alter-test/bar');
     $this->assertRaw('request_path=url-alter-test/bar', 'request_path() returns the requested path.');
     $this->assertRaw('current_path=url-alter-test/foo', 'current_path() returns the internal path.');
@@ -176,7 +176,7 @@ class UrlAlterFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests that $_GET['q'] is initialized when the request path is empty.
    */
-  function testGetQInitialized() {
+  public function testGetQInitialized() {
     $this->backdropGet('');
     $this->assertText("\$_GET['q'] is non-empty with an empty request path.", "\$_GET['q'] is initialized with an empty request path.");
   }
@@ -224,7 +224,7 @@ class PathLookupTest extends BackdropWebTestCase {
   /**
    * Test that backdrop_lookup_path() returns the correct path.
    */
-  function testBackdropLookupPath() {
+  public function testBackdropLookupPath() {
     $account = $this->backdropCreateUser();
     $uid = $account->uid;
     $name = $account->name;
@@ -303,7 +303,7 @@ class PathLookupTest extends BackdropWebTestCase {
  * Tests the path_save() function.
  */
 class PathSaveTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     // Enable a helper module that implements hook_path_update().
     parent::setUp('path_test');
     path_test_reset();
@@ -312,7 +312,7 @@ class PathSaveTest extends BackdropWebTestCase {
   /**
    * Tests that path_save() makes the original path available to modules.
    */
-  function testBackdropSaveOriginalPath() {
+  public function testBackdropSaveOriginalPath() {
     $account = $this->backdropCreateUser();
     $uid = $account->uid;
     $name = $account->name;

--- a/core/modules/simpletest/tests/schema.test
+++ b/core/modules/simpletest/tests/schema.test
@@ -16,7 +16,7 @@ class SchemaTestCase extends BackdropWebTestCase {
   /**
    *
    */
-  function testSchema() {
+  public function testSchema() {
     // Try creating a table.
     $table_specification = array(
       'description' => 'Schema table description.',
@@ -109,7 +109,7 @@ class SchemaTestCase extends BackdropWebTestCase {
     $this->assertEqual($count, 2, 'There were two rows.');
   }
 
-  function tryInsert($table = 'test_table') {
+  protected function tryInsert($table = 'test_table') {
     try {
        db_insert($table)
          ->fields(array('id' => mt_rand(10, 20)))
@@ -131,7 +131,7 @@ class SchemaTestCase extends BackdropWebTestCase {
    * @param $column
    *   Optional column to test.
    */
-  function checkSchemaComment($description, $table, $column = NULL) {
+  protected function checkSchemaComment($description, $table, $column = NULL) {
     if (method_exists(Database::getConnection()->schema(), 'getComment')) {
       $comment = Database::getConnection()->schema()->getComment($table, $column);
       $this->assertEqual($comment, $description, 'The comment matches the schema description.');
@@ -141,7 +141,7 @@ class SchemaTestCase extends BackdropWebTestCase {
   /**
    * Tests creating unsigned columns and data integrity thereof.
    */
-  function testUnsignedColumns() {
+  public function testUnsignedColumns() {
     // First create the table with just a serial column.
     $table_name = 'unsigned_table';
     $table_spec = array(
@@ -180,7 +180,7 @@ class SchemaTestCase extends BackdropWebTestCase {
    * @return
    *   TRUE if the insert succeeded, FALSE otherwise
    */
-  function tryUnsignedInsert($table_name, $column_name) {
+  protected function tryUnsignedInsert($table_name, $column_name) {
     try {
       db_insert($table_name)
          ->fields(array($column_name => -1))
@@ -195,7 +195,7 @@ class SchemaTestCase extends BackdropWebTestCase {
   /**
    * Test adding columns to an existing table.
    */
-  function testSchemaAddField() {
+  public function testSchemaAddField() {
     // Test varchar types.
     foreach (array(1, 32, 128, 256, 512) as $length) {
       $base_field_spec = array(

--- a/core/modules/simpletest/tests/session.test
+++ b/core/modules/simpletest/tests/session.test
@@ -5,7 +5,7 @@
  */
 
 class SessionTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('session_test');
 
     // Disable the cache.
@@ -15,7 +15,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Tests for backdrop_save_session() and backdrop_session_regenerate().
    */
-  function testSessionSaveRegenerate() {
+  public function testSessionSaveRegenerate() {
     $this->assertFalse(backdrop_save_session(), 'backdrop_save_session() correctly returns FALSE (inside of testing framework) when initially called with no arguments.', 'Session');
     $this->assertFalse(backdrop_save_session(FALSE), 'backdrop_save_session() correctly returns FALSE when called with FALSE.', 'Session');
     $this->assertFalse(backdrop_save_session(), 'backdrop_save_session() correctly returns FALSE when saving has been disabled.', 'Session');
@@ -63,7 +63,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Test data persistence via the session_test module callbacks.
    */
-  function testDataPersistence() {
+  public function testDataPersistence() {
     $user = $this->backdropCreateUser(array('access content'));
     // Enable sessions.
     $this->sessionReset($user->uid);
@@ -124,7 +124,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Test that empty anonymous sessions are destroyed.
    */
-  function testEmptyAnonymousSession() {
+  public function testEmptyAnonymousSession() {
     // Verify that no session is automatically created for anonymous user.
     $this->backdropGet('');
     $this->assertSessionCookie(FALSE);
@@ -174,7 +174,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Test that sessions are only saved when necessary.
    */
-  function testSessionWrite() {
+  public function testSessionWrite() {
     $user = $this->backdropCreateUser(array('access content'));
     $this->backdropLogin($user);
 
@@ -218,7 +218,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Test that empty session IDs are not allowed.
    */
-  function testEmptySessionID() {
+  public function testEmptySessionID() {
     $user = $this->backdropCreateUser(array('access content'));
     $this->backdropLogin($user);
     $this->backdropGet('session-test/is-logged-in');
@@ -244,7 +244,7 @@ class SessionTestCase extends BackdropWebTestCase {
    *
    * @param $uid User id to set as the active session.
    */
-  function sessionReset($uid = 0) {
+  protected function sessionReset($uid = 0) {
     // Close the internal browser.
     $this->curlClose();
     $this->loggedInUser = FALSE;
@@ -260,7 +260,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Assert whether the SimpleTest browser sent a session cookie.
    */
-  function assertSessionCookie($sent) {
+  protected function assertSessionCookie($sent) {
     if ($sent) {
       $this->assertNotNull($this->session_id, 'Session cookie was sent.');
     }
@@ -272,7 +272,7 @@ class SessionTestCase extends BackdropWebTestCase {
   /**
    * Assert whether $_SESSION is empty at the beginning of the request.
    */
-  function assertSessionEmpty($empty) {
+  protected function assertSessionEmpty($empty) {
     if ($empty) {
       $empty = $this->backdropGetHeader('X-Session-Empty');
       $this->assertTrue($empty === FALSE || $empty === '1', 'Session was empty.');

--- a/core/modules/simpletest/tests/simpletest.test
+++ b/core/modules/simpletest/tests/simpletest.test
@@ -38,7 +38,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
    */
   protected $test_ids = array();
 
-  function setUp() {
+  public function setUp() {
     if (!$this->inCURL()) {
       parent::setUp('simpletest');
 
@@ -54,7 +54,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Test the internal browsers functionality.
    */
-  function testInternalBrowser() {
+  public function testInternalBrowser() {
     if (!$this->inCURL()) {
       $this->backdropGet('node');
       $this->assertTrue($this->backdropGetHeader('Date'), 'An HTTP header was received.');
@@ -98,7 +98,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Test validation of the User-Agent header we use to perform test requests.
    */
-  function testUserAgentValidation() {
+  public function testUserAgentValidation() {
     if (!$this->inCURL()) {
       global $base_url;
       $simpletest_path = $base_url . '/' . backdrop_get_path('module', 'simpletest');
@@ -136,7 +136,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
    * Make sure that tests selected through the web interface are run and
    * that the results are displayed correctly.
    */
-  function testWebTestRunner() {
+  public function testWebTestRunner() {
     $this->pass = t('SimpleTest pass.');
     $this->fail = t('SimpleTest fail.');
     $this->valid_permission = 'access content';
@@ -163,7 +163,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Test to be run and the results confirmed.
    */
-  function stubTest() {
+  protected function stubTest() {
     $this->pass($this->pass);
     $this->fail($this->fail);
 
@@ -190,14 +190,14 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Assert nothing.
    */
-  function assertNothing() {
+  protected function assertNothing() {
     $this->pass("This is nothing.");
   }
 
   /**
    * Confirm that the stub test produced the desired results.
    */
-  function confirmStubTestResults() {
+  protected function confirmStubTestResults() {
     $this->assertAssertion(t('Enabled modules: %modules', array('%modules' => 'non_existent_module')), 'Other', 'Fail', 'simpletest.test', 'SimpleTestFunctionalTest->setUp()');
 
     $this->assertAssertion($this->pass, 'Other', 'Pass', 'simpletest.test', 'SimpleTestFunctionalTest->stubTest()');
@@ -237,7 +237,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Fetch the test id from the test results.
    */
-  function getTestIdFromResults() {
+  protected function getTestIdFromResults() {
     foreach ($this->childTestResults['assertions'] as $assertion) {
       if (preg_match('@^PASS: Test ID is ([0-9]*)\.$@', $assertion['message'], $matches)) {
         return $matches[1];
@@ -263,7 +263,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
    * @return boolean
    *   TRUE if the assertion is displayed, FALSE if it is not.
    */
-  function assertAssertion($message, $type, $status, $file, $function) {
+  protected function assertAssertion($message, $type, $status, $file, $function) {
     $message = trim(strip_tags($message));
     $found = FALSE;
     foreach ($this->childTestResults['assertions'] as $assertion) {
@@ -282,7 +282,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Get the results from a test and store them in the class array $results.
    */
-  function getTestResults() {
+  protected function getTestResults() {
     $results = array();
     if ($this->parse()) {
       if ($fieldset = $this->getResultFieldSet()) {
@@ -311,7 +311,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Get the fieldset containing the results for group this test is in.
    */
-  function getResultFieldSet() {
+  protected function getResultFieldSet() {
     $fieldsets = $this->xpath('//fieldset');
     $info = simpletest_test_get_by_class(get_class($this));
     foreach ($fieldsets as $fieldset) {
@@ -330,7 +330,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
    * @return
    *   Extracted text.
    */
-  function asText(SimpleXMLElement $element) {
+  protected function asText(SimpleXMLElement $element) {
     if (!is_object($element)) {
       return $this->fail('The element is not an element.');
     }
@@ -340,7 +340,7 @@ class SimpleTestFunctionalTest extends BackdropWebTestCase {
   /**
    * Check if the test is being run from inside a CURL request.
    */
-  function inCURL() {
+  protected function inCURL() {
     return (bool) backdrop_valid_test_ua();
   }
 }
@@ -356,7 +356,7 @@ class SimpleTestBrowserTestCase extends BackdropWebTestCase {
    */
   protected static $cookieSet = FALSE;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     config_set('system.core', 'user_register', USER_REGISTER_VISITORS);
   }
@@ -364,7 +364,7 @@ class SimpleTestBrowserTestCase extends BackdropWebTestCase {
   /**
    * Test BackdropWebTestCase::getAbsoluteUrl().
    */
-  function testGetAbsoluteUrl() {
+  public function testGetAbsoluteUrl() {
     // Testbed runs with Clean URLs disabled, so disable it here.
     config_set('system.core', 'clean_url', 0);
     backdrop_static_reset('url');
@@ -389,7 +389,7 @@ class SimpleTestBrowserTestCase extends BackdropWebTestCase {
   /**
    * Tests XPath escaping.
    */
-  function testXPathEscaping() {
+  public function testXPathEscaping() {
     $test_page = <<< EOF
 <html>
 <body>
@@ -452,7 +452,7 @@ class SimpleTestMailCaptureTestCase extends BackdropWebTestCase {
   /**
    * Test to see if the wrapper function is executed correctly.
    */
-  function testMailSend() {
+  public function testMailSend() {
     // Create an email.
     $subject = $this->randomString(64);
     $body = $this->randomString(128);
@@ -519,11 +519,11 @@ class SimpleTestMailCaptureTestCase extends BackdropWebTestCase {
 class SimpleTestFolderTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     return parent::setUp('image');
   }
 
-  function testFolderSetup() {
+  public function testFolderSetup() {
     $directory = file_default_scheme() . '://styles';
     $this->assertTrue(file_prepare_directory($directory, FALSE), 'Directory created.');
   }
@@ -536,7 +536,7 @@ class SimpleTestMissingDependentModuleUnitTest extends BackdropUnitTestCase {
   /**
    * Ensure that this test will not be loaded despite its dependency.
    */
-  function testFail() {
+  public function testFail() {
     $this->fail(t('Running test with missing required module.'));
   }
 }
@@ -551,7 +551,7 @@ class SimpleTestMissingDependentModuleUnitTest extends BackdropUnitTestCase {
  * @see BackdropTestCase
  */
 class SimpleTestBrokenSetUp extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     // If the test is being run from the main site, set up normally.
     if (!backdrop_valid_test_ua()) {
       parent::setUp('simpletest');
@@ -566,7 +566,7 @@ class SimpleTestBrokenSetUp extends BackdropWebTestCase {
     }
   }
 
-  function tearDown() {
+  protected function tearDown() {
     // If the test is being run from the main site, tear down normally.
     if (!backdrop_valid_test_ua()) {
       parent::tearDown();
@@ -580,7 +580,7 @@ class SimpleTestBrokenSetUp extends BackdropWebTestCase {
   /**
    * Runs this test case from within the simpletest child site.
    */
-  function testBreakSetUp() {
+  public function testBreakSetUp() {
     // If the test is being run from the main site, run it again from the web
     // interface within the simpletest child site.
     if (!backdrop_valid_test_ua()) {
@@ -604,7 +604,7 @@ class SimpleTestBrokenSetUp extends BackdropWebTestCase {
  * Tests missing requirements to run test.
  */
 class SimpleTestMissingCheckedRequirements extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('simpletest');
     $admin_user = $this->backdropCreateUser(array('administer unit tests'));
     $this->backdropLogin($admin_user);
@@ -664,7 +664,7 @@ class SimpleTestInstallationProfileModuleTestsTestCase extends BackdropWebTestCa
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('simpletest'));
 
     $this->admin_user = $this->backdropCreateUser(array('administer unit tests'));
@@ -674,7 +674,7 @@ class SimpleTestInstallationProfileModuleTestsTestCase extends BackdropWebTestCa
   /**
    * Tests existence of test case located in an installation profile module.
    */
-  function testInstallationProfileTests() {
+  public function testInstallationProfileTests() {
     $this->backdropGet('admin/config/development/testing');
     $this->assertText('Installation profile module tests helper');
     $edit = array(
@@ -707,7 +707,7 @@ class SimpleTestOtherInstallationProfileModuleTestsTestCase extends BackdropWebT
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('simpletest'));
 
     $this->admin_user = $this->backdropCreateUser(array('administer unit tests'));
@@ -717,7 +717,7 @@ class SimpleTestOtherInstallationProfileModuleTestsTestCase extends BackdropWebT
   /**
    * Tests that tests located in another installation profile do not appear.
    */
-  function testOtherInstallationProfile() {
+  public function testOtherInstallationProfile() {
     $this->backdropGet('admin/config/development/testing');
     $this->assertNoText('Installation profile module tests helper');
   }

--- a/core/modules/simpletest/tests/standard.test
+++ b/core/modules/simpletest/tests/standard.test
@@ -14,7 +14,7 @@ class StandardInstallTestCase extends BackdropWebTestCase {
   /**
    * Tests existence of test case located in an installation profile module.
    */
-  function testRolesExist() {
+  public function testRolesExist() {
     $user_1 = user_load(1);
     $this->assertTrue(user_has_role('administrator', $user_1), 'User ID 1 is an administrator');
 

--- a/core/modules/simpletest/tests/tablesort.test
+++ b/core/modules/simpletest/tests/tablesort.test
@@ -16,14 +16,14 @@ class TableSortTest extends BackdropUnitTestCase {
    */
   protected $GET = array();
 
-  function setUp() {
+  public function setUp() {
     // Save the original $_GET to be restored later.
     $this->GET = $_GET;
 
     parent::setUp();
   }
 
-  function tearDown() {
+  protected function tearDown() {
     // Revert $_GET.
     $_GET = $this->GET;
 
@@ -33,7 +33,7 @@ class TableSortTest extends BackdropUnitTestCase {
   /**
    * Test tablesort_init().
    */
-  function testTableSortInit() {
+  public function testTableSortInit() {
 
     // Test simple table headers.
 

--- a/core/modules/simpletest/tests/theme.test
+++ b/core/modules/simpletest/tests/theme.test
@@ -10,7 +10,7 @@
 class ThemeUnitTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('theme_test');
     theme_enable(array('test_theme'));
   }
@@ -18,7 +18,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Test function theme_get_suggestions() for SA-CORE-2009-003.
    */
-  function testThemeSuggestions() {
+  public function testThemeSuggestions() {
     // Set the home page as something random otherwise the CLI
     // test runner fails.
     config_set('system.core', 'site_frontpage', 'nobody-home');
@@ -49,7 +49,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
    * separate file, so this test also ensures that that file is correctly loaded
    * when needed.
    */
-  function testPreprocessForSuggestions() {
+  public function testPreprocessForSuggestions() {
     // Test with both an unprimed and primed theme registry.
     backdrop_theme_rebuild();
     for ($i = 0; $i < 2; $i++) {
@@ -61,7 +61,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Ensure page-front template suggestion is added when on home page.
    */
-  function testFrontPageThemeSuggestion() {
+  public function testFrontPageThemeSuggestion() {
     $q = $_GET['q'];
     // Set $_GET['q'] to node because theme_get_suggestions() will query it to
     // see if we are on the home page.
@@ -76,7 +76,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Ensures theme hook_*_alter() implementations can run before anything is rendered.
    */
-  function testAlter() {
+  public function testAlter() {
     $this->backdropGet('theme-test/alter');
     $this->assertText('The altered data is test_theme_theme_test_alter_alter was invoked.', 'The theme was able to implement an alter hook during page building before anything was rendered.');
   }
@@ -86,7 +86,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
    *
    * @see test_theme.info
    */
-  function testCSSOverride() {
+  public function testCSSOverride() {
     // Reuse the same page as in testPreprocessForSuggestions(). We're testing
     // what is output to the HTML HEAD based on what is in a theme's .info file,
     // so it doesn't matter what page we get, as long as it is themed with the
@@ -106,7 +106,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Ensures a themes template is overrideable based on the 'template' filename.
    */
-  function testTemplateOverride() {
+  public function testTemplateOverride() {
     config_set('system.core', 'theme_default', 'test_theme');
     $this->backdropGet('theme-test/template-test');
     $this->assertText('Success: Template overridden.', t('Template overridden by defined \'template\' filename.'));
@@ -115,7 +115,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Test the list_themes() function.
    */
-  function testListThemes() {
+  public function testListThemes() {
     $themes = list_themes();
     // Check if backdrop_theme_access() retrieves enabled themes properly from list_themes().
     $this->assertTrue(backdrop_theme_access('test_theme'), 'Enabled theme detected');
@@ -136,7 +136,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Test the theme_get_setting() function.
    */
-  function testThemeGetSetting() {
+  public function testThemeGetSetting() {
     $GLOBALS['theme_key'] = 'test_theme';
     $this->assertIdentical(theme_get_setting('theme_test_setting'), 'default value', 'theme_get_setting() uses the default theme automatically.');
     $this->assertNotEqual(theme_get_setting('subtheme_override', 'test_basetheme'), theme_get_setting('subtheme_override', 'test_subtheme'), 'Base theme\'s default settings values can be overridden by subtheme.');
@@ -146,7 +146,7 @@ class ThemeUnitTest extends BackdropWebTestCase {
   /**
    * Ensures the theme registry is rebuilt when modules are disabled/enabled.
    */
-  function testRegistryRebuild() {
+  public function testRegistryRebuild() {
     $this->assertIdentical(theme('theme_test_foo', array('foo' => 'a')), 'a', 'The theme registry contains theme_test_foo.');
 
     module_disable(array('theme_test'), FALSE);
@@ -164,7 +164,7 @@ class ThemeTableUnitTest extends BackdropWebTestCase {
   /**
    * Tableheader.js provides 'sticky' table headers, and is included by default.
    */
-  function testThemeTableStickyHeaders() {
+  public function testThemeTableStickyHeaders() {
     $header = array('one', 'two', 'three');
     $rows = array(array(1,2,3), array(4,5,6), array(7,8,9));
     $this->content = theme('table', array('header' => $header, 'rows' => $rows));
@@ -177,7 +177,7 @@ class ThemeTableUnitTest extends BackdropWebTestCase {
   /**
    * If $sticky is FALSE, no tableheader.js should be included.
    */
-  function testThemeTableNoStickyHeaders() {
+  public function testThemeTableNoStickyHeaders() {
     $header = array('one', 'two', 'three');
     $rows = array(array(1,2,3), array(4,5,6), array(7,8,9));
     $attributes = array();
@@ -194,7 +194,7 @@ class ThemeTableUnitTest extends BackdropWebTestCase {
    * Tests that the table header is printed correctly even if there are no rows,
    * and that the empty text is displayed correctly.
    */
-  function testThemeTableWithEmptyMessage() {
+  public function testThemeTableWithEmptyMessage() {
     $header = array(
       t('Header 1'),
       array(
@@ -210,7 +210,7 @@ class ThemeTableUnitTest extends BackdropWebTestCase {
   /**
    * Tests that the 'no_striping' option works correctly.
    */
-  function testThemeTableWithNoStriping() {
+  public function testThemeTableWithNoStriping() {
     $rows = array(
       array(
         'data' => array(1),
@@ -254,7 +254,7 @@ class ThemeFunctionsTestCase extends BackdropWebTestCase {
   /**
    * Tests theme_item_list().
    */
-  function testItemList() {
+  public function testItemList() {
     // Verify that empty items produce no output.
     $variables = array();
     $expected = '';
@@ -337,7 +337,7 @@ class ThemeFunctionsTestCase extends BackdropWebTestCase {
   /**
    * Tests theme_links().
    */
-  function testLinks() {
+  public function testLinks() {
     // Verify that empty variables produce no output.
     $variables = array();
     $expected = '';
@@ -426,7 +426,7 @@ class ThemeFunctionsTestCase extends BackdropWebTestCase {
   /**
    * Test the use of backdrop_pre_render_links() on a nested array of links.
    */
-  function testBackdropPreRenderLinks() {
+  public function testBackdropPreRenderLinks() {
     // Define the base array to be rendered, containing a variety of different
     // kinds of links.
     $base_array = array(
@@ -528,14 +528,14 @@ class ThemeFunctionsTestCase extends BackdropWebTestCase {
 class ThemeHookInitUnitTest extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('theme_test');
   }
 
   /**
    * Test that the theme system can generate output when called by hook_init().
    */
-  function testThemeInitializationHookInit() {
+  public function testThemeInitializationHookInit() {
     $this->backdropGet('theme-test/hook-init');
     $this->assertRaw('Themed output generated in hook_init()', 'Themed output generated in hook_init() correctly appears on the page.');
     $this->assertRaw('stark/layout.css', "The default theme's CSS appears on the page when the theme system is initialized in hook_init().");
@@ -552,7 +552,7 @@ class ThemeFastTestCase extends BackdropWebTestCase {
    */
   protected $account;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('theme_test');
     $this->account = $this->backdropCreateUser(array('access user profiles'));
   }
@@ -560,7 +560,7 @@ class ThemeFastTestCase extends BackdropWebTestCase {
   /**
    * Tests access to user autocompletion and verify the correct results.
    */
-  function testUserAutocomplete() {
+  public function testUserAutocomplete() {
     $this->backdropLogin($this->account);
     $this->backdropGet('user/autocomplete/' . $this->account->name);
     $this->assertText('registry not initialized', 'The registry was not initialized');
@@ -574,7 +574,7 @@ class ThemeHeadTag extends BackdropUnitTestCase {
   /**
    * Test function theme_head_tag()
    */
-  function testThemeHeadTag() {
+  public function testThemeHeadTag() {
     // Test auto-closure meta tag generation
     $tag['element'] = array('#tag' => 'meta', '#attributes' => array('name' => 'description', 'content' => 'Backdrop test'));
     $this->assertEqual('<meta name="description" content="Backdrop test" />'."\n", theme_head_tag($tag), 'Test auto-closure meta tag generation.');
@@ -600,7 +600,7 @@ class RenderElementTypesTestCase extends BackdropWebTestCase {
    *   - 'value': This is the render element to test.
    *   - 'expected': This is the expected markup for the element in 'value'.
    */
-  function assertElements($elements) {
+  protected function assertElements($elements) {
     foreach($elements as $element) {
       $this->assertIdentical(backdrop_render($element['value']), $element['expected'], '"' . $element['name'] . '" input rendered correctly by backdrop_render().');
     }
@@ -609,7 +609,7 @@ class RenderElementTypesTestCase extends BackdropWebTestCase {
   /**
    * Tests Form API #type 'container'.
    */
-  function testContainer() {
+  public function testContainer() {
     $elements = array(
       // Basic container with no attributes.
       array(
@@ -691,7 +691,7 @@ class RenderElementTypesTestCase extends BackdropWebTestCase {
   /**
    * Tests system #type 'head_tag'.
    */
-  function testHeadTag() {
+  public function testHeadTag() {
     $elements = array(
       // Test auto-closure meta tag generation.
       array(
@@ -726,14 +726,14 @@ class RenderElementTypesTestCase extends BackdropWebTestCase {
  * Functional test for attributes of html.tpl.php.
  */
 class ThemeHtmlTplPhpAttributesTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('theme_test');
   }
 
   /**
    * Tests that modules and themes can alter variables in html.tpl.php.
    */
-  function testThemeHtmlTplPhpAttributes() {
+  public function testThemeHtmlTplPhpAttributes() {
     $this->backdropGet('');
     $attributes = $this->xpath('/html[@theme_test_html_attribute="theme test html attribute value"]');
     $this->assertTrue(count($attributes) == 1, t('Attribute set in the html element via hook_preprocess_html() found.'));
@@ -747,14 +747,14 @@ class ThemeHtmlTplPhpAttributesTestCase extends BackdropWebTestCase {
  */
 class ThemeRegistryTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
-  function setUp() {
+  public function setUp() {
     parent::setUp('theme_test');
   }
 
   /**
    * Tests the behavior of the theme registry class.
    */
-  function testRaceCondition() {
+  public function testRaceCondition() {
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $cid = 'test_theme_registry';
 
@@ -795,7 +795,7 @@ class ThemeDatetime extends BackdropWebTestCase {
   /**
    * Test function theme_datetime().
    */
-  function testThemeDatetime() {
+  public function testThemeDatetime() {
     // Create timestamp and formatted date for testing.
     $timestamp = 1421394600;
     $date = format_date($timestamp);
@@ -847,7 +847,7 @@ class ThemeDebugMarkupTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('theme_test', 'node', 'taxonomy');
     theme_enable(array('test_theme'));
 
@@ -871,7 +871,7 @@ class ThemeDebugMarkupTestCase extends BackdropWebTestCase {
   /**
    * Tests debug node markup added to template output.
    */
-  function testDebugNodeOutput() {
+  public function testDebugNodeOutput() {
     config_set('system.core', 'theme_default', 'test_theme');
     // Enable the debug output.
     config_set('system.core', 'theme_debug', TRUE);
@@ -939,7 +939,7 @@ EOL;
   /**
    * Tests debug user markup added to template output.
    */
-  function testDebugUserOutput() {
+  public function testDebugUserOutput() {
     config_set('system.core', 'theme_default', 'test_theme');
     // Enable the debug output.
     config_set('system.core', 'theme_debug', TRUE);
@@ -1004,7 +1004,7 @@ EOL;
   /**
    * Tests debug taxonomy markup added to template output.
    */
-  function testDebugTaxonomyOutput() {
+  public function testDebugTaxonomyOutput() {
     config_set('system.core', 'theme_default', 'test_theme');
     // Enable the debug output.
     config_set('system.core', 'theme_debug', TRUE);

--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -13,7 +13,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Creates a user and a node, then tests the tokens generated from them.
    */
-  function testTokenReplacement() {
+  public function testTokenReplacement() {
     // Create the initial objects.
     $account = $this->backdropCreateUser();
     $node = $this->backdropCreateNode(array('uid' => $account->uid));
@@ -62,7 +62,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Test whether token-replacement works in various contexts.
    */
-  function testSystemTokenRecognition() {
+  public function testSystemTokenRecognition() {
     global $language;
 
     // Generate prefixes and suffixes for the token context.
@@ -91,7 +91,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Tests the generation of all system site information tokens.
    */
-  function testSystemSiteTokenReplacement() {
+  public function testSystemSiteTokenReplacement() {
     global $language;
     $url_options = array(
       'absolute' => TRUE,
@@ -135,7 +135,7 @@ class TokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Tests the generation of all system date tokens.
    */
-  function testSystemDateTokenReplacement() {
+  public function testSystemDateTokenReplacement() {
     global $language;
 
     // Set time to one hour before request.
@@ -167,7 +167,7 @@ class TokenScanTest extends BackdropUnitTestCase {
   /**
    * Scans dummy text, then tests the output.
    */
-  function testTokenScan() {
+  public function testTokenScan() {
     // Define text with valid and not valid, fake and existing token-like
     // strings.
     $text = 'First a [valid:simple], but dummy token, and a dummy [valid:token with: spaces].';
@@ -197,11 +197,11 @@ class TokenTestHelper extends BackdropWebTestCase {
     config_set('system.core', 'clean_url', 1);
   }
 
-  function assertToken($type, array $data, $token, $expected, array $options = array()) {
+  protected function assertToken($type, array $data, $token, $expected, array $options = array()) {
     return $this->assertTokens($type, $data, array($token => $expected), $options);
   }
 
-  function assertTokens($type, array $data, array $tokens, array $options = array()) {
+  protected function assertTokens($type, array $data, array $tokens, array $options = array()) {
     $input = $this->mapTokenNames($type, array_keys($tokens));
     $replacements = token_generate($type, $input, $data, $options);
     foreach ($tokens as $name => $expected) {
@@ -223,7 +223,7 @@ class TokenTestHelper extends BackdropWebTestCase {
     return $replacements;
   }
 
-  function mapTokenNames($type, array $tokens = array()) {
+  protected function mapTokenNames($type, array $tokens = array()) {
     $return = array();
     foreach ($tokens as $token) {
       $return[$token] = "[$type:$token]";
@@ -231,7 +231,7 @@ class TokenTestHelper extends BackdropWebTestCase {
     return $return;
   }
 
-  function assertNoTokens($type, array $data, array $tokens, array $options = array()) {
+  protected function assertNoTokens($type, array $data, array $tokens, array $options = array()) {
     $input = $this->mapTokenNames($type, $tokens);
     $replacements = token_generate($type, $input, $data, $options);
     foreach ($tokens as $name) {
@@ -240,7 +240,7 @@ class TokenTestHelper extends BackdropWebTestCase {
     }
   }
 
-  function saveAlias($source, $alias, $language = LANGUAGE_NONE) {
+  protected function saveAlias($source, $alias, $language = LANGUAGE_NONE) {
     $alias = array(
       'source' => $source,
       'alias' => $alias,
@@ -250,7 +250,7 @@ class TokenTestHelper extends BackdropWebTestCase {
     return $alias;
   }
 
-  function saveEntityAlias($entity_type, $entity, $alias, $language = LANGUAGE_NONE) {
+  protected function saveEntityAlias($entity_type, $entity, $alias, $language = LANGUAGE_NONE) {
     $uri = entity_uri($entity_type, $entity);
     return $this->saveAlias($uri['path'], $alias, $language);
   }
@@ -258,7 +258,7 @@ class TokenTestHelper extends BackdropWebTestCase {
   /**
    * Make a page request and test for token generation.
    */
-  function assertPageTokens($url, array $tokens, array $data = array(), array $options = array()) {
+  protected function assertPageTokens($url, array $tokens, array $data = array(), array $options = array()) {
     if (empty($tokens)) {
       return TRUE;
     }
@@ -375,7 +375,7 @@ class TokenURLTestCase extends TokenTestHelper {
     $this->saveAlias('node/1', 'first-node');
   }
 
-  function testURLTokens() {
+  public function testURLTokens() {
     $tokens = array(
       'absolute' => 'http://example.com/first-node',
       'relative' => base_path() . 'first-node',
@@ -405,7 +405,7 @@ class TokenCommentTestCase extends TokenTestHelper {
     parent::setUp($modules);
   }
 
-  function testCommentTokens() {
+  public function testCommentTokens() {
     $node = $this->backdropCreateNode(array('comment' => COMMENT_NODE_OPEN));
 
     $parent_comment = new Comment();
@@ -455,7 +455,7 @@ class TokenCommentTestCase extends TokenTestHelper {
 class TokenNodeTestCase extends TokenTestHelper {
   protected $profile = 'standard';
 
-  function testNodeTokens() {
+  public function testNodeTokens() {
     $admin_user = $this->backdropCreateUser(array('create post content', 'create url aliases'));
     $this->backdropLogin($admin_user);
 
@@ -533,7 +533,7 @@ class TokenMenuTestCase extends TokenTestHelper {
     parent::setUp($modules);
   }
 
-  function testMenuTokens() {
+  public function testMenuTokens() {
     // Add a root link.
     $root_link = array(
       'link_path' => 'root',
@@ -642,7 +642,7 @@ class TokenTaxonomyTestCase extends TokenTestHelper {
   /**
    * Test the additional taxonomy term tokens.
    */
-  function testTaxonomyTokens() {
+  public function testTaxonomyTokens() {
     $root_term = $this->addTerm($this->vocab, array('name' => 'Root term', 'path' => array('alias' => 'root-term', 'auto' => FALSE)));
     $tokens = array(
       'url' => url("taxonomy/term/{$root_term->tid}", array('absolute' => TRUE)),
@@ -690,7 +690,7 @@ class TokenTaxonomyTestCase extends TokenTestHelper {
   /**
    * Test the additional vocabulary tokens.
    */
-  function testVocabularyTokens() {
+  public function testVocabularyTokens() {
     $vocabulary = $this->vocab;
     $tokens = array(
       'machine-name' => 'tags',
@@ -699,7 +699,7 @@ class TokenTaxonomyTestCase extends TokenTestHelper {
     $this->assertTokens('vocabulary', array('vocabulary' => $vocabulary), $tokens);
   }
 
-  function addVocabulary(array $vocabulary = array()) {
+  protected function addVocabulary(array $vocabulary = array()) {
     $vocabulary += array(
       'name' => backdrop_strtolower($this->randomName(5)),
       'nodes' => array('post' => 'post'),
@@ -709,7 +709,7 @@ class TokenTaxonomyTestCase extends TokenTestHelper {
     return $vocabulary;
   }
 
-  function addTerm(TaxonomyVocabulary $vocabulary, array $term = array()) {
+  protected function addTerm(TaxonomyVocabulary $vocabulary, array $term = array()) {
     $term += array(
       'name' => backdrop_strtolower($this->randomName(5)),
       'vocabulary' => $vocabulary->machine_name,
@@ -742,7 +742,7 @@ class TokenUserTestCase extends TokenTestHelper {
     $this->backdropLogin($this->account);
   }
 
-  function testUserTokens() {
+  public function testUserTokens() {
     // Add a user picture to the account.
     $image = current($this->backdropGetTestFiles('image'));
     $edit = array('files[picture_upload]' => backdrop_realpath($image->uri));
@@ -814,7 +814,7 @@ class TokenEntityTestCase extends TokenTestHelper {
     $this->vocab = $vocabulary;
   }
 
-  function addTerm(TaxonomyVocabulary $vocabulary, array $term = array()) {
+  protected function addTerm(TaxonomyVocabulary $vocabulary, array $term = array()) {
     $term += array(
       'name' => backdrop_strtolower($this->randomName(5)),
       'vocabulary' => $vocabulary->machine_name,
@@ -828,7 +828,7 @@ class TokenEntityTestCase extends TokenTestHelper {
   /**
    * Test the [entity:original:*] tokens.
    */
-  function testEntityOriginal() {
+  public function testEntityOriginal() {
     $node = $this->backdropCreateNode(array('title' => 'Original title'));
 
     $tokens = array(
@@ -861,7 +861,7 @@ class TokenCurrentPageTestCase extends TokenTestHelper {
   protected $profile = 'standard';
   protected $config;
 
-  function testCurrentPageTokens() {
+  public function testCurrentPageTokens() {
     $tokens = array(
       '[current-page:title]' => t('Home', array('@site-name' => config_get('system.core', 'site_name'))),
       '[current-page:url]' => url('home', array('absolute' => TRUE)),
@@ -915,7 +915,7 @@ class TokenCurrentPageTestCase extends TokenTestHelper {
 
 class TokenArrayTestCase extends TokenTestHelper {
 
-  function testArrayTokens() {
+  public function testArrayTokens() {
     // Test a simple array.
     $array = array(0 => 'a', 1 => 'b', 2 => 'c', 4 => 'd');
     $tokens = array(
@@ -967,7 +967,7 @@ class TokenArrayTestCase extends TokenTestHelper {
 
 class TokenFileTestCase extends TokenTestHelper {
 
-  function testFileTokens() {
+  public function testFileTokens() {
     // Create a test file object.
     $file = new File();
     $file->fid = 1;

--- a/core/modules/simpletest/tests/unicode.test
+++ b/core/modules/simpletest/tests/unicode.test
@@ -19,7 +19,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
   /**
    * Test full unicode features implemented using the mbstring extension.
    */
-  function testMbStringUnicode() {
+  public function testMbStringUnicode() {
     global $multibyte;
 
     // mbstring was not detected on this installation, there is no way to test
@@ -44,7 +44,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
   /**
    * Test emulated unicode features.
    */
-  function testEmulatedUnicode() {
+  public function testEmulatedUnicode() {
     global $multibyte;
 
     $multibyte = UNICODE_SINGLEBYTE;
@@ -61,7 +61,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
     $this->helperTestTruncate();
   }
 
-  function helperTestStrToLower() {
+  protected function helperTestStrToLower() {
     $testcase = array(
       'tHe QUIcK bRoWn' => 'the quick brown',
       // cspell:disable-next-line
@@ -77,7 +77,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
     }
   }
 
-  function helperTestStrToUpper() {
+  protected function helperTestStrToUpper() {
     $testcase = array(
       'tHe QUIcK bRoWn' => 'THE QUICK BROWN',
       // cspell:disable-next-line
@@ -93,7 +93,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
     }
   }
 
-  function helperTestUcFirst() {
+  protected function helperTestUcFirst() {
     $testcase = array(
       // cspell:disable
       'tHe QUIcK bRoWn' => 'THe QUIcK bRoWn',
@@ -112,7 +112,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
     }
   }
 
-  function helperTestStrLen() {
+  protected function helperTestStrLen() {
     $testcase = array(
       'tHe QUIcK bRoWn' => 15,
       // cspell:disable-next-line
@@ -124,7 +124,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
     }
   }
 
-  function helperTestSubStr() {
+  protected function helperTestSubStr() {
     $testcase = array(
       //     012345678901234567890123
       // cspell:disable
@@ -188,7 +188,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
   /**
    * Test decode_entities().
    */
-  function testDecodeEntities() {
+  public function testDecodeEntities() {
     $testcase = array(
       'Backdrop' => 'Backdrop',
       '<script>' => '<script>',
@@ -220,7 +220,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
   /**
    * Tests truncate_utf8().
    */
-  function helperTestTruncate() {
+  protected function helperTestTruncate() {
     // Each case is an array with input string, length to truncate to, and
     // expected return value.
 
@@ -304,7 +304,7 @@ class UnicodeUnitTest extends BackdropUnitTestCase {
    * @param $ellipsis
    *   TRUE to append ... if the input is truncated, FALSE to not append ....
    */
-  function runTruncateTests($cases, $wordsafe, $ellipsis) {
+  protected function runTruncateTests($cases, $wordsafe, $ellipsis) {
     foreach ($cases as $case) {
       list($input, $max_length, $expected) = $case;
       $output = truncate_utf8($input, $max_length, $wordsafe, $ellipsis);

--- a/core/modules/simpletest/tests/update.test
+++ b/core/modules/simpletest/tests/update.test
@@ -8,7 +8,7 @@
  * Tests for the update dependency ordering system.
  */
 class UpdateDependencyOrderingTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('update_test_1', 'update_test_2', 'update_test_3');
     require_once BACKDROP_ROOT . '/core/includes/update.inc';
   }
@@ -16,7 +16,7 @@ class UpdateDependencyOrderingTestCase extends BackdropWebTestCase {
   /**
    * Test that updates within a single module run in the correct order.
    */
-  function testUpdateOrderingSingleModule() {
+  public function testUpdateOrderingSingleModule() {
     $starting_updates = array(
       'update_test_1' => 1000,
     );
@@ -32,7 +32,7 @@ class UpdateDependencyOrderingTestCase extends BackdropWebTestCase {
   /**
    * Test that dependencies between modules are resolved correctly.
    */
-  function testUpdateOrderingModuleInterdependency() {
+  public function testUpdateOrderingModuleInterdependency() {
     $starting_updates = array(
       'update_test_2' => 1000,
       'update_test_3' => 1000,
@@ -50,14 +50,14 @@ class UpdateDependencyOrderingTestCase extends BackdropWebTestCase {
  * Tests for missing update dependencies.
  */
 class UpdateDependencyMissingTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     // Only install update_test_2.module, even though its updates have a
     // dependency on update_test_3.module.
     parent::setUp('update_test_2');
     require_once BACKDROP_ROOT . '/core/includes/update.inc';
   }
 
-  function testMissingUpdate() {
+  public function testMissingUpdate() {
     $starting_updates = array(
       'update_test_2' => 1000,
     );
@@ -72,7 +72,7 @@ class UpdateDependencyMissingTestCase extends BackdropWebTestCase {
  * Tests for the invocation of hook_update_dependencies().
  */
 class UpdateDependencyHookInvocationTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('update_test_1', 'update_test_2');
     require_once BACKDROP_ROOT . '/core/includes/update.inc';
   }
@@ -80,7 +80,7 @@ class UpdateDependencyHookInvocationTestCase extends BackdropWebTestCase {
   /**
    * Test the structure of the array returned by hook_update_dependencies().
    */
-  function testHookUpdateDependencies() {
+  public function testHookUpdateDependencies() {
     $update_dependencies = update_retrieve_dependencies();
     $this->assertTrue($update_dependencies['system'][1000]['update_test_1'] == 1000, 'An update function that has a dependency on two separate modules has the first dependency recorded correctly.');
     $this->assertTrue($update_dependencies['system'][1000]['update_test_2'] == 1001, 'An update function that has a dependency on two separate modules has the second dependency recorded correctly.');
@@ -93,7 +93,7 @@ class UpdateDependencyHookInvocationTestCase extends BackdropWebTestCase {
  * Tests for ensuring updates from Drupal 7 execute properly.
  */
 class UpdateDrupal7TestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('update_d7_test_1', 'update_d7_test_2');
     require_once BACKDROP_ROOT . '/core/includes/update.inc';
   }
@@ -101,7 +101,7 @@ class UpdateDrupal7TestCase extends BackdropWebTestCase {
   /**
    * Tests that updates will be executed in the correct order.
    */
-  function testAvailableUpdates() {
+  public function testAvailableUpdates() {
     // Check that update numbers are ordered correctly.
     // 7xxx, then 0 - 6999.
     $schema_versions = backdrop_get_schema_versions('update_d7_test_1');

--- a/core/modules/syslog/tests/syslog.test
+++ b/core/modules/syslog/tests/syslog.test
@@ -5,14 +5,14 @@
  */
 
 class SyslogTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('syslog');
   }
 
   /**
    * Test the syslog settings page.
    */
-  function testSettings() {
+  public function testSettings() {
     $admin_user = $this->backdropCreateUser(array('administer site configuration'));
     $this->backdropLogin($admin_user);
 

--- a/core/modules/system/tests/system.test
+++ b/core/modules/system/tests/system.test
@@ -14,7 +14,7 @@ class ModuleTestCase extends WatchdogTestCase {
   protected $admin_user;
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
 
     $this->admin_user = $this->backdropCreateUser(array('access administration pages', 'administer modules'));
@@ -30,7 +30,7 @@ class ModuleTestCase extends WatchdogTestCase {
    *   (optional) Whether or not to assert that there are tables that match the
    *   specified base table. Defaults to TRUE.
    */
-  function assertTableCount($base_table, $count = TRUE) {
+  protected function assertTableCount($base_table, $count = TRUE) {
     $tables = db_find_tables(Database::getConnection()->prefixTables('{' . $base_table . '}') . '%');
 
     if ($count) {
@@ -45,7 +45,7 @@ class ModuleTestCase extends WatchdogTestCase {
    * @param $module
    *   The name of the module.
    */
-  function assertModuleTablesExist($module) {
+  protected function assertModuleTablesExist($module) {
     $tables = array_keys(backdrop_get_schema_unprocessed($module));
     $tables_exist = TRUE;
     foreach ($tables as $table) {
@@ -62,7 +62,7 @@ class ModuleTestCase extends WatchdogTestCase {
    * @param $module
    *   The name of the module.
    */
-  function assertModuleTablesDoNotExist($module) {
+  protected function assertModuleTablesDoNotExist($module) {
     $tables = array_keys(backdrop_get_schema_unprocessed($module));
     $tables_exist = FALSE;
     foreach ($tables as $table) {
@@ -81,7 +81,7 @@ class ModuleTestCase extends WatchdogTestCase {
    * @param $enabled
    *   Expected module state.
    */
-  function assertModules(array $modules, $enabled) {
+  protected function assertModules(array $modules, $enabled) {
     module_list(TRUE);
     foreach ($modules as $module) {
       if ($enabled) {
@@ -104,7 +104,7 @@ class FilterResetTestCase extends ModuleTestCase {
   /**
    * Test that the search and reset functionality on the modules page works.
    */
-  function testFilterReset() {
+  public function testFilterReset() {
     $edit = array();
     $edit['search'] = 'image';
     $this->backdropPost('admin/modules', $edit, t('Save configuration'));
@@ -128,7 +128,7 @@ class EnableDisableTestCase extends ModuleTestCase {
   /**
    * Test that all core modules can be enabled, disabled and uninstalled.
    */
-  function testEnableDisable() {
+  public function testEnableDisable() {
     // Try to enable, disable and uninstall all core modules.
     $modules = system_rebuild_module_data();
     foreach ($modules as $name => $module) {
@@ -269,7 +269,7 @@ class EnableDisableTestCase extends ModuleTestCase {
    *   The complete object representing the module to disable and uninstall, as
    *   retrieved with system_rebuild_module_data().
    */
-  function assertSuccessfulDisableAndUninstall($module) {
+  protected function assertSuccessfulDisableAndUninstall($module) {
     // Disable the module.
     $edit = array();
     $edit['modules[' . $module->info['package'] . '][' . $module->name . '][enable]'] = FALSE;
@@ -314,7 +314,7 @@ class HookRequirementsTestCase extends ModuleTestCase {
   /**
    * Assert that a module cannot be installed if it fails hook_requirements().
    */
-  function testHookRequirementsFailure() {
+  public function testHookRequirementsFailure() {
     $this->assertModules(array('requirements1_test'), FALSE);
 
     // Attempt to install the requirements1_test module.
@@ -335,7 +335,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Checks functionality of project namespaces for dependencies.
    */
-  function testProjectNamespaceForDependencies() {
+  public function testProjectNamespaceForDependencies() {
     // Enable module with project namespace to ensure nothing breaks.
     $edit = array(
       'modules[Testing][system_project_namespace_test][enable]' => TRUE,
@@ -347,7 +347,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Attempt to enable translation module without locale enabled.
    */
-  function testEnableWithoutDependency() {
+  public function testEnableWithoutDependency() {
     // Attempt to enable content translation without locale enabled.
     $edit = array();
     $edit['modules[Translation][translation][enable]'] = 'translation';
@@ -373,7 +373,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Attempt to enable a module with a missing dependency.
    */
-  function testMissingModules() {
+  public function testMissingModules() {
     // Test that the system_dependencies_test module is marked
     // as missing a dependency.
     $this->backdropGet('admin/modules');
@@ -399,7 +399,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Tests enabling a module that depends on an incompatible version of a module.
    */
-  function testIncompatibleModuleVersionDependency() {
+  public function testIncompatibleModuleVersionDependency() {
     // Test that the system_incompatible_module_version_dependencies_test is
     // marked as having an incompatible dependency.
     $this->backdropGet('admin/modules');
@@ -414,7 +414,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Tests enabling a module that depends on a module with an incompatible core version.
    */
-  function testIncompatibleCoreVersionDependency() {
+  public function testIncompatibleCoreVersionDependency() {
     // Test that the system_incompatible_core_version_dependencies_test is
     // marked as having an incompatible dependency.
     $this->backdropGet('admin/modules');
@@ -428,7 +428,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Tests enabling a module that depends on a module which fails hook_requirements().
    */
-  function testEnableRequirementsFailureDependency() {
+  public function testEnableRequirementsFailureDependency() {
     // Enable comment module before testing the dependencies.
     $edit = array();
     $edit['modules[Comments][comment][enable]'] = TRUE;
@@ -458,7 +458,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
    * Tests that module dependencies are enabled in the correct order via the
    * UI. Dependencies should be enabled before their dependents.
    */
-  function testModuleEnableOrder() {
+  public function testModuleEnableOrder() {
     module_enable(array('module_test'), FALSE);
     $this->resetAll();
     $this->assertModules(array('module_test'), TRUE);
@@ -486,7 +486,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Tests attempting to uninstall a module that has installed dependents.
    */
-  function testUninstallDependents() {
+  public function testUninstallDependents() {
     // Enable both language and locale modules.
     $edit = array('modules[Translation][language][enable]' => 'language');
     $this->backdropPost('admin/modules', $edit, t('Save configuration'));
@@ -522,7 +522,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Tests whether the correct module metadata is returned.
    */
-  function testModuleMetaData() {
+  public function testModuleMetaData() {
     // Generate the list of available modules.
     $modules = system_rebuild_module_data();
     // Check that the mtime field exists for the system module.
@@ -536,7 +536,7 @@ class ModuleDependencyTestCase extends ModuleTestCase {
   /**
    * Tests whether the correct theme metadata is returned.
    */
-  function testThemeMetaData() {
+  public function testThemeMetaData() {
     // Generate the list of available themes.
     $themes = system_rebuild_theme_data();
     // Check that the mtime field exists for the bartik theme.
@@ -552,14 +552,14 @@ class ModuleDependencyTestCase extends ModuleTestCase {
  * Test module dependency on specific versions.
  */
 class ModuleVersionTestCase extends ModuleTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('module_test');
   }
 
   /**
    * Test version dependencies.
    */
-  function testModuleVersions() {
+  public function testModuleVersions() {
     $dependencies = array(
       // All comparisons are done against 1.x-2.4.5-beta3.
       'common_test' => TRUE,
@@ -648,14 +648,14 @@ class ModuleVersionTestCase extends ModuleTestCase {
 class CronRunTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('common_test', 'common_test_cron_helper'));
   }
 
   /**
    * Test cron runs.
    */
-  function testCronRun() {
+  public function testCronRun() {
     global $base_url;
 
     // Run cron anonymously without any cron key.
@@ -679,7 +679,7 @@ class CronRunTestCase extends BackdropWebTestCase {
    * In these tests we do not use REQUEST_TIME to track start time, because we
    * need the exact time when cron is triggered.
    */
-  function testAutomaticCron() {
+  public function testAutomaticCron() {
     // Ensure cron does not run when the cron threshold is enabled and was
     // not passed.
     $cron_last = time();
@@ -718,7 +718,7 @@ class CronRunTestCase extends BackdropWebTestCase {
    * Create files for all the possible combinations of age and status. We are
    * using UPDATE statements because using the API would set the timestamp.
    */
-  function testTempFileCleanup() {
+  public function testTempFileCleanup() {
     // Temporary file that is older than BACKDROP_MAXIMUM_TEMP_FILE_AGE.
     $temp_old = file_save_data('');
     db_update('file_managed')
@@ -761,7 +761,7 @@ class CronRunTestCase extends BackdropWebTestCase {
   /**
    * Make sure exceptions thrown on hook_cron() don't affect other modules.
    */
-  function testCronExceptions() {
+  public function testCronExceptions() {
     state_del('common_test_cron');
     // The common_test module throws an exception. If it isn't caught, the tests
     // won't finish successfully.
@@ -802,14 +802,14 @@ class CronRunTestCase extends BackdropWebTestCase {
 class CronQueueTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('common_test', 'common_test_cron_helper', 'cron_queue_test'));
   }
 
   /**
    * Tests that exceptions thrown by workers are handled properly.
    */
-  function testExceptions() {
+  public function testExceptions() {
     $queue = BackdropQueue::get('cron_queue_test_exception');
 
     // Enqueue an item for processing.
@@ -826,7 +826,7 @@ class CronQueueTestCase extends BackdropWebTestCase {
   /**
    * Tests worker defined as a class method callable.
    */
-  function testCallable() {
+  public function testCallable() {
     $queue = BackdropQueue::get('cron_queue_test_callback');
 
     // Enqueue an item for processing.
@@ -865,7 +865,7 @@ class MetaTagsTestCase extends BackdropWebTestCase {
 class AccessDeniedTestCase extends BackdropWebTestCase {
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create an administrative user.
@@ -875,7 +875,7 @@ class AccessDeniedTestCase extends BackdropWebTestCase {
     config_set('system.core', 'cache', '0');
   }
 
-  function testAccessDenied() {
+  public function testAccessDenied() {
     $this->backdropLogout();
     $this->backdropGet('admin');
     $this->assertText(t('Access denied'), 'Found the default 403 page');
@@ -930,7 +930,7 @@ class AccessDeniedTestCase extends BackdropWebTestCase {
     $this->assertText(t('Site information'));
   }
 
-  function test403PathOnSystemForm() {
+  public function test403PathOnSystemForm() {
     $this->backdropLogin($this->admin_user);
     $edit = array(
       'title' => $this->randomName(10),
@@ -959,7 +959,7 @@ class PageNotFoundTestCase extends BackdropWebTestCase {
   /**
    * Implement setUp().
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create an administrative user.
@@ -967,7 +967,7 @@ class PageNotFoundTestCase extends BackdropWebTestCase {
     $this->backdropLogin($this->admin_user);
   }
 
-  function testPageNotFound() {
+  public function testPageNotFound() {
     $this->backdropGet($this->randomName(10));
     $this->assertText(t('Page not found'), 'Found the default 404 page');
 
@@ -984,7 +984,7 @@ class PageNotFoundTestCase extends BackdropWebTestCase {
     $this->assertText($node->title, 'Found the custom 404 page');
   }
 
-  function test404PathOnSystemForm() {
+  public function test404PathOnSystemForm() {
     $this->backdropLogin($this->admin_user);
     $edit = array(
       'title' => $this->randomName(10),
@@ -1013,7 +1013,7 @@ class DeprecatedRedirectPageCase extends BackdropWebTestCase {
   /**
    * {@inheritdoc}
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('deprecated_redirect_test', 'dblog'));
     // Enable deprecated watchdog messages (level 8).
     config_set('system.core', 'watchdog_enabled_severity_levels', array(0, 1, 2, 3, 4, 5, 6, 8));
@@ -1022,7 +1022,7 @@ class DeprecatedRedirectPageCase extends BackdropWebTestCase {
   /**
    * Tests redirecting from a old menu paths to new menu paths.
    */
-  function testRedirects() {
+  public function testRedirects() {
     // Message used in watchdog entries.
     $watchdog_message = 'The path %path has been deprecated and will be removed in the next major release of Backdrop. This path was called from %referrer. It is recommended to remove it from any existing links.';
 
@@ -1058,7 +1058,7 @@ class CustomLogoTestCase extends BackdropWebTestCase {
   /**
    * Implement setUp().
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create an administrative user.
@@ -1072,7 +1072,7 @@ class CustomLogoTestCase extends BackdropWebTestCase {
   /**
    * Test the use of a custom logo.
    */
-  function testCustomLogo() {
+  public function testCustomLogo() {
     $file_public_path = config_get('system.core', 'file_public_path');
 
     // Specify a filesystem path to be used for the logo.
@@ -1221,7 +1221,7 @@ class SiteMaintenanceTestCase extends BackdropWebTestCase {
   protected $admin_user;
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create a user allowed to access site in maintenance mode.
@@ -1234,7 +1234,7 @@ class SiteMaintenanceTestCase extends BackdropWebTestCase {
   /**
    * Verify site maintenance mode functionality.
    */
-  function testSiteMaintenance() {
+  public function testSiteMaintenance() {
     // Start with the page cache disabled.
     config_set('system.core', 'page_cache_maximum_age', 0);
 
@@ -1356,7 +1356,7 @@ class DateTimeFunctionalTest extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('locale'));
 
     // Create admin user and log in admin user.
@@ -1368,7 +1368,7 @@ class DateTimeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test time zones and DST handling.
    */
-  function testTimeZoneHandling() {
+  public function testTimeZoneHandling() {
     // Setup date/time settings for Honolulu time.
     $config = config('system.date')
       ->set('default_timezone', 'Pacific/Honolulu')
@@ -1401,7 +1401,7 @@ class DateTimeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test date format configuration.
    */
-  function testDateFormatConfiguration() {
+  public function testDateFormatConfiguration() {
     // Confirm 'no custom date formats available' message appears.
     $this->backdropGet('admin/config/regional/date-time/formats');
 
@@ -1445,7 +1445,7 @@ class DateTimeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test if the date formats are stored properly.
    */
-  function testDateFormatStorage() {
+  public function testDateFormatStorage() {
     $date_format_info = array(
       'label' => 'testDateFormatStorage Short Format',
       'name' => 'test_short',
@@ -1466,7 +1466,7 @@ class PageTitleFiltering extends BackdropWebTestCase {
   /**
    * Implement setUp().
    */
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->content_user = $this->backdropCreateUser(array('create page content', 'access content', 'administer themes', 'administer site configuration'));
@@ -1477,7 +1477,7 @@ class PageTitleFiltering extends BackdropWebTestCase {
   /**
    * Reset page title.
    */
-  function tearDown() {
+  protected function tearDown() {
     // Restore the page title.
     backdrop_set_title($this->saved_title, PASS_THROUGH);
 
@@ -1487,7 +1487,7 @@ class PageTitleFiltering extends BackdropWebTestCase {
   /**
    * Tests the handling of HTML by backdrop_set_title() and backdrop_get_title()
    */
-  function testTitleTags() {
+  public function testTitleTags() {
     $title = "string with <em>HTML</em>";
     // backdrop_set_title's $filter is CHECK_PLAIN by default, so the title should be
     // returned with check_plain().
@@ -1515,7 +1515,7 @@ class PageTitleFiltering extends BackdropWebTestCase {
   /**
    * Test if the title of the site is XSS proof.
    */
-  function testTitleXSS() {
+  public function testTitleXSS() {
     // Set some title with JavaScript and HTML chars to escape.
     $title = '</title><script type="text/javascript">alert("Title XSS!");</script> & < > " \' ';
     $title_filtered = check_plain($title);
@@ -1559,7 +1559,7 @@ class FrontPageTestCase extends BackdropWebTestCase {
    */
   protected $node_path;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
 
     // Create admin user, log in admin user, and create one node.
@@ -1574,7 +1574,7 @@ class FrontPageTestCase extends BackdropWebTestCase {
   /**
    * Test home page functionality.
    */
-  function testBackdropIsFrontPage() {
+  public function testBackdropIsFrontPage() {
     $this->backdropGet('');
     $this->assertText(t('On home page.'), 'Path is the home page.');
     config_set('system.core', 'site_frontpage', 'node');
@@ -1626,7 +1626,7 @@ class FrontPageTestCase extends BackdropWebTestCase {
 class SystemBlockTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('block');
 
     // Create and login user
@@ -1637,7 +1637,7 @@ class SystemBlockTestCase extends BackdropWebTestCase {
   /**
    * Test displaying and hiding the powered-by and help blocks.
    */
-  function testSystemBlocks() {
+  public function testSystemBlocks() {
     // The powered-by block is enabled by default. Confirm that the block is
     // being displayed.
     $this->backdropGet('node');
@@ -1692,7 +1692,7 @@ class SystemMainContentFallback extends BackdropWebTestCase {
   protected $admin_user;
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
 
     // Create and login admin user.
@@ -1712,7 +1712,7 @@ class SystemMainContentFallback extends BackdropWebTestCase {
   /**
    * Test availability of main content.
    */
-  function testMainContentFallback() {
+  public function testMainContentFallback() {
     // Disable the layout module.
     module_disable(array('layout'));
     // Remove the old layout path from the menu.
@@ -1754,7 +1754,7 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
    */
   protected $node;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('node', 'block'));
 
     $this->backdropCreateContentType(array('type' => 'page', 'name' => 'Page'));
@@ -1767,7 +1767,7 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test the individual per-theme settings form.
    */
-  function testPerThemeSettings() {
+  public function testPerThemeSettings() {
     // Enable the test theme and the module that controls it. Clear caches in
     // between so that the module's hook_system_theme_info() implementation is
     // correctly registered.
@@ -1790,7 +1790,7 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test the administration theme functionality.
    */
-  function testAdministrationTheme() {
+  public function testAdministrationTheme() {
     theme_enable(array('stark'));
     config_set('system.core', 'theme_default', 'stark');
     // Enable an administration theme and show it on the node admin pages.
@@ -1837,7 +1837,7 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test switching the default theme.
    */
-  function testSwitchDefaultTheme() {
+  public function testSwitchDefaultTheme() {
     // Enable Basis and set it as the default theme.
     theme_enable(array('basis'));
     $this->backdropGet('admin/appearance');
@@ -1853,7 +1853,7 @@ class SystemThemeFunctionalTest extends BackdropWebTestCase {
   /**
    * Test theme settings.
    */
-  function testThemeSettings() {
+  public function testThemeSettings() {
     theme_enable(array('basis'));
     module_enable(array('color', 'theme_test'));
     backdrop_flush_all_caches();
@@ -1893,7 +1893,7 @@ class QueueTestCase extends BackdropWebTestCase {
   /**
    * Queues and dequeues a set of items to check the basic queue functionality.
    */
-  function testQueue() {
+  public function testQueue() {
     // Create two queues.
     $queue1 = BackdropQueue::get($this->randomName());
     $queue1->createQueue();
@@ -1956,7 +1956,7 @@ class QueueTestCase extends BackdropWebTestCase {
   /**
    * This function returns the number of equal items in two arrays.
    */
-  function queueScore($items, $new_items) {
+  protected function queueScore($items, $new_items) {
     $score = 0;
     foreach ($items as $item) {
       foreach ($new_items as $new_item) {
@@ -1973,7 +1973,7 @@ class InfoFileParserTestCase extends BackdropUnitTestCase {
   /**
    * Test backdrop_parse_info_format().
    */
-  function testBackdropParseInfoFormat() {
+  public function testBackdropParseInfoFormat() {
     $config = '
 simple = Value
 quoted = " Value"
@@ -2039,7 +2039,7 @@ class InfoFileCoreTest extends BackdropUnitTestCase {
   /**
    * Tests that the .info files of all core projects specify a project type.
    */
-  function testProjectInfoFileContents() {
+  public function testProjectInfoFileContents() {
     $projects = backdrop_system_listing('/^' . BACKDROP_PHP_FUNCTION_PATTERN . '\.info$/', 'core');
     $allowed_project_types = array('module', 'theme', 'layout', 'profile');
     $type_fails = array();
@@ -2073,7 +2073,7 @@ class SystemInfoAlterTestCase extends BackdropWebTestCase {
    * hook_system_info_alter() is enabled. Also tests if core *_list() functions
    * return freshly altered info.
    */
-  function testSystemInfoAlter() {
+  public function testSystemInfoAlter() {
     // Enable our test module. Flush all caches, which we assert is the only
     // thing necessary to use the rebuilt {system}.info.
     module_enable(array('module_test'), FALSE);
@@ -2113,7 +2113,7 @@ class SystemInfoAlterTestCase extends BackdropWebTestCase {
    * @return
    *   Array of info, or FALSE if the record is not found.
    */
-  function getSystemInfo($name, $type) {
+  protected function getSystemInfo($name, $type) {
     $raw_info = db_query("SELECT info FROM {system} WHERE name = :name AND type = :type", array(':name' => $name, ':type' => $type))->fetchField();
     return $raw_info ? unserialize($raw_info) : FALSE;
   }
@@ -2126,7 +2126,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   private $update_url;
   private $update_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('update_script_test', 'dblog'));
     $this->update_url = $GLOBALS['base_url'] . '/core/update.php';
     $this->update_user = $this->backdropCreateUser(array('administer software updates'));
@@ -2135,7 +2135,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests that there are no pending updates for the first test method.
    */
-  function testNoPendingUpdates() {
+  public function testNoPendingUpdates() {
     // Ensure that for the first test method in a class, there are no pending
     // updates. This tests a backdrop_get_schema_versions() bug that previously
     // led to the wrong schema version being recorded for the initial install
@@ -2149,7 +2149,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests access to the update script.
    */
-  function testUpdateAccess() {
+  public function testUpdateAccess() {
     // Try accessing update.php without the proper permission.
     $regular_user = $this->backdropCreateUser();
     $this->backdropLogin($regular_user);
@@ -2180,7 +2180,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests that requirements warnings and errors are correctly displayed.
    */
-  function testRequirements() {
+  public function testRequirements() {
     $config = config('update.settings');
     $this->backdropLogin($this->update_user);
 
@@ -2242,7 +2242,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the effect of using the update script on the theme system.
    */
-  function testThemeSystem() {
+  public function testThemeSystem() {
     // Since visiting update.php triggers a rebuild of the theme system from an
     // unusual maintenance mode environment, we check that this rebuild did not
     // put any incorrect information about the themes into the database.
@@ -2256,7 +2256,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests update.php when there are no updates to apply.
    */
-  function testNoUpdateFunctionality() {
+  public function testNoUpdateFunctionality() {
     // Click through update.php with 'administer software updates' permission.
     $this->backdropLogin($this->update_user);
     $this->backdropPost($this->update_url, array(), t('Continue'), array('external' => TRUE));
@@ -2277,7 +2277,7 @@ class UpdateScriptFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests update.php after performing a successful update.
    */
-  function testSuccessfulUpdateFunctionality() {
+  public function testSuccessfulUpdateFunctionality() {
     backdrop_set_installed_schema_version('update_script_test', backdrop_get_installed_schema_version('update_script_test') - 1);
     // Click through update.php with 'administer software updates' permission.
     $this->backdropLogin($this->update_user);
@@ -2317,7 +2317,7 @@ class FloodFunctionalTest extends BackdropWebTestCase {
   /**
    * Test flood control mechanism clean-up.
    */
-  function testCleanUp() {
+  public function testCleanUp() {
     $threshold = 1;
     $window_expired = -1;
     $name = 'flood_test_cleanup';
@@ -2347,7 +2347,7 @@ class RetrieveFileTestCase extends BackdropWebTestCase {
   /**
    * Invokes system_retrieve_file() in several scenarios.
    */
-  function testFileRetrieving() {
+  public function testFileRetrieving() {
     // Test 404 handling by trying to fetch a randomly named file.
     backdrop_mkdir($sourcedir = 'public://' . $this->randomName());
     // cspell:disable-next-line
@@ -2387,14 +2387,14 @@ class RetrieveFileTestCase extends BackdropWebTestCase {
  * Functional tests shutdown functions.
  */
 class ShutdownFunctionsTest extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
   }
 
   /**
    * Test shutdown functions.
    */
-  function testShutdownFunctions() {
+  public function testShutdownFunctions() {
     $arg1 = $this->randomName();
     $arg2 = $this->randomName();
     $this->backdropGet('system-test/shutdown-functions/' . $arg1 . '/' . $arg2);
@@ -2439,7 +2439,7 @@ class SystemAdminTestCase extends BackdropWebTestCase {
    */
   protected $web_user;
 
-  function setUp() {
+  public function setUp() {
     // testAdminPages() requires Locale module.
     parent::setUp(array('locale'));
 
@@ -2457,7 +2457,7 @@ class SystemAdminTestCase extends BackdropWebTestCase {
   /**
    * Tests output on administrative listing pages.
    */
-  function testAdminPages() {
+  public function testAdminPages() {
     // Go to Administration.
     $this->backdropGet('admin');
 
@@ -2586,7 +2586,7 @@ class SystemAuthorizeCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('system_test'));
 
     $GLOBALS['settings']['allow_authorize_operations'] = TRUE;
@@ -2607,14 +2607,14 @@ class SystemAuthorizeCase extends BackdropWebTestCase {
    *
    * @see system_authorized_init().
    */
-  function backdropGetAuthorizePHP($page_title = 'system-test-auth') {
+  protected function backdropGetAuthorizePHP($page_title = 'system-test-auth') {
     $this->backdropGet('system-test/authorize-init/' . $page_title);
   }
 
   /**
    * Tests the FileTransfer hooks
    */
-  function testFileTransferHooks() {
+  public function testFileTransferHooks() {
     $page_title = $this->randomName(16);
     $this->backdropGetAuthorizePHP($page_title);
     $this->assertTitle(strtr('@title | Backdrop CMS', array('@title' => $page_title)), 'authorize.php page title is correct.');
@@ -2635,7 +2635,7 @@ class SystemIndexPhpTest extends BackdropWebTestCase {
   /**
    * Test index.php handling.
    */
-  function testIndexPhpHandling() {
+  public function testIndexPhpHandling() {
     $this->backdropGet('<front>');
     $this->assertResponse(200, 'Make sure the home page returns a valid page.');
 
@@ -2691,14 +2691,14 @@ class SystemValidTokenTest extends BackdropWebTestCase {
  */
 class BackdropSetMessageTest extends BackdropWebTestCase {
   protected $profile = 'testing';
-  function setUp() {
+  public function setUp() {
     parent::setUp('system_test');
   }
 
   /**
    * Tests setting messages and removing one before it is displayed.
    */
-  function testSetRemoveMessages() {
+  public function testSetRemoveMessages() {
     // The page at system-test/backdrop-set-message sets two messages and then
     // removes the first before it is displayed.
     $this->backdropGet('system-test/backdrop-set-message');
@@ -2713,7 +2713,7 @@ class BackdropSetMessageTest extends BackdropWebTestCase {
 class ConfirmFormTest extends BackdropWebTestCase {
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->admin_user = $this->backdropCreateUser(array('administer users'));
@@ -2723,7 +2723,7 @@ class ConfirmFormTest extends BackdropWebTestCase {
   /**
    * Tests that the confirm form does not use external destinations.
    */
-  function testConfirmForm() {
+  public function testConfirmForm() {
     $this->backdropGet('user/1/cancel');
     $this->assertCancelLinkUrl(url('user/1'));
     $this->backdropGet('user/1/cancel', array('query' => array('destination' => 'node')));
@@ -2735,7 +2735,7 @@ class ConfirmFormTest extends BackdropWebTestCase {
   /**
    * Asserts that a cancel link is present pointing to the provided URL.
    */
-  function assertCancelLinkUrl($url, $message = '', $group = 'Other') {
+  protected function assertCancelLinkUrl($url, $message = '', $group = 'Other') {
     $links = $this->xpath('//a[normalize-space(text())=:label and @href=:url]', array(':label' => t('Cancel'), ':url' => $url));
     $message = ($message ? $message : format_string('Cancel link with url %url found.', array('%url' => $url)));
     return $this->assertTrue(isset($links[0]), $message, $group);
@@ -2748,7 +2748,7 @@ class ConfirmFormTest extends BackdropWebTestCase {
 class BackdropRequestSanitizerUnitTestCase extends BackdropUnitTestCase {
   protected $testCases = array();
 
-  function setUp() {
+  public function setUp() {
     // Set up an array of test cases.
     $this->testCases = array(
       'invalid_param_get' => array(
@@ -2794,7 +2794,7 @@ class BackdropRequestSanitizerUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests request sanitation used in early bootstrap.
    */
-  function testBackdropRequestSanitizer() {
+  public function testBackdropRequestSanitizer() {
     foreach ($this->testCases as $provider_name => $arguments) {
       foreach ($arguments['setup'] as $global_name => $value) {
         $GLOBALS[$global_name] = $value;
@@ -2846,7 +2846,7 @@ class UuidUnitTestCase extends BackdropUnitTestCase {
   /**
    * Test UUID validation.
    */
-  function testUuidValidation() {
+  public function testUuidValidation() {
     // These valid UUIDs.
     $uuid_fqdn = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
     $uuid_min = '00000000-0000-0000-0000-000000000000';
@@ -2876,7 +2876,7 @@ class MenuBlockTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('menu');
 
     $this->admin_user = $this->backdropCreateUser(array(
@@ -2892,14 +2892,14 @@ class MenuBlockTestCase extends BackdropWebTestCase {
   /**
    * Test Menu Block functionality with a system menu.
    */
-  function testMainMenuBlocks() {
+  public function testMainMenuBlocks() {
     $this->doMenuBlockTests('main-menu', 'Primary navigation');
   }
 
   /**
    * Test Menu Block functionality with custom menu.
    */
-  function testCustomMenuBlocks() {
+  public function testCustomMenuBlocks() {
     // Add a new custom menu.
     $menu_name = substr(hash('sha256', $this->randomName(16)), 0, MENU_MAX_MENU_NAME_LENGTH_UI);
     $title = $this->randomName(16);
@@ -2916,7 +2916,7 @@ class MenuBlockTestCase extends BackdropWebTestCase {
   /**
    * Test Menu Block functionality.
    */
-  function doMenuBlockTests($menu_name, $menu_title) {
+  protected function doMenuBlockTests($menu_name, $menu_title) {
 
     // Add nodes to use as links for menu links.
     $node1 = $this->backdropCreateNode(array('type' => 'post'));
@@ -3062,7 +3062,7 @@ class MenuBlockTestCase extends BackdropWebTestCase {
    * @param string $menu_name Menu name.
    * @return array Menu link created.
    */
-  function addMenuLink($menu_name, $plid = 0, $link = 'user') {
+  protected function addMenuLink($menu_name, $plid = 0, $link = 'user') {
     // View add menu link page.
     $this->backdropGet("admin/structure/menu/manage/$menu_name/add");
     $this->assertResponse(200);

--- a/core/modules/taxonomy/tests/taxonomy.test
+++ b/core/modules/taxonomy/tests/taxonomy.test
@@ -12,7 +12,7 @@ class TaxonomyWebTestCase extends BackdropWebTestCase {
   /**
    * Returns a new vocabulary with random properties.
    */
-  function createVocabulary() {
+  protected function createVocabulary() {
     // Create a vocabulary.
     $vocabulary = new TaxonomyVocabulary(array(
       'name' => $this->randomName(),
@@ -27,7 +27,7 @@ class TaxonomyWebTestCase extends BackdropWebTestCase {
   /**
    * Returns a new term with random properties in the given vocabulary.
    */
-  function createTerm($vocabulary) {
+  protected function createTerm($vocabulary) {
     $term = entity_create('taxonomy_term', array(
       'name' => $this->randomName(),
       'description' => $this->randomName(),
@@ -56,7 +56,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
    */
   protected $vocabulary;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy'));
     $this->backdropLogin($this->admin_user);
@@ -66,7 +66,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
   /**
    * Create, configure and delete a vocabulary via the user interface.
    */
-  function testVocabularyInterface() {
+  public function testVocabularyInterface() {
     // Visit the main taxonomy administration page.
     $this->backdropGet('admin/structure/taxonomy');
 
@@ -141,7 +141,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
   /**
    * Tests that vocabulary permissions are correctly set from the Taxonomy UI.
    */
-  function testVocabularyPermissions() {
+  public function testVocabularyPermissions() {
     // Create admin user.
     $admin_user = $this->backdropCreateUser(array(
       'administer taxonomy',
@@ -229,7 +229,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
   /**
    * Test the vocabulary overview with no vocabularies.
    */
-  function testTaxonomyAdminNoVocabularies() {
+  public function testTaxonomyAdminNoVocabularies() {
     // Delete all vocabularies.
     $vocabularies = taxonomy_vocabulary_load_multiple(FALSE);
     foreach ($vocabularies as $key => $vocabulary) {
@@ -245,7 +245,7 @@ class TaxonomyVocabularyFunctionalTest extends TaxonomyWebTestCase {
   /**
    * Deleting a vocabulary.
    */
-  function testTaxonomyAdminDeletingVocabulary() {
+  public function testTaxonomyAdminDeletingVocabulary() {
     // Create a vocabulary.
     $vocabulary_name = backdrop_strtolower($this->randomName());
     $edit = array(
@@ -279,7 +279,7 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
    */
   protected $vocabulary;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy', 'field_test');
     $admin_user = $this->backdropCreateUser(array('create post content', 'administer taxonomy'));
     $this->backdropLogin($admin_user);
@@ -289,7 +289,7 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
   /**
    * Test deleting a taxonomy that contains terms.
    */
-  function testTaxonomyVocabularyDeleteWithTerms() {
+  public function testTaxonomyVocabularyDeleteWithTerms() {
     // Delete any existing vocabularies.
     foreach (taxonomy_vocabulary_load_multiple(FALSE) as $vocabulary) {
       taxonomy_vocabulary_delete($vocabulary->machine_name);
@@ -323,7 +323,7 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
   /**
    * Ensure that the vocabulary static reset works correctly.
    */
-  function testTaxonomyVocabularyLoadStaticReset() {
+  public function testTaxonomyVocabularyLoadStaticReset() {
     $original_vocabulary = taxonomy_vocabulary_load($this->vocabulary->machine_name);
     $this->assertTrue(is_object($original_vocabulary), 'Vocabulary loaded successfully.');
     $this->assertEqual($this->vocabulary->name, $original_vocabulary->name, 'Vocabulary loaded successfully.');
@@ -348,7 +348,7 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
   /**
    * Tests for loading multiple vocabularies.
    */
-  function testTaxonomyVocabularyLoadMultiple() {
+  public function testTaxonomyVocabularyLoadMultiple() {
 
     // Delete any existing vocabularies.
     foreach (taxonomy_vocabulary_load_multiple(FALSE) as $vocabulary) {
@@ -381,7 +381,7 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
   /**
    * Test uninstall and reinstall of the taxonomy module.
    */
-  function testUninstallReinstall() {
+  public function testUninstallReinstall() {
     // Fields and field instances attached to taxonomy term bundles should be
     // removed when the module is uninstalled.
     $field_name = backdrop_strtolower($this->randomName() . '_field_name');
@@ -437,7 +437,7 @@ class TaxonomyVocabularyUnitTest extends TaxonomyWebTestCase {
  * Unit tests for taxonomy term functions.
  */
 class TaxonomyTermUnitTest extends TaxonomyWebTestCase {
-  function testTermDelete() {
+  public function testTermDelete() {
     $vocabulary = $this->createVocabulary();
     $valid_term = $this->createTerm($vocabulary);
     // Delete a valid term.
@@ -452,7 +452,7 @@ class TaxonomyTermUnitTest extends TaxonomyWebTestCase {
   /**
    * Test a taxonomy with terms that have multiple parents of different depths.
    */
-  function testTaxonomyVocabularyTree() {
+  public function testTaxonomyVocabularyTree() {
     // Create a new vocabulary with 6 terms.
     $vocabulary = $this->createVocabulary();
     $term = array();
@@ -514,7 +514,7 @@ class TaxonomyLegacyTestCase extends TaxonomyWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy');
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy', 'administer nodes', 'bypass node access'));
     $this->backdropLogin($this->admin_user);
@@ -523,7 +523,7 @@ class TaxonomyLegacyTestCase extends TaxonomyWebTestCase {
   /**
    * Test taxonomy functionality with nodes prior to 1970.
    */
-  function testTaxonomyLegacyNode() {
+  public function testTaxonomyLegacyNode() {
     // Posts a post with a taxonomy term and a date prior to 1970.
     $langcode = LANGUAGE_NONE;
     $edit = array();
@@ -561,7 +561,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
    */
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy');
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy', 'bypass node access'));
     $this->backdropLogin($this->admin_user);
@@ -601,7 +601,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
   /**
    * Test terms in a single and multiple hierarchy.
    */
-  function testTaxonomyTermHierarchy() {
+  public function testTaxonomyTermHierarchy() {
     // Create two taxonomy terms.
     $term1 = $this->createTerm($this->vocabulary);
     $term2 = $this->createTerm($this->vocabulary);
@@ -640,7 +640,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
    *
    * Save & edit a node and assert that taxonomy terms are saved/loaded properly.
    */
-  function testTaxonomyNode() {
+  public function testTaxonomyNode() {
     // Create two taxonomy terms.
     $term1 = $this->createTerm($this->vocabulary);
     $term2 = $this->createTerm($this->vocabulary);
@@ -669,7 +669,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
   /**
    * Test term creation with a free-tagging vocabulary from the node form.
    */
-  function testNodeTermCreationAndDeletion() {
+  public function testNodeTermCreationAndDeletion() {
     // Enable tags in the vocabulary.
     $instance = $this->instance;
     $instance['widget'] = array('type' => 'taxonomy_autocomplete');
@@ -762,7 +762,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
   /**
    * Save, edit and delete a term using the user interface.
    */
-  function testTermInterface() {
+  public function testTermInterface() {
     $edit = array(
       'name' => $this->randomName(12),
       'description[value]' => $this->randomName(100),
@@ -834,7 +834,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
   /**
    * Save, edit and delete a term using the user interface.
    */
-  function testTermReorder() {
+  public function testTermReorder() {
     $this->createTerm($this->vocabulary);
     $this->createTerm($this->vocabulary);
     $this->createTerm($this->vocabulary);
@@ -893,7 +893,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
   /**
    * Test saving a term with multiple parents through the UI.
    */
-  function testTermMultipleParentsInterface() {
+  public function testTermMultipleParentsInterface() {
     // Add a new term to the vocabulary so that we can have multiple parents.
     $parent = $this->createTerm($this->vocabulary);
 
@@ -922,7 +922,7 @@ class TaxonomyTermTestCase extends TaxonomyWebTestCase {
   /**
    * Test taxonomy_term_load_multiple_by_name().
    */
-  function testTaxonomyGetTermByName() {
+  public function testTaxonomyGetTermByName() {
     $term = $this->createTerm($this->vocabulary);
 
     // Load the term with the exact name.
@@ -1023,7 +1023,7 @@ class TaxonomyRSSTestCase extends TaxonomyWebTestCase {
    */
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy');
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy', 'bypass node access', 'administer content types', 'administer fields', 'administer view modes'));
     $this->backdropLogin($this->admin_user);
@@ -1065,7 +1065,7 @@ class TaxonomyRSSTestCase extends TaxonomyWebTestCase {
    *
    * Create a node and assert that taxonomy terms appear in rss.xml.
    */
-  function testTaxonomyRSS() {
+  public function testTaxonomyRSS() {
     // Create two taxonomy terms.
     $term1 = $this->createTerm($this->vocabulary);
 
@@ -1148,7 +1148,7 @@ class TaxonomyTermIndexTestCase extends TaxonomyWebTestCase {
    */
   protected $instance_2;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy');
 
     // Create an administrative user.
@@ -1222,7 +1222,7 @@ class TaxonomyTermIndexTestCase extends TaxonomyWebTestCase {
   /**
    * Tests that the taxonomy index is maintained properly.
    */
-  function testTaxonomyIndex() {
+  public function testTaxonomyIndex() {
     // Create terms in the vocabulary.
     $term_1 = $this->createTerm($this->vocabulary);
     $term_2 = $this->createTerm($this->vocabulary);
@@ -1332,7 +1332,7 @@ class TaxonomyTermIndexTestCase extends TaxonomyWebTestCase {
   /**
    * Tests that there is a link to the parent term on the child term page.
    */
-  function testTaxonomyTermHierarchyBreadcrumbs() {
+  public function testTaxonomyTermHierarchyBreadcrumbs() {
     // Create two taxonomy terms and set term2 as the parent of term1.
     $term1 = $this->createTerm($this->vocabulary);
     $term2 = $this->createTerm($this->vocabulary);
@@ -1356,7 +1356,7 @@ class TaxonomyLoadMultipleUnitTest extends TaxonomyWebTestCase {
    */
   protected $taxonomy_admin;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->taxonomy_admin = $this->backdropCreateUser(array('administer taxonomy'));
     $this->backdropLogin($this->taxonomy_admin);
@@ -1366,7 +1366,7 @@ class TaxonomyLoadMultipleUnitTest extends TaxonomyWebTestCase {
    * Create a vocabulary and some taxonomy terms, ensuring they're loaded
    * correctly using taxonomy_term_load_multiple().
    */
-  function testTaxonomyTermMultipleLoad() {
+  public function testTaxonomyTermMultipleLoad() {
     // Create a vocabulary.
     $vocabulary = $this->createVocabulary();
 
@@ -1414,7 +1414,7 @@ class TaxonomyLoadMultipleUnitTest extends TaxonomyWebTestCase {
  * Tests for taxonomy hook invocation.
  */
 class TaxonomyHooksTestCase extends TaxonomyWebTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy', 'taxonomy_test');
     module_load_include('inc', 'taxonomy', 'includes/taxonomy.pages');
     $taxonomy_admin = $this->backdropCreateUser(array('administer taxonomy'));
@@ -1427,7 +1427,7 @@ class TaxonomyHooksTestCase extends TaxonomyWebTestCase {
    *
    * @see taxonomy_test.module
    */
-  function testTaxonomyTermHooks() {
+  public function testTaxonomyTermHooks() {
     $vocabulary = $this->createVocabulary();
 
     // Create a term with one antonym.
@@ -1482,7 +1482,7 @@ class TaxonomyTermFieldTestCase extends TaxonomyWebTestCase {
    */
   protected $field;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $web_user = $this->backdropCreateUser(array('access field_test content', 'administer field_test content', 'administer taxonomy'));
@@ -1523,7 +1523,7 @@ class TaxonomyTermFieldTestCase extends TaxonomyWebTestCase {
   /**
    * Test term field validation.
    */
-  function testTaxonomyTermFieldValidation() {
+  public function testTaxonomyTermFieldValidation() {
     // Test valid and invalid values with field_attach_validate().
     $langcode = LANGUAGE_NONE;
     $entity = field_test_create_entity();
@@ -1552,7 +1552,7 @@ class TaxonomyTermFieldTestCase extends TaxonomyWebTestCase {
   /**
    * Test widgets.
    */
-  function testTaxonomyTermFieldWidgets() {
+  public function testTaxonomyTermFieldWidgets() {
     // Create a term in the vocabulary.
     $term = $this->createTerm($this->vocabulary);
 
@@ -1603,7 +1603,7 @@ class TaxonomyTermFieldMultipleVocabularyTestCase extends TaxonomyWebTestCase {
    */
   protected $field;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('field_test');
 
     $web_user = $this->backdropCreateUser(array('access field_test content', 'administer field_test content', 'administer taxonomy'));
@@ -1650,7 +1650,7 @@ class TaxonomyTermFieldMultipleVocabularyTestCase extends TaxonomyWebTestCase {
   /**
    * Tests term reference field and widget with multiple vocabularies.
    */
-  function testTaxonomyTermFieldMultipleVocabularies() {
+  public function testTaxonomyTermFieldMultipleVocabularies() {
     // Create a term in each vocabulary.
     $term1 = $this->createTerm($this->vocabulary1);
     $term2 = $this->createTerm($this->vocabulary2);
@@ -1733,7 +1733,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
    */
   protected $instance;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy', 'bypass node access'));
     $this->backdropLogin($this->admin_user);
@@ -1774,7 +1774,7 @@ class TaxonomyTokenReplaceTestCase extends TaxonomyWebTestCase {
   /**
    * Creates some terms and a node, then tests the tokens generated from them.
    */
-  function testTaxonomyTokenReplacement() {
+  public function testTaxonomyTokenReplacement() {
     global $language;
 
     // Create two taxonomy terms.
@@ -1881,7 +1881,7 @@ class TaxonomyLanguageFunctionalTest extends TaxonomyWebTestCase {
    */
   protected $vocabulary;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node', 'language');
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy', 'bypass node access', 'administer languages', 'administer content types', 'administer fields'));
     $this->backdropLogin($this->admin_user);
@@ -1911,7 +1911,7 @@ class TaxonomyLanguageFunctionalTest extends TaxonomyWebTestCase {
   /**
    * Create, configure and delete a vocabulary via the user interface.
    */
-  function testVocabularyLanguageInterface() {
+  public function testVocabularyLanguageInterface() {
     // Configure the vocabulary.
     $this->backdropGet('admin/structure/taxonomy');
     $this->clickLink(t('Configure'));
@@ -1928,7 +1928,7 @@ class TaxonomyLanguageFunctionalTest extends TaxonomyWebTestCase {
   /**
    * Test term creation with a free-tagging vocabulary from the node form.
    */
-  function testNodeTermLanguageCreation() {
+  public function testNodeTermLanguageCreation() {
     // Configure the vocabulary.
     $this->backdropGet('admin/structure/taxonomy');
     $this->clickLink(t('Configure'));
@@ -1988,7 +1988,7 @@ class TaxonomyLanguageFunctionalTest extends TaxonomyWebTestCase {
 class TaxonomyThemeTestCase extends TaxonomyWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('taxonomy');
 
     // Make sure we are using distinct default and administrative themes for
@@ -2005,7 +2005,7 @@ class TaxonomyThemeTestCase extends TaxonomyWebTestCase {
   /**
    * Test the theme used when adding, viewing and editing taxonomy terms.
    */
-  function testTaxonomyTermThemes() {
+  public function testTaxonomyTermThemes() {
     // Adding a term to a vocabulary is considered an administrative action and
     // should use the administrative theme.
     $vocabulary = $this->createVocabulary();
@@ -2039,7 +2039,7 @@ class TaxonomyEFQTestCase extends TaxonomyWebTestCase {
    */
   protected $vocabulary;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array('administer taxonomy'));
     $this->backdropLogin($this->admin_user);
@@ -2049,7 +2049,7 @@ class TaxonomyEFQTestCase extends TaxonomyWebTestCase {
   /**
    * Tests that a basic taxonomy EntityFieldQuery works.
    */
-  function testTaxonomyEFQ() {
+  public function testTaxonomyEFQ() {
     $terms = array();
     for ($i = 0; $i < 5; $i++) {
       $term = $this->createTerm($this->vocabulary);

--- a/core/modules/taxonomy/tests/taxonomy_views_handler_relationship_node_term_data.test
+++ b/core/modules/taxonomy/tests/taxonomy_views_handler_relationship_node_term_data.test
@@ -29,7 +29,7 @@ class TaxonomyViewsHandlerRelationshipNodeTermDataTest extends ViewsSqlTest {
   /**
    * Returns a new term with random properties in vocabulary $vid.
    */
-  function createTerm($vocabulary) {
+  protected function createTerm($vocabulary) {
     $term = entity_create('taxonomy_term', array(
       'name' => $this->randomName(),
       'description' => $this->randomName(),
@@ -57,7 +57,7 @@ class TaxonomyViewsHandlerRelationshipNodeTermDataTest extends ViewsSqlTest {
     $this->node = $this->backdropCreateNode($node);
   }
 
-  function testViewsHandlerRelationshipNodeTermData() {
+  public function testViewsHandlerRelationshipNodeTermData() {
     $view = $this->view_taxonomy_node_term_data();
 
     $this->executeView($view, array($this->term_1->tid, $this->term_2->tid));
@@ -70,7 +70,7 @@ class TaxonomyViewsHandlerRelationshipNodeTermDataTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $column_map);
   }
 
-  function view_taxonomy_node_term_data() {
+  private function view_taxonomy_node_term_data() {
     $view = new view();
     $view->name = 'test_taxonomy_node_term_data';
     $view->description = '';

--- a/core/modules/translation/tests/translation.test
+++ b/core/modules/translation/tests/translation.test
@@ -20,7 +20,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    */
   protected $translator;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('node', 'language', 'locale', 'translation', 'translation_test');
 
     // Setup users.
@@ -61,7 +61,7 @@ class TranslationTestCase extends BackdropWebTestCase {
   /**
    * Creates, modifies, and updates a page with a translation.
    */
-  function testContentTranslation() {
+  public function testContentTranslation() {
     // Create Page in English.
     $node_title = $this->randomName();
     $node_body =  $this->randomName();
@@ -153,7 +153,7 @@ class TranslationTestCase extends BackdropWebTestCase {
   /**
    * Checks that the language switch links behave properly.
    */
-  function testLanguageSwitchLinks() {
+  public function testLanguageSwitchLinks() {
     // Create a Page in English and its translations in Spanish and
     // Italian.
     $node = $this->createPage($this->randomName(), $this->randomName(), 'en');
@@ -199,7 +199,7 @@ class TranslationTestCase extends BackdropWebTestCase {
   /**
    * Tests that the language switcher block alterations work as intended.
    */
-  function testLanguageSwitcherBlockIntegration() {
+  public function testLanguageSwitcherBlockIntegration() {
     // Enable Italian to have three items in the language switcher block.
     $this->backdropLogin($this->admin_user);
     $edit = array('languages[it][enabled]' => TRUE);
@@ -262,7 +262,7 @@ class TranslationTestCase extends BackdropWebTestCase {
   /**
    * Resets static caches to make the test code match the client-side behavior.
    */
-  function resetCaches() {
+  protected function resetCaches() {
     backdrop_static_reset('language_list');
     backdrop_static_reset('locale_url_outbound_alter');
     backdrop_static_reset('locale_language_url_rewrite_url');
@@ -277,7 +277,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @return
    *   An empty node data structure.
    */
-  function emptyNode($langcode) {
+  protected function emptyNode($langcode) {
     return (object) array('nid' => NULL, 'langcode' => $langcode);
   }
 
@@ -287,7 +287,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @param $language_code
    *   The language code to check.
    */
-  function addLanguage($language_code) {
+  protected function addLanguage($language_code) {
     // Check to make sure that language has not already been installed.
     $this->backdropGet('admin/config/regional/language');
 
@@ -331,7 +331,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @return
    *   A node object.
    */
-  function createPage($title, $body, $langcode = NULL) {
+  protected function createPage($title, $body, $langcode = NULL) {
     $edit = array();
     $field_langcode = LANGUAGE_NONE;
     $edit["title"] = $title;
@@ -364,7 +364,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @return
    *   Translation object.
    */
-  function createTranslation(Node $node, $title, $body, $langcode) {
+  protected function createTranslation(Node $node, $title, $body, $langcode) {
     $this->backdropGet('node/add/page', array('query' => array('translation' => $node->nid, 'target' => $langcode)));
 
     $field_langcode = LANGUAGE_NONE;
@@ -405,7 +405,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @return
    *   TRUE on pass, FALSE on fail.
    */
-  function assertContentByXPath($xpath, array $arguments = array(), $value = NULL, $message = '', $group = 'Other') {
+  protected function assertContentByXPath($xpath, array $arguments = array(), $value = NULL, $message = '', $group = 'Other') {
     $found = $this->findContentByXPath($xpath, $arguments, $value);
     return $this->assertTrue($found, $message, $group);
   }
@@ -425,7 +425,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @return
    *   TRUE if the language switch links are found, FALSE if not.
    */
-  function assertLanguageSwitchLinks($node, $translation, $find = TRUE, $types = NULL) {
+  protected function assertLanguageSwitchLinks($node, $translation, $find = TRUE, $types = NULL) {
     $language_default = config_get('system.core', 'language_default');
 
     if (empty($types)) {
@@ -499,7 +499,7 @@ class TranslationTestCase extends BackdropWebTestCase {
    * @return
    *   TRUE if found, otherwise FALSE.
    */
-  function findContentByXPath($xpath, array $arguments = array(), $value = NULL) {
+  protected function findContentByXPath($xpath, array $arguments = array(), $value = NULL) {
     $elements = $this->xpath($xpath, $arguments);
 
     $found = TRUE;

--- a/core/modules/update/tests/update.test
+++ b/core/modules/update/tests/update.test
@@ -59,7 +59,7 @@ class UpdateTestHelper extends BackdropWebTestCase {
 }
 
 class UpdateCoreTestCase extends UpdateTestHelper {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('update_test', 'update'));
     $admin_user = $this->backdropCreateUser(array(
       'administer site configuration',
@@ -72,7 +72,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Tests the Update Manager module when no updates are available.
    */
-  function testNoUpdatesAvailable() {
+  public function testNoUpdatesAvailable() {
     $this->setSystemInfo1_0();
     $this->refreshUpdateStatus(array('backdrop' => '0'));
     $this->assertText(t('Up to date'));
@@ -83,7 +83,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Tests the Update Manager module when one normal update is available.
    */
-  function testNormalUpdateAvailable() {
+  public function testNormalUpdateAvailable() {
     $this->setSystemInfo1_0();
     $this->refreshUpdateStatus(array('backdrop' => '1'));
     $this->assertStandardTests();
@@ -98,7 +98,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Tests the Update Manager module when a security update is available.
    */
-  function testSecurityUpdateAvailable() {
+  public function testSecurityUpdateAvailable() {
     $this->setSystemInfo1_0();
     $this->refreshUpdateStatus(array('backdrop' => '2-sec'));
     $this->assertStandardTests();
@@ -113,7 +113,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Ensures proper results where there are date mismatches among modules.
    */
-  function testDatestampMismatch() {
+  public function testDatestampMismatch() {
     $system_info = array(
       '#all' => array(
         // We need to think we're running a -dev snapshot to see dates.
@@ -136,7 +136,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Checks that running cron updates the list of available updates.
    */
-  function testModulePageRunCron() {
+  public function testModulePageRunCron() {
     $config = config('update.settings');
     $this->setSystemInfo1_0();
     $config->set('update_url', url('update-test', array('absolute' => TRUE)))->save();
@@ -150,7 +150,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Checks the messages at admin/modules when the site is up to date.
    */
-  function testModulePageUpToDate() {
+  public function testModulePageUpToDate() {
     $this->setSystemInfo1_0();
     $config = config('update.settings');
     // Instead of using refreshUpdateStatus(), set these manually.
@@ -168,7 +168,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Tests the Update Manager module when the update server returns 503 errors.
    */
-  function testServiceUnavailable() {
+  public function testServiceUnavailable() {
     $this->refreshUpdateStatus(array(), '503-error');
     // Ensure that no "Warning: SimpleXMLElement..." parse errors are found.
     $this->assertNoText('SimpleXMLElement');
@@ -178,7 +178,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Tests that exactly one fetch task per project is created and not more.
    */
-  function testFetchTasks() {
+  public function testFetchTasks() {
     $project_a = array(
       'name' => 'aaa_update_test',
     );
@@ -205,7 +205,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Tests _update_checking_enabled() returns the expected value during tests.
    */
-  function testUpdateCheckingEnabled() {
+  public function testUpdateCheckingEnabled() {
     $config = config('update.settings');
     $this->assertEqual($config->get('update_url'), '', 'No update server specified in the default installation.');
     $this->assertFalse(_update_checking_enabled(), 'Update checking is not enabled when using the default server.');
@@ -225,7 +225,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
   /**
    * Test that getUpdaterFromDirectory() gets the right class for core updates.
    */
-  function testGetUpdaterFromDirectory() {
+  public function testGetUpdaterFromDirectory() {
     module_load_include('inc', 'installer', 'installer.manager');
     // Extract our stub sample Backdrop zip archive to temporary.
     $extract_directory = _installer_manager_extract_directory();
@@ -258,7 +258,7 @@ class UpdateCoreTestCase extends UpdateTestHelper {
 }
 
 class UpdateTestContribCase extends UpdateTestHelper {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('update_test', 'update', 'aaa_update_test', 'bbb_update_test', 'ccc_update_test'));
     $admin_user = $this->backdropCreateUser(array(
       'administer site configuration',
@@ -270,7 +270,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
   /**
    * Tests when there is no available release data for a contrib module.
    */
-  function testNoReleasesAvailable() {
+  public function testNoReleasesAvailable() {
     $system_info = array(
       '#all' => array(
         'version' => '1.0',
@@ -298,7 +298,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
   /**
    * Tests the basic functionality of a contrib module on the status report.
    */
-  function testUpdateContribBasic() {
+  public function testUpdateContribBasic() {
     $system_info = array(
       '#all' => array(
         'version' => '1.0',
@@ -336,7 +336,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
    * if you sort alphabetically by module name (which is the order we see things
    * inside system_rebuild_module_data() for example).
    */
-  function testUpdateContribOrder() {
+  public function testUpdateContribOrder() {
     // We want core to be version 1.0.
     $system_info = array(
       '#all' => array(
@@ -397,7 +397,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
   /**
    * Tests that subthemes are notified about security updates for base themes.
    */
-  function testUpdateBaseThemeSecurityUpdate() {
+  public function testUpdateBaseThemeSecurityUpdate() {
     // Only enable the subtheme, not the base theme.
     db_update('system')
       ->fields(array('status' => 1))
@@ -438,7 +438,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
   /**
    * Tests that the admin theme is always notified about security updates.
    */
-  function testUpdateAdminThemeSecurityUpdate() {
+  public function testUpdateAdminThemeSecurityUpdate() {
     // Disable the admin theme.
     db_update('system')
       ->fields(array('status' => 0))
@@ -487,7 +487,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
   /**
    * Tests that disabled themes are only shown when desired.
    */
-  function testUpdateShowDisabledThemes() {
+  public function testUpdateShowDisabledThemes() {
     $config = config('update.settings');
     // Make sure all the update_test_* themes are disabled.
     db_update('system')
@@ -547,7 +547,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
   /**
    * Makes sure that if we fetch from a broken URL, sane things happen.
    */
-  function testUpdateBrokenFetchURL() {
+  public function testUpdateBrokenFetchURL() {
     $system_info = array(
       '#all' => array(
         'version' => '1.0',
@@ -608,7 +608,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
    * hook_update_status_alter() to try to mark this as missing a security
    * update, then assert if we see the appropriate warnings on the right pages.
    */
-  function testHookUpdateStatusAlter() {
+  public function testHookUpdateStatusAlter() {
     $GLOBALS['settings']['allow_authorize_operations'] = TRUE;
     $config = config('update.settings');
     $update_admin_user = $this->backdropCreateUser(array(
@@ -661,7 +661,7 @@ class UpdateTestContribCase extends UpdateTestHelper {
  * Tests update functionality unrelated to the database.
  */
 class UpdateCoreUnitTestCase extends BackdropUnitTestCase {
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('update'));
     module_load_include('inc', 'update', 'update.fetch');
   }
@@ -669,7 +669,7 @@ class UpdateCoreUnitTestCase extends BackdropUnitTestCase {
   /**
    * Tests that _update_build_fetch_url() builds the URL correctly.
    */
-  function testUpdateBuildFetchUrl() {
+  public function testUpdateBuildFetchUrl() {
     //first test that we didn't break the trivial case
     $project['name'] = 'update_test';
     $project['project_type'] = '';

--- a/core/modules/user/tests/user.test
+++ b/core/modules/user/tests/user.test
@@ -9,7 +9,7 @@ include_once(BACKDROP_ROOT . '/core/modules/simpletest/tests/system_config_test.
 class UserLoginTestBase extends BackdropWebTestCase {
   protected $profile = 'minimal';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('dblog', 'user_flood_test');
   }
 
@@ -26,7 +26,7 @@ class UserLoginTestBase extends BackdropWebTestCase {
    *   Whether or not to expect that the flood control mechanism will be
    *   triggered..
    */
-  function assertFailedLogin($account, $by_email = FALSE, $incorrect_pass = FALSE, $flood_trigger = NULL) {
+  protected function assertFailedLogin($account, $by_email = FALSE, $incorrect_pass = FALSE, $flood_trigger = NULL) {
     if ($this->loggedInUser) {
       $this->backdropLogout();
     }
@@ -85,7 +85,7 @@ class UserLoginTestBase extends BackdropWebTestCase {
 class UserRegistrationTestCase extends UserLoginTestBase {
   protected $profile = 'testing';
 
-  function testRegistrationWithEmailVerification() {
+  public function testRegistrationWithEmailVerification() {
     $config = config('system.core');
 
     // Require email verification.
@@ -119,7 +119,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $this->assertFalse($new_user->status, 'New account is blocked until approved by an administrator.');
   }
 
-  function testRegistrationWithoutEmailVerification() {
+  public function testRegistrationWithoutEmailVerification() {
     $config = config('system.core');
 
     // Don't require email verification.
@@ -170,7 +170,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $this->assertText(t('Member for'), 'User can log in after administrator approval.');
   }
 
-  function testRegistrationEmailDuplicates() {
+  public function testRegistrationEmailDuplicates() {
     $config = config('system.core');
 
     // Don't require email verification.
@@ -197,7 +197,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
     $this->assertRaw(t('The email address %email is already registered.', array('%email' => $duplicate_user->mail)), 'Supplying a duplicate email address with added whitespace displays an error message');
   }
 
-  function testRegistrationDefaultValues() {
+  public function testRegistrationDefaultValues() {
     $config_user_settings = config('system.core');
 
     // Allow registration by site visitors without administrator approval.
@@ -241,7 +241,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
   /**
    * Tests Field API fields on user registration forms.
    */
-  function testRegistrationWithUserFields() {
+  public function testRegistrationWithUserFields() {
     module_enable(array('field', 'field_test'));
     $config_user_settings = config('system.core');
 
@@ -330,7 +330,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
   /**
    * Tests new users username matches their email if username is an email.
    */
-  function testRegistrationEmailAsUsername() {
+  public function testRegistrationEmailAsUsername() {
     // Don't require email verification.
     // Allow registration by site visitors without administrator approval.
     config('system.core')
@@ -365,7 +365,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
   /**
    * Tests new users username not matching their email if username is an email.
    */
-  function testRegistrationEmailAsUsernameDisabled() {
+  public function testRegistrationEmailAsUsernameDisabled() {
     // Test that 'user_email_match' turned off allows emails that don't match.
     config('system.core')
       ->set('user_email_match', FALSE)
@@ -391,7 +391,7 @@ class UserRegistrationTestCase extends UserLoginTestBase {
 
 class UserValidationTestCase extends BackdropUnitTestCase {
   // Username validation.
-  function testUsernames() {
+  public function testUsernames() {
     $test_cases = array( // '<username>' => array('<description>', 'assert<testName>'),
       'foo'                    => array('Valid username', 'assertNull'),
       'FOO'                    => array('Valid username', 'assertNull'),
@@ -432,14 +432,14 @@ class UserValidationTestCase extends BackdropUnitTestCase {
 class UserLoginTestCase extends UserLoginTestBase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('user_session_test');
   }
 
   /**
    * Test that login credentials work (or not) in different login modes.
    */
-  function testLoginMethods() {
+  public function testLoginMethods() {
     $account = $this->backdropCreateUser(array());
 
     // Login via name or email (both succeed). The default for new sites.
@@ -471,7 +471,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test the global login flood control.
    */
-  function testGlobalLoginFloodControl() {
+  public function testGlobalLoginFloodControl() {
     config('user.flood')
       ->set('flood_ip_limit', 10)
       // Set a high per-user limit out so that it is not relevant in the test.
@@ -516,7 +516,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test the per-user login flood control.
    */
-  function testPerUserLoginFloodControl() {
+  public function testPerUserLoginFloodControl() {
     config('user.flood')
       // Set a high global limit out so that it is not relevant in the test.
       ->set('flood_ip_limit', 4000)
@@ -567,7 +567,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test that user password is re-hashed upon login after changing $count_log2.
    */
-  function testPasswordRehashOnLogin() {
+  public function testPasswordRehashOnLogin() {
     // Load password hashing API.
     require_once BACKDROP_ROOT . '/' . settings_get('password_inc', 'core/includes/password.inc');
     // Set initial $count_log2 to the default, BACKDROP_HASH_COUNT.
@@ -599,7 +599,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Test logging in when an anon session already exists.
    */
-  function testLoginWithAnonSession() {
+  public function testLoginWithAnonSession() {
     // Visit the callback to generate a session for this anon user.
     $this->backdropGet('user_session_test_anon_session');
     // Now login.
@@ -610,7 +610,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Attempt to login with an unregistered username.
    */
-  function testAccountNotFound() {
+  public function testAccountNotFound() {
     $edit = array(
       'name' => $this->randomName(8),
       'pass' => $this->randomName(8),
@@ -622,7 +622,7 @@ class UserLoginTestCase extends UserLoginTestBase {
   /**
    * Attempt to login with an invalid array users and passwords.
    */
-  function testArrayLoginValues() {
+  public function testArrayLoginValues() {
     $edit = array(
       'pass' => $this->randomName(8),
     );
@@ -688,7 +688,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Attempt to cancel account without permission.
    */
-  function testUserCancelWithoutPermission() {
+  public function testUserCancelWithoutPermission() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a user.
@@ -722,7 +722,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
    * This should never be possible, or the site owner would become unable to
    * administer the site.
    */
-  function testUserCancelUid1() {
+  public function testUserCancelUid1() {
     // Update uid 1's name and password to we know it.
     $password = user_password();
     require_once BACKDROP_ROOT . '/' . settings_get('password_inc', 'core/includes/password.inc');
@@ -758,7 +758,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Attempt invalid account cancellations.
    */
-  function testUserCancelInvalid() {
+  public function testUserCancelInvalid() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a user.
@@ -800,7 +800,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Disable account and keep all content.
    */
-  function testUserBlock() {
+  public function testUserBlock() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_block');
 
     // Create a user.
@@ -835,7 +835,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Disable account and unpublish all content.
    */
-  function testUserBlockUnpublish() {
+  public function testUserBlockUnpublish() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_block_unpublish');
 
     // Create a user.
@@ -879,7 +879,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Delete account and anonymize all content.
    */
-  function testUserAnonymize() {
+  public function testUserAnonymize() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a user.
@@ -930,7 +930,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Delete account and remove all content.
    */
-  function testUserDelete() {
+  public function testUserDelete() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_delete');
 
     // Create a user.
@@ -997,7 +997,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Create an administrative user and delete another user.
    */
-  function testUserCancelByAdmin() {
+  public function testUserCancelByAdmin() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
 
     // Create a regular user.
@@ -1022,7 +1022,7 @@ class UserCancelTestCase extends BackdropWebTestCase {
   /**
    * Create an administrative user and mass-delete other users.
    */
-  function testMassUserCancelByAdmin() {
+  public function testMassUserCancelByAdmin() {
     config_set('system.core', 'user_cancel_method', 'user_cancel_reassign');
     // Enable account cancellation notification.
     config_set('system.core', 'user_mail_status_canceled_notify', TRUE);
@@ -1079,7 +1079,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   protected $user;
   protected $_directory_test;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('image'));
 
     // Enable user pictures.
@@ -1100,7 +1100,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
     $this->assertTrue($this->_directory_test, "The directory $picture_path doesn't exist or is not writable. Further tests won't be made.");
   }
 
-  function testNoPicture() {
+  public function testNoPicture() {
     $this->backdropLogin($this->user);
 
     // Try to upload a file that is not an image for the user picture.
@@ -1117,7 +1117,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image should be uploaded because ImageGDToolkit resizes the picture
    */
-  function testWithGDinvalidDimension() {
+  public function testWithGDinvalidDimension() {
     if ($this->_directory_test && image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1152,7 +1152,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image should be uploaded because ImageGDToolkit resizes the picture
    */
-  function testWithGDinvalidSize() {
+  public function testWithGDinvalidSize() {
     if ($this->_directory_test && image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1190,7 +1190,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image shouldn't be uploaded
    */
-  function testWithoutGDinvalidDimension() {
+  public function testWithoutGDinvalidDimension() {
     if ($this->_directory_test && !image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1224,7 +1224,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image shouldn't be uploaded
    */
-  function testWithoutGDinvalidSize() {
+  public function testWithoutGDinvalidSize() {
     if ($this->_directory_test && !image_get_toolkit()) {
       $this->backdropLogin($this->user);
 
@@ -1258,7 +1258,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
    *
    * results: The image should be uploaded
    */
-  function testPictureIsValid() {
+  public function testPictureIsValid() {
     if ($this->_directory_test) {
       $this->backdropLogin($this->user);
 
@@ -1304,7 +1304,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   /**
    * Test HTTP schema working with user pictures.
    */
-  function testExternalPicture() {
+  public function testExternalPicture() {
     $this->backdropLogin($this->user);
     // Set the default picture to an URI with a HTTP schema.
     $images = $this->backdropGetTestFiles('image');
@@ -1324,7 +1324,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   /**
    * Tests deletion of user pictures.
    */
-  function testDeletePicture() {
+  public function testDeletePicture() {
     $this->backdropLogin($this->user);
 
     $image = current($this->backdropGetTestFiles('image'));
@@ -1367,7 +1367,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
     $this->assertFalse(is_file($pic_path), 'File is removed from file system');
   }
 
-  function saveUserPicture($image) {
+  protected function saveUserPicture($image) {
     $edit = array('files[picture_upload]' => backdrop_realpath($image->uri));
     $this->backdropPost('user/' . $this->user->uid . '/edit', $edit, t('Save'));
 
@@ -1379,7 +1379,7 @@ class UserPictureTestCase extends BackdropWebTestCase {
   /**
    * Tests the admin form validates user picture settings.
    */
-  function testUserPictureAdminFormValidation() {
+  public function testUserPictureAdminFormValidation() {
     $this->backdropLogin($this->backdropCreateUser(array('administer account settings')));
 
     // The default values are valid.
@@ -1403,7 +1403,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   protected $admin_role_name;
   protected $editor_role_name;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'access user profiles', 'administer site configuration', 'administer account settings', 'administer content types', 'administer modules'));
@@ -1419,7 +1419,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Change user permissions and check user_access().
    */
-  function testUserPermissionChanges() {
+  public function testUserPermissionChanges() {
     $this->backdropLogin($this->admin_user);
     $role_name = $this->admin_role_name;
     $account = $this->admin_user;
@@ -1452,7 +1452,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Test assigning of permissions for the administrator role.
    */
-  function testAdministratorRole() {
+  public function testAdministratorRole() {
     $this->backdropLogin($this->admin_user);
     $this->backdropGet('admin/config/people/roles');
 
@@ -1473,7 +1473,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Test assigning of permissions for the editor role.
    */
-  function testEditorRole() {
+  public function testEditorRole() {
     $this->backdropLogin($this->admin_user);
     $this->backdropGet('admin/config/people/roles');
 
@@ -1548,7 +1548,7 @@ class UserPermissionsTestCase extends BackdropWebTestCase {
   /**
    * Verify proper permission changes by user_role_change_permissions().
    */
-  function testUserRoleChangePermissions() {
+  public function testUserRoleChangePermissions() {
     $role_name = $this->admin_role_name;
     $account = $this->admin_user;
 
@@ -1575,7 +1575,7 @@ class UserAdminTestCase extends BackdropWebTestCase {
   /**
    * Registers a user and deletes it.
    */
-  function testUserAdmin() {
+  public function testUserAdmin() {
     // Create admin user to delete registered user.
     $admin_user = $this->backdropCreateUser(array('administer users', 'access user profiles'));
     $admin_user->created -= 2;
@@ -1692,7 +1692,7 @@ class UserTimeZoneFunctionalTest extends BackdropWebTestCase {
   /**
    * Tests the display of dates and time when user-configurable time zones are set.
    */
-  function testUserTimeZone() {
+  public function testUserTimeZone() {
     // Setup date/time settings for Los Angeles time.
     config('system.date')
       ->set('user_configurable_timezones', 1)
@@ -1759,7 +1759,7 @@ class UserAutocompleteTestCase extends BackdropWebTestCase {
    */
   protected $privileged_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Set up two users with different permissions to test access.
@@ -1770,7 +1770,7 @@ class UserAutocompleteTestCase extends BackdropWebTestCase {
   /**
    * Tests access to user autocompletion and verify the correct results.
    */
-  function testUserAutocomplete() {
+  public function testUserAutocomplete() {
     // Check access from unprivileged user, should be denied.
     $this->backdropLogin($this->unprivileged_user);
     $this->backdropGet('user/autocomplete/' . $this->unprivileged_user->name[0]);
@@ -1797,7 +1797,7 @@ class UserAccountLinksUnitTests extends BackdropWebTestCase {
   /**
    * Test the user login block.
    */
-  function testAccountMenu() {
+  public function testAccountMenu() {
     // Create a regular user.
     $user = $this->backdropCreateUser(array());
 
@@ -1840,7 +1840,7 @@ class UserBlocksUnitTests extends BackdropWebTestCase {
   /**
    * Tests the secondary menu.
    */
-  function testUserLoginBlock() {
+  public function testUserLoginBlock() {
     // Create a user with some permission that anonymous users lack.
     $user = $this->backdropCreateUser(array('administer permissions'));
 
@@ -1873,14 +1873,14 @@ class UserBlocksUnitTests extends BackdropWebTestCase {
     $this->assertEqual(url('node', array('absolute' => TRUE)), $this->getUrl(), 'Redirected to frontpage and not external site after login.');
   }
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('menu');
   }
 
   /**
    * Tests disabling the 'My account' link.
    */
-  function testDisabledAccountLink() {
+  public function testDisabledAccountLink() {
     // Create an admin user and log in.
     $this->backdropLogin($this->backdropCreateUser(array('access administration pages', 'administer menu')));
 
@@ -1919,7 +1919,7 @@ class UserSaveTestCase extends BackdropWebTestCase {
   /**
    * Test creating a user with arbitrary uid.
    */
-  function testUserImport() {
+  public function testUserImport() {
     // User ID must be a number that is not in the database.
     $max_uid = db_query('SELECT MAX(uid) FROM {users}')->fetchField();
     $test_uid = $max_uid + mt_rand(1000, 1000000);
@@ -1952,7 +1952,7 @@ class UserSaveTestCase extends BackdropWebTestCase {
 class UserCreateTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('views'));
   }
 
@@ -2081,7 +2081,7 @@ class UserEditTestCase extends BackdropWebTestCase {
   /**
    * Test user edit page.
    */
-  function testUserEdit() {
+  public function testUserEdit() {
     // Test user edit functionality with user pictures disabled.
     $config = config('system.core');
     $config->set('user_pictures', 0)->save();
@@ -2192,14 +2192,14 @@ class UserEditTestCase extends BackdropWebTestCase {
  */
 class UserEditRebuildTestCase extends BackdropWebTestCase {
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('user_form_test');
   }
 
   /**
    * Test user edit page when the form is set to rebuild.
    */
-  function testUserEditFormRebuild() {
+  public function testUserEditFormRebuild() {
     $user1 = $this->backdropCreateUser(array('change own username'));
     $this->backdropLogin($user1);
 
@@ -2253,7 +2253,7 @@ class UserSignatureTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('comment');
 
     // Enable user signatures.
@@ -2278,7 +2278,7 @@ class UserSignatureTestCase extends BackdropWebTestCase {
    * Test that a user can change their signature format and that it is respected
    * upon display.
    */
-  function testUserSignature() {
+  public function testUserSignature() {
     // Enable comment subjects on 'page' nodes
     $node_type = node_type_get_type('page');
     $node_type->settings['comment_title_options'] = COMMENT_TITLE_CUSTOM;
@@ -2338,7 +2338,7 @@ class UserEditedOwnAccountTestCase extends BackdropWebTestCase {
   /**
    * Tests a user editing their own account.
    */
-  function testUserEditedOwnAccount() {
+  public function testUserEditedOwnAccount() {
     // Change account setting 'Who can register accounts?' to Administrators
     // only.
     config_set('system.core', 'user_register', USER_REGISTER_ADMINISTRATORS_ONLY);
@@ -2395,7 +2395,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
    */
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array('administer permissions', 'administer users', 'assign roles'));
   }
@@ -2403,7 +2403,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
   /**
    * Test adding, renaming and deleting roles.
    */
-  function testRoleAdministration() {
+  public function testRoleAdministration() {
     $this->backdropLogin($this->admin_user);
 
     // Visit the main roles administration page.
@@ -2533,7 +2533,7 @@ class UserRoleAdminTestCase extends BackdropWebTestCase {
   /**
    * Test user role weight change operation.
    */
-  function testRoleWeightChange() {
+  public function testRoleWeightChange() {
     $this->backdropLogin($this->admin_user);
 
     // Pick up a role and get its weight.
@@ -2563,7 +2563,7 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
   /**
    * Creates a user, then tests the tokens generated from it.
    */
-  function testUserTokenReplacement() {
+  public function testUserTokenReplacement() {
     global $language;
     $url_options = array(
       'absolute' => TRUE,
@@ -2621,11 +2621,11 @@ class UserTokenReplaceTestCase extends BackdropWebTestCase {
 class UserUserSearchTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
 
-  function setUp() {
+  public function setUp() {
     parent::setUp(array('search'));
   }
 
-  function testUserSearch() {
+  public function testUserSearch() {
     // Verify that a user without 'administer users' permission cannot search
     // for users by email address. Additionally, ensure that the username has a
     // plus sign to ensure searching works with that.
@@ -2690,7 +2690,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
   protected $profile = 'testing';
   protected $admin_user;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->admin_user = $this->backdropCreateUser(array(
       'administer permissions',
@@ -2704,7 +2704,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
    * Tests that a user can be assigned a role and that the role can be removed
    * again.
    */
-  function testAssignAndRemoveRole()  {
+  public function testAssignAndRemoveRole()  {
     $role_name = $this->backdropCreateRole(array('administer content types'));
     $account = $this->backdropCreateUser();
 
@@ -2727,7 +2727,7 @@ class UserRolesAssignmentTestCase extends BackdropWebTestCase {
    * Tests that when creating a user the role can be assigned. And that it can
    * be removed again.
    */
-  function testCreateUserWithRole() {
+  public function testCreateUserWithRole() {
     $role_name = $this->backdropCreateRole(array('administer content types'));
     // Create a new user and add the role at the same time.
     $edit = array(
@@ -2788,7 +2788,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
    */
   protected $adminUser;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp('user_form_test');
     // Create two users
     $this->accessUser = $this->backdropCreateUser(array('access content'));
@@ -2798,7 +2798,7 @@ class UserValidateCurrentPassCustomForm extends BackdropWebTestCase {
   /**
    * Tests that user_validate_current_pass can be reused on a custom form.
    */
-  function testUserValidateCurrentPassCustomForm() {
+  public function testUserValidateCurrentPassCustomForm() {
     $this->backdropLogin($this->adminUser);
 
     // Check that filling out a single password field does not validate.
@@ -2840,7 +2840,7 @@ class UserEntityCallbacksTestCase extends BackdropWebTestCase {
    */
   protected $anonymous;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $this->account = $this->backdropCreateUser();
     $this->anonymous = backdrop_anonymous_user();
@@ -2849,7 +2849,7 @@ class UserEntityCallbacksTestCase extends BackdropWebTestCase {
   /**
    * Test label callback.
    */
-  function testLabelCallback() {
+  public function testLabelCallback() {
     $this->assertEqual(entity_label('user', $this->account), $this->account->name, t('The username should be used as label'));
 
     // Setup a random anonymous name to be sure the name is used.
@@ -2861,7 +2861,7 @@ class UserEntityCallbacksTestCase extends BackdropWebTestCase {
   /**
    * Test URI callback.
    */
-  function testUriCallback() {
+  public function testUriCallback() {
     $uri = entity_uri('user', $this->account);
     $this->assertEqual('user/' . $this->account->uid, $uri['path'], t('Correct user URI.'));
   }

--- a/core/modules/user/tests/user_password_reset.test
+++ b/core/modules/user/tests/user_password_reset.test
@@ -12,7 +12,7 @@ class UserPasswordResetTest extends BackdropWebTestCase {
    */
   protected $account;
 
-  function setUp($modules = array()) {
+  public function setUp($modules = array()) {
     $modules = array_merge($modules, array('image'));
     parent::setUp($modules);
 

--- a/core/modules/user/tests/user_views.test
+++ b/core/modules/user/tests/user_views.test
@@ -45,7 +45,7 @@ class UserViewsTestCase extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $expected);
   }
 
-  function test_view_user_relationship() {
+  public function test_view_user_relationship() {
     $view = new view;
     $view->name = 'test_user_relationship';
     $view->description = '';

--- a/core/modules/user/tests/user_views_argument_default.test
+++ b/core/modules/user/tests/user_views_argument_default.test
@@ -33,7 +33,7 @@ class UserViewsArgumentDefault extends ViewsSqlTest {
     backdrop_save_session(TRUE);
   }
 
-  function view_plugin_argument_default_current_user() {
+  private function view_plugin_argument_default_current_user() {
     $view = new view;
     $view->name = 'test_plugin_argument_default_current_user';
     $view->description = '';

--- a/core/modules/user/tests/user_views_argument_validate.test
+++ b/core/modules/user/tests/user_views_argument_validate.test
@@ -21,7 +21,7 @@ class UserViewsArgumentValidate extends ViewsSqlTest {
     $this->account = $this->backdropCreateUser();
   }
 
-  function testArgumentValidateUserUid() {
+  public function testArgumentValidateUserUid() {
     $account = $this->account;
     // test 'uid' case
     $view = $this->view_argument_validate_user('uid');
@@ -39,7 +39,7 @@ class UserViewsArgumentValidate extends ViewsSqlTest {
     $this->assertFalse($view->argument['null']->validate_arg(32));
   }
 
-  function testArgumentValidateUserName() {
+  public function testArgumentValidateUserName() {
     $account = $this->account;
     // test 'name' case
     $view = $this->view_argument_validate_user('name');
@@ -57,7 +57,7 @@ class UserViewsArgumentValidate extends ViewsSqlTest {
     $this->assertFalse($view->argument['null']->validate_arg($this->randomName()));
   }
 
-  function testArgumentValidateUserEither() {
+  public function testArgumentValidateUserEither() {
     $account = $this->account;
     // test 'either' case
     $view = $this->view_argument_validate_user('either');
@@ -79,7 +79,7 @@ class UserViewsArgumentValidate extends ViewsSqlTest {
     $this->assertFalse($view->argument['null']->validate_arg(32));
   }
 
-  function view_argument_validate_user($argtype) {
+  private function view_argument_validate_user($argtype) {
     $view = new view;
     $view->name = 'view_argument_validate_user';
     $view->description = '';

--- a/core/modules/user/tests/user_views_handler_field_name.test
+++ b/core/modules/user/tests/user_views_handler_field_name.test
@@ -12,7 +12,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * @see views_handler_field_user_name
  */
 class UserViewsHandlerFieldNameTest extends ViewsSqlTest {
-  function testUserName() {
+  public function testUserName() {
     $view = $this->view_user_name();
     $view->init_display();
     $this->executeView($view);
@@ -47,7 +47,7 @@ class UserViewsHandlerFieldNameTest extends ViewsSqlTest {
     $this->assertIdentical($render, $anon_name , 'For user0 it should use the configured anonymous text, if overwrite_anonymous is checked.');
   }
 
-  function view_user_name() {
+  private function view_user_name() {
     $view = new view;
     $view->name = 'test_views_handler_field_user_name';
     $view->description = '';

--- a/core/modules/views/tests/handlers/views_handler_argument_null.test
+++ b/core/modules/views/tests/handlers/views_handler_argument_null.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the core views_handler_argument_null handler.
  */
 class ViewsHandlerArgumentNullTest extends ViewsSqlTest {
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['id']['argument']['handler'] = 'views_handler_argument_null';
 

--- a/core/modules/views/tests/handlers/views_handler_argument_string.test
+++ b/core/modules/views/tests/handlers/views_handler_argument_string.test
@@ -15,7 +15,7 @@ class ViewsHandlerArgumentStringTest extends ViewsSqlTest {
   /**
    * Tests the glossary feature.
    */
-  function testGlossary() {
+  public function testGlossary() {
     // Setup some nodes, one with a, two with b and three with c.
     $counter = 1;
     foreach (array('a', 'b', 'c') as $char) {
@@ -51,7 +51,7 @@ class ViewsHandlerArgumentStringTest extends ViewsSqlTest {
    * @see testGlossary
    * @return view
    */
-  function viewGlossary() {
+  protected function viewGlossary() {
     $view = new view();
     $view->name = 'test_glossary';
     $view->description = '';

--- a/core/modules/views/tests/handlers/views_handler_field.test
+++ b/core/modules/views/tests/handlers/views_handler_field.test
@@ -25,7 +25,7 @@ class ViewsHandlerFieldTest extends ViewsSqlTest {
     );
   }
 
-  function testEmpty() {
+  public function testEmpty() {
     $this->_testHideIfEmpty();
     $this->_testEmptyText();
   }
@@ -35,7 +35,7 @@ class ViewsHandlerFieldTest extends ViewsSqlTest {
    *
    * This tests alters the result to get easier and less coupled results.
    */
-  function _testHideIfEmpty() {
+  private function _testHideIfEmpty() {
     $view = $this->getBasicView();
     $view->init_display();
     $this->executeView($view);
@@ -253,7 +253,7 @@ class ViewsHandlerFieldTest extends ViewsSqlTest {
   /**
    * Tests the usage of the empty text.
    */
-  function _testEmptyText() {
+  private function _testEmptyText() {
     $view = $this->getBasicView();
     $view->init_display();
     $this->executeView($view);
@@ -290,7 +290,7 @@ class ViewsHandlerFieldTest extends ViewsSqlTest {
   /**
    * Tests views_handler_field::is_value_empty().
    */
-  function testIsValueEmpty() {
+  public function testIsValueEmpty() {
     $view = $this->getBasicView();
     $view->init_display();
     $view->init_handlers();

--- a/core/modules/views/tests/handlers/views_handler_field_boolean.test
+++ b/core/modules/views/tests/handlers/views_handler_field_boolean.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the core views_handler_field_boolean handler.
  */
 class ViewsHandlerFieldBooleanTest extends ViewsSqlTest {
-  function dataSet() {
+  protected function dataSet() {
     // Use default dataset but remove the age from john and paul
     $data = parent::dataSet();
     $data[0]['age'] = 0;
@@ -18,7 +18,7 @@ class ViewsHandlerFieldBooleanTest extends ViewsSqlTest {
     return $data;
   }
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['age']['field']['handler'] = 'views_handler_field_boolean';
     return $data;

--- a/core/modules/views/tests/handlers/views_handler_field_bulk_form.test
+++ b/core/modules/views/tests/handlers/views_handler_field_bulk_form.test
@@ -47,7 +47,7 @@ class ViewsHandlerFieldBulkFormTest extends ViewsSqlTest {
   /**
    * Defines bulk form handler for custom entity views_test.
    */
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
 
     // This is needed for views_handler_field_entity, used by the bulk form.
@@ -111,7 +111,7 @@ class ViewsHandlerFieldBulkFormTest extends ViewsSqlTest {
   /**
    * Assert that the form checkbox values match the entity ids.
    */
-  function assertCorrectBulkFormEntityIds($id_field, $entity_type) {
+  protected function assertCorrectBulkFormEntityIds($id_field, $entity_type) {
     // Generate a preview of the view in order to populate the field aliases.
     $this->view->preview();
     $field_alias = $this->view->field[$id_field]->field_alias;

--- a/core/modules/views/tests/handlers/views_handler_field_counter.test
+++ b/core/modules/views/tests/handlers/views_handler_field_counter.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the views_handler_field_counter handler.
  */
 class ViewsHandlerFilterCounterTest extends ViewsSqlTest {
-  function testSimple() {
+  public function testSimple() {
     $view = $this->getBasicView();
     $view->display['default']->handler->override_option('fields', array(
       'counter' => array(
@@ -58,6 +58,6 @@ class ViewsHandlerFilterCounterTest extends ViewsSqlTest {
   }
 
   // @TODO: Write tests for pager.
-  function testPager() {
+  public function testPager() {
   }
 }

--- a/core/modules/views/tests/handlers/views_handler_field_custom.test
+++ b/core/modules/views/tests/handlers/views_handler_field_custom.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the core views_handler_field_custom handler.
  */
 class ViewsHandlerFieldCustomTest extends ViewsSqlTest {
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['name']['field']['handler'] = 'views_handler_field_custom';
     return $data;

--- a/core/modules/views/tests/handlers/views_handler_field_date.test
+++ b/core/modules/views/tests/handlers/views_handler_field_date.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the core views_handler_field_date handler.
  */
 class ViewsHandlerFieldDateTest extends ViewsSqlTest {
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['created']['field']['handler'] = 'views_handler_field_date';
     return $data;

--- a/core/modules/views/tests/handlers/views_handler_field_file_extension.test
+++ b/core/modules/views/tests/handlers/views_handler_field_file_extension.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the views_handler_field_file_extension handler.
  */
 class ViewsHandlerFileExtensionTest extends ViewsSqlTest {
-  function dataSet() {
+  protected function dataSet() {
     $data = parent::dataSet();
     $data[0]['name'] = 'file.png';
     $data[1]['name'] = 'file.tar';
@@ -20,7 +20,7 @@ class ViewsHandlerFileExtensionTest extends ViewsSqlTest {
     return $data;
   }
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['name']['field']['handler'] = 'views_handler_field_file_extension';
     $data['views_test']['name']['real field'] = 'name';

--- a/core/modules/views/tests/handlers/views_handler_field_file_size.test
+++ b/core/modules/views/tests/handlers/views_handler_field_file_size.test
@@ -12,7 +12,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * @see CommonXssUnitTest
  */
 class ViewsHandlerTestFileSize extends ViewsSqlTest {
-  function dataSet() {
+  protected function dataSet() {
     $data = parent::dataSet();
     $data[0]['age'] = 0;
     $data[1]['age'] = 10;
@@ -22,7 +22,7 @@ class ViewsHandlerTestFileSize extends ViewsSqlTest {
     return $data;
   }
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['age']['field']['handler'] = 'views_handler_field_file_size';
 

--- a/core/modules/views/tests/handlers/views_handler_field_url.test
+++ b/core/modules/views/tests/handlers/views_handler_field_url.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the core views_handler_field_url handler.
  */
 class ViewsHandlerFieldUrlTest extends ViewsSqlTest {
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['name']['field']['handler'] = 'views_handler_field_url';
     return $data;

--- a/core/modules/views/tests/handlers/views_handler_field_xss.test
+++ b/core/modules/views/tests/handlers/views_handler_field_xss.test
@@ -12,7 +12,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * @see CommonXssUnitTest
  */
 class ViewsHandlerTestXss extends ViewsSqlTest {
-  function dataHelper() {
+  protected function dataHelper() {
     $map = array(
       'John' => 'John',
       "Foo\xC0barbaz" => '',
@@ -24,7 +24,7 @@ class ViewsHandlerTestXss extends ViewsSqlTest {
   }
 
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['name']['field']['handler'] = 'views_handler_field_xss';
 

--- a/core/modules/views/tests/handlers/views_handler_filter_date.test
+++ b/core/modules/views/tests/handlers/views_handler_filter_date.test
@@ -41,7 +41,7 @@ class ViewsHandlerFilterDateTest extends ViewsSqlTest {
   /**
    * Test the general offset functionality.
    */
-  function testOffset() {
+  public function testOffset() {
     $view = $this->views_test_offset();
     // Test offset for simple operator.
     $view->set_display('default');
@@ -105,7 +105,7 @@ class ViewsHandlerFilterDateTest extends ViewsSqlTest {
   /**
    * Tests the filter operator between/not between.
    */
-  function testBetween() {
+  public function testBetween() {
     // Test between with min and max.
     $view = $this->views_test_between();
     $view->set_display('default');
@@ -169,7 +169,7 @@ class ViewsHandlerFilterDateTest extends ViewsSqlTest {
   /**
    * Make sure the validation callbacks works.
    */
-  function testUiValidation() {
+  public function testUiValidation() {
     $view = $this->views_test_between();
     $view->save();
 
@@ -186,7 +186,7 @@ class ViewsHandlerFilterDateTest extends ViewsSqlTest {
     $this->assertText(t('Invalid date format.'), 'Make sure that validation is run and the invalidate date format is identified.');
   }
 
-  function views_test_between() {
+  protected function views_test_between() {
     $view = new view;
     $view->name = 'test_filter_date_between';
     $view->description = '';
@@ -219,7 +219,7 @@ class ViewsHandlerFilterDateTest extends ViewsSqlTest {
     return $view;
   }
 
-  function views_test_offset() {
+  protected function views_test_offset() {
     $view = $this->views_test_between();
     return $view;
   }

--- a/core/modules/views/tests/handlers/views_handler_filter_equality.test
+++ b/core/modules/views/tests/handlers/views_handler_filter_equality.test
@@ -23,14 +23,14 @@ class ViewsHandlerFilterEqualityTest extends ViewsSqlTest {
     );
   }
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['name']['filter']['handler'] = 'views_handler_filter_equality';
 
     return $data;
   }
 
-  function testEqual() {
+  public function testEqual() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -72,7 +72,7 @@ class ViewsHandlerFilterEqualityTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testNotEqual() {
+  public function testNotEqual() {
     $view = $this->getBasicView();
 
     // Change the filtering

--- a/core/modules/views/tests/handlers/views_handler_filter_in_operator.test
+++ b/core/modules/views/tests/handlers/views_handler_filter_in_operator.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests the core views_handler_filter_in_operator handler.
  */
 class ViewsHandlerFilterInOperator extends ViewsSqlTest {
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['age']['filter']['handler'] = 'views_handler_filter_in_operator';
 

--- a/core/modules/views/tests/handlers/views_handler_filter_multiple.test
+++ b/core/modules/views/tests/handlers/views_handler_filter_multiple.test
@@ -44,7 +44,7 @@ class ViewsHandlerFilterMultipleTest extends ViewsSqlTest {
   /**
    * Tests combining an exposed filter with a non-exposed one.
    */
-  function testMultipleFilters() {
+  public function testMultipleFilters() {
     $term = $this->viewsCreateTerm('tags');
 
     $node1 = $this->backdropCreateNode(array('type' => 'post', 'created' => REQUEST_TIME));

--- a/core/modules/views/tests/handlers/views_handler_filter_numeric.test
+++ b/core/modules/views/tests/handlers/views_handler_filter_numeric.test
@@ -20,7 +20,7 @@ class ViewsHandlerFilterNumericTest extends ViewsSqlTest {
     );
   }
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['age']['filter']['allow empty'] = TRUE;
     $data['views_test']['id']['filter']['allow empty'] = FALSE;

--- a/core/modules/views/tests/handlers/views_handler_filter_string.test
+++ b/core/modules/views/tests/handlers/views_handler_filter_string.test
@@ -19,7 +19,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     );
   }
 
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['name']['filter']['allow empty'] = TRUE;
     $data['views_test']['job']['filter']['allow empty'] = FALSE;
@@ -65,7 +65,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     return $view;
   }
 
-  function testFilterStringEqual() {
+  public function testFilterStringEqual() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -89,7 +89,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedEqual() {
+  public function testFilterStringGroupedExposedEqual() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -109,7 +109,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringNotEqual() {
+  public function testFilterStringNotEqual() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -142,7 +142,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedNotEqual() {
+  public function testFilterStringGroupedExposedNotEqual() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -172,7 +172,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringContains() {
+  public function testFilterStringContains() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -197,7 +197,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
   }
 
 
-  function testFilterStringGroupedExposedContains() {
+  public function testFilterStringGroupedExposedContains() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -218,7 +218,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
   }
 
 
-  function testFilterStringWord() {
+  public function testFilterStringWord() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -269,7 +269,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
   }
 
 
-  function testFilterStringGroupedExposedWord() {
+  public function testFilterStringGroupedExposedWord() {
       $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -309,7 +309,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringStarts() {
+  public function testFilterStringStarts() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -333,7 +333,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedStarts() {
+  public function testFilterStringGroupedExposedStarts() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -352,7 +352,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringNotStarts() {
+  public function testFilterStringNotStarts() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -383,7 +383,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedNotStarts() {
+  public function testFilterStringGroupedExposedNotStarts() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -409,7 +409,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringEnds() {
+  public function testFilterStringEnds() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -436,7 +436,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedEnds() {
+  public function testFilterStringGroupedExposedEnds() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -458,7 +458,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringNotEnds() {
+  public function testFilterStringNotEnds() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -486,7 +486,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedNotEnds() {
+  public function testFilterStringGroupedExposedNotEnds() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -509,7 +509,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringNot() {
+  public function testFilterStringNot() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -538,7 +538,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
   }
 
 
-  function testFilterStringGroupedExposedNot() {
+  public function testFilterStringGroupedExposedNot() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -562,7 +562,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
 
   }
 
-  function testFilterStringShorter() {
+  public function testFilterStringShorter() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -589,7 +589,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedShorter() {
+  public function testFilterStringGroupedExposedShorter() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -610,7 +610,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringLonger() {
+  public function testFilterStringLonger() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -634,7 +634,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedLonger() {
+  public function testFilterStringGroupedExposedLonger() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 
@@ -653,7 +653,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
   }
 
 
-  function testFilterStringEmpty() {
+  public function testFilterStringEmpty() {
     $view = $this->getBasicView();
 
     // Change the filtering
@@ -676,7 +676,7 @@ class ViewsHandlerFilterStringTest extends ViewsSqlTest {
     $this->assertIdenticalResultset($view, $resultset, $this->column_map);
   }
 
-  function testFilterStringGroupedExposedEmpty() {
+  public function testFilterStringGroupedExposedEmpty() {
     $filters = $this->getGroupedExposedFilters();
     $view = $this->getBasicPageView();
 

--- a/core/modules/views/tests/plugins/views_plugin_display.test
+++ b/core/modules/views/tests/plugins/views_plugin_display.test
@@ -13,7 +13,7 @@ class ViewsPluginDisplayTestCase extends ViewsSqlTest {
   /**
    * Tests the overriding of filter_groups.
    */
-  function testFilterGroupsOverriding() {
+  public function testFilterGroupsOverriding() {
     $view = $this->viewFilterGroupsUpdating();
     $view->init_display();
 
@@ -29,7 +29,7 @@ class ViewsPluginDisplayTestCase extends ViewsSqlTest {
    * @see testFilterGroupsOverriding
    * @return view
    */
-  function viewFilterGroupsOverriding() {
+  protected function viewFilterGroupsOverriding() {
     $view = new view();
     $view->name = 'test_filter_group_override';
     $view->description = '';
@@ -79,7 +79,7 @@ class ViewsPluginDisplayTestCase extends ViewsSqlTest {
    * @see http://drupal.org/node/1259608
    * @see views_plugin_display::init()
    */
-  function testFilterGroupsUpdating() {
+  public function testFilterGroupsUpdating() {
     $view = $this->viewFilterGroupsUpdating();
     $view->init_display();
 
@@ -94,7 +94,7 @@ class ViewsPluginDisplayTestCase extends ViewsSqlTest {
    *
    * @return view
    */
-  function viewFilterGroupsUpdating() {
+  protected function viewFilterGroupsUpdating() {
     $view = new view();
     $view->name = 'test_filter_groups';
     $view->description = '';

--- a/core/modules/views/tests/styles/views_plugin_style.test
+++ b/core/modules/views/tests/styles/views_plugin_style.test
@@ -13,7 +13,7 @@ class ViewsPluginStyleTestCase extends ViewsPluginStyleTestBase {
   /**
    * Tests the grouping legacy features of styles.
    */
-  function testGroupingLegacy() {
+  public function testGroupingLegacy() {
     $view = $this->getBasicView();
     // Setup grouping by the job.
     $view->init_display();
@@ -101,7 +101,7 @@ class ViewsPluginStyleTestCase extends ViewsPluginStyleTestBase {
     $this->assertEqual($sets_new_value, $expected, t('The style plugins should proper group the results with grouping by the value.'));
   }
 
-  function testGrouping() {
+  public function testGrouping() {
     $this->_testGrouping(FALSE);
     $this->_testGrouping(TRUE);
   }
@@ -109,7 +109,7 @@ class ViewsPluginStyleTestCase extends ViewsPluginStyleTestBase {
   /**
    * Tests the grouping features of styles.
    */
-  function _testGrouping($stripped = FALSE) {
+  private function _testGrouping($stripped = FALSE) {
     $view = $this->getBasicView();
     // Setup grouping by the job and the age field.
     $view->init_display();
@@ -228,7 +228,7 @@ class ViewsPluginStyleTestCase extends ViewsPluginStyleTestBase {
   /**
    * Tests custom css classes.
    */
-  function testCustomRowClasses() {
+  public function testCustomRowClasses() {
     $view = $this->getBasicView();
 
     // Setup some random css class.

--- a/core/modules/views/tests/styles/views_plugin_style_base.test
+++ b/core/modules/views/tests/styles/views_plugin_style_base.test
@@ -21,7 +21,7 @@ abstract class ViewsPluginStyleTestBase extends ViewsSqlTest {
   /**
    * Stores a view output in the elements.
    */
-  function storeViewPreview($output) {
+  protected function storeViewPreview($output) {
     $htmlDom = new DOMDocument();
     @$htmlDom->loadHTML($output);
     if ($htmlDom) {

--- a/core/modules/views/tests/styles/views_plugin_style_jump_menu.test
+++ b/core/modules/views/tests/styles/views_plugin_style_jump_menu.test
@@ -40,7 +40,7 @@ class ViewsPluginStyleJumpMenuTest extends ViewsSqlTest {
   /**
    * Tests jump menus with more than one same path but maybe different titles.
    */
-  function testDuplicatePaths() {
+  public function testDuplicatePaths() {
     $view = $this->getJumpMenuView();
     $view->set_display();
     $view->init_handlers();
@@ -64,7 +64,7 @@ class ViewsPluginStyleJumpMenuTest extends ViewsSqlTest {
     }
   }
 
-  function getJumpMenuView() {
+  protected function getJumpMenuView() {
     $view = new view;
     $view->name = 'test_jump_menu';
     $view->description = '';

--- a/core/modules/views/tests/styles/views_plugin_style_unformatted.test
+++ b/core/modules/views/tests/styles/views_plugin_style_unformatted.test
@@ -13,7 +13,7 @@ class ViewsPluginStyleUnformattedTestCase extends ViewsPluginStyleTestBase {
   /**
    * Take sure that the default css classes works as expected.
    */
-  function testDefaultRowClasses() {
+  public function testDefaultRowClasses() {
     $view = $this->getBasicView();
     $rendered_output = $view->preview();
     $this->storeViewPreview($rendered_output);

--- a/core/modules/views/tests/views_access.test
+++ b/core/modules/views/tests/views_access.test
@@ -50,7 +50,7 @@ class ViewsAccessTest extends ViewsSqlTest {
     views_fetch_plugin_data(NULL, NULL, TRUE);
   }
 
-  function viewsPlugins() {
+  protected function viewsPlugins() {
     $plugins = array(
       'access' =>  array(
         'test_static' => array(
@@ -74,7 +74,7 @@ class ViewsAccessTest extends ViewsSqlTest {
   /**
    * Tests none access plugin.
    */
-  function testAccessNone() {
+  public function testAccessNone() {
     $view = $this->view_access_none();
 
     $view->set_display('default');
@@ -87,7 +87,7 @@ class ViewsAccessTest extends ViewsSqlTest {
   /**
    * Tests perm access plugin.
    */
-  function testAccessPerm() {
+  public function testAccessPerm() {
     $view = $this->view_access_perm();
 
     $view->set_display('default');
@@ -101,7 +101,7 @@ class ViewsAccessTest extends ViewsSqlTest {
   /**
    * Tests role access plugin.
    */
-  function testAccessRole() {
+  public function testAccessRole() {
     $view = $this->view_access_role();
 
     $view->set_display('default');
@@ -119,7 +119,7 @@ class ViewsAccessTest extends ViewsSqlTest {
   /**
    * Tests static access check.
    */
-  function testStaticAccessPlugin() {
+  public function testStaticAccessPlugin() {
     $view = $this->view_access_static();
 
     $view->set_display('default');
@@ -146,7 +146,7 @@ class ViewsAccessTest extends ViewsSqlTest {
   /**
    * Tests dynamic access plugin.
    */
-  function testDynamicAccessPlugin() {
+  public function testDynamicAccessPlugin() {
     $view = $this->view_access_dynamic();
     $argument1 = $this->randomName();
     $argument2 = $this->randomName();
@@ -177,7 +177,7 @@ class ViewsAccessTest extends ViewsSqlTest {
     $this->assertTrue(views_access($expected_hook_menu, $argument1, $argument2));
   }
 
-  function view_access_none() {
+  private function view_access_none() {
     $view = new view;
     $view->name = 'test_access_none';
     $view->description = '';
@@ -200,7 +200,7 @@ class ViewsAccessTest extends ViewsSqlTest {
     return $view;
   }
 
-  function view_access_perm() {
+  private function view_access_perm() {
     $view = new view;
     $view->name = 'test_access_perm';
     $view->description = '';
@@ -224,7 +224,7 @@ class ViewsAccessTest extends ViewsSqlTest {
     return $view;
   }
 
-  function view_access_role() {
+  private function view_access_role() {
     $view = new view;
     $view->name = 'test_access_role';
     $view->description = '';
@@ -250,7 +250,7 @@ class ViewsAccessTest extends ViewsSqlTest {
     return $view;
   }
 
-  function view_access_dynamic() {
+  private function view_access_dynamic() {
     $view = new view;
     $view->name = 'test_access_dynamic';
     $view->description = '';
@@ -276,7 +276,7 @@ class ViewsAccessTest extends ViewsSqlTest {
     return $view;
   }
 
-  function view_access_static() {
+  private function view_access_static() {
     $view = new view;
     $view->name = 'test_access_static';
     $view->description = '';

--- a/core/modules/views/tests/views_analyze.test
+++ b/core/modules/views/tests/views_analyze.test
@@ -26,7 +26,7 @@ class ViewsAnalyzeTest extends ViewsSqlTest {
   /**
    * Tests that analyze works in general.
    */
-  function testAnalyzeBasic() {
+  public function testAnalyzeBasic() {
     $this->backdropLogin($this->admin);
     // Enable the taxonomy_term view and click the analyse button.
     $view = views_get_view('taxonomy_term');

--- a/core/modules/views/tests/views_argument_default.test
+++ b/core/modules/views/tests/views_argument_default.test
@@ -24,7 +24,7 @@ class ViewsArgumentDefaultTest extends ViewsSqlTest {
   /**
    * Tests the use of a default argument plugin that provides no options.
    */
-  function testArgumentDefaultNoOptions() {
+  public function testArgumentDefaultNoOptions() {
     module_enable(array('views_ui', 'views_test'));
     $admin_user = $this->backdropCreateUser(array('administer views', 'administer site configuration'));
     $this->backdropLogin($admin_user);
@@ -49,7 +49,7 @@ class ViewsArgumentDefaultTest extends ViewsSqlTest {
   /**
    * Tests fixed default argument.
    */
-  function testArgumentDefaultFixed() {
+  public function testArgumentDefaultFixed() {
     $view = $this->view_argument_default_fixed();
 
     $view->set_display('default');
@@ -73,18 +73,18 @@ class ViewsArgumentDefaultTest extends ViewsSqlTest {
   /**
    * @todo Test php default argument.
    */
-  function testArgumentDefaultPhp() {
+  public function testArgumentDefaultPhp() {
 
   }
 
   /**
    * @todo Test node default argument.
    */
-  function testArgumentDefaultNode() {
+  public function testArgumentDefaultNode() {
 
   }
 
-  function view_argument_default_fixed() {
+  private function view_argument_default_fixed() {
     $view = new view;
     $view->name = 'test_argument_default_fixed';
     $view->description = '';

--- a/core/modules/views/tests/views_argument_validator.test
+++ b/core/modules/views/tests/views_argument_validator.test
@@ -10,7 +10,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * Tests Views argument validators.
  */
 class ViewsArgumentValidatorTest extends ViewsSqlTest {
-  function testArgumentValidatePhp() {
+  public function testArgumentValidatePhp() {
     $string = $this->randomName();
     $view = $this->view_test_argument_validate_php($string);
     $view->set_display('default');
@@ -22,7 +22,7 @@ class ViewsArgumentValidatorTest extends ViewsSqlTest {
     $this->assertFalse($view->argument['null']->validate_arg($this->randomName()));
   }
 
-  function testArgumentValidateNumeric() {
+  public function testArgumentValidateNumeric() {
     $view = $this->view_argument_validate_numeric();
     $view->set_display('default');
     $view->pre_execute();
@@ -36,7 +36,7 @@ class ViewsArgumentValidatorTest extends ViewsSqlTest {
   /**
    * Make sure argument validation works properly.
    */
-  function testArgumentValidatePhpFailure() {
+  public function testArgumentValidatePhpFailure() {
     $view = $this->view_test_argument_validate_php_failure();
     $view->save();
     $this->backdropGet('test-php-failure');
@@ -50,7 +50,7 @@ class ViewsArgumentValidatorTest extends ViewsSqlTest {
     $this->assertResponse(403);
   }
 
-  function view_test_argument_validate_php($string) {
+  private function view_test_argument_validate_php($string) {
     $code = 'return $argument == \''. $string .'\';';
     $view = new view;
     $view->name = 'view_argument_validate_php';
@@ -83,7 +83,7 @@ class ViewsArgumentValidatorTest extends ViewsSqlTest {
     return $view;
   }
 
-  function view_argument_validate_numeric() {
+  private function view_argument_validate_numeric() {
     $view = new view;
     $view->name = 'view_argument_validate_numeric';
     $view->description = '';
@@ -114,7 +114,7 @@ class ViewsArgumentValidatorTest extends ViewsSqlTest {
     return $view;
   }
 
-  function view_test_argument_validate_php_failure() {
+  private function view_test_argument_validate_php_failure() {
     $view = new view();
     $view->name = 'view_argument_validate_php_failure';
     $view->description = '';

--- a/core/modules/views/tests/views_cache.test
+++ b/core/modules/views/tests/views_cache.test
@@ -68,7 +68,7 @@ class ViewsCacheTest extends ViewsSqlTest {
    *
    * @see views_plugin_cache_time
    */
-  function testTimeCaching() {
+  public function testTimeCaching() {
     // Create a basic result which just 2 results.
     $view = $this->getBasicView();
     $view->set_display();
@@ -109,7 +109,7 @@ class ViewsCacheTest extends ViewsSqlTest {
    *
    * @see views_plugin_cache_time
    */
-  function testNoneCaching() {
+  public function testNoneCaching() {
     // Create a basic result which just 2 results.
     $view = $this->getBasicView();
     $view->set_display();
@@ -145,7 +145,7 @@ class ViewsCacheTest extends ViewsSqlTest {
   /**
    * Tests css/js storage and restoring mechanism.
    */
-  function testHeaderStorage() {
+  public function testHeaderStorage() {
     // Create a view with output caching enabled.
     // Some hook_views_pre_render in views_test.module adds the test css/js file.
     // so they should be added to the css/js storage.
@@ -204,7 +204,7 @@ class ViewsCacheTest extends ViewsSqlTest {
   /**
    * Check that HTTP headers are cached for views.
    */
-  function testHttpHeadersCaching() {
+  public function testHttpHeadersCaching() {
     // Create a few nodes to appear in RSS feed.
     for ($i = 0; $i < 5; $i++) {
       $this->backdropCreateNode();
@@ -239,7 +239,7 @@ class ViewsCacheTest extends ViewsSqlTest {
    *
    * Make sure the output is different.
    */
-  function testExposedFilterSameResultsCaching() {
+  public function testExposedFilterSameResultsCaching() {
     // Create the view with time-based cache with hour lifetimes and add exposed
     // filter to it with "Starts with" operator.
     $view = $this->getBasicView();

--- a/core/modules/views/tests/views_exposed_form.test
+++ b/core/modules/views/tests/views_exposed_form.test
@@ -43,7 +43,7 @@ class ViewsExposedFormTest extends ViewsSqlTest {
   /**
    * Test remembering exposed filters.
    */
-  function testExposedRemember() {
+  public function testExposedRemember() {
     $admin_user = $this->backdropCreateUser(array('administer views', 'administer site configuration'));
     $this->backdropLogin($admin_user);
 
@@ -87,7 +87,7 @@ class ViewsExposedFormTest extends ViewsSqlTest {
   /**
    * Tests the admin interface of exposed filter and sort items.
    */
-  function testExposedAdminUi() {
+  public function testExposedAdminUi() {
     $admin_user = $this->backdropCreateUser(array('administer views', 'administer site configuration'));
     $this->backdropLogin($admin_user);
     menu_rebuild();

--- a/core/modules/views/tests/views_groupby.test
+++ b/core/modules/views/tests/views_groupby.test
@@ -104,7 +104,7 @@ class ViewsQueryGroupByTest extends ViewsSqlTest {
    * @param array|null $values
    *   (optional) Expected values.
    */
-  function GroupByTestHelper($group_by = NULL, $values = NULL) {
+  protected function GroupByTestHelper($group_by = NULL, $values = NULL) {
     // Create 4 nodes of type1 and 3 nodes of type2.
     $type1 = $this->backdropCreateContentType();
     $type2 = $this->backdropCreateContentType();
@@ -150,7 +150,7 @@ class ViewsQueryGroupByTest extends ViewsSqlTest {
     $this->assertEqual($results[$type2->type], $values[1]);
   }
 
-  function viewsGroupByViewHelper($group_by = NULL) {
+  protected function viewsGroupByViewHelper($group_by = NULL) {
     $view = new view;
     $view->name = 'group_by_count';
     $view->description = '';
@@ -213,24 +213,24 @@ class ViewsQueryGroupByTest extends ViewsSqlTest {
     $this->GroupByTestHelper('count', array(4, 3));
   }
 
-  function testGroupBySum() {
+  public function testGroupBySum() {
     $this->GroupByTestHelper('sum', array(10, 18));
   }
 
 
-  function testGroupByAverage() {
+  public function testGroupByAverage() {
     $this->GroupByTestHelper('avg', array(2.5, 6));
   }
 
-  function testGroupByMin() {
+  public function testGroupByMin() {
     $this->GroupByTestHelper('min', array(1, 5));
   }
 
-  function testGroupByMax() {
+  public function testGroupByMax() {
     $this->GroupByTestHelper('max', array(4, 7));
   }
 
-  function testGroupByNone() {
+  public function testGroupByNone() {
     $this->GroupByTestHelper();
   }
 
@@ -254,7 +254,7 @@ class ViewsQueryGroupByTest extends ViewsSqlTest {
     $this->assertTrue(strpos($view->build_info['query'], 'HAVING'), t('Make sure that HAVING is in the query'));
   }
 
-  function viewsGroupByCountViewOnlyFilters() {
+  protected function viewsGroupByCountViewOnlyFilters() {
     $view = new view;
     $view->name = 'group_by_in_filters';
     $view->description = '';
@@ -304,7 +304,7 @@ class ViewsQueryGroupByTest extends ViewsSqlTest {
  * Tests UI of aggregate functionality..
  */
 class viewsUiGroupbyTestCase extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     // Enable views_ui.
     parent::setUp('views_ui', 'views_test');
 
@@ -318,7 +318,7 @@ class viewsUiGroupbyTestCase extends BackdropWebTestCase {
    *
    * @todo: this should check the change of the settings as well.
    */
-  function testGroupBySave() {
+  public function testGroupBySave() {
     $this->backdropGet('admin/structure/views/view/test_views_groupby_save/configure');
 
     $edit = array(

--- a/core/modules/views/tests/views_handlers.test
+++ b/core/modules/views/tests/views_handlers.test
@@ -11,7 +11,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  */
 class ViewsHandlersTest extends ViewsSqlTest {
 
-  function testFilterInOperatorUi() {
+  public function testFilterInOperatorUi() {
     $admin_user = $this->backdropCreateUser(array('administer views', 'administer site configuration'));
     $this->backdropLogin($admin_user);
     menu_rebuild();
@@ -31,7 +31,7 @@ class ViewsHandlersTest extends ViewsSqlTest {
   /**
    * Tests views_break_phrase_string function.
    */
-  function test_views_break_phrase_string() {
+  public function test_views_break_phrase_string() {
     module_load_include('inc', 'views', 'includes/utility');
     $empty_class = new stdClass();
     $empty_class->operator = 'or';
@@ -87,7 +87,7 @@ class ViewsHandlersTest extends ViewsSqlTest {
   /**
    * Tests views_break_phrase function.
    */
-  function test_views_break_phrase() {
+  public function test_views_break_phrase() {
     $empty_class = new stdClass();
     $empty_class->operator = 'or';
     $empty_class->value = array();

--- a/core/modules/views/tests/views_module.test
+++ b/core/modules/views/tests/views_module.test
@@ -90,7 +90,7 @@ class ViewsModuleTest extends ViewsSqlTest {
   /**
    * Tests the dynamic includes of templates via module feature.
    */
-  function testModuleTemplates() {
+  public function testModuleTemplates() {
     $existing = array();
     $type = array();
     $theme = array();
@@ -102,7 +102,7 @@ class ViewsModuleTest extends ViewsSqlTest {
   /**
    * Tests the views_get_handler method.
    */
-  function testviews_get_handler() {
+  public function testviews_get_handler() {
     $types = array('field', 'area', 'filter');
     foreach ($types as $type) {
       $handler = views_get_handler($this->randomName(), $this->randomName(), $type);
@@ -151,7 +151,7 @@ class ViewsModuleTest extends ViewsSqlTest {
   /**
    * Tests views_fetch_data().
    */
-  function testFetchData() {
+  public function testFetchData() {
 
     // Make sure we start with a empty cache.
     $this->resetStaticViewsDataCache();
@@ -219,7 +219,7 @@ class ViewsModuleTest extends ViewsSqlTest {
   /**
    * Ensure that a certain handler is a instance of a certain table/field.
    */
-  function assertInstanceHandler($handler, $table, $field, $id) {
+  protected function assertInstanceHandler($handler, $table, $field, $id) {
     $table_data = views_fetch_data($table);
     $field_data = $table_data[$field][$id];
 

--- a/core/modules/views/tests/views_pager.test
+++ b/core/modules/views/tests/views_pager.test
@@ -297,7 +297,7 @@ class ViewsPagerTest extends ViewsSqlTest {
     $this->assertEqual(count($view->result), 11);
   }
 
-  function viewPagerFullZeroItemsPerPage() {
+  protected function viewPagerFullZeroItemsPerPage() {
     $view = new view;
     $view->name = 'view_pager_full_zero_items_per_page';
     $view->description = '';
@@ -337,7 +337,7 @@ class ViewsPagerTest extends ViewsSqlTest {
     return $view;
   }
 
-  function viewsPagerFull() {
+  protected function viewsPagerFull() {
     $view = new view;
     $view->name = 'test_pager_full';
     $view->description = '';
@@ -363,7 +363,7 @@ class ViewsPagerTest extends ViewsSqlTest {
     return $view;
   }
 
-  function viewsPagerFullFields() {
+  protected function viewsPagerFullFields() {
     $view = new view;
     $view->name = 'test_pager_full';
     $view->description = '';
@@ -429,7 +429,7 @@ class ViewsPagerTest extends ViewsSqlTest {
   /**
    * Test the api functions on the view object.
    */
-  function testPagerApi() {
+  public function testPagerApi() {
     $view = $this->viewsPagerFull();
     // On the first round don't initialize the pager.
 

--- a/core/modules/views/tests/views_query.test
+++ b/core/modules/views/tests/views_query.test
@@ -173,7 +173,7 @@ abstract class ViewsSqlTest extends ViewsTestCase {
    * @TODO
    *   Convert existing setUp functions.
    */
-  function enableViewsUi() {
+  protected function enableViewsUi() {
     module_enable(array('views_ui'));
     // @TODO Figure out why it's required to clear the cache here.
     views_get_all_views(TRUE);

--- a/core/modules/views/tests/views_ui.test
+++ b/core/modules/views/tests/views_ui.test
@@ -8,7 +8,7 @@
  * Views UI wizard tests.
  */
 class ViewsUIWizardHelper extends BackdropWebTestCase {
-  function setUp() {
+  public function setUp() {
     // Enable views_ui.
     parent::setUp('views_ui');
 
@@ -22,7 +22,7 @@ class ViewsUIWizardHelper extends BackdropWebTestCase {
  * Tests creating views with the wizard and viewing them on the listing page.
  */
 class ViewsUIWizardBasicTestCase extends ViewsUIWizardHelper {
-  function testViewsWizardAndListing() {
+  public function testViewsWizardAndListing() {
     // Check if we can access the main views admin page.
     $this->backdropGet('admin/structure/views');
     $this->assertLinkByHref(url('admin/config/development/configuration/single/export'));
@@ -141,7 +141,7 @@ class ViewsUIWizardDefaultViewsTestCase extends ViewsUIWizardHelper {
   /**
    * Tests default views.
    */
-  function testDefaultViews() {
+  public function testDefaultViews() {
     // Make sure the taxonomy term view starts off as disabled.
     $edit_href = 'admin/structure/views/view/taxonomy_term';
     $this->backdropGet('admin/structure/views');
@@ -213,7 +213,7 @@ class ViewsUIWizardDefaultViewsTestCase extends ViewsUIWizardHelper {
    *   The page content that results from clicking on the link, or FALSE on
    *   failure. Failure also results in a failed assertion.
    */
-  function clickViewsOperationLink($label, $unique_href_part) {
+  protected function clickViewsOperationLink($label, $unique_href_part) {
     $links = $this->xpath('//a[normalize-space(text())=:label]', array(':label' => $label));
     foreach ($links as $link_index => $link) {
       $position = strpos($link['href'], $unique_href_part);
@@ -242,7 +242,7 @@ class ViewsUIWizardTaggedWithTestCase extends ViewsUIWizardHelper {
   protected $tag_field;
   protected $tag_instance;
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
 
     // Create two content types. One will have an autocomplete tagging field,
@@ -299,7 +299,7 @@ class ViewsUIWizardTaggedWithTestCase extends ViewsUIWizardHelper {
   /**
    * Tests the "tagged with" functionality.
    */
-  function testTaggedWith() {
+  public function testTaggedWith() {
     // In this test we will only create nodes that have an instance of the tag
     // field.
     $node_add_path = 'node/add/' . $this->node_type_with_tags->type;
@@ -363,7 +363,7 @@ class ViewsUIWizardTaggedWithTestCase extends ViewsUIWizardHelper {
   /**
    * Tests that the "tagged with" form element only shows for node types that support it.
    */
-  function testTaggedWithByNodeType() {
+  public function testTaggedWithByNodeType() {
     // The tagging field is associated with one of our node types only. So the
     // "tagged with" form element on the view wizard should appear on the form
     // by default (when the wizard is configured to display all content) and
@@ -400,7 +400,7 @@ class ViewsUIWizardSortingTestCase extends ViewsUIWizardHelper {
   /**
    * Tests the sorting functionality.
    */
-  function testSorting() {
+  public function testSorting() {
     // Create nodes, each with a different creation time so that we can do a
     // meaningful sort.
     $node1 = $this->backdropCreateNode(array('created' => REQUEST_TIME));
@@ -462,7 +462,7 @@ class ViewsUIWizardItemsPerPageTestCase extends ViewsUIWizardHelper {
   /**
    * Tests the number of items per page.
    */
-  function testItemsPerPage() {
+  public function testItemsPerPage() {
     // Create posts, each with a different creation time so that we can do a
     // meaningful sort.
     $node1 = $this->backdropCreateNode(array('type' => 'post', 'created' => REQUEST_TIME));
@@ -539,7 +539,7 @@ class ViewsUIWizardMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Tests the menu functionality.
    */
-  function testMenus() {
+  public function testMenus() {
     // Create a view with a page display and a menu link in the Main Menu.
     $view = array();
     $view['human_name'] = $this->randomName(16);
@@ -577,7 +577,7 @@ class ViewsUIWizardMenuTestCase extends ViewsUIWizardHelper {
  */
 class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
 
-  function setup() {
+  public function setUp() {
     parent::setup();
 
     // Make sure we're using UTC
@@ -587,7 +587,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Tests the jump menu style plugin.
    */
-  function testJumpMenus() {
+  public function testJumpMenus() {
     // We'll run this test for several different base tables that appear in the
     // wizard.
     $base_table_methods = array(
@@ -654,7 +654,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Helper function to create a node and return its expected path.
    */
-  function createNodeAndGetPath() {
+  protected function createNodeAndGetPath() {
     $node = $this->backdropCreateNode();
     return entity_uri('node', $node);
   }
@@ -662,7 +662,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Helper function to create a user and return its expected path.
    */
-  function createUserAndGetPath() {
+  protected function createUserAndGetPath() {
     $account = $this->backdropCreateUser();
     return entity_uri('user', $account);
   }
@@ -670,7 +670,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Helper function to create a comment and return its expected path.
    */
-  function createCommentAndGetPath() {
+  protected function createCommentAndGetPath() {
     $node = $this->backdropCreateNode();
     $comment = entity_create('comment', array(
       'cid' => NULL,
@@ -689,7 +689,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Helper function to create a taxonomy term and return its expected path.
    */
-  function createTaxonomyTermAndGetPath() {
+  protected function createTaxonomyTermAndGetPath() {
     $vocabulary = new TaxonomyVocabulary(array(
       'name' => $this->randomName(),
       'machine_name' => backdrop_strtolower($this->randomName()),
@@ -708,7 +708,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Helper function to create a file and return its expected path.
    */
-  function createFileAndGetPath() {
+  protected function createFileAndGetPath() {
     $file = entity_create('file', array(
       'uid' => 1,
       'filename' => 'views-ui-jump-menu-test.txt',
@@ -725,7 +725,7 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
   /**
    * Helper function to create a node revision and return its expected path.
    */
-  function createNodeRevisionAndGetPath() {
+  protected function createNodeRevisionAndGetPath() {
     // The node needs at least two revisions in order for Backdrop to allow
     // access to the revision path.
     $settings = array('revision' => TRUE);
@@ -743,7 +743,7 @@ class ViewsUIWizardDisplaysTestCase extends ViewsUIWizardHelper {
   /**
    * Tests that displays can be overridden via the UI.
    */
-  function testOverrideDisplays() {
+  public function testOverrideDisplays() {
     // Create a basic view that shows all content, with a page and a block
     // display.
     $view['human_name'] = $this->randomName(16);
@@ -806,7 +806,7 @@ class ViewsUIWizardDisplaysTestCase extends ViewsUIWizardHelper {
   /**
    * Tests that the wizard correctly sets up default and overridden displays.
    */
-  function testWizardMixedDefaultOverriddenDisplays() {
+  public function testWizardMixedDefaultOverriddenDisplays() {
     // Create a basic view with a page, block, and feed. Give the page and feed
     // identical titles, but give the block a different one, so we expect the
     // page and feed to inherit their titles from the default display, but the
@@ -891,7 +891,7 @@ class ViewsUIWizardDisplaysTestCase extends ViewsUIWizardHelper {
   /**
    * Tests that the revert to all displays select-option works as expected.
    */
-  function testRevertAllDisplays() {
+  public function testRevertAllDisplays() {
     // Create a basic view with a page, block.
     // Because there is both a title on page and block we expect the title on
     // the block be overridden.
@@ -918,7 +918,7 @@ class ViewsUIWizardDisplaysTestCase extends ViewsUIWizardHelper {
   /**
    * Test reordering of displays.
    */
-  function testReorderDisplays() {
+  public function testReorderDisplays() {
     // Create a basic view with a page, block.
     $view['human_name'] = $this->randomName(16);
     $view['name'] = strtolower($this->randomName(16));

--- a/core/modules/views/tests/views_upgrade.test
+++ b/core/modules/views/tests/views_upgrade.test
@@ -12,7 +12,7 @@ require_once BACKDROP_ROOT . '/core/modules/views/tests/views_query.test';
  * You can find all conversions by searching for "moved to".
  */
 class ViewsUpgradeTestCase extends ViewsSqlTest {
-  function viewsData() {
+  protected function viewsData() {
     $data = parent::viewsData();
     $data['views_test']['old_field_1']['moved to'] = array('views_test', 'id');
     $data['views_test']['old_field_2']['field']['moved to'] = array('views_test', 'name');
@@ -26,7 +26,7 @@ class ViewsUpgradeTestCase extends ViewsSqlTest {
     return $data;
   }
 
-  function debugField($field) {
+  protected function debugField($field) {
     $keys = array('id', 'table', 'field', 'actual_field', 'original_field', 'real_field');
     $info = array();
     foreach ($keys as $key) {

--- a/core/modules/views/tests/views_view.test
+++ b/core/modules/views/tests/views_view.test
@@ -13,7 +13,7 @@ class ViewsViewTest extends ViewsSqlTest {
   /**
    * Tests the deconstructor to be sure that every kind of heavy objects are removed.
    */
-  function testDestroy() {
+  public function testDestroy() {
     $view = $this->view_test_destroy();
 
     $view->preview();
@@ -29,7 +29,7 @@ class ViewsViewTest extends ViewsSqlTest {
     $this->assertViewDestroy($view);
   }
 
-  function assertViewDestroy($view) {
+  protected function assertViewDestroy($view) {
     $this->assertFalse(isset($view->display['default']->handler), 'Make sure all displays are destroyed.');
     $this->assertFalse(isset($view->display['attachment_1']->handler), 'Make sure all displays are destroyed.');
 
@@ -51,7 +51,7 @@ class ViewsViewTest extends ViewsSqlTest {
     $this->assertEqual($view->attachment_after, '');
   }
 
-  function testDelete() {
+  public function testDelete() {
     // Delete a database view
     $view = $this->view_test_delete();
     $view->save();
@@ -62,7 +62,7 @@ class ViewsViewTest extends ViewsSqlTest {
     $this->assertFalse($view, 'Make sure that the old view is removed from the static cache.');
   }
 
-  function testValidate() {
+  public function testValidate() {
     // Test a view with multiple displays.
     // Validating a view shouldn't change the active display.
     // @todo: Create an extra validation view.
@@ -82,7 +82,7 @@ class ViewsViewTest extends ViewsSqlTest {
   /**
    * This view provides some filters, fields, arguments, relationships, sorts, areas and attachments.
    */
-  function view_test_destroy() {
+  private function view_test_destroy() {
     $view = new view;
     $view->name = 'test_destroy';
     $view->description = '';
@@ -242,7 +242,7 @@ class ViewsViewTest extends ViewsSqlTest {
 
     return $view;
   }
-  function view_test_delete() {
+  private function view_test_delete() {
     $view = new view;
     $view->name = 'test_view_delete';
     $view->description = '';

--- a/core/profiles/testing/modules/backdrop_system_listing_compatible_test/backdrop_system_listing_compatible_test.test
+++ b/core/profiles/testing/modules/backdrop_system_listing_compatible_test/backdrop_system_listing_compatible_test.test
@@ -14,7 +14,7 @@ class BackdropSystemListingCompatibleTestCase extends BackdropWebTestCase {
    */
   protected $profile = 'minimal';
 
-  function setUp() {
+  public function setUp() {
     // Attempt to install a module in Testing profile, while this test runs with
     // a different profile.
     parent::setUp(array('backdrop_system_listing_compatible_test'));
@@ -23,7 +23,7 @@ class BackdropSystemListingCompatibleTestCase extends BackdropWebTestCase {
   /**
    * Non-empty test* method required to executed the test case class.
    */
-  function testBackdropSystemListing() {
+  public function testBackdropSystemListing() {
     $this->pass(__CLASS__ . ' test executed.');
   }
 }


### PR DESCRIPTION
Part of https://github.com/backdrop/backdrop-issues/issues/6004

This adds scoping to all methods within `*.test` files. This was done via find/replace with the following rules:

- `setUp()` is always `public`
- Any `test[Something]()` method is always `public`
- Methods that start with `_` are `private`
- Views-specific tests where  a view is separated out into a dedicated method with the name `view_[view_id]` are `private`
- All `assert[Something]()` methods are `protected` (matching SimpleTest `assert` methods).
- Everything else is `protected`, usually utility methods for reuse within a test or sub-class.

EDIT: See this alternative that sets `setUp()` and `test` methods to `protected`, which also seems to work https://github.com/backdrop/backdrop/pull/4963