### PR TITLE
Issue #6952: Fix Locale URL rewriting breaking public file URLs

### DIFF
--- a/core/includes/locale.inc
+++ b/core/includes/locale.inc
@@ -487,6 +487,10 @@ function locale_language_url_rewrite_url(&$path, &$options) {
         $prefixes = locale_language_negotiation_url_prefixes();
         if (!empty($prefixes[$options['language']->langcode])) {
           $path = ltrim((string) $path, '/');
+          $public_path = config_get('system.core', 'file_public_path');
+          if (substr($path, 0, strlen($public_path)) == $public_path) {
+            break;
+          }
           $prefix = $prefixes[$options['language']->langcode] . '/';
           $options['prefix'] = $prefix;
           if (substr($path, 0, strlen($prefix)) == $prefix) {

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2527,6 +2527,23 @@ class LocaleUrlRewritingTest extends BackdropWebTestCase {
     $url = url($url, array('language' => $language));
     $this->assertEqual($url, '/fr/node', 'The URL is not rewritten again.');
   }
+
+  /**
+   * Check that rewriting a URL that is a public file url does not prefix
+   * the current langcode.
+   */
+  public function testPublicFileUrlPrefixRewriting() {
+    // Create a URL pointing to a public file.
+    $public_path = config_get('system.core', 'file_public_path');
+    $file_url = '/' . $public_path . '/test.pdf';
+    $languages = language_list();
+    $language = $languages['fr'];
+    $url = url($file_url, array('language' => $language));
+
+    // Check that the URL is rewritten correctly, meaning it should not have
+    // the language prefix added.
+    $this->assertEqual($url, $file_url);
+  }
 }
 
 /**


### PR DESCRIPTION
This is happening because public file URLs are not handled the same as other routes in Backdrop and are instead handled directly by the web server and don't pass through any of the multilingual URL handling that other routes do. For that reason, we don't want them to get prefixed by the langcode if the locale module is enabled and the Prefix URL detection/selection method is in use as the prefixed URL will return a 404.

This change checks to see if the path passed in is a public file URL and opts out of prefixing the path in that case.

Fixes https://github.com/backdrop/backdrop-issues/issues/6952