### PR TITLE
Add a langcode() method to entities

### DIFF
--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1973,7 +1973,7 @@ function comment_form($form, &$form_state, $comment) {
 
   // If a content type has multilingual support we set the comment to inherit the
   // content language. Otherwise mark the comment as language neutral.
-  $comment_langcode = $comment->langcode;
+  $comment_langcode = $comment->langcode();
   if (($comment_langcode == LANGUAGE_NONE) && $node_type->settings['language']) {
     $comment_langcode = $language_content->langcode;
   }
@@ -2172,8 +2172,13 @@ function comment_submit($comment) {
     // 2) Strip out all HTML tags
     // 3) Convert entities back to plain-text.
     $comment_text = '';
-    if (isset($comment->comment_body) && !empty($comment->comment_body[LANGUAGE_NONE][0])) {
-      $comment_body = $comment->comment_body[LANGUAGE_NONE][0];
+    $field = field_info_field('comment_body');
+    $langcode = LANGUAGE_NONE;
+    if ($field && $comment->langcode() != NULL && field_is_translatable('comment', $field)) {
+      $langcode = $comment->langcode();
+    }
+    if (isset($comment->comment_body) && !empty($comment->comment_body[$langcode][0])) {
+      $comment_body = $comment->comment_body[$langcode][0];
       if (isset($comment_body['format'])) {
         $comment_text = check_markup($comment_body['value'], $comment_body['format']);
       }

--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -58,7 +58,7 @@ interface EntityInterface {
   /**
    * Returns the langcode for the entity.
    *
-   * @return
+   * @return string
    *   The langcode for the entity or NULL as a default.
    *
    */

--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -266,6 +266,7 @@ abstract class Entity extends stdClass implements EntityInterface {
     foreach ($values as $key => $value) {
       $this->$key = $value;
     }
+    $this->langcode();
   }
 
   /**

--- a/core/modules/entity/entity.class.inc
+++ b/core/modules/entity/entity.class.inc
@@ -56,6 +56,15 @@ interface EntityInterface {
   public function bundle();
 
   /**
+   * Returns the langcode for the entity.
+   *
+   * @return
+   *   The langcode for the entity or NULL as a default.
+   *
+   */
+  public function langcode();
+
+  /**
    * Returns the label of the entity.
    *
    * @return
@@ -276,6 +285,24 @@ abstract class Entity extends stdClass implements EntityInterface {
    */
   public function bundle() {
     return $this->entityType();
+  }
+
+  /**
+   * Implements EntityInterface::langcode().
+   *
+   * Entity types that do not support translation return NULL as a default.
+   */
+  public function langcode() {
+    $langcode = NULL;
+    if (isset($this->langcode)) {
+      $langcode = $this->langcode;
+    }
+    $info = entity_get_info($this->entityType());
+    if (isset($info['langcode callback']) && function_exists($info['langcode callback'])) {
+      $langcode = $info['langcode callback']($this->entityType(), $this);
+    }
+    $this->langcode = $langcode;
+    return $langcode;
   }
 
   /**

--- a/core/modules/file/file.entity.inc
+++ b/core/modules/file/file.entity.inc
@@ -287,7 +287,8 @@ class FileStorageController extends EntityDatabaseStorageController {
   protected function preSave(EntityInterface $entity) {
     $entity->timestamp = REQUEST_TIME;
     $entity->filesize = filesize($entity->uri);
-    if (!isset($entity->langcode)) {
+    $entity->langcode();
+    if (!isset($entity->langcode) || $entity->langcode == NULL) {
       // Default the file's language code to none, because files are language
       // neutral more often than language dependent.
       $entity->langcode = LANGUAGE_NONE;

--- a/core/modules/file/file.entity.inc
+++ b/core/modules/file/file.entity.inc
@@ -287,7 +287,6 @@ class FileStorageController extends EntityDatabaseStorageController {
   protected function preSave(EntityInterface $entity) {
     $entity->timestamp = REQUEST_TIME;
     $entity->filesize = filesize($entity->uri);
-    $entity->langcode();
     if (!isset($entity->langcode) || $entity->langcode == NULL) {
       // Default the file's language code to none, because files are language
       // neutral more often than language dependent.

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2703,7 +2703,11 @@ class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
           ->execute()
           ->fetchAssoc();
         $comment = new Comment($comment_array);
-        $args = array('%node_language' => $node_langcode, '%comment_language' => $comment->langcode(), '%langcode' => $langcode);
+        $args = array(
+          '%node_language' => $node_langcode,
+          '%comment_language' => $comment->langcode(),
+          '%langcode' => $langcode
+        );
         $this->assertEqual($comment->langcode(), $langcode, format_string('The comment posted with content language %langcode and belonging to the node with language %node_language has language %comment_language', $args));
       }
     }

--- a/core/modules/locale/tests/locale.test
+++ b/core/modules/locale/tests/locale.test
@@ -2669,7 +2669,6 @@ class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
    */
   function testCommentLanguage() {
     backdrop_static_reset('language_list');
-
     // Create two nodes, one for english and one for french, and comment each
     // node using both english and french as content language by changing URL
     // language prefixes. Meanwhile interface language is always French, which
@@ -2697,19 +2696,19 @@ class LocaleCommentLanguageFunctionalTest extends BackdropWebTestCase {
         $this->backdropPost("{$prefix}node/{$node->nid}", $edit, t('Save'));
 
         // Check that comment language matches the current content language.
-        $comment = db_select('comment', 'c')
+        $comment_array = db_select('comment', 'c')
           ->fields('c')
           ->condition('nid', $node->nid)
           ->orderBy('cid', 'DESC')
           ->execute()
-          ->fetchObject();
-        $args = array('%node_language' => $node_langcode, '%comment_language' => $comment->langcode, '%langcode' => $langcode);
-        $this->assertEqual($comment->langcode, $langcode, format_string('The comment posted with content language %langcode and belonging to the node with language %node_language has language %comment_language', $args));
+          ->fetchAssoc();
+        $comment = new Comment($comment_array);
+        $args = array('%node_language' => $node_langcode, '%comment_language' => $comment->langcode(), '%langcode' => $langcode);
+        $this->assertEqual($comment->langcode(), $langcode, format_string('The comment posted with content language %langcode and belonging to the node with language %node_language has language %comment_language', $args));
       }
     }
   }
 }
-
 /**
  * Functional tests for localizing date formats.
  */

--- a/core/modules/menu/menu.module
+++ b/core/modules/menu/menu.module
@@ -596,7 +596,7 @@ function menu_node_save(Node $node) {
     elseif (trim($link['link_title'])) {
       $link['link_title'] = trim($link['link_title']);
       $link['link_path'] = "node/$node->nid";
-      $link['langcode'] = $node->langcode;
+      $link['langcode'] = $node->langcode();
       if (trim($link['description'])) {
         $link['options']['attributes']['title'] = trim($link['description']);
       }
@@ -656,7 +656,7 @@ function menu_node_prepare(Node $node) {
     }
     // Set the dummy item langcode to the same language as the node.
     if (module_exists('language') && empty($item)) {
-      $item['langcode'] = $node->langcode;
+      $item['langcode'] = $node->langcode();
     }
     // Set default values.
     $node->menu = $item + array(

--- a/core/modules/node/node.block.inc
+++ b/core/modules/node/node.block.inc
@@ -103,7 +103,7 @@ class NodeBlock extends Block {
 
     $node = node_load($this->settings['nid']);
 
-    if (!empty($node->tnid) && !empty($node->langcode)) {
+    if (!empty($node->tnid) && !empty($node->langcode())) {
       $translations = translation_node_get_translations($node->tnid);
 
       foreach ($translations as $code => $translation) {

--- a/core/modules/node/node.module
+++ b/core/modules/node/node.module
@@ -1437,7 +1437,7 @@ function node_search_execute($keys = NULL, $conditions = NULL) {
       'extra' => $extra,
       'score' => $item->calculated_score,
       'snippet' => search_excerpt($keys, $node->rendered),
-      'langcode' => $node->langcode,
+      'langcode' => $node->langcode(),
     );
   }
   return $results;

--- a/core/modules/node/node.pages.inc
+++ b/core/modules/node/node.pages.inc
@@ -198,7 +198,7 @@ function node_form($form, &$form_state, Node $node) {
     $form['langcode'] = array(
       '#type' => 'select',
       '#title' => t('Language'),
-      '#default_value' => (isset($node->langcode) ? $node->langcode : ''),
+      '#default_value' => $node->langcode(),
       '#options' => $language_options,
       '#empty_value' => LANGUAGE_NONE,
     );
@@ -208,7 +208,7 @@ function node_form($form, &$form_state, Node $node) {
       '#type' => 'value',
       // New nodes without multilingual support have undefined language, old
       // nodes keep their language if language.module is not available.
-      '#value' => !isset($form['#node']->nid) ? LANGUAGE_NONE : $node->langcode,
+      '#value' => !isset($form['#node']->nid) ? LANGUAGE_NONE : $node->langcode(),
     );
   }
 
@@ -489,7 +489,7 @@ function node_form($form, &$form_state, Node $node) {
   }
   $form += array('#submit' => array());
 
-  field_attach_form('node', $node, $form, $form_state, $node->langcode);
+  field_attach_form('node', $node, $form, $form_state, $node->langcode());
   return $form;
 }
 

--- a/core/modules/node/node.tokens.inc
+++ b/core/modules/node/node.tokens.inc
@@ -212,7 +212,7 @@ function node_tokens($type, $tokens, array $data = array(), array $options = arr
           break;
 
         case 'langcode':
-          $replacements[$original] = $sanitize ? check_plain($node->langcode) : $node->langcode;
+          $replacements[$original] = $sanitize ? check_plain($node->langcode()) : $node->langcode();
           break;
 
         case 'url':

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -3346,9 +3346,9 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
     $tests['[node:type]'] = 'post';
     $tests['[node:type-name]'] = 'Post';
     $tests['[node:title]'] = check_plain($node->title);
-    $tests['[node:body]'] = _text_sanitize($instance, $node->langcode, $node->body[$node->langcode][0], 'value');
-    $tests['[node:summary]'] = _text_sanitize($instance, $node->langcode, $node->body[$node->langcode][0], 'summary');
-    $tests['[node:langcode]'] = check_plain($node->langcode);
+    $tests['[node:body]'] = _text_sanitize($instance, $node->langcode(), $node->body[$node->langcode()][0], 'value');
+    $tests['[node:summary]'] = _text_sanitize($instance, $node->langcode(), $node->body[$node->langcode()][0], 'summary');
+    $tests['[node:langcode]'] = check_plain($node->langcode());
     $tests['[node:url]'] = url('node/' . $node->nid, $url_options);
     $tests['[node:edit-url]'] = url('node/' . $node->nid . '/edit', $url_options);
     $tests['[node:author]'] = check_plain(user_format_name($account));
@@ -3367,9 +3367,9 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
 
     // Generate and test unsanitized tokens.
     $tests['[node:title]'] = $node->title;
-    $tests['[node:body]'] = $node->body[$node->langcode][0]['value'];
-    $tests['[node:summary]'] = $node->body[$node->langcode][0]['summary'];
-    $tests['[node:langcode]'] = $node->langcode;
+    $tests['[node:body]'] = $node->body[$node->langcode()][0]['value'];
+    $tests['[node:summary]'] = $node->body[$node->langcode()][0]['summary'];
+    $tests['[node:langcode]'] = $node->langcode();
     $tests['[node:author:name]'] = user_format_name($account);
 
     foreach ($tests as $input => $expected) {
@@ -3388,7 +3388,7 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
 
     // Generate and test sanitized token - use full body as expected value.
     $tests = array();
-    $tests['[node:summary]'] = _text_sanitize($instance, $node->langcode, $node->body[$node->langcode][0], 'value');
+    $tests['[node:summary]'] = _text_sanitize($instance, $node->langcode(), $node->body[$node->langcode()][0], 'value');
 
     // Test to make sure that we generated something for each token.
     $this->assertFalse(in_array(0, array_map('strlen', $tests)), 'No empty tokens generated for node without a summary.');
@@ -3399,7 +3399,7 @@ class NodeTokenReplaceTestCase extends BackdropWebTestCase {
     }
 
     // Generate and test unsanitized tokens.
-    $tests['[node:summary]'] = $node->body[$node->langcode][0]['value'];
+    $tests['[node:summary]'] = $node->body[$node->langcode()][0]['value'];
 
     foreach ($tests as $input => $expected) {
       $output = token_replace($input, array('node' => $node), array('language' => $language, 'sanitize' => FALSE));

--- a/core/modules/path/path.inc
+++ b/core/modules/path/path.inc
@@ -421,7 +421,10 @@ function path_generate_entity_alias(Entity $entity, $source = NULL, $langcode = 
     $source = $uri['path'];
   }
   if (!isset($langcode)) {
-    $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+    $langcode = $entity->langcode();
+    if ($langcode == NULL) {
+      $langcode = LANGUAGE_NONE;
+    }
   }
 
   // Retrieve and apply the pattern for this content type.
@@ -509,7 +512,10 @@ function path_generate_entity_alias(Entity $entity, $source = NULL, $langcode = 
  *   The path array saved into the database or FALSE if the path was not saved.
  */
 function path_save_automatic_entity_alias(Entity $entity) {
-  $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+  $langcode = $entity->langcode();
+  if ($langcode == NULL) {
+    $langcode = LANGUAGE_NONE;
+  }
   $uri = $entity->uri();
   $path = FALSE;
   if ($alias = path_generate_entity_alias($entity, $uri['path'], $langcode)) {

--- a/core/modules/path/path.module
+++ b/core/modules/path/path.module
@@ -451,7 +451,8 @@ function path_entity_load($entities, $type) {
  * Implements hook_entity_insert().
  */
 function path_entity_insert(Entity $entity) {
-  $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+  $entity_langcode = $entity->langcode();
+  $langcode = $entity_langcode != NULL ? $entity->langcode() : LANGUAGE_NONE;
   $uri = $entity->uri();
 
   // Only generate alias if entity has a URI.
@@ -497,7 +498,8 @@ function path_entity_insert(Entity $entity) {
  */
 function path_entity_update(Entity $entity) {
   if (isset($entity->path)) {
-    $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+    $entity_langcode = $entity->langcode();
+    $langcode = $entity_langcode != NULL ? $entity_langcode : LANGUAGE_NONE;
     $uri = $entity->uri();
     $path = $entity->path;
     $path['source'] = $uri['path'];
@@ -683,7 +685,10 @@ function path_get_pattern_by_entity_type($entity_type, $bundle = '', $langcode =
  */
 function path_load_by_entity(Entity $entity) {
   $uri = $entity->uri();
-  $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+  $langcode = $entity->langcode();
+  if ($langcode == NULL) {
+    $langcode = LANGUAGE_NONE;
+  }
   $conditions = array(
     'source' => $uri['path'],
     'langcode' => $langcode,
@@ -718,7 +723,10 @@ function path_load_multiple_by_entities(array $entities) {
   foreach ($entities as $entity) {
     $uri = $entity->uri();
     if (!empty($uri)) {
-      $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+      $langcode = $entity->langcode();
+      if ($langcode == NULL) {
+        $langcode = LANGUAGE_NONE;
+      }
       $sources[$langcode][] = $uri['path'];
       $map[$langcode][$uri['path']] = $entity->id();
 
@@ -801,7 +809,10 @@ function path_delete_all_by_entity(Entity $entity, $default_uri = NULL) {
  * Return a portion of a form for setting an alias on an entity.
  */
 function path_form_element(Entity $entity) {
-  $langcode = isset($entity->langcode) ? $entity->langcode : LANGUAGE_NONE;
+  $langcode = $entity->langcode();
+  if ($langcode == NULL) {
+    $langcode = LANGUAGE_NONE;
+  }
   $entity_type = $entity->entityType();
   $bundle = $entity->bundle();
 

--- a/core/modules/path/tests/path.test
+++ b/core/modules/path/tests/path.test
@@ -386,7 +386,7 @@ class PathLanguageTestCase extends BackdropWebTestCase {
     backdrop_static_reset('locale_url_outbound_alter');
     backdrop_static_reset('locale_language_url_rewrite_url');
     $languages = language_list();
-    $url = url('node/' . $french_node->nid, array('language' => $languages[$french_node->langcode]));
+    $url = url('node/' . $french_node->nid, array('language' => $languages[$french_node->langcode()]));
     $this->assertTrue(strpos($url, $edit['path[alias]']), 'URL contains the URL alias.');
 
     // Confirm that the alias works even when changing language negotiation
@@ -436,17 +436,17 @@ class PathLanguageTestCase extends BackdropWebTestCase {
     // backdrop_lookup_path() has an internal static cache. Check to see that
     // it has the appropriate contents at this point.
     backdrop_lookup_path('wipe');
-    $french_node_path = backdrop_lookup_path('source', $french_alias, $french_node->langcode);
+    $french_node_path = backdrop_lookup_path('source', $french_alias, $french_node->langcode());
     $this->assertEqual($french_node_path, 'node/' . $french_node->nid, 'Normal path works.');
     // Second call should return the same path.
-    $french_node_path = backdrop_lookup_path('source', $french_alias, $french_node->langcode);
+    $french_node_path = backdrop_lookup_path('source', $french_alias, $french_node->langcode());
     $this->assertEqual($french_node_path, 'node/' . $french_node->nid, 'Normal path is the same.');
 
     // Confirm that the alias works.
-    $french_node_alias = backdrop_lookup_path('alias', 'node/' . $french_node->nid, $french_node->langcode);
+    $french_node_alias = backdrop_lookup_path('alias', 'node/' . $french_node->nid, $french_node->langcode());
     $this->assertEqual($french_node_alias, $french_alias, 'Alias works.');
     // Second call should return the same alias.
-    $french_node_alias = backdrop_lookup_path('alias', 'node/' . $french_node->nid, $french_node->langcode);
+    $french_node_alias = backdrop_lookup_path('alias', 'node/' . $french_node->nid, $french_node->langcode());
     $this->assertEqual($french_node_alias, $french_alias, 'Alias is the same.');
   }
 }

--- a/core/modules/simpletest/tests/upgrade/upgrade.language.test
+++ b/core/modules/simpletest/tests/upgrade/upgrade.language.test
@@ -55,7 +55,7 @@ class LanguageUpgradePathTestCase extends UpgradePathTestCase {
 
     // Directly check the comment language property on the first comment.
     $comment = db_query('SELECT * FROM {comment} WHERE cid = :cid', array(':cid' => 1))->fetchObject();
-    $this->assertTrue($comment->langcode == 'und', t('Comment 1 language code found.'));
+    $this->assertTrue($comment->langcode() == 'und', t('Comment 1 language code found.'));
 
     // Ensure that the language switcher has been correctly upgraded. We need to
     // assert the expected HTML id because the block might appear even if the
@@ -70,9 +70,9 @@ class LanguageUpgradePathTestCase extends UpgradePathTestCase {
     $spanish_nid = 39;
     $translation_source_nid = 40;
     $translation_nid = 41;
-    // Check directly for the $node->langcode property.
-    $this->assertEqual(node_load($language_none_nid)->langcode, LANGUAGE_NONE, "'language' property was renamed to 'langcode' for LANGUAGE_NONE node.");
-    $this->assertEqual(node_load($spanish_nid)->langcode, 'ca', "'language' property was renamed to 'langcode' for Catalan node.");
+    // Check directly for the $node->langcode callback.
+    $this->assertEqual(node_load($language_none_nid)->langcode(), LANGUAGE_NONE, "'language' property was renamed to 'langcode' for LANGUAGE_NONE node.");
+    $this->assertEqual(node_load($spanish_nid)->langcode(), 'ca', "'language' property was renamed to 'langcode' for Catalan node.");
     // Check that the translation table works correctly.
     $this->backdropGet("node/$translation_source_nid/translate");
     $this->assertResponse(200, 'The translated node has a proper translation table.');

--- a/core/modules/simpletest/tests/upgrade/upgrade.language.test
+++ b/core/modules/simpletest/tests/upgrade/upgrade.language.test
@@ -55,7 +55,7 @@ class LanguageUpgradePathTestCase extends UpgradePathTestCase {
 
     // Directly check the comment language property on the first comment.
     $comment = db_query('SELECT * FROM {comment} WHERE cid = :cid', array(':cid' => 1))->fetchObject();
-    $this->assertTrue($comment->langcode() == 'und', t('Comment 1 language code found.'));
+    $this->assertTrue($comment->langcode == 'und', t('Comment 1 language code found.'));
 
     // Ensure that the language switcher has been correctly upgraded. We need to
     // assert the expected HTML id because the block might appear even if the

--- a/core/modules/taxonomy/taxonomy.admin.inc
+++ b/core/modules/taxonomy/taxonomy.admin.inc
@@ -470,7 +470,7 @@ function taxonomy_overview_terms($form, &$form_state, TaxonomyVocabulary $vocabu
 
   $delta = 0;
   $term_deltas = array();
-  $tree = taxonomy_get_tree($vocabulary->machine_name);
+  $tree = taxonomy_get_tree($vocabulary->machine_name, 0, NULL, TRUE);
   $term = current($tree);
   do {
     // In case this tree is completely empty.
@@ -480,7 +480,8 @@ function taxonomy_overview_terms($form, &$form_state, TaxonomyVocabulary $vocabu
 
     // Skip all terms not in the requested language.
     $tree_langcode = $filter_langcode === LANGUAGE_NONE ? NULL : $filter_langcode;
-    if ($tree_langcode && $term->langcode !== $tree_langcode && $term->langcode !== LANGUAGE_NONE) {
+
+    if ($tree_langcode && $term->langcode() !== $tree_langcode && $term->langcode() !== LANGUAGE_NONE) {
       continue;
     }
 
@@ -589,7 +590,7 @@ function taxonomy_overview_terms($form, &$form_state, TaxonomyVocabulary $vocabu
         '#default_value' => $term->depth,
       );
       // Language
-      $langcode_label = isset($language_options[$term->langcode]) ? $language_options[$term->langcode] : $term->langcode;
+      $langcode_label = isset($language_options[$term->langcode()]) ? $language_options[$term->langcode()] : $term->langcode();
       if (module_exists('language') && $vocabulary->language == TAXONOMY_LANGUAGE_ENABLED) {
         $form[$key]['langcode'] = array(
           '#type' => 'markup',
@@ -847,7 +848,7 @@ function taxonomy_form_term($form, &$form_state, ?TaxonomyTerm $term = NULL, ?Ta
     $form['langcode'] = array(
       '#type' => 'select',
       '#title' => t('Language'),
-      '#default_value' => isset($_GET['langcode_term']) ? $_GET['langcode_term'] : $term->langcode,
+      '#default_value' => isset($_GET['langcode_term']) ? $_GET['langcode_term'] : $term->langcode(),
       '#options' => language_list(TRUE, TRUE),
       '#empty_value' => LANGUAGE_NONE,
       '#empty_option' => t('- All (always shown) -'),
@@ -858,7 +859,7 @@ function taxonomy_form_term($form, &$form_state, ?TaxonomyTerm $term = NULL, ?Ta
     // Maintain langcode settings if Language module is not present.
     $form['langcode'] = array(
       '#type' => 'value',
-      '#value' => $term->langcode,
+      '#value' => $term->langcode(),
     );
   }
 

--- a/core/modules/translation/tests/translation.test
+++ b/core/modules/translation/tests/translation.test
@@ -211,14 +211,19 @@ class TranslationTestCase extends BackdropWebTestCase {
     $type = 'block-locale';
     $node = $this->createPage($this->randomName(), $this->randomName(), 'en');
     $this->assertLanguageSwitchLinks($node, $node, TRUE, $type);
-    $this->assertLanguageSwitchLinks($node, $this->emptyNode('es'), TRUE, $type);
-    $this->assertLanguageSwitchLinks($node, $this->emptyNode('it'), TRUE, $type);
+    $empty_node_es = clone $node;
+    $empty_node_es->nid = NULL;
+    $empty_node_es->langcode = 'es';
+    $this->assertLanguageSwitchLinks($node, $empty_node_es, TRUE, $type);
+    $empty_node_it = clone $empty_node_es;
+    $empty_node_it->langcode = 'it';
+    $this->assertLanguageSwitchLinks($node, $empty_node_it, TRUE, $type);
 
     // Create the Spanish translation.
     $translation_es = $this->createTranslation($node, $this->randomName(), $this->randomName(), 'es');
     $this->assertLanguageSwitchLinks($node, $node, TRUE, $type);
     $this->assertLanguageSwitchLinks($node, $translation_es, TRUE, $type);
-    $this->assertLanguageSwitchLinks($node, $this->emptyNode('it'), TRUE, $type);
+    $this->assertLanguageSwitchLinks($node, $empty_node_it, TRUE, $type);
 
     // Create the Italian translation.
     $translation_it = $this->createTranslation($node, $this->randomName(), $this->randomName(), 'it');
@@ -229,9 +234,12 @@ class TranslationTestCase extends BackdropWebTestCase {
     // Create a language neutral node and check that the language switcher is
     // left untouched.
     $node2 = $this->createPage($this->randomName(), $this->randomName(), LANGUAGE_NONE);
-    $node2_en = (object) array('nid' => $node2->nid, 'langcode' => 'en');
-    $node2_es = (object) array('nid' => $node2->nid, 'langcode' => 'es');
-    $node2_it = (object) array('nid' => $node2->nid, 'langcode' => 'it');
+    $node2_en = clone $node2;
+    $node2_en->langcode = 'en';
+    $node2_es = clone $node2;
+    $node2_es->langcode = 'es';
+    $node2_it = clone $node2;
+    $node2_it->langcode = 'it';
     $this->assertLanguageSwitchLinks($node2_en, $node2_en, TRUE, $type);
     $this->assertLanguageSwitchLinks($node2_en, $node2_es, TRUE, $type);
     $this->assertLanguageSwitchLinks($node2_en, $node2_it, TRUE, $type);
@@ -252,8 +260,10 @@ class TranslationTestCase extends BackdropWebTestCase {
     // Check that new nodes with a language assigned do not trigger language
     // switcher alterations when translation support is disabled.
     $node = $this->createPage($this->randomName(), $this->randomName());
-    $node_es = (object) array('nid' => $node->nid, 'langcode' => 'es');
-    $node_it = (object) array('nid' => $node->nid, 'langcode' => 'it');
+    $node_es = clone $node;
+    $node_es->langcode = 'es';
+    $node_it = clone $node;
+    $node_it->langcode = 'it';
     $this->assertLanguageSwitchLinks($node, $node, TRUE, $type);
     $this->assertLanguageSwitchLinks($node, $node_es, TRUE, $type);
     $this->assertLanguageSwitchLinks($node, $node_it, TRUE, $type);
@@ -266,19 +276,6 @@ class TranslationTestCase extends BackdropWebTestCase {
     backdrop_static_reset('language_list');
     backdrop_static_reset('locale_url_outbound_alter');
     backdrop_static_reset('locale_language_url_rewrite_url');
-  }
-
-  /**
-   * Returns an empty node data structure.
-   *
-   * @param $langcode
-   *   The language code.
-   *
-   * @return
-   *   An empty node data structure.
-   */
-  function emptyNode($langcode) {
-    return (object) array('nid' => NULL, 'langcode' => $langcode);
   }
 
   /**
@@ -437,8 +434,8 @@ class TranslationTestCase extends BackdropWebTestCase {
 
     $result = TRUE;
     $languages = language_list();
-    $node_langcode = $node->langcode === LANGUAGE_NONE ? $language_default : $node->langcode;
-    $translation_langcode = $translation->langcode === LANGUAGE_NONE ? $language_default : $translation->langcode;
+    $node_langcode = $node->langcode() === LANGUAGE_NONE ? $language_default : $node->langcode();
+    $translation_langcode = $translation->langcode() === LANGUAGE_NONE ? $language_default : $translation->langcode();
     $page_language = $languages[$node_langcode];
     $translation_language = $languages[$translation_langcode];
     $url = url("node/$translation->nid", array('language' => $translation_language));

--- a/core/modules/translation/tests/translation.test
+++ b/core/modules/translation/tests/translation.test
@@ -273,30 +273,30 @@ class TranslationTestCase extends BackdropWebTestCase {
    * Tests entity class 'langcode callback' property
    */
   function testLangcodeCallback() {
-    $node_none = $this->createPage($this->randomName(), $this->randomName(), LANGUAGE_NONE);
+    $node_none_default = $this->createPage($this->randomName(), $this->randomName(), LANGUAGE_NONE);
     $node_none_test = $this->createPage($this->randomName(), $this->randomName(), LANGUAGE_NONE);
-    $node_es = $this->createPage($this->randomName(), $this->randomName(), 'es');
+    $node_es_default = $this->createPage($this->randomName(), $this->randomName(), 'es');
     $node_es_test = $this->createPage($this->randomName(), $this->randomName(), 'es');
     $this->resetCaches();
 
     $langcode_alter = &backdrop_static('translation_test_langcode_callback', array());
 
-    $node_none = node_load($node_none->nid, NULL, TRUE);
-    $this->assertEqual($node_none->langcode(), LANGUAGE_NONE, t('Langcode is LANGUAGE_NONE'));
+    $node_none_default = node_load($node_none_default->nid, NULL, TRUE);
+    $this->assertEqual($node_none_default->langcode(), LANGUAGE_NONE, t('Langcode is unaltered and is LANGUAGE_NONE'));
 
-    $node_none_test_langcode = 'zh';
-    $langcode_alter[$node_none_test->nid] = $node_none_test_langcode;
+    $target_langcode = 'zh';
+    $langcode_alter[$node_none_test->nid] = $target_langcode;
     $node_none_test = node_load($node_none_test->nid, NULL, TRUE);
-    $this->assertEqual($node_none_test->langcode(), $node_none_test_langcode, t('Langcode is altered by langcode callback and is @langcode', ['@langcode' => $node_none_test_langcode]));
+    $this->assertEqual($node_none_test->langcode(), $target_langcode, t('Langcode is altered by langcode callback and is @langcode', ['@langcode' => $target_langcode]));
 
 
-    $node_es = node_load($node_es->nid, NULL, TRUE);
-    $this->assertEqual($node_es->langcode(), 'es', t('Langcode is unaltered and is @langcode', ['@langcode' => 'es']));
+    $node_es_default = node_load($node_es_default->nid, NULL, TRUE);
+    $this->assertEqual($node_es_default->langcode(), 'es', t('Langcode is unaltered and is @langcode', ['@langcode' => 'es']));
 
-    $node_es_test_langcode = 'en';
-    $langcode_alter[$node_es_test->nid] = $node_es_test_langcode;
+    $target_langcode = 'en';
+    $langcode_alter[$node_es_test->nid] = $target_langcode;
     $node_es_test = node_load($node_es_test->nid, NULL, TRUE);
-    $this->assertEqual($node_es_test->langcode(), $node_es_test_langcode, t('Langcode is altered by langcode callback and is @langcode', ['@langcode' => $node_es_test_langcode]));
+    $this->assertEqual($node_es_test->langcode(), $target_langcode, t('Langcode is altered by langcode callback and is @langcode', ['@langcode' => $target_langcode]));
   }
 
   /**

--- a/core/modules/translation/tests/translation.test
+++ b/core/modules/translation/tests/translation.test
@@ -270,6 +270,36 @@ class TranslationTestCase extends BackdropWebTestCase {
   }
 
   /**
+   * Tests entity class 'langcode callback' property
+   */
+  function testLangcodeCallback() {
+    $node_none = $this->createPage($this->randomName(), $this->randomName(), LANGUAGE_NONE);
+    $node_none_test = $this->createPage($this->randomName(), $this->randomName(), LANGUAGE_NONE);
+    $node_es = $this->createPage($this->randomName(), $this->randomName(), 'es');
+    $node_es_test = $this->createPage($this->randomName(), $this->randomName(), 'es');
+    $this->resetCaches();
+
+    $langcode_alter = &backdrop_static('translation_test_langcode_callback', array());
+
+    $node_none = node_load($node_none->nid, NULL, TRUE);
+    $this->assertEqual($node_none->langcode(), LANGUAGE_NONE, t('Langcode is LANGUAGE_NONE'));
+
+    $node_none_test_langcode = 'zh';
+    $langcode_alter[$node_none_test->nid] = $node_none_test_langcode;
+    $node_none_test = node_load($node_none_test->nid, NULL, TRUE);
+    $this->assertEqual($node_none_test->langcode(), $node_none_test_langcode, t('Langcode is altered by langcode callback and is @langcode', ['@langcode' => $node_none_test_langcode]));
+
+
+    $node_es = node_load($node_es->nid, NULL, TRUE);
+    $this->assertEqual($node_es->langcode(), 'es', t('Langcode is unaltered and is @langcode', ['@langcode' => 'es']));
+
+    $node_es_test_langcode = 'en';
+    $langcode_alter[$node_es_test->nid] = $node_es_test_langcode;
+    $node_es_test = node_load($node_es_test->nid, NULL, TRUE);
+    $this->assertEqual($node_es_test->langcode(), $node_es_test_langcode, t('Langcode is altered by langcode callback and is @langcode', ['@langcode' => $node_es_test_langcode]));
+  }
+
+  /**
    * Resets static caches to make the test code match the client-side behavior.
    */
   function resetCaches() {

--- a/core/modules/translation/tests/translation_test/translation_test.module
+++ b/core/modules/translation/tests/translation_test/translation_test.module
@@ -10,3 +10,26 @@
 function translation_test_node_insert(Node $node) {
   backdrop_write_record('node', $node, 'nid');
 }
+
+/**
+ * Langcode callback for testing.
+ */
+function translation_test_langcode_callback($entity_type, $node) {
+  $langcode_test = &backdrop_static(__FUNCTION__, array());
+  if (isset($langcode_test[$node->nid])) {
+    $node->langcode = $langcode_test[$node->nid];
+  }
+  return $node->langcode;
+}
+
+/**
+ * Implements hook_entity_info().
+ */
+function translation_test_entity_info() {
+
+  $info['node'] = array(
+    'langcode callback' => 'translation_test_langcode_callback',
+  );
+
+  return $info;
+}

--- a/core/modules/translation/translation.module
+++ b/core/modules/translation/translation.module
@@ -57,7 +57,7 @@ function translation_menu() {
  * @see translation_menu()
  */
 function _translation_tab_access($node) {
-  if ($node->langcode != LANGUAGE_NONE && translation_supported_type($node->type) && node_access('view', $node)) {
+  if ($node->langcode() != LANGUAGE_NONE && translation_supported_type($node->type) && node_access('view', $node)) {
     return user_access('translate content');
   }
   return FALSE;
@@ -279,7 +279,7 @@ function translation_node_view(Node $node, $view_mode) {
     foreach ($translations as $langcode => $translation) {
       // Do not show links to the same node, to unpublished translations or to
       // translations in disabled languages.
-      if ($translation->status && isset($languages[$langcode]) && $langcode != $node->langcode) {
+      if ($translation->status && isset($languages[$langcode]) && $langcode != $node->langcode()) {
         $language = $languages[$langcode];
         $key = "translation_$langcode";
 
@@ -363,7 +363,7 @@ function translation_node_prepare(Node $node) {
 
     // Add field translations and let other modules module add custom translated
     // fields.
-    field_attach_prepare_translation('node', $node, $node->langcode, $source_node, $source_node->langcode);
+    field_attach_prepare_translation('node', $node, $node->langcode(), $source_node, $source_node->langcode());
   }
 }
 
@@ -412,7 +412,7 @@ function translation_node_insert(Node $node) {
 function translation_node_update(Node $node) {
   // Only act if we are dealing with a content type supporting translations.
   if (translation_supported_type($node->type)) {
-    if (isset($node->translation) && $node->translation && !empty($node->langcode) && $node->tnid) {
+    if (isset($node->translation) && $node->translation && !empty($node->langcode()) && $node->tnid) {
       // Update translation information.
       db_update('node')
         ->fields(array(
@@ -453,7 +453,7 @@ function translation_node_validate(Node $node, $form) {
   if (translation_supported_type($node->type) && (!empty($node->tnid) || !empty($form['#node']->translation_source->nid))) {
     $tnid = !empty($node->tnid) ? $node->tnid : $form['#node']->translation_source->nid;
     $translations = translation_node_get_translations($tnid);
-    if (isset($translations[$node->langcode]) && $translations[$node->langcode]->nid != $node->nid ) {
+    if (isset($translations[$node->langcode()]) && $translations[$node->langcode()]->nid != $node->nid ) {
       form_set_error('langcode', t('There is already a translation in this language.'));
     }
   }
@@ -604,10 +604,10 @@ function translation_language_switch_links_alter(array &$links, $type, $path) {
       // have translations it might be a language neutral node, in which case we
       // must leave the language switch links unaltered. This is true also for
       // nodes not having translation support enabled.
-      if (empty($node) || $node->langcode == LANGUAGE_NONE || !translation_supported_type($node->type)) {
+      if (empty($node) || $node->langcode() == LANGUAGE_NONE || !translation_supported_type($node->type)) {
         return;
       }
-      $translations = array($node->langcode => $node);
+      $translations = array($node->langcode() => $node);
     }
     else {
       $translations = translation_node_get_translations($node->tnid);

--- a/core/modules/translation/translation.pages.inc
+++ b/core/modules/translation/translation.pages.inc
@@ -26,7 +26,7 @@ function translation_node_overview(Node $node) {
   else {
     // We have no translation source nid, this could be a new set, emulate that.
     $tnid = $node->nid;
-    $translations = array($node->langcode => $node);
+    $translations = array($node->langcode() => $node);
   }
 
   $type = config_get('translation.settings', 'language_type');

--- a/core/modules/translation/views/views_handler_field_node_link_translate.inc
+++ b/core/modules/translation/views/views_handler_field_node_link_translate.inc
@@ -14,6 +14,7 @@ class views_handler_field_node_link_translate extends views_handler_field_node_l
     // ensure user has access to edit this node.
     $node = $this->get_value($values);
     $node->status = 1; // unpublished nodes ignore access control
+    $node->langcode();
     if (empty($node->langcode) || $node->langcode == LANGUAGE_NONE || !translation_supported_type($node->type) || !node_access('view', $node) || !user_access('translate content')) {
       return;
     }


### PR DESCRIPTION
langcode() is a new method that basically should replace the entity_language method that existed in Drupal 7. This was largely replaced with just the use of the langcode property in Backdrop but this creates problems with entity_translation because that provides field-based translation rather than whole node translation. We need a way to set a handler to return the langcode rather than just grabbing that the node row in the database.

Fixes 185

Fixes https://github.com/backdrop/backdrop-issues/issues/185
