### PR TITLE
Issue #6864: Fix query string to export custom blocks.

### DIFF
--- a/core/modules/block/block.admin.inc
+++ b/core/modules/block/block.admin.inc
@@ -50,7 +50,7 @@ function block_admin_list() {
         'title' => t('Export'),
         'href' => 'admin/config/development/configuration/single/export',
         'query' => array(
-          'group' => 'Reusable custom blocks',
+          'group' => 'Custom blocks',
           'name' => 'block.custom.' . $delta,
         ),
       );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6864