### PR TITLE
Fix two typos and a variable name in ConfigDatabaseStorage.

### DIFF
--- a/core/includes/config.inc
+++ b/core/includes/config.inc
@@ -1392,7 +1392,7 @@ class ConfigDatabaseStorage implements ConfigStorageInterface {
           'type' => 'int',
           'not null' => TRUE,
           'default' => 0,
-          'description' => 'The timestamp this config item was last changed',
+          'description' => 'The timestamp this config item was last changed.',
         ),
       ),
       'primary key' => array('name'),
@@ -1433,7 +1433,7 @@ class ConfigDatabaseStorage implements ConfigStorageInterface {
   }
 
   /**
-   * Create the database table if does not already exist.
+   * Create the database table if it does not already exist.
    *
    * @return bool
    *   TRUE on success, FALSE in case of an error.
@@ -1545,7 +1545,7 @@ class ConfigDatabaseStorage implements ConfigStorageInterface {
         ->execute();
     }
     catch (\Exception $e) {
-      throw new ConfigStorageException('Failed to write configuration to the database: ' . $this->$name, 0, $e);
+      throw new ConfigStorageException('Failed to write configuration to the database: ' . $name, 0, $e);
     }
     return TRUE;
   }


### PR DESCRIPTION
Fixes backdrop/backdrop-issues#7051:

- Add a period to the database description of the `changed` field.
- Change "if does not" to "if it does not" in the docblock of `initializeStorage()`
- Use `$name` instead of `$this->$name` in the exception thrown by `write()`.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
