### PR TITLE
Issue #7060: Fix taxonomy term pages with few nodes displayed.

### DIFF
--- a/core/modules/taxonomy/taxonomy.pages.inc
+++ b/core/modules/taxonomy/taxonomy.pages.inc
@@ -48,6 +48,7 @@ function taxonomy_term_page(TaxonomyTerm $term) {
     '#prefix' => '<div class="term-listing-heading">',
     '#suffix' => '</div>',
     'term' => taxonomy_term_view($term, 'full'),
+    '#weight' => -1,
   );
 
   if ($nids = taxonomy_select_nodes($term->tid, TRUE, $site_config->get('default_nodes_main'))) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7060.