### PR TITLE
Issue #5531: Fix exposed form submit with views blocks

### DIFF
--- a/core/modules/views/plugins/views_plugin_display_block.inc
+++ b/core/modules/views/plugins/views_plugin_display_block.inc
@@ -481,11 +481,14 @@ class views_plugin_display_block extends views_plugin_display {
     return $this->view->override_path;
   }
 
-  function get_url() {
+  /**
+   * {@inheritdoc}
+   */
+  public function get_url() {
     if ($this->get_option('inherit_path')) {
       return $this->get_path();
     }
-    return parent::get_url();
+    return current_path();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/5531

WIP and a starting point for further discussion.

- Gets exposed forms working without ajax - submit and reset
- Gets reset with ajax *sort of* working (it's not ajax, but a page load, but to the same page)

No clue how to fix reset with ajax - looping over the buttons in ajax_view.js (Backdrop.views.ajaxView.prototype.attachExposedFormAjax) is easy, but the "ajaxified" reset button does not reset then, although views_plugin_exposed_form::reset_form() seems to run. :shrug: 