### PR TITLE
Issue #7052: Exclude comments in listings from disabled content types.

### DIFF
--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1497,6 +1497,43 @@ function comment_node_search_result(Node $node) {
 }
 
 /**
+ * Implements hook_query_TAG_alter().
+ *
+ * Lists of comments (such as at admin/content/comment) are always tied to
+ * queries that use the "node_access" tag, since the comments are shown on
+ * node paths. Alter node access queries to hide comments when they are disabled
+ * at the node type level.
+ */
+function comment_query_node_access_alter(QueryAlterableInterface $query) {
+  $comment_alias = FALSE;
+  $node_alias = FALSE;
+
+  foreach ($query->getTables() as $alias => $table) {
+    if ($table['table'] == 'comment') {
+      $comment_alias = $alias;
+    }
+    elseif ($table['table'] == 'node') {
+      $node_alias = $alias;
+    }
+  }
+
+  if ($comment_alias && $node_alias) {
+    $node_types = node_type_get_types();
+
+    $excluded_content_types = array();
+    foreach ($node_types as $type_name => $node_type) {
+      if (empty($node_type->settings['comment_enabled'])) {
+        $excluded_content_types[] = $type_name;
+      }
+    }
+
+    if ($excluded_content_types) {
+      $query->condition($node_alias . '.type', array($excluded_content_types), 'NOT IN');
+    }
+  }
+}
+
+/**
  * Implements hook_user_cancel().
  */
 function comment_user_cancel($edit, $account, $method) {

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2141,6 +2141,7 @@ class CommentFieldsTest extends CommentHelperCase {
       'administer fields',
       'administer content types',
       'administer comment settings',
+      'administer comments',
     ));
     $this->backdropLogin($this->admin_user);
 
@@ -2178,17 +2179,39 @@ class CommentFieldsTest extends CommentHelperCase {
     $this->assertLink(t('Comment fields'));
     $this->assertLink(t('Comment display'));
 
-    // Create nodes of each type.
+    // Create a few test nodes on which comments can be posted.
     $book_node = $this->backdropCreateNode(array('type' => 'book'));
+    $post_node = $this->backdropCreateNode(array('type' => 'post'));
 
     $this->backdropLogout();
 
-    // Try to post a comment on each node. A failure will be triggered if the
-    // comment body is missing on one of these forms, due to postComment()
+    // Try to post a comment on the book node. A failure will be triggered if
+    // the comment body is missing on one of these forms, due to postComment()
     // asserting that the body is actually posted correctly.
     $this->web_user = $this->backdropCreateUser(array('access content', 'access comments', 'post comments', 'skip comment approval'));
     $this->backdropLogin($this->web_user);
-    $this->postComment($book_node, $this->randomName(), '');
+    $book_comment_value = $this->randomName();
+    $this->postComment($book_node, $book_comment_value);
+
+    // Post an additional comment on a "post" node.
+    $post_comment_value = $this->randomName();
+    $this->postComment($post_node, $post_comment_value);
+
+    $this->backdropLogout();
+    $this->backdropLogin($this->admin_user);
+
+    // Verify comments are shown on admin/content/node.
+    $this->backdropGet('admin/content/comment');
+    $this->assertText($book_comment_value, 'Book comment found');
+    $this->assertText($post_comment_value, 'Post comment found');
+
+    // Disable comments on the book content type and verify the comment is
+    // removed from the listing.
+    $edit = array('comment_enabled' => FALSE);
+    $this->backdropPost('admin/structure/types/manage/book', $edit, t('Save content type'));
+    $this->backdropGet('admin/content/comment');
+    $this->assertNoText($book_comment_value, 'Book comment removed when comments are disabled on book content type');
+    $this->assertText($post_comment_value, 'Post comment still present when comments disabled on book content type');
   }
 
   /**

--- a/core/modules/views/tests/views_ui.test
+++ b/core/modules/views/tests/views_ui.test
@@ -672,7 +672,9 @@ class ViewsUIWizardJumpMenuTestCase extends ViewsUIWizardHelper {
    * Helper function to create a comment and return its expected path.
    */
   function createCommentAndGetPath() {
-    $node = $this->backdropCreateNode();
+    $node = $this->backdropCreateNode(array(
+      'type' => 'post',
+    ));
     /** @var Comment $comment */
     $comment = entity_create('comment', array(
       'cid' => NULL,


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7052

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
