### PR TITLE
Issue #7149. CKeditor flash of html on submit

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -121,7 +121,10 @@
 
       // Destroy the instance if fully detaching.
       if (trigger !== 'serialize') {
-        editor.destroy();
+        // Prevent flash of HTML from being seen by user when the form is submitted.
+        if (!Backdrop.settings.formIsSubmitting) {          
+          editor.destroy();
+        }
         Backdrop.ckeditor5.instances.delete(editor.id);
         delete element.ckeditor5AttachedEditor;
         delete element.ckeditor5Processed;

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -80,6 +80,7 @@ Backdrop.behaviors.filterEditors = {
         if (event.isDefaultPrevented()) {
           return;
         }
+        Backdrop.settings.formIsSubmitting = true;
         Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor]);
       });
     });


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7149

Video of it working now (see original issue for video of problem):

[ckeditor_html_no_flash.webm](https://github.com/user-attachments/assets/e8e260e8-5914-42f4-b9a9-e87f231868f6)

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
