### PR TITLE
Swap out custom code with image_style_url function Issue #6860

### DIFF
--- a/core/modules/file/views/views_handler_field_file_uri.inc
+++ b/core/modules/file/views/views_handler_field_file_uri.inc
@@ -40,17 +40,9 @@ class views_handler_field_file_uri extends views_handler_field_file {
   function render($values) {
     $data = $values->{$this->field_alias};
     if (!empty($this->options['file_download_path']) && $data !== NULL && $data !== '') {
-      $data = file_create_url($data);
-      if (!image_is_svg($data) && !empty($this->options['image_style'])) {
-        // $data contains url of image.
-        // Get public file system path and its length.
-        $file_public_path = '/' . config_get('system.core', 'file_public_path');
-        $file_public_path_strlen = strlen($file_public_path);
-        // Find insertion position of public file system path.
-        $insert_at = strpos($data, $file_public_path);
-        // Text to insert in order to modify url.
-        $add_to_url = '/styles/' . $this->options['image_style'] . '/public';
-        $data = substr_replace($data, $add_to_url, $insert_at + $file_public_path_strlen, 0);
+      $url = file_create_url($data);
+      if (!image_is_svg($url) && !empty($this->options['image_style'])) {
+        $url = image_style_url($this->options['image_style'], $data);
       }
     }
     return $this->render_link($data, $values);


### PR DESCRIPTION
There is a bunch of custom code in the render function of views_handler_field_file_uri.inc that attempts to generate the image style url. This code breaks when you're using modules such as s3fs which doesn't use the site default file path. I'm swapping that code out instead with image_style_url which fixes the problem.

Fixes [Issue 6860](https://github.com/backdrop/backdrop-issues/issues/6860)
