### PR TITLE
#3795: Disable scheduling for Page content type.

### DIFF
--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -737,9 +737,6 @@ class PagePreviewTestCase extends BackdropWebTestCase {
     $name = $this->randomName(8);
     $edit = array();
     $edit[$title_key] = $name;
-    $edit['status'] = 2;
-    $edit['scheduled[date]'] = format_date(REQUEST_TIME + 360, 'custom', 'Y-m-d', $web_user->timezone);
-    $edit['scheduled[time]'] = format_date(REQUEST_TIME + 360, 'custom', 'H:i:s', $web_user->timezone);
     $this->backdropPost(NULL, $edit, t('Preview'));
     // Make sure that the preview warnings are shown, and that they are only
     // shown once.
@@ -750,9 +747,6 @@ class PagePreviewTestCase extends BackdropWebTestCase {
     $this->assertNoText(t('This is a preview. Links within the page are disabled.'), 'Preview warning NOT displayed.');
     $this->assertNoText(t('Changes are stored temporarily.'), 'Temporary changes warning NOT displayed.');
     $node = $this->backdropGetNodeByTitle($name, TRUE);
-    $this->assertEqual($node->status, '0', 'The node is in the state Draft.');
-
-    $this->assertNotEqual($node->scheduled, 0, 'The node has a non zero published date.');
 
     // Test that a user with permissions to create, but not edit, can still
     // access preview.

--- a/core/profiles/standard/standard.install
+++ b/core/profiles/standard/standard.install
@@ -122,6 +122,7 @@ function standard_install() {
         'sticky_default' => FALSE,
         'revision_enabled' => TRUE,
         'revision_default' => FALSE,
+        'scheduling_enabled' => FALSE,
         'node_submitted' => FALSE,
         'node_user_picture' => FALSE,
         'comment_enabled' => FALSE,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/3795

Replaces https://github.com/backdrop/backdrop/pull/3777

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
