### PR TITLE
Issue #6845: Allow layout dialogs to be wider if space is available

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -161,7 +161,7 @@
 
 /* Layout dialogs. */
 .layout-dialog {
-  max-width: min(95vw, 912px);
+  max-width: min(95vw, 48em);
 }
 .layout-block-list {
   max-height: 300px;

--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -161,7 +161,7 @@
 
 /* Layout dialogs. */
 .layout-dialog {
-  max-width: 600px;
+  max-width: min(95vw, 912px);
 }
 .layout-block-list {
   max-height: 300px;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6845