### PR TITLE
Issue #6883: Update phpcs-lint.yml GHA to use a more current Ubuntu image.

### DIFF
--- a/.github/workflows/phpcs-lint.yml
+++ b/.github/workflows/phpcs-lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          tools: phpcs:3.7
+          tools: phpcs
 
       # The checkout action refuses to put it outside, so we have to do it in
       # two steps.

--- a/.github/workflows/phpcs-lint.yml
+++ b/.github/workflows/phpcs-lint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   phpcs:
     name: Run phpcs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup PHP with CodeSniffer tool
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpcs-lint.yml
+++ b/.github/workflows/phpcs-lint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   phpcs:
     name: Run phpcs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup PHP with CodeSniffer tool
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6883