### PR TITLE
Issue #6821 Fix hook_ckeditor_PLUGIN_plugin_check documentation [skip_tests]

### DIFF
--- a/core/modules/ckeditor/ckeditor.api.php
+++ b/core/modules/ckeditor/ckeditor.api.php
@@ -205,10 +205,12 @@ function hook_ckeditor_settings_alter(array &$settings, $format) {
  * @ingroup callbacks
  */
 function hook_ckeditor_PLUGIN_plugin_check($format, $plugin_name) {
-  // Automatically enable this plugin if the Underline button is enabled.
-  foreach ($format->editor_settings['toolbar']['buttons'] as $row) {
-    if (in_array('Underline', $row)) {
-      return TRUE;
+  $toolbars = $format->editor_settings['toolbar'];
+  foreach ($toolbars as $toolbar) {
+    foreach ($toolbar as $group) {
+      if (in_array('Underline', $group['items'])) {
+        return TRUE;
+      }
     }
   }
 }


### PR DESCRIPTION
The foreach loop in the documentation was incorrect and it doesn't reflect the current structure of the array. Additionally, I think we should change $row to $group because we're looping through the groups set up in each of the toolbar rows.

Fixes Issue #6821

Fixes https://github.com/backdrop/backdrop-issues/issues/6821