### PR TITLE
Issue #7009: Remove unused default_status_code from Redirect module.

### DIFF
--- a/core/modules/redirect/redirect.admin.inc
+++ b/core/modules/redirect/redirect.admin.inc
@@ -849,8 +849,6 @@ function redirect_list_404_filter_form_reset($form, &$form_state) {
  */
 function redirect_list_table($redirects, $header) {
   $destination = backdrop_get_destination();
-  $config = config('redirect.settings');
-  $default_status_code = $config->get('default_status_code');
 
   // Set up the header.
   $header = array_combine($header, $header);
@@ -877,7 +875,7 @@ function redirect_list_table($redirects, $header) {
     $redirect_url = redirect_url($redirect->redirect, array_merge($redirect->redirect_options, array('alias' => TRUE)));
     $row['data']['source'] = l($source_url, $redirect->source, $redirect->source_options);
     $row['data']['redirect'] = l($redirect_url, $redirect->redirect, $redirect->redirect_options);
-    $row['data']['status_code'] = $redirect->status_code ? $redirect->status_code : t('Default (@default)', array('@default' => $default_status_code));
+    $row['data']['status_code'] = $redirect->status_code;
     $row['data']['language'] = language_name($redirect->langcode);
     $row['data']['count'] = $redirect->count;
     if ($redirect->access) {

--- a/core/modules/redirect/redirect.install
+++ b/core/modules/redirect/redirect.install
@@ -171,7 +171,7 @@ function redirect_update_1003() {
   $config = config('redirect.settings');
   $default_status = $config->get('default_status_code');
   $additional_statuses = !in_array($default_status, array(301, 302));
-  $config->clear('default_status');
+  $config->clear('default_status_code');
   $config->clear('warning');
   $config->set('additional_statuses', $additional_statuses);
   $config->save();
@@ -189,4 +189,13 @@ function redirect_update_1004() {
     }
     db_drop_field('redirect', 'status');
   }
+}
+
+/**
+ * Remove the unused default_status_code config value.
+ */
+function redirect_update_1005() {
+  // This value was not cleared properly in redirect_update_1003(). Remove it
+  // again for sites that upgraded from Drupal 7.
+  config_clear('redirect.settings', 'default_status_code');
 }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7006
