### PR TITLE
Issue #404: allow Pager to use SQL_CALC_FOUND_ROWS

### DIFF
--- a/core/includes/bootstrap.classes.inc
+++ b/core/includes/bootstrap.classes.inc
@@ -113,6 +113,7 @@ function backdrop_class_list() {
     'InsertQuery_mysql' => $path . 'database/mysql/query.inc',
     'TruncateQuery_mysql' => $path . 'database/mysql/query.inc',
     'DatabaseSchema_mysql' => $path . 'database/mysql/schema.inc',
+    'PagerDefault_mysql' => $path . 'database/mysql/pager.inc',
 
     'FileTransfer' => $path . 'filetransfer/filetransfer.inc',
     'FileTransferException' => $path . 'filetransfer/filetransfer.inc',

--- a/core/includes/database/mysql/pager.inc
+++ b/core/includes/database/mysql/pager.inc
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @file
+ * Functions to aid in presenting mysql database results as a set of pages.
+ */
+
+
+/**
+ * Query extender for mysql pager queries.
+ *
+ * This is the mysql specific pager mechanism. It creates a paged query with a
+ * fixed number of entries per page and simultaneously counts the total number
+ * of rows.
+ */
+class PagerDefault_mysql extends PagerDefault {
+
+  /**
+   * Override the execute method.
+   *
+   * Before we run the query, we need to add pager-based range() instructions
+   * to it.
+   */
+  public function execute() {
+    global $pager_page_array, $pager_total, $pager_total_items, $pager_limits;
+
+    // Add convenience tag to mark that this is an extended query. We have to
+    // do this in the constructor to ensure that it is set before preExecute()
+    // gets called.
+    if (!$this->preExecute($this)) {
+      return NULL;
+    }
+
+    // A NULL limit is the "kill switch" for pager queries.
+    if (empty($this->limit)) {
+      return;
+    }
+    $this->ensureElement();
+
+    $page = isset($_GET['page']) ? $_GET['page'] : '';
+
+    // Convert comma-separated $page to an array, used by other functions.
+    $pager_page_array = explode(',', $page);
+
+    if (!isset($pager_page_array[$this->element])) {
+      $pager_page_array[$this->element] = 0;
+    }
+
+    // Rather than rely on the countQuery, add a query hint to prepare for a
+    // FOUND_ROWS() call a bit later on. That means we don't need to load the
+    // entire table index twice, which should see a nice speed increase when
+    // paging through large tables, esepecially on InnoDB.
+    $this->query->setHints('SQL_CALC_FOUND_ROWS');
+
+    // We usually calculate the total number of pages as ceil(items / limit) but
+    // now that we don't run a countQuery, we don't know the total number of
+    // rows before running the pager_query. For now we assume that the total
+    // items is the current page number multiplied by the limit. We recalculate
+    // when we know the correct total number.
+    $this->range((int) $page * $this->limit, $this->limit);
+
+    // Now that we've added our pager-based range instructions, run the query
+    // normally.
+    $result = $this->query->execute();
+
+    // And now we can fetch the total number of results, had there not been
+    // a range.
+    $pager_total_items[$this->element] = $this->connection->query('SELECT FOUND_ROWS()')->fetchField();
+
+    // This does unfortunately mean that a user can override the page variable
+    // in the query string and end up with an empty pager. Previously this would
+    // make this default to the last page. We can emulate this behaviour by
+    // checking the total number of rows returned and re-run an adjusted query
+    // in that case.
+    //
+    // What we do now is check if our query range was out of bounds, which can
+    // happen if the user manually overrode the page variable in the query
+    // string. If no rows were returned and if we're not looking at the first
+    // page of this pager, adjust the range to return the last page of results
+    // only, just as we would normally do.
+    if (((int) $page * $this->limit) > $pager_total_items[$this->element] && (int) $page) {
+      // Calculate the new range and re-run the pager query to return the last
+      // page of results.
+      $page_max = ceil($pager_total_items[$this->element] / $this->limit) - 1;
+      $this->range($page_max * $this->limit, $this->limit);
+      // No need to re-count all rows, so remove the hint.
+      $this->query->setHints('');
+      $result = $this->query->execute();
+    }
+
+    // Redo the page number calculation, because we now know the total humber of results.
+    $pager_total[$this->element] = ceil($pager_total_items[$this->element] / $this->limit);
+    $pager_page_array[$this->element] = max(0, min((int)$pager_page_array[$this->element], ((int)$pager_total[$this->element]) - 1));
+    $pager_limits[$this->element] = $this->limit;
+
+    return $result;
+  }
+}

--- a/core/includes/database/mysql/pager.inc
+++ b/core/includes/database/mysql/pager.inc
@@ -1,10 +1,8 @@
 <?php
-
 /**
  * @file
  * Functions to aid in presenting mysql database results as a set of pages.
  */
-
 
 /**
  * Query extender for mysql pager queries.
@@ -40,7 +38,7 @@ class PagerDefault_mysql extends PagerDefault {
     $page = isset($_GET['page']) ? $_GET['page'] : '';
 
     // Convert comma-separated $page to an array, used by other functions.
-    $pager_page_array = explode(',', $page);
+    $pager_page_array = array_map('intval', explode(',', $page));
 
     if (!isset($pager_page_array[$this->element])) {
       $pager_page_array[$this->element] = 0;
@@ -49,7 +47,7 @@ class PagerDefault_mysql extends PagerDefault {
     // Rather than rely on the countQuery, add a query hint to prepare for a
     // FOUND_ROWS() call a bit later on. That means we don't need to load the
     // entire table index twice, which should see a nice speed increase when
-    // paging through large tables, esepecially on InnoDB.
+    // paging through large tables, especially on InnoDB.
     $this->query->setHints('SQL_CALC_FOUND_ROWS');
 
     // We usually calculate the total number of pages as ceil(items / limit) but
@@ -88,9 +86,10 @@ class PagerDefault_mysql extends PagerDefault {
       $result = $this->query->execute();
     }
 
-    // Redo the page number calculation, because we now know the total humber of results.
+    // Redo the page number calculation, because we now know the total number of
+    // results.
     $pager_total[$this->element] = ceil($pager_total_items[$this->element] / $this->limit);
-    $pager_page_array[$this->element] = max(0, min((int)$pager_page_array[$this->element], ((int)$pager_total[$this->element]) - 1));
+    $pager_page_array[$this->element] = max(0, min((int) $pager_page_array[$this->element], ((int) $pager_total[$this->element]) - 1));
     $pager_limits[$this->element] = $this->limit;
 
     return $result;

--- a/core/includes/database/mysql/query.inc
+++ b/core/includes/database/mysql/query.inc
@@ -51,6 +51,9 @@ class InsertQuery_mysql extends InsertQuery {
     // Create a sanitized comment string to prepend to the query.
     $comments = $this->connection->makeComment($this->comments);
 
+    // Create a hints string to include in the query.
+    $hints = (!empty($this->hints)) ? $this->hints . ' ' : '';
+
     // Default fields are always placed first for consistency.
     $insert_fields = array_merge($this->defaultFields, $this->insertFields);
 
@@ -63,10 +66,10 @@ class InsertQuery_mysql extends InsertQuery {
     // pass it back, as any remaining options are irrelevant.
     if (!empty($this->fromQuery)) {
       $insert_fields_string = $insert_fields ? ' (' . implode(', ', $insert_fields) . ') ' : ' ';
-      return $comments . 'INSERT INTO {' . $this->table . '}' . $insert_fields_string . $this->fromQuery;
+      return $comments . 'INSERT ' . $hints . 'INTO {' . $this->table . '} ' . $insert_fields_string . ' ' . $this->fromQuery;
     }
 
-    $query = $comments . 'INSERT INTO {' . $this->table . '} (' . implode(', ', $insert_fields) . ') VALUES ';
+    $query = $comments . 'INSERT ' . $hints . 'INTO {' . $this->table . '} (' . implode(', ', $insert_fields) . ') VALUES ';
 
     $max_placeholder = 0;
     $values = array();

--- a/core/includes/database/query.inc
+++ b/core/includes/database/query.inc
@@ -327,6 +327,13 @@ abstract class Query implements QueryPlaceholderInterface {
   protected $comments = array();
 
   /**
+   * Query hints or flags that can be set on a query.
+   *
+   * @var string
+   */
+  protected $hints = '';
+
+  /**
    * Constructs a Query object.
    *
    * @param DatabaseConnection $connection
@@ -342,6 +349,20 @@ abstract class Query implements QueryPlaceholderInterface {
     $this->connectionTarget = $this->connection->getTarget();
 
     $this->queryOptions = $options;
+  }
+
+  /**
+   * Sets the hints or flags on a query.
+   *
+   * Hints and flags directly affect the way in which the query is run
+   * on the database server. Their syntax is database specific, so they
+   * should be used internally in database-specific classes only.
+   *
+   * @param string $hints
+   *   The hint string to be inserted into the query.
+   */
+  public function setHints($hints) {
+    $this->hints = $hints;
   }
 
   /**

--- a/core/includes/database/select.inc
+++ b/core/includes/database/select.inc
@@ -1951,8 +1951,11 @@ class SelectQuery extends Query implements SelectQueryInterface {
     // Create a sanitized comment string to prepend to the query.
     $comments = $this->connection->makeComment($this->comments);
 
+    // Create a hints string to include in the query.
+    $hints = (!empty($this->hints)) ? $this->hints . ' ' : '';
+
     // SELECT:
-    $query = $comments . 'SELECT ';
+    $query = $comments . 'SELECT ' . $hints;
     if ($this->distinct) {
       $query .= 'DISTINCT ';
     }


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/404

I haven't done any testing or figured out if I've got all the pieces for implementing from the d7 issue https://www.drupal.org/project/drupal/issues/778050.

Update: partially working. Going past the first page is a fatal error with a negative `OFFSET` in a comment query, when testing on Search. Doesn't seem to be called with Views so this might have limited applicability.