### PR TITLE
Issue #7061: Fix broken PHP 7.1 compatibility

### DIFF
--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -451,7 +451,7 @@ abstract class BackdropCacheArray implements ArrayAccess {
    * @param bool $lock
    *   Whether to acquire a lock before writing to cache.
    */
-  protected function set(array $data, $lock = TRUE) {
+  protected function set($data, $lock = TRUE) {// phpcs:ignore
     // Lock cache writes to help avoid stampedes.
     // To implement locking for cache misses, override __construct().
     $lock_name = $this->cid . ':' . $this->bin;

--- a/core/includes/bootstrap.inc
+++ b/core/includes/bootstrap.inc
@@ -451,7 +451,7 @@ abstract class BackdropCacheArray implements ArrayAccess {
    * @param bool $lock
    *   Whether to acquire a lock before writing to cache.
    */
-  protected function set($data, $lock = TRUE) {// phpcs:ignore
+  protected function set($data, $lock = TRUE) { // phpcs:ignore
     // Lock cache writes to help avoid stampedes.
     // To implement locking for cache misses, override __construct().
     $lock_name = $this->cid . ':' . $this->bin;


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7061

Tests run again on 7.1 and, of course, unrelated BareUpgradePathTestCase, was eager to fail. :roll_eyes: 