### PR TITLE
Issue #6998: Rename 'disabled' to 'locked' in module info files.

### DIFF
--- a/core/modules/field/field.module
+++ b/core/modules/field/field.module
@@ -321,14 +321,14 @@ function field_cron() {
 /**
  * Implements hook_system_info_alter().
  *
- * Goes through a list of all modules that provide a field type, and makes them
- * required if there are any active fields of that type.
+ * Goes through a list of all modules that provide a field type, and locks them
+ * if there are any active fields of that type.
  */
 function field_system_info_alter(&$info, $file, $type) {
   if ($type == 'module' && module_hook($file->name, 'field_info')) {
     $fields = field_read_fields(array('module' => $file->name), array('include_deleted' => TRUE));
     if ($fields) {
-      $info['disabled'] = TRUE;
+      $info['locked'] = TRUE;
 
       // Provide an explanation message (only mention pending deletions if there
       // remains no actual, non-deleted fields)

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -643,7 +643,7 @@ function system_modules($form, $form_state = array()) {
   foreach ($visible_files as $filename => $module) {
     $extra = array();
     $extra['enabled'] = (bool) $module->status;
-    $extra['disabled'] = (array_key_exists('disabled', $module->info)) ? $module->info['disabled'] : FALSE;
+    $extra['disabled'] = (array_key_exists('locked', $module->info)) ? $module->info['locked'] : FALSE;
     if ($extra['disabled'] && !empty($module->info['explanation']) ) {
       $extra['required_by'][] = $module->info['explanation'];
     }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6998

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
