### PR TITLE
Issue #7061: GitHub Workflow is passing even when Backdrop fails to install.

### DIFF
--- a/core/scripts/install.sh
+++ b/core/scripts/install.sh
@@ -111,7 +111,7 @@ if ($options['url']) {
   }
   else {
     print "--url option is invalid. Specify the URL of your site as --url=http://example.com/ or --url=example.com.\n";
-    exit;
+    exit(1);
   }
 }
 unset($options['url']);
@@ -119,7 +119,7 @@ unset($options['url']);
 // Parse the database URL.
 if (empty($options['db-url'])) {
   print "--db-url option is required. Specify one as --db-url=mysql://user:pass@host_name/db_name.\n";
-  exit;
+  exit(1);
 }
 $url = parse_url($options['db-url']);
 
@@ -128,7 +128,7 @@ $url = array_map('urldecode', $url);
 // Check if the driver is set to mysql and report error if it is not.
 if ($url['scheme'] != 'mysql') {
   print "Only mysql connections are supported. Specify one as --db-url=mysql://user:pass@host_name/db_name.\n";
-  exit;
+  exit(1);
 }
 
 $url += array(
@@ -197,7 +197,7 @@ try {
   print "Backdrop installed successfully.\n";
   exit(0);
 }
-catch (Exception $e) {
+catch (Throwable $e) {
   print "An error occurred. Output of installation attempt is as follows:\n";
   print $e->getMessage() . "\n";
   exit(1);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7061

Note this does not actually fix the PHP 7.1 install problem, it's just trying to fix the tests incorrectly passing when they should be failing.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
