### PR TITLE
Issue #6820: Fix CKEditor 5 content comparison when content contains ul or ol tag.

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.formatter.js
+++ b/core/modules/ckeditor5/js/ckeditor5.formatter.js
@@ -143,7 +143,10 @@
       let isPreformattedLine = false;
 
       return lines
-        .filter((line) => { return line.length })
+        .filter((line) => {
+          isPreformattedLine = this._isPreformattedBlockLine(line, isPreformattedLine);
+          return isPreformattedLine || line.trim().length
+        })
         .map((line) => {
           isPreformattedLine = this._isPreformattedBlockLine(line, isPreformattedLine);
           if (this._isNonVoidOpeningTag(line)) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6820
