### PR TITLE
Issue #6380: Force site logos and favicons to be public.

### DIFF
--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -1568,7 +1568,8 @@ function system_site_information_settings_submit($form, &$form_state) {
   if (!empty($form_state['values']['site_logo_upload'])) {
     $file = $form_state['values']['site_logo_upload'];
     unset($form_state['values']['site_logo_upload']);
-    $filename = file_unmanaged_copy($file->uri);
+    // Site logos must always be public.
+    $filename = file_unmanaged_copy($file->uri, 'public://');
     $form_state['values']['site_logo_theme'] = 0;
     $form_state['values']['site_logo_path'] = $filename;
     // Delete the file entity record.
@@ -1593,7 +1594,8 @@ function system_site_information_settings_submit($form, &$form_state) {
   if (!empty($form_state['values']['site_favicon_upload'])) {
     $file = $form_state['values']['site_favicon_upload'];
     unset($form_state['values']['site_favicon_upload']);
-    $filename = file_unmanaged_copy($file->uri);
+    // Site favicons must always be public.
+    $filename = file_unmanaged_copy($file->uri, 'public://');
     $form_state['values']['site_favicon_theme'] = 0;
     $form_state['values']['site_favicon_path'] = $filename;
     // Delete the file entity record.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6380

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
