### PR TITLE
Issue #6852: Adding since docblock lines for join methods.

### DIFF
--- a/core/includes/database/select.inc
+++ b/core/includes/database/select.inc
@@ -278,6 +278,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    *
    * @return string
    *   The unique alias that was assigned for this table.
+   *
+   * @since 1.30.1 $condition can now be a DatabaseCondition object.
    */
   public function join($table, $alias = NULL, $condition = NULL, $arguments = array()); // phpcs:ignore -- No type hint on $arguments, add in 2.x.
 
@@ -302,6 +304,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    *
    * @return string
    *   The unique alias that was assigned for this table.
+   *
+   * @since 1.30.1 $condition can now be a DatabaseCondition object.
    */
   public function innerJoin($table, $alias = NULL, $condition = NULL, $arguments = array()); // phpcs:ignore -- No type hint on $arguments, add in 2.x.
 
@@ -326,6 +330,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    *
    * @return string
    *   The unique alias that was assigned for this table.
+   *
+   * @since 1.30.1 $condition can now be a DatabaseCondition object.
    */
   public function leftJoin($table, $alias = NULL, $condition = NULL, $arguments = array()); // phpcs:ignore -- No type hint on $arguments, add in 2.x.
 
@@ -350,6 +356,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    *
    * @return string
    *   The unique alias that was assigned for this table.
+   *
+   * @since 1.30.1 $condition can now be a DatabaseCondition object.
    */
   public function rightJoin($table, $alias = NULL, $condition = NULL, $arguments = array()); // phpcs:ignore -- No type hint on $arguments, add in 2.x.
 
@@ -382,6 +390,8 @@ interface SelectQueryInterface extends QueryConditionInterface, QueryAlterableIn
    *
    * @return string
    *   The unique alias that was assigned for this table.
+   *
+   * @since 1.30.1 $condition can now be a DatabaseCondition object.
    */
   public function addJoin($type, $table, $alias = NULL, $condition = NULL, $arguments = array()); // phpcs:ignore -- No type hint on $arguments, add in 2.x.
 


### PR DESCRIPTION
Relates to https://github.com/backdrop/backdrop-issues/issues/6852

Follow-up PR to https://github.com/backdrop/backdrop/pull/5017

This just adds missing `@since` documentation to the various `join()` methods. Normally I add `@since` lines before committing but I missed these.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
