### PR TITLE
Fix for issue #7164

### DIFF
--- a/core/modules/filter/filter.module
+++ b/core/modules/filter/filter.module
@@ -2299,7 +2299,7 @@ function _filter_url($text, $filter) {
     $text = preg_replace_callback('`<!--(.*?)-->`s', '_filter_url_escape_comments', $text);
 
     // Split at all tags; ensures that no tags or attributes are processed.
-    $chunks = preg_split('/(<.+?>)/is', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
+    $chunks = preg_split('/(<[^>]*>)/s', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
     // PHP ensures that the array consists of alternating delimiters and
     // literals, and begins and ends with a literal (inserting NULL as
     // required). Therefore, the first chunk is always text:


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7164

It seems that `preg_split()` chokes with big inline base64 images in case such an image is stored inside the node body. This line fixes the issue for me.