### PR TITLE
Issue #7120: Make sure selectable event is not lost when using pager in dialog

### DIFF
--- a/core/modules/file/js/file.js
+++ b/core/modules/file/js/file.js
@@ -174,10 +174,10 @@ Backdrop.file = Backdrop.file || {
    */
   dialogOpenEvent: function(e, dialog, $element, settings) {
     var $browserContainer = $element.find(".file-browser");
-    var $viewContent = $element.find(".view-content");
     var fieldCardinality = parseInt(Backdrop.settings.file.browser.fieldCardinality);
     if (fieldCardinality != 1) {
-      $viewContent.selectable({
+      $browserContainer.selectable({
+        filter: '.image-library-choose-file',
         classes: {
           "ui-selected": "image-library-image-selected"
         },

--- a/core/modules/file/js/file.js
+++ b/core/modules/file/js/file.js
@@ -174,7 +174,6 @@ Backdrop.file = Backdrop.file || {
    */
   dialogOpenEvent: function(e, dialog, $element, settings) {
     var $browserContainer = $element.find(".file-browser");
-    var fieldCardinality = parseInt(Backdrop.settings.file.browser.fieldCardinality);
     let fieldCardinality = 1;
     if (typeof Backdrop.settings.file !== 'undefined') {
       fieldCardinality = parseInt(Backdrop.settings.file.browser.fieldCardinality);

--- a/core/modules/file/js/file.js
+++ b/core/modules/file/js/file.js
@@ -178,14 +178,14 @@ Backdrop.file = Backdrop.file || {
     if (typeof Backdrop.settings.file !== 'undefined') {
       fieldCardinality = parseInt(Backdrop.settings.file.browser.fieldCardinality);
     }
-    if (fieldCardinality != 1) {
+    if (fieldCardinality !== 1) {
       $browserContainer.selectable({
         filter: '.image-library-choose-file',
         classes: {
           "ui-selected": "image-library-image-selected"
         },
         selecting: function(event, ui) {
-          if (fieldCardinality == -1) {
+          if (fieldCardinality === -1) {
             return false;
           }
           else if ($(".image-library-choose-file.ui-selecting").length > fieldCardinality) {
@@ -201,14 +201,14 @@ Backdrop.file = Backdrop.file || {
             fids.push($(this).children("img").data("fid"));
           });
           // Set the FID in the modal submit form.
-          $('form.file-managed-file-browser-form [name="fid"]').val(fids.join(' '));
-        }  
+          $('form.file-managed-file-browser-form [name="fid"]').val(fids.join(','));
+        }
       });
     }
     else {
       $browserContainer.once('file-browser').on('click', '[data-fid]', function () {
         var $selectedElement = $(this);
-        if ($selectedElement.is('img') && fieldCardinality==1) {
+        if ($selectedElement.is('img') && fieldCardinality === 1) {
           $browserContainer.find('.image-library-image-selected').removeClass('image-library-image-selected');
           $selectedElement.parent('.image-library-choose-file').addClass('image-library-image-selected');
         }
@@ -230,7 +230,7 @@ Backdrop.file = Backdrop.file || {
   },
 
   /**
-   * After closing a dialog, check if the file ID needs to be updated..
+   * After closing a dialog, check if the file ID needs to be updated.
    */
   dialogCloseEvent: function(e, dialog, $element) {
     var $browserContainer = $element.find(".file-browser");


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7120

Turns out, jQuery UI provides what we need: A filter, so we don't have to use the immediate parent (which gets replaced on pager click).