### PR TITLE
Issue #5769: Fix weird gap for messages on home page

### DIFF
--- a/core/themes/basis/css/component/cards.css
+++ b/core/themes/basis/css/component/cards.css
@@ -20,7 +20,7 @@ body.update-1-30 .l-wrapper > .l-top:has(.block-views-promoted-cards-block) {
   margin-top: -2rem; /* Negative top margin on parent limited in scope. */
 }
 body.update-1-30 .l-wrapper > .l-top:has(.block-views-promoted-cards-block) .block,
-body.update-1-30 .l-wrapper > .l-top:has(.block-views-promoted-cards-block) .l-messages {
+body.update-1-30 .l-wrapper > .l-top .block-system-messages:has(+ .block-views-promoted-cards-block) .l-messages {
   margin-bottom: 0;
 }
 .block-views-promoted-cards-block .views-view-grid-cols-3 {

--- a/core/themes/basis/css/component/cards.css
+++ b/core/themes/basis/css/component/cards.css
@@ -12,7 +12,9 @@
   padding-bottom: 2rem;
   background-color: #f2f2f2;
 }
-
+.front.update-1-30 .l-top:has(.block-views-promoted-cards-block) {
+  background-color: #f2f2f2;
+}
 .block-views-promoted-cards-block .views-view-grid-cols-3 {
   grid-template-columns: repeat(1, 1fr);
 }

--- a/core/themes/basis/css/component/cards.css
+++ b/core/themes/basis/css/component/cards.css
@@ -15,12 +15,12 @@
 body.update-1-30 .l-top .block-views-promoted-cards-block {
   margin-top: 0;
 }
-body.update-1-30 .l-top:has(.block-views-promoted-cards-block) {
+body.update-1-30 .l-wrapper > .l-top:has(.block-views-promoted-cards-block) {
   background-color: #f2f2f2;
-  margin-top: -2rem;
+  margin-top: -2rem; /* Negative top margin on parent limited in scope. */
 }
-body.update-1-30 .l-top:has(.block-views-promoted-cards-block) .block,
-body.update-1-30 .l-top:has(.block-views-promoted-cards-block) .l-messages {
+body.update-1-30 .l-wrapper > .l-top:has(.block-views-promoted-cards-block) .block,
+body.update-1-30 .l-wrapper > .l-top:has(.block-views-promoted-cards-block) .l-messages {
   margin-bottom: 0;
 }
 .block-views-promoted-cards-block .views-view-grid-cols-3 {

--- a/core/themes/basis/css/component/cards.css
+++ b/core/themes/basis/css/component/cards.css
@@ -12,8 +12,16 @@
   padding-bottom: 2rem;
   background-color: #f2f2f2;
 }
-.front.update-1-30 .l-top:has(.block-views-promoted-cards-block) {
+body.update-1-30 .l-top .block-views-promoted-cards-block {
+  margin-top: 0;
+}
+body.update-1-30 .l-top:has(.block-views-promoted-cards-block) {
   background-color: #f2f2f2;
+  margin-top: -2rem;
+}
+body.update-1-30 .l-top:has(.block-views-promoted-cards-block) .block,
+body.update-1-30 .l-top:has(.block-views-promoted-cards-block) .l-messages {
+  margin-bottom: 0;
 }
 .block-views-promoted-cards-block .views-view-grid-cols-3 {
   grid-template-columns: repeat(1, 1fr);

--- a/core/themes/basis/css/component/hero.css
+++ b/core/themes/basis/css/component/hero.css
@@ -28,8 +28,8 @@
 body.update-1-30 .l-top .block-hero {
   margin-top: 0;
 }
-body.update-1-30 .l-top:has(.block-hero:first-child) {
-  margin-top: -2em;
+body.update-1-30 .l-top:has(.block-hero) {
+  margin-top: -2rem;
 }
 .container .block-hero {
   margin-top: 0; /* If hero is in a container don't collapse top spacing */

--- a/core/themes/basis/css/component/hero.css
+++ b/core/themes/basis/css/component/hero.css
@@ -25,7 +25,12 @@
 .l-top .block-hero {
   margin-top: -2rem;/* Negative top margin collapses spacing under header */
 }
-
+body.update-1-30 .l-top .block-hero {
+  margin-top: 0;
+}
+body.update-1-30 .l-top:has(.block-hero:first-child) {
+  margin-top: -2em;
+}
 .container .block-hero {
   margin-top: 0; /* If hero is in a container don't collapse top spacing */
 }

--- a/core/themes/basis/css/component/hero.css
+++ b/core/themes/basis/css/component/hero.css
@@ -28,8 +28,8 @@
 body.update-1-30 .l-top .block-hero {
   margin-top: 0;
 }
-body.update-1-30 .l-top:has(.block-hero) {
-  margin-top: -2rem;
+body.update-1-30 .l-wrapper > .l-top:has(.block-hero) {
+  margin-top: -2rem; /* Negative top margin on parent limited in scope. */
 }
 .container .block-hero {
   margin-top: 0; /* If hero is in a container don't collapse top spacing */


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5769

This approach uses a (conditional) background for the .l-top region only, if the region contains the cards block.
To avoid the messages gap and also avoid the gray stripe if the cards views block has been removed from this region.