### PR TITLE
Issue #6835: Specify CSS update defaults in .info file as fallback.

### DIFF
--- a/core/themes/basis/basis.info
+++ b/core/themes/basis/basis.info
@@ -45,3 +45,11 @@ scripts[] = js/script.js
 ; We need at least one setting for the theme settings page to appear in the
 ; menu. Color module provides our defaults, so we just register a dummy setting.
 settings[color] = true
+
+; These defaults are used when the Basis theme is disabled but a sub-theme is
+; active. These can be overridden by a sub-theme's [theme].settings.json config
+; file or the sub-themes [theme].info file.
+settings[css_update] = "install"
+
+; An empty string is the same as "no updates".
+settings[css_update_version] = ""


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6835

Alternative to https://github.com/backdrop/backdrop/pull/5002.

Rather than writing a new update hook that creates a `basis.settings.json` file even if the Basis theme is disabled, this populates a default value in the `basis.info` file, which should apply even if the Basis theme is disabled and the `basis.settings.json` file does not exist.
