### PR TITLE
Issue #6877: Use label callback for labels

### DIFF
--- a/core/modules/comment/comment.entity.inc
+++ b/core/modules/comment/comment.entity.inc
@@ -117,13 +117,6 @@ class Comment extends Entity {
   }
 
   /**
-   * Implements EntityInterface::label().
-   */
-  public function label() {
-    return $this->subject;
-  }
-
-  /**
    * Implements EntityInterface::uri().
    */
   public function uri() {

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -98,6 +98,7 @@ function comment_entity_info() {
       'entity keys' => array(
         'id' => 'cid',
         'bundle' => 'node_type',
+        'label' => 'subject',
       ),
       'bundles' => array(),
       'view modes' => array(

--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -64,7 +64,7 @@
  *       the same as the entity type.
  *      - label: The name of the property that contains the label for the entity.
  *       This property is used in the core entity class's label method. The label
- *       can be overriden by setting a 'label callback' on the entity which the
+ *       can be overridden by setting a 'label callback' on the entity which the
  *       core entity class will call instead if it's set.
  *   - label callback: The name of a function that will be called to override the
  *     label property set in 'entity keys'. By default the core entity class will

--- a/core/modules/entity/entity.api.php
+++ b/core/modules/entity/entity.api.php
@@ -62,6 +62,15 @@
  *       omitted if this entity type exposes a single bundle (all entities have
  *       the same collection of fields). The name of this single bundle will be
  *       the same as the entity type.
+ *      - label: The name of the property that contains the label for the entity.
+ *       This property is used in the core entity class's label method. The label
+ *       can be overriden by setting a 'label callback' on the entity which the
+ *       core entity class will call instead if it's set.
+ *   - label callback: The name of a function that will be called to override the
+ *     label property set in 'entity keys'. By default the core entity class will
+ *     use the default label method and the label property set in 'entity keys'
+ *     to set the entity's label. The argument passed to 'label callback' is the
+ *     entity object.
  *   - bundle keys: An array describing how the Field API can extract the
  *     information it needs from the bundle objects for this type (e.g
  *     $vocabulary objects for terms; not applicable for nodes). This entry can
@@ -134,6 +143,7 @@ function hook_entity_info() {
         'id' => 'nid',
         'revision' => 'vid',
         'bundle' => 'type',
+        'label' => 'title',
       ),
       'bundle keys' => array(
         'bundle' => 'type',

--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -279,9 +279,9 @@ abstract class Entity extends stdClass implements EntityInterface {
   }
 
   /**
-   * Returns the label of the entity.
+   * Implements EntityInterface::label().
    *
-   * @return
+   * @return string|null
    *   The label of the entity, or NULL if there is no label defined.
    */
   public function label() {

--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -279,6 +279,24 @@ abstract class Entity extends stdClass implements EntityInterface {
   }
 
   /**
+   * Returns the label of the entity.
+   *
+   * @return
+   *   The label of the entity, or NULL if there is no label defined.
+   */
+  public function label() {
+    $entity_info = entity_get_info($this->entityType());
+    $label = NULL;
+    if (isset($entity_info['label callback'])) {
+      $label = call_user_func($entity_info['label callback'], $this);
+    }
+    else if (isset($entity_info['entity keys']['label']))  {
+      $label = $this->{$entity_info['entity keys']['label']};
+    }
+    return $label;
+  }
+
+  /**
    * Implements EntityInterface::createAccess().
    */
   public static function createAccess($bundle = NULL, $account = NULL) {

--- a/core/modules/file/file.entity.inc
+++ b/core/modules/file/file.entity.inc
@@ -125,13 +125,6 @@ class File extends Entity {
   }
 
   /**
-   * Implements EntityInterface::label().
-   */
-  public function label() {
-    return $this->filename;
-  }
-
-  /**
    * Implements EntityInterface::uri().
    */
   public function uri() {

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -487,7 +487,8 @@ function file_entity_info() {
       'entity class' => 'File',
       'entity keys' => array(
         'id' => 'fid',
-        'bundle' => 'type'
+        'bundle' => 'type',
+        'label' => 'filename',
       ),
       'bundle keys' => array(
         'bundle' => 'type'

--- a/core/modules/node/node.entity.inc
+++ b/core/modules/node/node.entity.inc
@@ -200,13 +200,6 @@ class Node extends Entity {
   }
 
   /**
-   * Implements EntityInterface::label().
-   */
-  public function label() {
-    return $this->title;
-  }
-
-  /**
    * Implements EntityInterface::uri().
    */
   public function uri() {

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -152,6 +152,7 @@ function node_entity_info() {
         'id' => 'nid',
         'revision' => 'vid',
         'bundle' => 'type',
+        'label' => 'title',
       ),
       'bundle keys' => array(
         'bundle' => 'type',

--- a/core/modules/taxonomy/taxonomy.entity.inc
+++ b/core/modules/taxonomy/taxonomy.entity.inc
@@ -81,13 +81,6 @@ class TaxonomyTerm extends Entity {
   }
 
   /**
-   * Implements EntityInterface::label().
-   */
-  public function label() {
-    return $this->name;
-  }
-
-  /**
    * Implements EntityInterface::bundle().
    */
   public function bundle() {

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -96,6 +96,7 @@ function taxonomy_entity_info() {
       'entity keys' => array(
         'id' => 'tid',
         'bundle' => 'vocabulary',
+        'label' => 'name',
       ),
       'bundle keys' => array(
         'bundle' => 'machine_name',

--- a/core/modules/user/user.entity.inc
+++ b/core/modules/user/user.entity.inc
@@ -150,13 +150,6 @@ class User extends Entity implements UserInterface {
   }
 
   /**
-   * Implements EntityInterface::label().
-   */
-  public function label() {
-    return user_format_name($this);
-  }
-
-  /**
    * Implements EntityInterface::uri().
    */
   public function uri() {

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -141,7 +141,6 @@ function user_entity_info() {
       'entity class' => 'User',
       'entity keys' => array(
         'id' => 'uid',
-        'label' => 'name',
       ),
       'label callback' => 'user_format_name',
       'bundles' => array(

--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -141,7 +141,9 @@ function user_entity_info() {
       'entity class' => 'User',
       'entity keys' => array(
         'id' => 'uid',
+        'label' => 'name',
       ),
+      'label callback' => 'user_format_name',
       'bundles' => array(
         'user' => array(
           'label' => t('User account'),


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6877

This came out of a discussion around the removal of the 'label callback' setting in hook_entity_info() and some problems I was having porting entity_translation to Backdrop. During the developer meeting, it was decided that we would switch back to using the 'label callback' and use it if it's set in the core entity class. This patch removes the label methods from core classes and uses the one in the core entity class. Doing this also necesitiated adding the 'label' property back to the $entity_info['entity keys'] array.



<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
