### PR TITLE
Issue 6919. Reset field type cache if needed when creating field from config file.

### DIFF
--- a/core/modules/field/field.module
+++ b/core/modules/field/field.module
@@ -576,6 +576,12 @@ function field_config_create(Config $staging_config) {
     }
 
     if (!$field_data_table_exists) {
+      if (!field_info_field_types($field['type'])) {
+        // If there is no available cached information about the field type (for
+        // example if we enabled a dependency that defines a new type), reset
+        // the field type cache.
+        _field_info_collate_types_reset();
+      }
       field_create_field($field);
     }
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6919