### PR TITLE
Issue #2658: Allow Image Styles to be used with inline images (3rd approach)

### DIFF
--- a/core/modules/ckeditor5/ckeditor5.admin.inc
+++ b/core/modules/ckeditor5/ckeditor5.admin.inc
@@ -54,6 +54,17 @@ function ckeditor5_settings_form(&$form, $form_state, $format) {
     '#parents' => array('editor_settings', 'image_upload'),
   );
 
+  $elements['plugins']['image_styles'] = filter_editor_image_styles_settings_form($format);
+  $elements['plugins']['image_styles'] += array(
+    '#type' => 'fieldset',
+    '#title' => t('Inline image styles'),
+    '#attributes' => array(
+      'class' => array('ckeditor5-plugin-backdropimage'),
+      'data-ckeditor5-feature-dependency' => 'backdropImage',
+    ),
+    '#parents' => array('editor_settings', 'image_styles'),
+  );
+
   $elements['plugins']['file'] = filter_editor_file_upload_settings_form($format);
   $elements['plugins']['file'] += array(
     '#type' => 'fieldset',

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -959,11 +959,6 @@ function filter_editor_image_styles_settings_form($format) {
     'use_image_styles' => FALSE,
     'available_styles' => array(),
   );
-
-  // @todo CKE5: actually we should unload 'image.ImageResize' entirely, but
-  // backdropImage declares a dependency on it in an info hook, where we have no
-  // info about formats. And core has no concept for "conditional plugin
-  // dependencies" for CKE5.
   $form['use_image_styles'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use image styles'),

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -933,6 +933,28 @@ function filter_editor_image_upload_settings_form($format) {
     '#field_suffix' => 'pixels',
     '#states' => $show_if_image_uploads_enabled,
   );
+  // @todo Is this the right place in this form, anyway? (I don't think so.)
+  // @todo CKE5: actually we should unload 'image.ImageResize' entirely, but
+  // backdropImage declares a dependency on it in an info hook, where we have no
+  // info about formats. And core has no concept for "conditional plugin
+  // dependencies" for CKE5.
+  $form['use_image_styles'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use image styles'),
+    '#default_value' => isset($settings['use_image_styles']) ? $settings['use_image_styles'] : FALSE,
+    '#description' => t('Instead of letting people freely resize images, let them pick from pre-defined image styles.'),
+  );
+  $form['available_styles'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Available image styles'),
+    '#options' => image_style_options(FALSE, PASS_THROUGH),
+    '#default_value' => isset($settings['available_styles']) ? $settings['available_styles'] : NULL,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="editor_settings[image_upload][use_image_styles]"]' => array('checked' => TRUE),
+      ),
+    ),
+  );
 
   return $form;
 }

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -970,10 +970,12 @@ function filter_editor_image_styles_settings_form($format) {
     '#default_value' => $settings['use_image_styles'],
     '#description' => t('Instead of letting people freely resize images, let them pick from pre-defined image styles. Note that styles do not initially apply to drag-and-drop uploads.'),
   );
+  $style_options = array('' => t('None (original image)'));
+  $style_options += image_style_options(FALSE);
   $form['available_styles'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Available image styles'),
-    '#options' => image_style_options(),
+    '#options' => $style_options,
     '#default_value' => $settings['available_styles'],
     '#states' => array(
       'visible' => array(

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -956,25 +956,24 @@ function filter_editor_image_styles_settings_form($format) {
   }
   $settings = isset($format->editor_settings['image_styles']) ? $format->editor_settings['image_styles'] : array();
   $settings += array(
-    'use_image_styles' => FALSE,
-    'available_styles' => array(),
+    'status' => FALSE,
+    'list' => array(),
   );
-  $form['use_image_styles'] = array(
+  $form['status'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Use image styles'),
-    '#default_value' => $settings['use_image_styles'],
-    '#description' => t('Instead of letting people freely resize images, let them pick from pre-defined image styles. Note that styles do not initially apply to drag-and-drop uploads.'),
+    '#title' => t('Enable image styles'),
+    '#default_value' => $settings['status'],
   );
   $style_options = array('' => t('None (original image)'));
   $style_options += image_style_options(FALSE);
-  $form['available_styles'] = array(
+  $form['list'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Available image styles'),
     '#options' => $style_options,
-    '#default_value' => $settings['available_styles'],
+    '#default_value' => $settings['list'],
     '#states' => array(
       'visible' => array(
-        ':input[name="editor_settings[image_styles][use_image_styles]"]' => array('checked' => TRUE),
+        ':input[name="editor_settings[image_styles][status]"]' => array('checked' => TRUE),
       ),
     ),
   );

--- a/core/modules/filter/filter.admin.inc
+++ b/core/modules/filter/filter.admin.inc
@@ -933,7 +933,33 @@ function filter_editor_image_upload_settings_form($format) {
     '#field_suffix' => 'pixels',
     '#states' => $show_if_image_uploads_enabled,
   );
-  // @todo Is this the right place in this form, anyway? (I don't think so.)
+
+  return $form;
+}
+
+/**
+ * Subform constructor to configure the text editor's inline image styles.
+ *
+ * Each text editor implementation using the Filter dialog can use this form to
+ * configure image styles for inline images instead of free resizing.
+ *
+ * @param object $format
+ *   The filter format object.
+ *
+ * @return array
+ *   Subform items or empty array if not applicable.
+ */
+function filter_editor_image_styles_settings_form($format) {
+  $form = array();
+  if (!module_exists('image')) {
+    return $form;
+  }
+  $settings = isset($format->editor_settings['image_styles']) ? $format->editor_settings['image_styles'] : array();
+  $settings += array(
+    'use_image_styles' => FALSE,
+    'available_styles' => array(),
+  );
+
   // @todo CKE5: actually we should unload 'image.ImageResize' entirely, but
   // backdropImage declares a dependency on it in an info hook, where we have no
   // info about formats. And core has no concept for "conditional plugin
@@ -941,24 +967,23 @@ function filter_editor_image_upload_settings_form($format) {
   $form['use_image_styles'] = array(
     '#type' => 'checkbox',
     '#title' => t('Use image styles'),
-    '#default_value' => isset($settings['use_image_styles']) ? $settings['use_image_styles'] : FALSE,
-    '#description' => t('Instead of letting people freely resize images, let them pick from pre-defined image styles.'),
+    '#default_value' => $settings['use_image_styles'],
+    '#description' => t('Instead of letting people freely resize images, let them pick from pre-defined image styles. Note that styles do not initially apply to drag-and-drop uploads.'),
   );
   $form['available_styles'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Available image styles'),
-    '#options' => image_style_options(FALSE, PASS_THROUGH),
-    '#default_value' => isset($settings['available_styles']) ? $settings['available_styles'] : NULL,
+    '#options' => image_style_options(),
+    '#default_value' => $settings['available_styles'],
     '#states' => array(
       'visible' => array(
-        ':input[name="editor_settings[image_upload][use_image_styles]"]' => array('checked' => TRUE),
+        ':input[name="editor_settings[image_styles][use_image_styles]"]' => array('checked' => TRUE),
       ),
     ),
   );
 
   return $form;
 }
-
 
 /**
  * Subform constructor to configure the text editor's file upload settings.

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -175,7 +175,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
       }
     }
   }
-  // If the image style list is empty (the image styles may no longer exists),
+  // If the image style list is empty (the image styles may no longer exist),
   // fallback to the normal no image style behavior.
   $use_image_styles = !empty($available_style_options);
   $form['image_style'] = array(

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -269,11 +269,23 @@ function _filter_image_library_ajax() {
  * Submit handler for filter_format_editor_image_form().
  */
 function filter_format_editor_image_form_submit($form, &$form_state) {
-  // Convert any uploaded files from the FID values to the src attribute.
-  if (!empty($form_state['values']['fid'])) {
+  // Determine the file either from fid (when upload is enabled) or from src
+  // attribute (if image upload in editor is disabled).
+  $file = NULL;
+  $fid = 0;
+  if (!empty($form_state['values']['fid']) && empty($form_state['values']['attributes']['src'])) {
+    $file = file_load($form_state['values']['fid']);
     $fid = $form_state['values']['fid'];
-    $file = file_load($fid);
-
+    unset($form_state['values']['fid']);
+  }
+  elseif (!empty($form_state['values']['attributes']['src'])) {
+    $fid = _filter_get_file_id($form_state['values']['attributes']['src']);
+    if ($fid) {
+      $file = file_load($fid);
+      unset($form_state['values']['attributes']['src']);
+    }
+  }
+  if (!empty($file)) {
     // Try to make a local path if possible for better portability.
     $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
 
@@ -302,7 +314,6 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
 
     $form_state['values']['attributes']['src'] = $url;
     $form_state['values']['attributes']['data-file-id'] = $fid;
-    unset($form_state['values']['fid']);
   }
 }
 

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -132,7 +132,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#required' => $upload_settings['alt_required'],
   );
 
-  $use_image_styles = !empty($format->editor_settings['image_upload']['use_image_styles']);
+  $use_image_styles = !empty($format->editor_settings['image_styles']['use_image_styles']) && module_exists('image');
   $form['size'] = array(
     '#title' => t('Image size'),
     '#wrapper_attributes' => array('class' => array('editor-image-size')),
@@ -162,9 +162,13 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   $available_style_options = array();
   if ($use_image_styles) {
     $all_image_styles = image_style_options(FALSE, PASS_THROUGH);
-    $enabled = array_filter($format->editor_settings['image_upload']['available_styles']);
-    foreach ($enabled as $name) {
-      $available_style_options[$name] = $all_image_styles[$name];
+    foreach ($format->editor_settings['image_styles']['available_styles'] as $key => $value) {
+      if ($key === '') {
+        $available_style_options[$key] = t('None (original image)');
+      }
+      elseif (!empty($value) && array_key_exists($key, $all_image_styles)) {
+        $available_style_options[$key] = $all_image_styles[$key];
+      }
     }
   }
   $default_value = NULL;
@@ -179,7 +183,6 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#options' => $available_style_options,
     '#default_value' => $default_value,
     '#access' => $use_image_styles,
-    '#required' => $use_image_styles,
   );
 
   $form['align'] = array(
@@ -274,13 +277,24 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
 
     if (empty($form_state['values']['image_style'])) {
       $url = file_create_url($file->uri);
+      $form_state['values']['attributes']['width'] = $file->width;
+      $form_state['values']['attributes']['height'] = $file->height;
     }
     else {
       $style_name = $form_state['values']['image_style'];
       $url = image_style_url($style_name, $file->uri);
-      // Let the editor determine (possibly changed) dimensions.
-      $form_state['values']['attributes']['width'] = '';
-      $form_state['values']['attributes']['height'] = '';
+      $dimensions = array('width' => '', 'height' => '');
+      // Although the editor could determine dimensions, this would not work
+      // with SVG.
+      if (!empty($file->width)) {
+        $dimensions = array(
+          'width' => $file->width,
+          'height' => $file->height,
+        );
+        image_style_transform_dimensions($style_name, $dimensions);
+      }
+      $form_state['values']['attributes']['width'] = $dimensions['width'];
+      $form_state['values']['attributes']['height'] = $dimensions['height'];
     }
     $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -727,7 +727,7 @@ function _filter_get_file_id($href) {
   $public_path = config_get('system.core', 'file_public_path');
   // Private files have "system/files/" in their URL.
   // @see BackdropPrivateStreamWrapper::getExternalUrl()
-  $pattern = '#^' . $base_path . '(\?q=)?(' . $public_path . '|system/files/' . ')#';
+  $pattern = '#^' . $base_path . '(\?q=)?(' . $public_path . '|system/files/)#';
   if (preg_match($pattern, $href) === FALSE) {
     return $result;
   }

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -57,6 +57,9 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   if (isset($form_state['input']['editor_object'])) {
     $values = array_merge($values, $form_state['input']['editor_object']);
   }
+  // Store original values for reference.
+  $values['previous_width'] = $values['width'];
+  $values['previous_height'] = $values['height'];
 
   // Determine the style from path - this does not work with SVG, as those get
   // always served from their original path.
@@ -213,6 +216,15 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#parents' => array('attributes', 'height'),
     '#field_suffix' => ' ' . t('pixels'),
   );
+  // Original values used for reference in submit handler.
+  $form['size']['previous_width'] = array(
+    '#type' => 'value',
+    '#value' => $values['previous_width'],
+  );
+  $form['size']['previous_height'] = array(
+    '#type' => 'value',
+    '#value' => $values['previous_height'],
+  );
 
   $form['align'] = array(
     '#title' => t('Align'),
@@ -326,19 +338,26 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
     }
     else {
       $style_name = $form_state['values']['image_style'];
+      $style_changed = $form['image_style']['#default_value'] != $style_name;
       $url = image_style_url($style_name, $file->uri);
-      $dimensions = array('width' => '', 'height' => '');
-      // Although the editor could determine dimensions, this would not work
-      // with SVG.
-      if (!empty($file->width)) {
-        $dimensions = array(
-          'width' => $file->width,
-          'height' => $file->height,
-        );
-        image_style_transform_dimensions($style_name, $dimensions);
+      if ($style_changed) {
+        $dimensions = array('width' => '', 'height' => '');
+        // Although the editor could determine dimensions, this would not work
+        // with SVG.
+        if (!empty($file->width)) {
+          $dimensions = array(
+            'width' => $file->width,
+            'height' => $file->height,
+          );
+          image_style_transform_dimensions($style_name, $dimensions);
+        }
+        $attributes['width'] = $dimensions['width'];
+        $attributes['height'] = $dimensions['height'];
       }
-      $attributes['width'] = $dimensions['width'];
-      $attributes['height'] = $dimensions['height'];
+      elseif (!empty($form_state['values']['previous_width'])) {
+        $attributes['width'] = $form_state['values']['previous_width'];
+        $attributes['height'] = $form_state['values']['previous_height'];
+      }
     }
     $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -172,7 +172,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     }
   }
   $default_value = NULL;
-  // Determine the style from path - this doesn not work with SVG, as those get
+  // Determine the style from path - this does not work with SVG, as those get
   // always served from their original path.
   if ($use_image_styles && !empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
     $path_parts = explode('/', $values['src']);

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -132,12 +132,49 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#required' => $upload_settings['alt_required'],
   );
 
-  $use_image_styles = !empty($format->editor_settings['image_styles']['use_image_styles']) && module_exists('image');
+  $use_image_styles = !empty($format->editor_settings['image_styles']['status']) && module_exists('image');
+
+  $available_style_options = array();
+  if ($use_image_styles) {
+    $all_image_styles = image_style_options(FALSE, PASS_THROUGH);
+    foreach ($format->editor_settings['image_styles']['list'] as $key => $value) {
+      if ($key === '' && $value !== 0) {
+        $available_style_options[$key] = t('None (original image)');
+      }
+      elseif (!empty($value) && array_key_exists($key, $all_image_styles)) {
+        $available_style_options[$key] = $all_image_styles[$key];
+      }
+    }
+  }
+  // If the image style list is empty (the image styles may no longer exists),
+  // fallback to the normal no image style behavior.
+  $use_image_styles = !empty($available_style_options);
+
+  $default_value = NULL;
+  // Determine the style from path - this does not work with SVG, as those get
+  // always served from their original path.
+  if ($use_image_styles && !empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
+    $path_parts = explode('/', $values['src']);
+    $before_style = array_search('styles', $path_parts);
+    $default_value = $path_parts[$before_style + 1];
+  }
+  $form['image_style'] = array(
+    '#title' => t('Image style'),
+    '#type' => 'select',
+    '#options' => $available_style_options,
+    '#default_value' => $default_value,
+    '#access' => $use_image_styles,
+  );
+
   $form['size'] = array(
     '#title' => t('Image size'),
     '#wrapper_attributes' => array('class' => array('editor-image-size')),
-    '#theme_wrappers' => array('form_element'),
-    '#access' => !$use_image_styles,
+    '#type' => 'item',
+    '#states' => array(
+      'visible' => array(
+        ':input[name="image_style"]' => array('value' => ''),
+      ),
+    ),
   );
   $form['size']['width'] = array(
     '#title' => t('Width'),
@@ -157,34 +194,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#max' => 99999,
     '#attributes' => array('placeholder' => t('height')),
     '#parents' => array('attributes', 'height'),
-    '#field_suffix' => ' ' . t('pixels')
-  );
-  $available_style_options = array();
-  if ($use_image_styles) {
-    $all_image_styles = image_style_options(FALSE, PASS_THROUGH);
-    foreach ($format->editor_settings['image_styles']['available_styles'] as $key => $value) {
-      if ($key === '' && $value !== 0) {
-        $available_style_options[$key] = t('None (original image)');
-      }
-      elseif (!empty($value) && array_key_exists($key, $all_image_styles)) {
-        $available_style_options[$key] = $all_image_styles[$key];
-      }
-    }
-  }
-  $default_value = NULL;
-  // Determine the style from path - this does not work with SVG, as those get
-  // always served from their original path.
-  if ($use_image_styles && !empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
-    $path_parts = explode('/', $values['src']);
-    $before_style = array_search('styles', $path_parts);
-    $default_value = $path_parts[$before_style + 1];
-  }
-  $form['image_style'] = array(
-    '#title' => t('Image style'),
-    '#type' => 'select',
-    '#options' => $available_style_options,
-    '#default_value' => $default_value,
-    '#access' => $use_image_styles,
+    '#field_suffix' => ' ' . t('pixels'),
   );
 
   $form['align'] = array(
@@ -273,16 +283,17 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
   // attribute (if image upload in editor is disabled).
   $file = NULL;
   $fid = 0;
-  if (!empty($form_state['values']['fid']) && empty($form_state['values']['attributes']['src'])) {
+  $attributes = $form_state['values']['attributes'] ?? array();
+  if (!empty($form_state['values']['fid']) && empty($attributes['src'])) {
     $file = file_load($form_state['values']['fid']);
     $fid = $form_state['values']['fid'];
     unset($form_state['values']['fid']);
   }
-  elseif (!empty($form_state['values']['attributes']['src'])) {
-    $fid = _filter_get_file_id($form_state['values']['attributes']['src']);
+  elseif (!empty($attributes['src'])) {
+    $fid = _filter_get_file_id($attributes['src']);
     if ($fid) {
       $file = file_load($fid);
-      unset($form_state['values']['attributes']['src']);
+      unset($attributes['src']);
     }
   }
   if (!empty($file)) {
@@ -291,8 +302,10 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
 
     if (empty($form_state['values']['image_style'])) {
       $url = file_create_url($file->uri);
-      $form_state['values']['attributes']['width'] = $file->width;
-      $form_state['values']['attributes']['height'] = $file->height;
+      if (empty($attributes['width']) && empty($attributes['height'])) {
+        $attributes['width'] = $file->width;
+        $attributes['height'] = $file->height;
+      }
     }
     else {
       $style_name = $form_state['values']['image_style'];
@@ -307,14 +320,16 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
         );
         image_style_transform_dimensions($style_name, $dimensions);
       }
-      $form_state['values']['attributes']['width'] = $dimensions['width'];
-      $form_state['values']['attributes']['height'] = $dimensions['height'];
+      $attributes['width'] = $dimensions['width'];
+      $attributes['height'] = $dimensions['height'];
     }
     $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 
-    $form_state['values']['attributes']['src'] = $url;
-    $form_state['values']['attributes']['data-file-id'] = $fid;
+    $attributes['src'] = $url;
+    $attributes['data-file-id'] = $fid;
   }
+
+  $form_state['values']['attributes'] = $attributes;
 }
 
 /**

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -163,7 +163,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   if ($use_image_styles) {
     $all_image_styles = image_style_options(FALSE, PASS_THROUGH);
     foreach ($format->editor_settings['image_styles']['available_styles'] as $key => $value) {
-      if ($key === '') {
+      if ($key === '' && $value !== 0) {
         $available_style_options[$key] = t('None (original image)');
       }
       elseif (!empty($value) && array_key_exists($key, $all_image_styles)) {
@@ -172,6 +172,8 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     }
   }
   $default_value = NULL;
+  // Determine the style from path - this doesn not work with SVG, as those get
+  // always served from their original path.
   if ($use_image_styles && !empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
     $path_parts = explode('/', $values['src']);
     $before_style = array_search('styles', $path_parts);

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -43,10 +43,36 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   // Record if image uploading is requested by the calling element.
   $element_supports_uploads = !isset($form_state['input']['dialogOptions']['uploads']) || (bool) $form_state['input']['dialogOptions']['uploads'];
 
+  // Populate defaults.
+  $values = array(
+    'src' => '',
+    'data-file-id' => NULL,
+    'alt' => '',
+    'width' => '',
+    'height' => '',
+    'data-align' => 'none',
+    'data-has-caption' => 'false',
+  );
   // Pull in any default values set by the editor.
-  $values = array();
   if (isset($form_state['input']['editor_object'])) {
-    $values = $form_state['input']['editor_object'];
+    $values = array_merge($values, $form_state['input']['editor_object']);
+  }
+
+  // Determine the style from path - this does not work with SVG, as those get
+  // always served from their original path.
+  $image_style_default = NULL;
+  if (!empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
+    $path_parts = explode('/', $values['src']);
+    $before_style = array_search('styles', $path_parts);
+    $image_style_default = $path_parts[$before_style + 1];
+  }
+
+  // If an image style is set, remove the width and height, which do not apply
+  // to image styles (they reset on save). This also lets images take on their
+  // original dimensions if setting back to the original image.
+  if (isset($image_style_default)) {
+    $values['width'] = '';
+    $values['height'] = '';
   }
 
   // Set the dialog title and submit button label.
@@ -108,7 +134,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#type' => 'textfield',
     '#element_validate' => array('_filter_format_editor_link_url_validate'),
     '#placeholder' => '/example/image.jpg',
-    '#default_value' => isset($values['src']) ? $values['src'] : NULL,
+    '#default_value' => $values['src'],
     '#parents' => array('attributes', 'src'),
     '#wrapper_attributes' => array(
       'data-editor-image-toggle' => t('Select from library'),
@@ -126,7 +152,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   $form['alt'] = array(
     '#title' => t('Alternative text'),
     '#type' => 'textfield',
-    '#default_value' => isset($values['alt']) ? $values['alt'] : NULL,
+    '#default_value' => $values['alt'],
     '#description' => t('The alt attribute may be used by screen readers, search engines, and when the image cannot be loaded.'),
     '#parents' => array('attributes', 'alt'),
     '#required' => $upload_settings['alt_required'],
@@ -149,20 +175,11 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   // If the image style list is empty (the image styles may no longer exists),
   // fallback to the normal no image style behavior.
   $use_image_styles = !empty($available_style_options);
-
-  $default_value = NULL;
-  // Determine the style from path - this does not work with SVG, as those get
-  // always served from their original path.
-  if ($use_image_styles && !empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
-    $path_parts = explode('/', $values['src']);
-    $before_style = array_search('styles', $path_parts);
-    $default_value = $path_parts[$before_style + 1];
-  }
   $form['image_style'] = array(
     '#title' => t('Image style'),
     '#type' => 'select',
     '#options' => $available_style_options,
-    '#default_value' => $default_value,
+    '#default_value' => $image_style_default,
     '#access' => $use_image_styles,
   );
 
@@ -180,7 +197,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#title' => t('Width'),
     '#title_display' => 'attribute',
     '#type' => 'number',
-    '#default_value' => !empty($values['width']) ? $values['width'] : '',
+    '#default_value' => $values['width'],
     '#max' => 99999,
     '#attributes' => array('placeholder' => t('width')),
     '#parents' => array('attributes', 'width'),
@@ -190,7 +207,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#title' => t('Height'),
     '#title_display' => 'attribute',
     '#type' => 'number',
-    '#default_value' => !empty($values['height']) ? $values['height'] : '',
+    '#default_value' => $values['height'],
     '#max' => 99999,
     '#attributes' => array('placeholder' => t('height')),
     '#parents' => array('attributes', 'height'),
@@ -200,7 +217,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   $form['align'] = array(
     '#title' => t('Align'),
     '#type' => 'radios',
-    '#default_value' => isset($values['data-align']) ? $values['data-align'] : 'none',
+    '#default_value' => $values['data-align'],
     '#options' => array(
       'none' => t('None'),
       'left' => t('Left'),
@@ -214,7 +231,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   $form['caption'] = array(
     '#title' => t('Add a caption'),
     '#type' => 'checkbox',
-    '#default_value' => (isset($values['data-has-caption']) && strcmp($values['data-has-caption'], 'false') !== 0) ? (bool) $values['data-has-caption'] : FALSE,
+    '#default_value' => (strcmp($values['data-has-caption'], 'false') !== 0) ? (bool) $values['data-has-caption'] : FALSE,
     '#parents' => array('attributes', 'data-has-caption'),
     '#access' => !empty($format->filters['filter_image_caption']->status),
   );

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -131,10 +131,13 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#parents' => array('attributes', 'alt'),
     '#required' => $upload_settings['alt_required'],
   );
+
+  $use_image_styles = !empty($format->editor_settings['image_upload']['use_image_styles']);
   $form['size'] = array(
     '#title' => t('Image size'),
     '#wrapper_attributes' => array('class' => array('editor-image-size')),
     '#theme_wrappers' => array('form_element'),
+    '#access' => !$use_image_styles,
   );
   $form['size']['width'] = array(
     '#title' => t('Width'),
@@ -156,6 +159,29 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#parents' => array('attributes', 'height'),
     '#field_suffix' => ' ' . t('pixels')
   );
+  $available_style_options = array();
+  if ($use_image_styles) {
+    $all_image_styles = image_style_options(FALSE, PASS_THROUGH);
+    $enabled = array_filter($format->editor_settings['image_upload']['available_styles']);
+    foreach ($enabled as $name) {
+      $available_style_options[$name] = $all_image_styles[$name];
+    }
+  }
+  $default_value = NULL;
+  if ($use_image_styles && !empty($values['src']) && strpos($values['src'], 'styles/') > 0) {
+    $path_parts = explode('/', $values['src']);
+    $before_style = array_search('styles', $path_parts);
+    $default_value = $path_parts[$before_style + 1];
+  }
+  $form['image_style'] = array(
+    '#title' => t('Image style'),
+    '#type' => 'select',
+    '#options' => $available_style_options,
+    '#default_value' => $default_value,
+    '#access' => $use_image_styles,
+    '#required' => $use_image_styles,
+  );
+
   $form['align'] = array(
     '#title' => t('Align'),
     '#type' => 'radios',
@@ -245,7 +271,17 @@ function filter_format_editor_image_form_submit($form, &$form_state) {
 
     // Try to make a local path if possible for better portability.
     $absolute_path = parse_url($GLOBALS['base_url'], PHP_URL_PATH) . '/';
-    $url = file_create_url($file->uri);
+
+    if (empty($form_state['values']['image_style'])) {
+      $url = file_create_url($file->uri);
+    }
+    else {
+      $style_name = $form_state['values']['image_style'];
+      $url = image_style_url($style_name, $file->uri);
+      // Let the editor determine (possibly changed) dimensions.
+      $form_state['values']['attributes']['width'] = '';
+      $form_state['values']['attributes']['height'] = '';
+    }
     $url = str_replace($GLOBALS['base_url'] . '/', $absolute_path, $url);
 
     $form_state['values']['attributes']['src'] = $url;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2658

Alternative to https://github.com/backdrop/backdrop/pull/5060

This is largely the same as @indigoxela's PR with the following changes:

- Height and width options are shown if using "Original image"
- Terminology for enabling image styles updated to match enabling image uploads, file uploads, and headings.