### PR TITLE
Issue 7148 - Change text field to the fallback text format if we lose access or if the format gets deleted

### DIFF
--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -1424,35 +1424,14 @@ function filter_process_format($element) {
     // user only has access to a single format).
     $element['format']['format']['#access'] = TRUE;
   }
-  // Disable this widget, if the user is not allowed to use the stored format,
+  // Convert to our fallback text format if the user is not allowed to use the stored format,
   // or if the stored format does not exist, and only if the field is not empty.
   // The 'administer filters' permission only grants access to the filter
   // administration, not to all formats.
   elseif (!$user_has_access || !$format_exists) {
     if (!empty($element['#default_value'])) {
-      // Overload default values into #value to make them unalterable.
-      $element['value']['#value'] = $element['value']['#default_value'];
-      $element['format']['format']['#value'] = $element['format']['format']['#default_value'];
-
-      // Prepend #pre_render callback to replace field value with user notice
-      // prior to rendering.
-      $element['value'] += array('#pre_render' => array());
-      array_unshift($element['value']['#pre_render'], 'filter_form_access_denied');
-
-      // Cosmetic adjustments.
-      if (isset($element['value']['#rows'])) {
-        $element['value']['#rows'] = 3;
-      }
-      $element['value']['#disabled'] = TRUE;
-      $element['value']['#resizable'] = 'none';
-
-      // Hide the text format selector and any other child element (such as text
-      // field's summary).
-      foreach (element_children($element) as $key) {
-        if ($key != 'value') {
-          $element[$key]['#access'] = FALSE;
-        }
-      }
+      $element['format']['format']['#default_value'] = filter_fallback_format();
+      $element['#format'] = filter_fallback_format();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7148

**Current behavior:**  If a text format is deleted or we lose access, we cannot edit the text field/textarea (it becomes disabled) on every node where it was saved with that format.

Video of CURRENT (undesired) behavior:
https://github.com/user-attachments/assets/75fa6be7-b85e-4f68-96ff-45014006437e


**New behavior with this PR:** In this condition, the element's format is switched to the "fallback" format and does not get disabled.

Video of new (desired) behavior with this PR in place:
https://github.com/user-attachments/assets/66c906ce-c7d0-4519-806a-0ce13ddaf4be


<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
