### PR TITLE
Issue #6304: book_admin_settings() sets $form['array_filter'] but that value will be ignored

### DIFF
--- a/core/modules/book/book.admin.inc
+++ b/core/modules/book/book.admin.inc
@@ -103,7 +103,6 @@ function book_admin_settings($form, &$form_state) {
       'book_reorder' => t('Reorder book'),
     ),
   );
-  $form['array_filter'] = array('#type' => 'value', '#value' => TRUE);
   $form['#validate'][] = 'book_admin_settings_validate';
 
   $form['actions']['#type'] = 'actions';


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6304

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
