### PR TITLE
Issue #4984 Prevent duplicate locale prefixes

### DIFF
--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -486,7 +486,12 @@ function locale_language_url_rewrite_url(&$path, &$options) {
       case LANGUAGE_NEGOTIATION_URL_PREFIX:
         $prefixes = locale_language_negotiation_url_prefixes();
         if (!empty($prefixes[$options['language']->langcode])) {
-          $options['prefix'] = $prefixes[$options['language']->langcode] . '/';
+          $path = ltrim((string) $path, '/');
+          $prefix = $prefixes[$options['language']->langcode] . '/';
+          $options['prefix'] = $prefix;
+          if (substr($path, 0, strlen($prefix)) == $prefix) {
+            $path = substr($path, strlen($prefix));
+          }
         }
         break;
     }

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2510,6 +2510,23 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
     // Restore HTTP_HOST.
     $_SERVER['HTTP_HOST'] = $http_host;
   }
+
+  /**
+   * Check that rewriting a URL that is already rewritten produces the same URL
+   */
+  public function testUrlRewritingTwice() {
+    // Create a URL with a language prefix.
+    $languages = language_list();
+    $language = $languages['fr'];
+    $url = url('node', array('language' => $language));
+
+    // Check that the URL is rewritten correctly.
+    $this->assertEqual($url, '/fr/node', 'The URL is rewritten correctly.');
+
+    // Check that the URL is not rewritten again.
+    $url = url($url, array('language' => $language));
+    $this->assertEqual($url, '/fr/node', 'The URL is not rewritten again.');
+  }
 }
 
 /**


### PR DESCRIPTION
The link module calls url() twice on the the same URL. If the site has local enabled and is setup to detect the language with URL prefixes, then it will add the prefix a second time to a path that already has the language prefix. For example, it will rewrite fr/node/16 to fr/fr/node/16. Having the locale module not add the prefix again if it's already there, fixes this.

Fixes: https://github.com/backdrop/backdrop-issues/issues/4984