### PR TITLE
Issue #6534: Mark user_filters() and user_build_filter_query() as deprecated

### DIFF
--- a/core/modules/user/user.module
+++ b/core/modules/user/user.module
@@ -3056,7 +3056,9 @@ function user_role_revoke_permissions($role_name, array $permissions = array()) 
 }
 
 /**
- * List user administration filters that can be applied.
+ * Lists user administration filters that can be applied.
+ *
+ * @deprecated since 1.34.0
  */
 function user_filters() {
   $filters = array();
@@ -3110,6 +3112,8 @@ function user_filters() {
  *
  * @param $query
  *   Query object that should be filtered.
+ *
+ * @deprecated since 1.34.0
  */
 function user_build_filter_query(SelectQuery $query) {
   $filters = user_filters();


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/6534

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
