### PR TITLE
Issue #7154: Fix breaking date filters by reverting 6976

### DIFF
--- a/core/modules/date/date.elements.inc
+++ b/core/modules/date/date.elements.inc
@@ -142,12 +142,12 @@ function _date_element_info() {
  */
 function date_default_date($element) {
   $granularity = date_format_order($element['#date_format']);
-  $default_value = is_array($element['#default_value']) ? reset($element['#default_value']) : $element['#default_value'];
+  $default_value = $element['#default_value'];
   $format = DATE_FORMAT_DATETIME;
 
   // The text and popup widgets might return less than a full datetime string.
-  if (strlen((string) $default_value) < 19) {
-    switch (strlen((string) $default_value)) {
+  if (strlen($element['#default_value']) < 19) {
+    switch (strlen($element['#default_value'])) {
       case 16:
         $format = 'Y-m-d H:i';
         break;

--- a/core/modules/date/views/date_views_filter_handler.inc
+++ b/core/modules/date/views/date_views_filter_handler.inc
@@ -143,15 +143,7 @@ class date_views_filter_handler extends date_views_filter_handler_simple {
     $widget_options = $this->widget_options();
     // If the filter is exposed, display the granularity.
     if ($this->options['exposed']) {
-      $summary = t('(@field) <strong>Exposed</strong> @widget @format', array(
-        '@field' => $field,
-        '@format' => $parts[$handler->granularity],
-        '@widget' => $widget_options[$this->options['form_type']],
-      ));
-      if (!empty($this->options['value']['type']) && $this->options['value']['type'] == 'relative') {
-        $summary .= ' ' . t('(Relative)');
-      }
-      return $summary;
+      return t('(@field) <strong>Exposed</strong> @widget @format', array('@field' => $field, '@format' => $parts[$handler->granularity], '@widget' => $widget_options[$this->options['form_type']]));
     }
     // If not exposed, display the value.
     if (in_array($this->operator, $this->operator_values(2))) {
@@ -161,9 +153,6 @@ class date_views_filter_handler extends date_views_filter_handler_simple {
     }
     else {
       $output .= check_plain(!empty($this->options['default_date']) ? $this->options['default_date'] : $this->options['value']['value']);
-    }
-    if (!empty($this->options['value']['type']) && $this->options['value']['type'] == 'relative') {
-      $output .= ' ' . t('(Relative)');
     }
     return $output;
   }

--- a/core/modules/date/views/date_views_filter_handler_simple.inc
+++ b/core/modules/date/views/date_views_filter_handler_simple.inc
@@ -21,11 +21,6 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
   protected $base_table;
 
   /**
-   * @var int
-   */
-  public $element_number = 1;
-
-  /**
    * @var views_plugin_query_default
    */
   var $query;
@@ -77,15 +72,7 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
    */
   function date_default_value($prefix, $options = NULL) {
     if (empty($options)) {
-      if ($this->options['is_grouped']) {
-        if ('All' == $this->options['group_info']['default_group']) {
-          return '';
-        }
-        $options = $this->options['group_info']['group_items'][$this->options['group_info']['default_group']]['value'][$prefix . '_group'];
-      }
-      else {
-        $options = $this->options;
-      }
+      $options = $this->options;
     }
     // If this is a remembered value, use the value from the SESSION.
     if (!empty($this->options['expose']['remember'])) {
@@ -95,19 +82,18 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
       }
     }
 
+    // This is a date that needs to be constructed from options like 'now' .
     $default_option = $prefix == 'max' ? $options['default_to_date'] : $options['default_date'];
-    $is_relative = ($this->options['is_grouped'] && isset($options[$prefix . '_choose_input_type']) && $options[$prefix . '_choose_input_type'] == 'relative') || (!empty($this->options['value']['type']) && $this->options['value']['type'] == 'relative');
-    if ($is_relative) {
-      $default_date = $default_option;
+    if (!empty($default_option)) {
+      str_replace('now', 'today', $default_option);
+      $date = date_create($default_option, date_default_timezone_object());
+      $default_date = !empty($date) ? $date->format($this->format) : '';
+
+      // The format for our filter is in ISO format, but the widget will need it in datetime format.
+      $default_date = str_replace('T', ' ', $default_date);
     }
-    // This a fixed date.
     else {
-      if ($this->options['is_grouped']) {
-        $default_date = empty($options[$prefix]) ? '' : $options[$prefix];
-      }
-      else {
-        $default_date = isset($options['value'][$prefix]) ? $options['value'][$prefix] : '';
-      }
+      $default_date = isset($options['value'][$prefix]) ? $options['value'][$prefix] : '';
     }
     return $default_date;
   }
@@ -123,155 +109,24 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     // All our date widgets provide datetime values but we use ISO in our SQL
     // for consistency between the way filters and arguments work (arguments
     // cannot contain spaces).
-
-    // If this is a relative date, we need to convert it to an absolute date.
-    // If this input comes from a group, we then must check if it's a relative
-    // string before sending it to the database.
-    $is_relative = ($this->options['value']['type'] == 'relative' || $this->options['is_grouped']);
-
-    if ($is_relative && !empty($input)) {
-      if (is_array($input)) {
-        // Find the first non-empty value in the array.
-        $flattened = array_filter($input);
-        $input = !empty($flattened) ? reset($flattened) : '';
-      }
-      if (is_string($input)) {
-        $input = trim($input);
-      }
-      if (is_string($input) && $input !== '') {
-        $date = date_create($input, date_default_timezone_object());
-        if ($date) {
-          $input = $date->format($this->format);
-        }
-      }
-    }
-
-    if (!isset($input) || $input === '') {
-      $prefix_val = $this->date_default_value($prefix);
-      if (is_null($prefix_val)) {
-        $prefix_val = '';
-      }
+    if (empty($input)) {
       if (empty($this->options['exposed'])) {
-        if (is_array($prefix_val)) {
-          $prefix_val = reset($prefix_val);
-        }
-        return str_replace(' ', 'T', (string) $prefix_val);
+        return str_replace(' ', 'T', $this->date_default_value($prefix));
       }
-      // If it's exposed and we have input for this identifier, it means
-      // the user explicitly submitted an empty value.
-      elseif (isset($this->view->exposed_raw_input[$this->options['expose']['identifier']])) {
-        return '';
-      }
-      elseif ($this->options['is_grouped'] && isset($this->view->exposed_raw_input[$this->options['group_info']['identifier']])) {
-        $identifier = $this->view->exposed_raw_input[$this->options['group_info']['identifier']];
-        $group_item = $this->options['group_info']['group_items'][$identifier];
-        $options = $group_item['value'][$prefix . '_group'];
-        $prefix_val = $this->date_default_value($prefix, $options);
-
-        // If the group item is configured as a relative date, resolve it here.
-        $is_item_relative = (isset($options[$prefix . '_choose_input_type']) &&
-          $options[$prefix . '_choose_input_type'] == 'relative');
-        if ($is_item_relative && !empty($prefix_val)) {
-          if (is_array($prefix_val)) {
-            $flattened = array_filter($prefix_val);
-            $prefix_val = !empty($flattened) ? reset($flattened) : '';
-          }
-          if (is_string($prefix_val) && $prefix_val !== '') {
-            $date = date_create($prefix_val, date_default_timezone_object());
-            if ($date) {
-              $prefix_val = $date->format($this->format);
-            }
-          }
-        }
-
-        if (is_array($prefix_val)) {
-          $prefix_val = reset($prefix_val);
-        }
-        return str_replace(' ', 'T', (string) $prefix_val);
-      }
-      elseif (isset($this->options['expose']['identifier']) && !isset($this->view->exposed_raw_input[$this->options['expose']['identifier']]['value'])) {
-        if (is_array($prefix_val)) {
-          $prefix_val = reset($prefix_val);
-        }
-        return str_replace(' ', 'T', (string) $prefix_val);
+      elseif (isset($this->options['expose']['identifier']) && !isset($_GET[$this->options['expose']['identifier']])) {
+        return str_replace(' ', 'T', $this->date_default_value($prefix));
       }
     }
 
-    if (is_array($input)) {
-      $flattened = array_filter($input);
-      $input = !empty($flattened) ? reset($flattened) : '';
-    }
-
-    return str_replace(' ', 'T', (string) $input);
+    return str_replace(' ', 'T', $input);
   }
 
   function accept_exposed_input($input) {
     if (!empty($this->options['exposed'])) {
-      $identifier = $this->options['expose']['identifier'];
-
-      // If there is no input for this filter, and it is not a grouped filter,
-      // or if it's a grouped filter and there is no input for the group info,
-      // it's a "cold start" (initial view load).
-      $is_cold_start = FALSE;
-      if ($this->options['is_grouped']) {
-        if (!isset($input[$this->options['group_info']['identifier']])) {
-          $is_cold_start = TRUE;
-        }
-      }
-      else {
-        if (!isset($input[$identifier])) {
-          $is_cold_start = TRUE;
-        }
-      }
-
-      if ($is_cold_start) {
-        // Cold start: populate $this->value with configured defaults.
-        if ($this->options['is_grouped']) {
-          // Grouped filters handle their own defaults in parent/logic.
-          return parent::accept_exposed_input($input);
-        }
-        else {
-          foreach (array('value', 'min', 'max') as $key) {
-            $this->value[$key] = $this->date_default_value($key);
-          }
-          return TRUE;
-        }
-      }
-
-      if (!isset($input[$identifier])) {
-        return parent::accept_exposed_input($input);
-      }
-      $element_input = $input[$identifier];
-      if ($this->options['is_grouped']) {
-        foreach (array('value', 'min', 'max') as $key) {
-          $element_input[$key] = '';
-          if (!empty($element_input[$key . '_group'])) {
-            $val = $this->date_default_value($key, $element_input[$key . '_group']);
-            $element_input[$key] = $this->get_filter_value($key, $val);
-          }
-        }
-      }
-      else {
-        $is_relative = ($this->options['value']['type'] == 'relative');
-        $element_input['value'] = isset($element_input['value']) ? $element_input['value'] : '';
-        $element_input['min'] = isset($element_input['min']) ? $element_input['min'] : '';
-        $element_input['max'] = isset($element_input['max']) ? $element_input['max'] : '';
-
-        // Trim input for relative dates to prevent issues with spaces.
-        if ($is_relative) {
-          foreach (array('value', 'min', 'max') as $key) {
-            if (isset($element_input[$key])) {
-              $element_input[$key] = is_array($element_input[$key]) ? reset($element_input[$key]) : $element_input[$key];
-              $element_input[$key] = trim($element_input[$key]);
-            }
-          }
-        }
-        else {
-          $element_input['value'] = $this->get_filter_value('value', $element_input['value']);
-          $element_input['min'] = $this->get_filter_value('min', $element_input['min']);
-          $element_input['max'] = $this->get_filter_value('max', $element_input['max']);
-        }
-      }
+      $element_input = $input[$this->options['expose']['identifier']];
+      $element_input['value'] = $this->get_filter_value('value', !empty($element_input['value']) ? $element_input['value'] : '');
+      $element_input['min'] = $this->get_filter_value('min', !empty($element_input['min']) ? $element_input['min'] : '');
+      $element_input['max'] = $this->get_filter_value('max', !empty($element_input['max']) ? $element_input['max'] : '');
       if (is_array($element_input) && isset($element_input['default_date'])) {
         unset($element_input['default_date']);
       }
@@ -300,16 +155,6 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     $min_comp_date = new BackdropDateTime($min_value, date_default_timezone(), $this->format);
     $max_value = $this->get_filter_value('max', $this->value['max']);
     $max_comp_date = new BackdropDateTime($max_value, date_default_timezone(), $this->format);
-
-    if (is_array($min_value)) {
-      $flattened = array_filter($min_value);
-      $min_value = !empty($flattened) ? reset($flattened) : '';
-    }
-    if (is_array($max_value)) {
-      $flattened = array_filter($max_value);
-      $max_value = !empty($flattened) ? reset($flattened) : '';
-    }
-
     $field_min = $this->date_handler->sql_field($field, NULL, $min_comp_date);
     $field_min = $this->date_handler->sql_format($this->format, $field_min);
     $field_max = $this->date_handler->sql_field($field, NULL, $max_comp_date);
@@ -338,12 +183,6 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
 
     $value = $this->get_filter_value('value', $this->value['value']);
     $comp_date = new BackdropDateTime($value, date_default_timezone(), $this->format);
-
-    if (is_array($value)) {
-      $flattened = array_filter($value);
-      $value = !empty($flattened) ? reset($flattened) : '';
-    }
-
     $field = $this->date_handler->sql_field($field, NULL, $comp_date);
     $field = $this->date_handler->sql_format($this->format, $field);
     $placeholder = $this->placeholder();
@@ -361,12 +200,6 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
 
     $value = $this->get_filter_value('value', $this->value['value']);
     $comp_date = new BackdropDateTime($value, date_default_timezone(), $this->format);
-
-    if (is_array($value)) {
-      $flattened = array_filter($value);
-      $value = !empty($flattened) ? reset($flattened) : '';
-    }
-
     $fields = date_views_fields($this->base_table);
     $fields = $fields['name'];
     $fromto = $fields[$field]['fromto'];
@@ -474,21 +307,13 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     }
 
     if ($which == 'all' || $which == 'value') {
-      $form['value'] += $this->date_parts_form($form_state, 'value', $source, $which, $this->operator_values(1), $identifier, 'default_date', $this->element_number);
+      $form['value'] += $this->date_parts_form($form_state, 'value', $source, $which, $this->operator_values(1), $identifier, 'default_date');
     }
 
     if ($which == 'all' || $which == 'minmax') {
-      $value2 = $this->operator_values(2);
-
-      foreach (array(
-        'min' => 'default_date',
-        'max' => 'default_to_date',
-      ) as $type => $prop) {
-        $form['value'] += $this->date_parts_form($form_state, $type, $source, $which, $value2, $identifier, $prop, $this->element_number);
-      }
+      $form['value'] += $this->date_parts_form($form_state, 'min', $source, $which, $this->operator_values(2), $identifier, 'default_date');
+      $form['value'] += $this->date_parts_form($form_state, 'max', $source, $which, $this->operator_values(2), $identifier, 'default_to_date');
     }
-
-    $this->element_number++;
 
     // Add some extra validation for the select widget to be sure that
     // the user inputs all parts of the date.
@@ -514,10 +339,10 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
    * @param string $relative_id
    *   Form element ID to use for the relative date field.
    *
-   * @return array
+   * @return
    *   The form date part element for this instance.
    */
-  public function date_parts_form(array &$form_state, $prefix, $source, $which, array $operator_values, $identifier, $relative_id, $element_no = 0) {
+  function date_parts_form(&$form_state, $prefix, $source, $which, $operator_values, $identifier, $relative_id) {
     module_load_include('inc', 'date', 'date.elements');
     switch ($prefix) {
       case 'min':
@@ -537,65 +362,21 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     $type = $this->options['form_type'];
     $format = $this->date_handler->views_formats($this->options['granularity'], 'display');
     $granularity = array_keys($this->date_handler->date_parts($this->options['granularity']));
-    $default_date = $this->date_default_value($prefix);
-    $relative_value_key = $prefix == 'max' ? 'default_to_date' : 'default_date';
-    $relative_value = $this->options[$relative_value_key];
+    $relative_value = ($prefix == 'max' ? $this->options['default_to_date'] : $this->options['default_date']);
 
     if (!empty($form_state['exposed'])) {
       // UI when the date selector is exposed.
-      $identifier = $this->options['expose']['identifier'];
-      $is_relative = ($this->options['value']['type'] == 'relative');
-      if ($is_relative) {
-        $default_relative_value = '';
-        if (isset($this->view->exposed_input[$identifier][$prefix]) && is_string($this->view->exposed_input[$identifier][$prefix]) && trim($this->view->exposed_input[$identifier][$prefix]) !== '') {
-          $default_relative_value = trim($this->view->exposed_input[$identifier][$prefix]);
-        }
-        elseif (isset($this->value[$prefix]) && is_string($this->value[$prefix]) && trim($this->value[$prefix]) !== '') {
-          $default_relative_value = trim($this->value[$prefix]);
-        }
-        elseif (!empty($relative_value)) {
-          $default_relative_value = $relative_value;
-        }
-
-        if (is_array($default_relative_value)) {
-          $default_relative_value = reset($default_relative_value);
-        }
-        $form[$prefix] = array(
-          '#type' => 'textfield',
-          '#title' => check_plain($relative_label),
-          '#size' => 20,
-          '#default_value' => (string) $default_relative_value,
-          '#description' => t('Examples: now, now +1 day, 12AM today, Monday next week.'),
-        );
-      }
-      else {
-        $form_default_value = '';
-        if (isset($this->view->exposed_input[$identifier][$prefix]) && $this->view->exposed_input[$identifier][$prefix] !== '') {
-          $form_default_value = $this->view->exposed_input[$identifier][$prefix];
-        }
-        elseif (isset($this->value[$prefix]) && $this->value[$prefix] !== '') {
-          $form_default_value = $this->value[$prefix];
-        }
-        elseif (!empty($default_date)) {
-          $form_default_value = $default_date;
-        }
-
-        if (is_array($form_default_value)) {
-          $flattened = array_filter($form_default_value);
-          $form_default_value = !empty($flattened) ? reset($flattened) : '';
-        }
-
-        $form[$prefix] = array(
-          '#title' => check_plain($label),
-          '#type' => $type,
-          '#size' => 20,
-          '#default_value' => (string) $form_default_value,
-          '#date_format' => date_limit_format($format, $granularity),
-          '#date_label_position' => 'within',
-          '#date_year_range' => $this->options['year_range'],
-          '#process' => array($type . '_element_process'),
-        );
-      }
+      $default_date = $this->date_default_value($prefix);
+      $form[$prefix] = array(
+        '#title' => check_plain($label),
+        '#type' => $type,
+        '#size' => 20,
+        '#default_value' => !empty($this->value[$prefix]) ? $this->value[$prefix] : $default_date,
+        '#date_format' => date_limit_format($format, $granularity),
+        '#date_label_position' => 'within',
+        '#date_year_range' => $this->options['year_range'],
+        '#process' => array($type . '_element_process'),
+      );
       if ($which == 'all') {
         $form[$prefix]['#states']['visible'] = array();
         foreach ($operator_values as $operator) {
@@ -604,7 +385,7 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
           );
         }
       }
-      if (!$is_relative && !isset($form_state['input'][$identifier][$prefix])) {
+      if (!isset($form_state['input'][$identifier][$prefix])) {
         // Handle bogus input from the query string to prevent fatal errors.
         if (isset($form_state['input'][$identifier]) && !is_array($form_state['input'][$identifier])) {
           $form_state['input'][$identifier] = array();
@@ -617,57 +398,30 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     }
     else {
       // UI when the date selector is on the views configuration screen.
-      // Fix for grouped between filter. Input class has to be different
-      // for each group and default value needs to be taken from group item.
-      $input_type_key = $prefix . '_choose_input_type';
-      if ($this->options['is_grouped']) {
-        $source = "#edit-options-group-info-group-items-{$element_no}-operator";
-        $input_class = "$prefix-$element_no-choose-input-type";
-        $default_select_date_value = !empty($this->options['group_info']['group_items'][$element_no]['value'][$prefix . '_group'][$prefix]) ? $this->options['group_info']['group_items'][$element_no]['value'][$prefix . '_group'][$prefix] : $default_date;
-        $relative_value = !empty($this->options['group_info']['group_items'][$element_no]['value'][$prefix . '_group'][$relative_value_key]) ? $this->options['group_info']['group_items'][$element_no]['value'][$prefix . '_group'][$relative_value_key] : $this->options[$relative_value_key];
-        $default_select_date_type = !empty($this->options['group_info']['group_items'][$element_no]['value'][$prefix . '_group'][$input_type_key]) ? $this->options['group_info']['group_items'][$element_no]['value'][$prefix . '_group'][$input_type_key] : 'date';
-      }
-      else {
-        $input_class = "$prefix-choose-input-type";
-        $default_select_date_value = !empty($this->value[$prefix]) ? $this->value[$prefix] : $default_date;
-        $default_select_date_type = !empty($relative_value) ? 'relative' : 'date';
-      }
-
-      if (is_array($default_select_date_value)) {
-        $flattened = array_filter($default_select_date_value);
-        $default_select_date_value = !empty($flattened) ? reset($flattened) : '';
-      }
-
+      $default_date = '';
       $form[$prefix . '_group'] = array(
         '#type' => 'fieldset',
         '#attributes' => array('class' => array('date-views-filter-fieldset')),
       );
-      $form[$prefix . '_group'][$input_type_key] = array(
+      $form[$prefix . '_group'][$prefix . '_choose_input_type'] = array(
         '#title' => check_plain($label),
         '#type' => 'select',
-        '#options' => array(
-          'date' => t('Select a date'),
-          'relative' => ('Enter a relative date'),
-        ),
-        '#attributes' => array(
-          'class' => array(
-            $input_class,
-          ),
-        ),
-        '#default_value' => $default_select_date_type,
+        '#options' => array('date' => t('Select a date'), 'relative' => ('Enter a relative date')),
+        '#attributes' => array('class' => array($prefix . '-choose-input-type')),
+        '#default_value' => !empty($relative_value) ? 'relative' : 'date',
       );
       $form[$prefix . '_group'][$prefix] = array(
         '#title' => t('Select a date'),
         '#type' => $type,
         '#size' => 20,
-        '#default_value' => $default_select_date_value,
+        '#default_value' => !empty($this->value[$prefix]) ? $this->value[$prefix] : $default_date,
         '#date_format' => date_limit_format($format, $granularity),
         '#date_label_position' => 'within',
         '#date_year_range' => $this->options['year_range'],
         '#process' => array($type . '_element_process'),
         '#states' => array(
           'visible' => array(
-            ":input.$input_class" => array('value' => 'date'),
+            ":input.{$prefix}-choose-input-type" => array('value' => 'date'),
           ),
         ),
       );
@@ -675,12 +429,10 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
         '#type' => 'textfield',
         '#title' => check_plain($relative_label),
         '#default_value' => $relative_value,
-        '#description' => t('Relative dates are computed when the view is displayed. Examples: now, now +1 day, 12AM today, Monday next week. <a href="https://www.php.net/manual/datetime.formats.php#datetime.formats.relative">More examples of relative date formats in the PHP documentation</a>.'),
+        '#description' => t('Relative dates are computed when the view is displayed. Examples: now, now +1 day, 12AM today, Monday next week. <a href="https://www.php.net/manual/en/datetime.formats.php#datetime.formats.relative">More examples of relative date formats in the PHP documentation</a>.'),
         '#states' => array(
           'visible' => array(
-            ":input.$input_class" => array(
-              'value' => 'relative',
-            ),
+            ":input.{$prefix}-choose-input-type" => array('value' => 'relative'),
           ),
         ),
       );
@@ -708,10 +460,6 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
    */
   function value_validate($form, &$form_state) {
 
-    if (!isset($form_state['values']['options']['operator'])) {
-      return;
-    }
-
     $options = &$form_state['values']['options'];
 
     if ($options['operator'] == 'between' || $options['operator'] == 'not between') {
@@ -723,13 +471,11 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
           $this->options['default_date'] = $options['value']['min_group']['default_date'];
           // NULL out the value field, user wanted the relative value to take hold.
           $options['value']['min_group']['min'] = NULL;
-          $this->options['value']['type'] = 'relative';
         }
       }
       // If an absolute date was used, be sure to wipe the relative date.
       else {
         $this->options['default_date'] = '';
-        $this->options['value']['type'] = 'date';
       }
       if ($options['value']['max_group']['max_choose_input_type'] == 'relative') {
         if (empty($options['value']['max_group']['default_to_date'])) {
@@ -739,13 +485,11 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
           $this->options['default_to_date'] = $options['value']['max_group']['default_to_date'];
           // NULL out the value field, user wanted the relative value to take hold.
           $options['value']['max_group']['max'] = NULL;
-          $this->options['value']['type'] = 'relative';
         }
       }
       // If an absolute date was used, be sure to wipe the relative date.
       else {
         $this->options['default_to_date'] = '';
-        $this->options['value']['type'] = 'date';
       }
     }
     elseif (in_array($options['operator'], array('<', '<=', '=', '!=', '>=', '>'))) {
@@ -757,13 +501,11 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
           $this->options['default_date'] = $options['value']['value_group']['default_date'];
           // NULL out the value field, user wanted the relative value to take hold.
           $options['value']['value_group']['value'] = NULL;
-          $this->options['value']['type'] = 'relative';
         }
       }
       // If an absolute date was used, be sure to wipe the relative date.
       else {
         $this->options['default_date'] = '';
-        $this->options['value']['type'] = 'date';
       }
     }
     // Flatten the form structure for views, so the values can be saved.
@@ -787,14 +529,7 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     $widget_options = $this->widget_options();
     // If the filter is exposed, display the granularity.
     if ($this->options['exposed']) {
-      $output = t('<strong>Exposed</strong> @widget @format', array(
-        '@format' => $parts[$this->date_handler->granularity],
-        '@widget' => $widget_options[$this->options['form_type']],
-      ));
-      if (!empty($this->options['value']['type']) && $this->options['value']['type'] == 'relative') {
-        $output .= ' ' . t('(Relative)');
-      }
-      return $output;
+      return t('<strong>Exposed</strong> @widget @format', array('@format' => $parts[$this->date_handler->granularity], '@widget' => $widget_options[$this->options['form_type']]));
     }
     // If not exposed, display the value.
     $output = '';
@@ -805,9 +540,6 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     }
     else {
       $output .= check_plain(!empty($this->options['default_date']) ? $this->options['default_date'] : $this->options['value']['value']);
-    }
-    if (!empty($this->options['value']['type']) && $this->options['value']['type'] == 'relative') {
-      $output .= ' ' . t('(Relative)');
     }
     return $output;
   }
@@ -822,18 +554,7 @@ class date_views_filter_handler_simple extends views_handler_filter_date {
     if (empty($form['value']) && empty($form['min'])) {
       return;
     }
-    // Determine granularity from the date format.
-    $granularity = array();
-    if (!empty($form['value']['#date_format'])) {
-      $granularity = date_format_order($form['value']['#date_format']);
-    }
-    elseif (!empty($form['min']['#date_format'])) {
-      $granularity = date_format_order($form['min']['#date_format']);
-    }
-    // If no granularity is found (e.g., for relative date textfields), return.
-    if (empty($granularity)) {
-      return;
-    }
+    $granularity = (!empty($form['min']['#date_format'])) ? date_format_order($form['min']['#date_format']) : date_format_order($form['value']['#date_format']);
     $filled = array();
     $value = backdrop_array_get_nested_value($form_state['input'], $form['#parents']);
     foreach ($granularity as $part) {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7154

Even if this wouldn't break existing (not exposed) date filters - even grouped filters are very buggy. We should revert that as a whole. It needs a lot more work to get into core.

The coding standard violations from reverted code (not actually mine) - should I fix that? I hesitate.