### PR TITLE
Issue #6881: Fix CKEditor 5 code formatter handling of single-line code blocks.

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.formatter.js
+++ b/core/modules/ckeditor5/js/ckeditor5.formatter.js
@@ -145,7 +145,7 @@
       return lines
         .filter((line) => {
           isPreformattedLine = this._isPreformattedBlockLine(line, isPreformattedLine);
-          return isPreformattedLine || line.trim().length
+          return isPreformattedLine || line.trim().length;
         })
         .map((line) => {
           isPreformattedLine = this._isPreformattedBlockLine(line, isPreformattedLine);
@@ -222,18 +222,23 @@
      *   Information on whether the previous line was preformatted (and how).
      */
     _isPreformattedBlockLine(line, isPreviousLinePreFormatted) {
+      let preLineType = false;
       if (new RegExp('<pre( .*?)?>').test(line)) {
-        return 'first';
+        preLineType = 'first';
       }
-      else if (new RegExp('</pre>').test(line)) {
-        return 'last';
+      if (new RegExp('</pre>').test(line)) {
+        // If both an opening and closing a <pre> tag, no special treatment needed.
+        if (preLineType === 'first') {
+          preLineType = false;
+        }
+        else {
+          preLineType = 'last';
+        }
       }
-      else if (isPreviousLinePreFormatted === 'first' || isPreviousLinePreFormatted === 'middle') {
-        return 'middle';
+      if (!preLineType && (isPreviousLinePreFormatted === 'first' || isPreviousLinePreFormatted === 'middle')) {
+        preLineType = 'middle';
       }
-      else {
-        return false;
-      }
+      return preLineType;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6881
