### PR TITLE
Stop run-tests.sh script from truncating simpletests results

### DIFF
--- a/core/scripts/run-tests.sh
+++ b/core/scripts/run-tests.sh
@@ -945,7 +945,7 @@ function simpletest_script_format_result($result) {
   list($class, $function) = explode('->', $result->function, 2);
 
   $summary = sprintf(
-    "%-9.9s %-10.10s %-17.17s %-7.7s %-72.72s\n",
+    "%-9s %-10s %-17s %-7s %-72s\n",
     $results_map[$result->status],
     $result->message_group,
     basename($result->file),


### PR DESCRIPTION
Fixes [#7000](https://github.com/backdrop/backdrop-issues/issues/7000)

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
