### PR TITLE
Fix pager links breaking for the Views with exposed filters

### DIFF
--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -85,7 +85,7 @@ function template_preprocess_views_view(&$variables) {
   $variables['title'] = !empty($view->views_ui_context) ? filter_xss_admin($view->get_title()) : '';
 
   if ($view->display_handler->render_pager()) {
-    $exposed_input = isset($view->exposed_raw_input) ? $view->exposed_raw_input : NULL;
+    $exposed_input = $view->get_exposed_input();
     $variables['pager']      = $view->query->render_pager($exposed_input);
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6843

This is a relatively old issue with Views that hasn't been ported to Backdrop yet. It's currently tracked in
https://github.com/backdrop/backdrop-issues/issues/3723 under "2f23c3e0 | Issue #2315365 by alexdmccabe: Pager should be built with view::get_exposed_input(), not $view->exposed_raw_input." which links to https://www.drupal.org/node/2315365 and the patch https://www.drupal.org/files/issues/views-raw-exposed-input-2315365-14.patch.

