### PR TITLE
Issue #7103: Display 0 value in text fields

### DIFF
--- a/core/modules/field/modules/text/text.module
+++ b/core/modules/field/modules/text/text.module
@@ -355,7 +355,7 @@ function text_field_formatter_view($entity_type, $entity, $field, $instance, $la
     case 'text_default':
     case 'text_trimmed':
       foreach ($items as $delta => $item) {
-        if (empty($item['value'])) {
+        if (!isset($item['value']) || $item['value'] === '') {
           continue;
         }
         $output = _text_sanitize($instance, $langcode, $item, 'value');


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7103

Fixes empty checking value not showing 0 value in text fields.