### PR TITLE
Issue #7038: Re-namespace Views select all pages functionality.

### DIFF
--- a/core/modules/views/css/views.css
+++ b/core/modules/views/css/views.css
@@ -143,26 +143,26 @@
 }
 
 /* Bulk form select all pages */
-.bulk-form-table-select-all-markup {
-  display: none;
-} 
-
-.bulk-form-views-table-row-select-all {
+.views-select-all-pages--wrapper {
   display: none;
 }
-.bulk-form-views-table-row-select-all td {
+
+.views-select-all-pages--row {
+  display: none;
+}
+.views-select-all-pages--row td {
   text-align: center;
 }
 
 /* Generic bulk form "select all" for non-tables */
-.bulk-form-fieldset-select-all {
+.views-select-all-pages--fieldset {
   text-align: left;
   padding: 0.6em 0;
 }
-.bulk-form-fieldset-select-all .form-item {
+.views-select-all-pages--fieldset .form-item {
   margin-bottom: 0;
 }
-.bulk-form-fieldset-select-all div {
+.views-select-all-pages--fieldset div {
   padding: 0;
   margin: 0;
 }

--- a/core/modules/views/handlers/views_handler_field_bulk_form.inc
+++ b/core/modules/views/handlers/views_handler_field_bulk_form.inc
@@ -150,9 +150,9 @@ class views_handler_field_bulk_form extends views_handler_field {
       if (!empty($this->view->result)) {
         $form['#attached']['js'][] = backdrop_get_path('module', 'views') . '/js/bulk_form.js';
         // Set by JS to indicate that all rows on all pages are selected.
-        $form['bulk_form_select_all_pages_flag'] = array(
+        $form['select_all_pages'] = array(
           '#type' => 'hidden',
-          '#attributes' => array('class' => 'bulk-form-select-all-pages-flag'),
+          '#attributes' => array('class' => 'views-select-all-pages--value'),
           '#default_value' => FALSE,
         );
         $enable_select_all_pages = FALSE;
@@ -161,9 +161,9 @@ class views_handler_field_bulk_form extends views_handler_field {
         if ($this->options['enable_select_all_pages'] && isset($this->view->total_rows) && count($this->view->result) != $this->view->total_rows) {
           $enable_select_all_pages = TRUE;
         }
-        $form['bd_select_all_markup'] = array(
+        $form['select_all_pages_markup'] = array(
           '#type' => 'markup',
-          '#markup' => theme('bulk_operations_select_all', array(
+          '#markup' => theme('views_select_all_pages', array(
             'view' => $this->view,
             'enable_select_all_pages' => $enable_select_all_pages,
           )),
@@ -188,7 +188,7 @@ class views_handler_field_bulk_form extends views_handler_field {
 
       // If the flag to select all results in all pages is true, retrieve all
       // entity IDs.
-      if ($form_state['values']['bulk_form_select_all_pages_flag'] && ($this->view->query->pager->has_more_records() || $this->view->query->pager->get_current_page() > 0)) {
+      if ($form_state['values']['select_all_pages'] && ($this->view->query->pager->has_more_records() || $this->view->query->pager->get_current_page() > 0)) {
         // We need to build a new view with the same parameters, but without a
         // pager.
         $new_view = views_get_view($this->view->name);

--- a/core/modules/views/js/ajax.js
+++ b/core/modules/views/js/ajax.js
@@ -56,7 +56,7 @@
    */
   Backdrop.theme.tableDragChangedWarning = function () {
     return [];
-  }
+  };
 
   /**
    * Trigger preview when the "live preview" checkbox is checked.
@@ -69,7 +69,7 @@
         }
       });
     }
-  }
+  };
 
   /**
    * Sync preview display.

--- a/core/modules/views/js/ajax_view.js
+++ b/core/modules/views/js/ajax_view.js
@@ -15,6 +15,7 @@ Backdrop.behaviors.ViewsAjaxView.attach = function() {
     });
   }
 };
+
 /**
  * Removes configuration and state from the page when a view is removed.
  */
@@ -28,7 +29,7 @@ Backdrop.behaviors.ViewsAjaxView.attach = function() {
       }
     });
   }
-}
+};
 
 Backdrop.views = {};
 Backdrop.views.instances = {};

--- a/core/modules/views/js/bulk_form.js
+++ b/core/modules/views/js/bulk_form.js
@@ -1,31 +1,33 @@
 (function ($) {
 
-Backdrop.behaviors.bulk_form = {
+Backdrop.behaviors.viewsBulkForm = {
   attach: function(context) {
     $('.views-form', context).each(function() {
-      Backdrop.bulk_form.initTableBehaviors(this);
-      Backdrop.bulk_form.initGenericBehaviors(this);
+      Backdrop.viewsBulkForm.initTableBehaviors(this);
+      Backdrop.viewsBulkForm.initGenericBehaviors(this);
     });
   }
-}
+};
 
-Backdrop.bulk_form = Backdrop.bulk_form || {};
-Backdrop.bulk_form.initTableBehaviors = function(form) {
+Backdrop.viewsBulkForm = Backdrop.viewsBulkForm || {};
+Backdrop.viewsBulkForm.initTableBehaviors = function(form) {
   // If the table is not grouped, "Select all on this page / all pages"
   // markup gets inserted below the table header.
-  var selectAllMarkup = $('.bulk-form-table-select-all-markup', form);
-  if (selectAllMarkup.length) {
-    $('.views-table > tbody', form).prepend('<tr class="bulk-form-views-table-row-select-all even">></tr>');
+  var $selectAllElement = $('.views-select-all-pages--wrapper', form);
+  if ($selectAllElement.length) {
+    $('.views-table > tbody', form).prepend('<tr class="views-select-all-pages--row even">></tr>');
     var colspan = $('table th', form).length;
-    // Add the select all pages markup as the first row spanning all columns.
-    $('.bulk-form-views-table-row-select-all', form).html('<td colspan="' + colspan + '">' + selectAllMarkup.html() + '</td>');
 
-    $('.bulk-form-table-select-all-pages', form).on('click', function() {
-      Backdrop.bulk_form.tableSelectAllPages(form);
+    // Add the select all pages markup as the first row spanning all columns.
+    $('.views-select-all-pages--row', form).html('<td colspan="' + colspan + '"></td>');
+    $('.views-select-all-pages--row td', form).prepend($selectAllElement);
+
+    $('.views-select-all-pages--all-pages-button', form).on('click', function() {
+      Backdrop.viewsBulkForm.tableSelectAllPages(form);
       return false;
     });
-    $('.bulk-form-table-select-this-page', form).on('click', function() {
-      Backdrop.bulk_form.tableSelectThisPage(form);
+    $('.views-select-all-pages--this-page-button', form).on('click', function() {
+      Backdrop.viewsBulkForm.tableSelectThisPage(form);
       return false;
     });
   }
@@ -36,71 +38,75 @@ Backdrop.bulk_form.initTableBehaviors = function(form) {
 
     // Toggle the visibility of the "select all" row (if any).
     if (this.checked) {
-      $('.bulk-form-views-table-row-select-all', table).show();
+      $('.views-select-all-pages--row', table).show();
     }
     else {
-      $('.bulk-form-views-table-row-select-all', table).hide();
+      $('.views-select-all-pages--row', table).hide();
       // Disable "select all across pages".
-      Backdrop.bulk_form.tableSelectThisPage(form);
+      Backdrop.viewsBulkForm.tableSelectThisPage(form);
     }
   });
-}
+};
 
 /**
  * Prepares the select all across pages functionality.
  */
-Backdrop.bulk_form.tableSelectAllPages = function(form) {
-  $('.bulk-form-table-this-page', form).hide();
-  $('.bulk-form-table-all-pages', form).show();
+Backdrop.viewsBulkForm.tableSelectAllPages = function(form) {
+  $('.views-select-all-pages--this-page', form).hide();
+  $('.views-select-all-pages--all-pages', form).show();
   // Modify the value of the hidden form flag field.
-  $('.bulk-form-select-all-pages-flag', form).val('1');
-}
+  $('input[name="select_all_pages"]', form).val('1');
+};
+
 /**
  * Prepares the select all on this page functionality.
  */
-Backdrop.bulk_form.tableSelectThisPage = function(form) {
-  $('.bulk-form-table-all-pages', form).hide();
-  $('.bulk-form-table-this-page', form).show();
+Backdrop.viewsBulkForm.tableSelectThisPage = function(form) {
+  $('.views-select-all-pages--all-pages', form).hide();
+  $('.views-select-all-pages--this-page', form).show();
   // Modify the value of the hidden form field.
-  $('.bulk-form-select-all-pages-flag', form).val('0');
-}
+  $('input[name="select_all_pages"]', form).val('0');
+};
 
-Backdrop.bulk_form.initGenericBehaviors = function(form) {
+Backdrop.viewsBulkForm.initGenericBehaviors = function(form) {
   // Show the "select all" fieldset for non-tables.
-  $('.bulk-form-select-all-markup', form).show();
+  $('.views-select-all-pages--wrapper', form).show();
 
-  // Listener for the non-table page-wise "select all" checkbox. 
-  $('.bulk-form-select-this-page', form).on('click', function() {
+  // Listener for the non-table page-wise "select all" checkbox.
+  $('.views-select-all-pages--this-page-checkbox', form).on('change', function() {
     // Check or uncheck all checkbox within this page.
     $('input:checkbox[name^="bulk_form"]', form).prop('checked', this.checked);
+
     // Uncheck the "select all items in all pages" checkbox.
-    $('.bulk-form-select-all-pages', form).prop('checked', false);
+    $('.views-select-all-pages--all-pages-checkbox', form).prop('checked', false);
 
     // Toggle the "select all" checkbox in grouped tables (if any).
     $('.bulk-form-table-select-all', form).prop('checked', this.checked);
   });
 
-  // Listener for the non-table "select all in all pages" checkbox. 
-  $('.bulk-form-select-all-pages', form).on('click', function() {
+  // Listener for the non-table "select all in all pages" checkbox.
+  $('.views-select-all-pages--all-pages-checkbox', form).on('change', function() {
     $('input:checkbox[name^="bulk_form"]', form).prop('checked', this.checked);
+
     // Uncheck the "select all" checkbox.
-    $('.bulk-form-select-this-page', form).prop('checked', false);
+    $('.views-select-all-pages--this-page-checkbox', form).prop('checked', false);
 
     // Toggle the "select all" checkbox in grouped tables (if any).
-    $('.bulk-form-table-select-all', form).prop('checked', this.checked);
+    $('.views-select-all-pages--all-pages-checkbox', form).prop('checked', this.checked);
 
     // Modify the value of the hidden form field.
-    $('.bulk-form-select-all-pages-flag', form).val(this.checked);
+    $('input[name="select_all_pages"]', form).val(this.checked ? '1' : '0');
   });
 
-  $('input:checkbox[name^="bulk_form"]', form).on('click', function() {
+  $('input:checkbox[name^="bulk_form"]', form).on('change', function() {
     // If a checkbox was deselected, uncheck any "select all" checkboxes.
     if (!this.checked) {
       // Uncheck the select all checkboxes for non-tables.
-      $('.bulk-form-select-this-page', form).prop('checked', false);
-      $('.bulk-form-select-all-pages', form).prop('checked', false);
+      $('.views-select-all-pages--this-page-checkbox', form).prop('checked', false);
+      $('.views-select-all-pages--all-pages-checkbox', form).prop('checked', false);
+
       // Modify the value of the hidden form field.
-      $('.bulk-form-select-all-pages-flag', form).val('0')
+      $('input[name="select_all_pages"]', form).val('0');
 
       var table = $(this).closest('table')[0];
       if (table) {
@@ -108,12 +114,12 @@ Backdrop.bulk_form.initGenericBehaviors = function(form) {
         if ($('.bulk-form-table-select-this-page', table).length) {
           $('.bulk-form-views-table-row-select-all', table).hide();
           // Disable "select all across pages".
-          Backdrop.bulk_form.tableSelectThisPage(form);
+          Backdrop.viewsBulkForm.tableSelectThisPage(form);
         }
       }
     }
 
   });
-}
+};
 
 })(jQuery);

--- a/core/modules/views/js/bulk_form.js
+++ b/core/modules/views/js/bulk_form.js
@@ -1,5 +1,7 @@
 (function ($) {
 
+"use strict";
+
 Backdrop.behaviors.viewsBulkForm = {
   attach: function(context) {
     $('.views-form', context).each(function() {
@@ -111,8 +113,8 @@ Backdrop.viewsBulkForm.initGenericBehaviors = function(form) {
       var table = $(this).closest('table')[0];
       if (table) {
         // If there's a "select all" row, hide it.
-        if ($('.bulk-form-table-select-this-page', table).length) {
-          $('.bulk-form-views-table-row-select-all', table).hide();
+        if ($('.views-select-all-pages--row', table).length) {
+          $('.views-select-all-pages--row', table).hide();
           // Disable "select all across pages".
           Backdrop.viewsBulkForm.tableSelectThisPage(form);
         }

--- a/core/modules/views/templates/views.theme.inc
+++ b/core/modules/views/templates/views.theme.inc
@@ -1234,9 +1234,9 @@ function theme_views_container($variables) {
 }
 
 /**
- * Default theme function for the Bulk Operations select all rows in view.
+ * Default theme function for selecting all rows in view for bulk operations.
  */
-function theme_bulk_operations_select_all(&$variables) {
+function theme_views_select_all_pages(&$variables) {
   $view = $variables['view'];
   $enable_select_all_pages = $variables['enable_select_all_pages'];
   $build_array = array();
@@ -1248,84 +1248,84 @@ function theme_bulk_operations_select_all(&$variables) {
     // Provide hidden markup that will be shown as needed on the first row
     // of the table.
     $this_page_count = format_plural(count($view->result), '1 row', '@count rows');
-    $this_page = t('Selected <strong>!row_count</strong> in this page.', array('!row_count' => $this_page_count));
+    $this_page = t('Selected <strong>!row_count</strong> on this page.', array('!row_count' => $this_page_count));
     $all_pages_count = format_plural($view->total_rows, '1 row', '@count rows');
-    $all_pages = t('Selected <strong>!row_count</strong> in this view.', array('!row_count' => $all_pages_count));
-    $build_array['bulk_form_select_all_pages_wrapper'] = array(
+    $all_pages = t('Selected <strong>!row_count</strong> on all pages.', array('!row_count' => $all_pages_count));
+    $build_array['select_all_pages_wrapper'] = array(
       '#type' => 'container',
       '#tree' => FALSE,
       '#attributes' => array(
         'class' => array(
-          'bulk-form-table-select-all-markup'
+          'views-select-all-pages--wrapper'
         ),
       ),
     );
-    $build_array['bulk_form_select_all_pages_wrapper']['bulk_form_select_all_pages'] = array(
+    $build_array['select_all_pages_wrapper']['select_all_pages'] = array(
       '#type' => 'button',
       '#attributes' => array(
         'class' => array(
-          'bulk-form-table-select-all-pages',
+          'views-select-all-pages--all-pages-button',
         ),
       ),
-      '#value' => t('Select all !row_count in this view.', array('!row_count' => $all_pages_count)),
-      '#prefix' => '<span class="bulk-form-table-this-page">' . $this_page . ' &nbsp;',
+      '#value' => t('Select all !row_count on all pages', array('!row_count' => $all_pages_count)),
+      '#prefix' => '<span class="views-select-all-pages--this-page">' . $this_page . ' &nbsp;',
       '#suffix' => '</span>',
     );
-    $build_array['bulk_form_select_all_pages_wrapper']['bulk_form_select_this_page'] = array(
+    $build_array['select_all_pages_wrapper']['select_this_page'] = array(
       '#type' => 'button',
       '#attributes' => array(
         'class' => array(
-          'bulk-form-table-select-this-page',
+          'views-select-all-pages--this-page-button',
         ),
       ),
-      '#value' => t('Select only !row_count in this page.', array('!row_count' => $this_page_count)),
-      '#prefix' => '<span class="bulk-form-table-all-pages" style="display: none">' . $all_pages . ' &nbsp;',
+      '#value' => t('Select only !row_count on this page', array('!row_count' => $this_page_count)),
+      '#prefix' => '<span class="views-select-all-pages--all-pages" style="display: none">' . $all_pages . ' &nbsp;',
       '#suffix' => '</span>',
     );
   }
   else {
     $this_page_count = format_plural(count($view->result), '1 item', '@count items');
     $all_pages_count = format_plural($view->total_rows, '1 item', '@count items');
-    $build_array['bulk_form_select_all'] = array(
+    $build_array['select_all_pages'] = array(
       '#type' => 'fieldset',
       '#attributes' => array(
         'class' => array(
-          'bulk-form-fieldset-select-all',
-          'bulk-form-select-all-markup'
+          'views-select-all-pages--fieldset',
+          'views-select-all-pages--wrapper'
         ),
       ),
     );
-    $build_array['bulk_form_select_all']['this_page'] = array(
+    $build_array['select_all_pages']['this_page'] = array(
       '#type' => 'checkbox',
       '#title' => t('Select !this_page_count on this page', array('!this_page_count' => $this_page_count)),
       '#default_value' => '',
       '#attributes' => array(
         'class' => array(
-          'bulk-form-select-this-page',
+          'views-select-all-pages--this-page-checkbox',
         ),
       ),
       // Since this build array is not form-processed, we supply a unique id so
       // that the label contains a "for" attribute, making it clickable.
-      '#id' => backdrop_html_id('bulk-form-select-this-page'),
+      '#id' => backdrop_html_id('views-select-all-pages--this-page-checkbox'),
     );
 
     if ($enable_select_all_pages) {
-      $build_array['bulk_form_select_all']['or'] = array(
+      $build_array['select_all_pages']['or'] = array(
         '#type' => 'markup',
         '#markup' => '<em>' . t('or') . '</em>',
       );
-      $build_array['bulk_form_select_all']['all_pages'] = array(
+      $build_array['select_all_pages']['all_pages'] = array(
         '#type' => 'checkbox',
-        '#title' => t('Select !all_pages_count on all pages', array('!all_pages_count' => $all_pages_count)),
+        '#title' => t('Select @count on all pages', array('@count' => $all_pages_count)),
         '#default_value' => '',
         '#attributes' => array(
           'class' => array(
-            'bulk-form-select-all-pages',
+            'views-select-all-pages--all-pages-checkbox',
           ),
         ),
         // Since this build array is not form-processed, we supply a unique id so
         // that the label contains a "for" attribute, making it clickable.
-        '#id' => backdrop_html_id('bulk-form-select-all-pages'),
+        '#id' => backdrop_html_id('views-select-all-pages--all-pages-checkbox'),
       );
     }
   }

--- a/core/modules/views/tests/handlers/views_handler_field_bulk_form.test
+++ b/core/modules/views/tests/handlers/views_handler_field_bulk_form.test
@@ -293,7 +293,7 @@ class ViewsHandlerFieldBulkFormTest extends ViewsSqlTest {
     // Submit the form to select all pages and execute unpublish action.
     $data = array(
       'action' => 'node_unpublish_action',
-      'bulk_form_select_all_pages_flag' => 1,
+      'select_all_pages' => 1,
     );
     $this->backdropPost('test-bulk-form', $data, 'Execute');
 

--- a/core/modules/views/views.module
+++ b/core/modules/views/views.module
@@ -176,7 +176,7 @@ function views_theme($existing, $type, $theme, $path) {
     'file' => 'templates/views.theme.inc',
   );
 
-  $hooks['bulk_operations_select_all'] = $base + array(
+  $hooks['views_select_all_pages'] = $base + array(
     'variables' => array('view' => NULL, 'enable_select_all_pages' => TRUE),
     'file' => 'views.theme.inc',
   );


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7038

Re-namespaces everything related to the new bulk form "Select all pages" functionality to be under `select_all_pages` (PHP side) or `views-select-all-pages--*` (CSS).

This initial PR might break some things, it's not fully tested but it's exploring the direction.