### PR TITLE
Swap out $term->name with entity_label() call

### DIFF
--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -1603,7 +1603,7 @@ function taxonomy_field_formatter_view($entity_type, $entity, $field, $instance,
           $uri = entity_uri('taxonomy_term', $term);
           $element[$delta] = array(
             '#type' => 'link',
-            '#title' => $term->name,
+            '#title' => entity_label('taxonomy_term', $term),
             '#href' => $uri['path'],
             '#options' => $uri['options'],
           );

--- a/core/modules/taxonomy/taxonomy.module
+++ b/core/modules/taxonomy/taxonomy.module
@@ -1613,7 +1613,7 @@ function taxonomy_field_formatter_view($entity_type, $entity, $field, $instance,
 
     case 'taxonomy_term_reference_plain':
       foreach ($items as $delta => $item) {
-        $name = ($item['tid'] != 'autocreate' ? $item['taxonomy_term']->name : $item['name']);
+        $name = ($item['tid'] != 'autocreate' ? entity_label('taxonomy_term', $item['taxonomy_term']) : $item['name']);
         $element[$delta] = array(
           '#markup' => check_plain($name),
         );
@@ -1624,7 +1624,7 @@ function taxonomy_field_formatter_view($entity_type, $entity, $field, $instance,
       foreach ($items as $delta => $item) {
         $entity->rss_elements[] = array(
           'key' => 'category',
-          'value' => $item['tid'] != 'autocreate' ? $item['taxonomy_term']->name : $item['name'],
+          'value' => $item['tid'] != 'autocreate' ? entity_label('taxonomy_term', $item['taxonomy_term']) : $item['name'],
           'attributes' => array(
             'domain' => $item['tid'] != 'autocreate' ? url('taxonomy/term/' . $item['tid'], array('absolute' => TRUE)) : '',
           ),


### PR DESCRIPTION
Using the cached value in $term->name is causing issues with field translation in Backdrop where the name will appear in the first language it's cached in rather than the translation. The

Fixes #6980

Fixes https://github.com/backdrop/backdrop-issues/issues/6980

Now that I'm looking at this maybe I should address all the uses of `$term->name` in `taxonomy_field_formatter_view`. I'm assuming that the `autocreate` case stays as is, but everywhere else it uses name I'd swap out with `entity_label`
