### PR TITLE
Issue 7166: Make the GET page variable consistent with real page number

### DIFF
--- a/core/includes/pager.inc
+++ b/core/includes/pager.inc
@@ -25,9 +25,11 @@
 function pager_find_page($element = 0) {
   $page = isset($_GET['page']) ? $_GET['page'] : '';
   $page_array = explode(',', $page);
-  if (!isset($page_array[$element])) {
-    $page_array[$element] = 0;
+  if (empty($page_array[$element])) {
+    $page_array[$element] = 1;
   }
+  // Translate human readable page numbers to PHP offset logic.
+  $page_array[$element]--;
   return (int) $page_array[$element];
 }
 
@@ -446,7 +448,8 @@ function theme_pager_link($variables) {
 
   $page = isset($_GET['page']) ? $_GET['page'] : '';
   if ($new_page = implode(',', pager_load_array($page_new[$element], $element, explode(',', $page)))) {
-    $parameters['page'] = $new_page;
+    // Translate PHP offset logic to human readable page numbers.
+    $parameters['page'] = $new_page + 1;
   }
 
   $query = array();

--- a/core/modules/comment/comment.module
+++ b/core/modules/comment/comment.module
@@ -1801,7 +1801,7 @@ function comment_get_display_page($cid, $node_type) {
   $ordinal = comment_get_display_ordinal($cid, $node_type);
   $type = node_type_get_type($node_type);
   $comments_per_page = $type->settings['comment_per_page'];
-  return floor($ordinal / $comments_per_page);
+  return floor($ordinal / $comments_per_page) + 1;
 }
 
 /**

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -479,8 +479,8 @@ class CommentInterfaceTest extends CommentHelperCase {
     $this->setCommentsPerPage(2);
     $comment_new_page = $this->postComment($this->node, $this->randomName(), $this->randomName(), TRUE);
     $this->assertTrue($this->commentExists($comment_new_page), 'Page one exists. %s');
-    $this->backdropGet('node/' . $this->node->nid, array('query' => array('page' => 2)));
-    $this->assertTrue($this->commentExists($reply, TRUE), 'Page two exists. %s');
+    $this->backdropGet('node/' . $this->node->nid, array('query' => array('page' => 3)));
+    $this->assertTrue($this->commentExists($reply, TRUE), 'Page three exists. %s');
     $this->setCommentsPerPage(50);
 
     // Attempt to post to node with comments disabled.
@@ -1386,13 +1386,13 @@ class CommentPagerTest extends CommentHelperCase {
     $this->assertFalse($this->commentExists($comments[2]), 'Comment 3 does not appear on page 1.');
 
     // Check the second page.
-    $this->backdropGet('node/' . $node->nid, array('query' => array('page' => 1)));
+    $this->backdropGet('node/' . $node->nid, array('query' => array('page' => 2)));
     $this->assertTrue($this->commentExists($comments[1]), 'Comment 2 appears on page 2.');
     $this->assertFalse($this->commentExists($comments[0]), 'Comment 1 does not appear on page 2.');
     $this->assertFalse($this->commentExists($comments[2]), 'Comment 3 does not appear on page 2.');
 
     // Check the third page.
-    $this->backdropGet('node/' . $node->nid, array('query' => array('page' => 2)));
+    $this->backdropGet('node/' . $node->nid, array('query' => array('page' => 3)));
     $this->assertTrue($this->commentExists($comments[2]), 'Comment 3 appears on page 3.');
     $this->assertFalse($this->commentExists($comments[0]), 'Comment 1 does not appear on page 3.');
     $this->assertFalse($this->commentExists($comments[1]), 'Comment 2 does not appear on page 3.');

--- a/core/modules/entity/tests/entity_query.test
+++ b/core/modules/entity/tests/entity_query.test
@@ -1272,7 +1272,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
    */
   function testEntityFieldQueryPager() {
     // Test pager in propertyQuery
-    $_GET['page'] = '0,1';
+    $_GET['page'] = '1,2';
     $query = new EntityFieldQuery();
     $query
       ->entityCondition('entity_type', 'test_entity_bundle_key')
@@ -1296,7 +1296,7 @@ class EntityFieldQueryTestCase extends BackdropWebTestCase {
     ), 'Test pager integration in propertyQuery: page 2.', TRUE);
 
     // Test pager in field storage
-    $_GET['page'] = '0,1';
+    $_GET['page'] = '1,2';
     $query = new EntityFieldQuery();
     $query
       ->entityCondition('entity_type', 'test_entity_bundle_key')

--- a/core/modules/node/tests/node.test
+++ b/core/modules/node/tests/node.test
@@ -3574,12 +3574,12 @@ class NodeAccessPagerTestCase extends BackdropWebTestCase {
     $this->backdropLogin($this->web_user);
 
     // View the node page. With the default 50 comments per page there should
-    // be two pages (0, 1) but no third (2) page.
+    // be two pages (1, 2) but no third (3) page.
     $this->backdropGet('node/' . $node->nid);
     $this->assertText($node->title);
     $this->assertText('Comments');
-    $this->assertRaw('page=1');
-    $this->assertNoRaw('page=2');
+    $this->assertRaw('page=2');
+    $this->assertNoRaw('page=3');
   }
 }
 

--- a/core/modules/search/tests/search.test
+++ b/core/modules/search/tests/search.test
@@ -659,16 +659,16 @@ class SearchExactTestCase extends BackdropWebTestCase {
     // Test that the correct number of pager links are found for keyword search.
     $edit = array('keys' => 'love pizza');
     $this->backdropPost('search/node', $edit, t('Search'));
-    $this->assertLinkByHref('page=1', 0, '2nd page link is found for keyword search.');
-    $this->assertLinkByHref('page=2', 0, '3rd page link is found for keyword search.');
-    $this->assertLinkByHref('page=3', 0, '4th page link is found for keyword search.');
-    $this->assertNoLinkByHref('page=4', '5th page link is not found for keyword search.');
+    $this->assertLinkByHref('page=2', 0, '2nd page link is found for keyword search.');
+    $this->assertLinkByHref('page=3', 0, '3rd page link is found for keyword search.');
+    $this->assertLinkByHref('page=4', 0, '4th page link is found for keyword search.');
+    $this->assertNoLinkByHref('page=5', '5th page link is not found for keyword search.');
 
     // Test that the correct number of pager links are found for exact phrase search.
     $edit = array('keys' => '"love pizza"');
     $this->backdropPost('search/node', $edit, t('Search'));
-    $this->assertLinkByHref('page=1', 0, '2nd page link is found for exact phrase search.');
-    $this->assertNoLinkByHref('page=2', '3rd page link is not found for exact phrase search.');
+    $this->assertLinkByHref('page=2', 0, '2nd page link is found for exact phrase search.');
+    $this->assertNoLinkByHref('page=3', '3rd page link is not found for exact phrase search.');
   }
 }
 

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2394,7 +2394,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     $count = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $correct_number = $limit;
-    $num_pages = ceiling($count / $limit);
+    $num_pages = ceil($count / $limit);
 
     // If there is no remainder from rounding, subtract 1 since we index from 0.
     if (!($num_pages * $limit < $count)) {
@@ -2428,7 +2428,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     $count = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();  //7
 
     $correct_number = $limit; //2
-    $num_pages = ceiling($count / $limit); //3 //4
+    $num_pages = ceil($count / $limit); //3 //4
 
     // If there is no remainder from rounding, subtract 1 since we index from 0.
     if (!($num_pages * $limit < $count)) { // 3 * 2 < 7 = TRUE

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2432,10 +2432,10 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
 
     // If there is no remainder from rounding, subtract 1 since we index from 0.
     if (!($num_pages * $limit < $count)) {
-      $num_pages--;
+      // $num_pages--;
     }
 
-    for ($page = 0; $page <= $num_pages; ++$page) {
+    for ($page = 1; $page <= $num_pages; ++$page) {
       $this->backdropGet('database_test/pager_query_odd/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
 

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2406,7 +2406,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
       $data = json_decode($this->backdropGetContent());
 
       if ($page == $num_pages) {
-        $correct_number = $count - ($limit * $page);
+        $correct_number = ($limit * $page) - $count;
       }
 
       $this->assertEqual(count($data->names), $correct_number, format_string('Correct number of records returned by pager: @number', array('@number' => $correct_number)));
@@ -2440,7 +2440,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
       $data = json_decode($this->backdropGetContent());
 
       if ($page == $num_pages) {
-        $correct_number = $count - ($limit * $page);
+        $correct_number = ($limit * $page) - $count;
       }
 
       $this->assertEqual(count($data->names), $correct_number, format_string('Correct number of records returned by pager: @number', array('@number' => $correct_number)));

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2420,7 +2420,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     // information forward to the actual query on the other side of the
     // HTTP request.
     $limit = 2;
-    $count = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();  //7
+    $count = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();
 
     $correct_number = $limit;
     $num_pages = ceil($count / $limit);

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2396,11 +2396,6 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     $correct_number = $limit;
     $num_pages = ceil($count / $limit);
 
-    // If there is no remainder from rounding, subtract 1 since we index from 0.
-    if (!($num_pages * $limit < $count)) {
-      // $num_pages--;
-    }
-
     for ($page = 1; $page <= $num_pages; ++$page) {
       $this->backdropGet('database_test/pager_query_even/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
@@ -2427,13 +2422,8 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     $limit = 2;
     $count = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();  //7
 
-    $correct_number = $limit; //2
-    $num_pages = ceil($count / $limit); //3 //4
-
-    // If there is no remainder from rounding, subtract 1 since we index from 0.
-    if (!($num_pages * $limit < $count)) { // 3 * 2 < 7 = TRUE
-      // $num_pages--;
-    }
+    $correct_number = $limit;
+    $num_pages = ceil($count / $limit);
 
     for ($page = 1; $page <= $num_pages; ++$page) {
       $this->backdropGet('database_test/pager_query_odd/' . $limit, array('query' => array('page' => $page)));

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2435,7 +2435,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
       $num_pages--;
     }
 
-    for ($page = 0; $page <= $num_pages; ++$page) {
+    for ($page = 1; $page <= $num_pages; ++$page) {
       $this->backdropGet('database_test/pager_query_odd/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
 
@@ -2492,7 +2492,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
    * Confirm that every pager gets a valid non-overlapping element ID.
    */
   function testElementNumbers() {
-    $_GET['page'] = '3, 2, 1, 0';
+    $_GET['page'] = '4, 3, 2, 1';
 
     $query = db_select('test', 't')->extend('PagerDefault');
     $query->element(2)

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2405,7 +2405,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
       $this->backdropGet('database_test/pager_query_even/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
 
-      if ($page == $num_pages) {
+      if ($page == $num_pages && ($limit * $page) > $count) {
         $correct_number = ($limit * $page) - $count;
       }
 
@@ -2439,7 +2439,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
       $this->backdropGet('database_test/pager_query_odd/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
 
-      if ($page == $num_pages) {
+      if ($page == $num_pages && ($limit * $page) > $count) {
         $correct_number = ($limit * $page) - $count;
       }
 

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2435,7 +2435,7 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
       $num_pages--;
     }
 
-    for ($page = 1; $page <= $num_pages; ++$page) {
+    for ($page = 0; $page <= $num_pages; ++$page) {
       $this->backdropGet('database_test/pager_query_odd/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
 

--- a/core/modules/simpletest/tests/database_test.test
+++ b/core/modules/simpletest/tests/database_test.test
@@ -2394,14 +2394,14 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     $count = db_query('SELECT COUNT(*) FROM {test}')->fetchField();
 
     $correct_number = $limit;
-    $num_pages = floor($count / $limit);
+    $num_pages = ceiling($count / $limit);
 
     // If there is no remainder from rounding, subtract 1 since we index from 0.
     if (!($num_pages * $limit < $count)) {
-      $num_pages--;
+      // $num_pages--;
     }
 
-    for ($page = 0; $page <= $num_pages; ++$page) {
+    for ($page = 1; $page <= $num_pages; ++$page) {
       $this->backdropGet('database_test/pager_query_even/' . $limit, array('query' => array('page' => $page)));
       $data = json_decode($this->backdropGetContent());
 
@@ -2425,13 +2425,13 @@ class DatabaseSelectPagerDefaultTestCase extends DatabaseTestCase {
     // information forward to the actual query on the other side of the
     // HTTP request.
     $limit = 2;
-    $count = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();
+    $count = db_query('SELECT COUNT(*) FROM {test_task}')->fetchField();  //7
 
-    $correct_number = $limit;
-    $num_pages = floor($count / $limit);
+    $correct_number = $limit; //2
+    $num_pages = ceiling($count / $limit); //3 //4
 
     // If there is no remainder from rounding, subtract 1 since we index from 0.
-    if (!($num_pages * $limit < $count)) {
+    if (!($num_pages * $limit < $count)) { // 3 * 2 < 7 = TRUE
       // $num_pages--;
     }
 

--- a/core/modules/simpletest/tests/pager.test
+++ b/core/modules/simpletest/tests/pager.test
@@ -35,7 +35,7 @@ class PagerFunctionalWebTestCase extends BackdropWebTestCase {
   function testActiveClass() {
     // Verify first page.
     $this->backdropGet('admin/reports/dblog');
-    $current_page = 0;
+    $current_page = 1;
     $this->assertPagerItems($current_page);
 
     // Verify any page but first/last.

--- a/core/modules/simpletest/tests/pager.test
+++ b/core/modules/simpletest/tests/pager.test
@@ -77,9 +77,6 @@ class PagerFunctionalWebTestCase extends BackdropWebTestCase {
     $elements = $this->xpath('//ul[@class=:class]/li', array(':class' => 'pager'));
     $this->assertTrue(!empty($elements), 'Pager found.');
 
-    // Make current page 1-based.
-    $current_page++;
-
     // Extract first/previous and next/last items.
     // first/previous only exist, if the current page is not the first.
     if ($current_page > 1) {

--- a/core/modules/views/plugins/views_plugin_pager_full.inc
+++ b/core/modules/views/plugins/views_plugin_pager_full.inc
@@ -319,6 +319,8 @@ class views_plugin_pager_full extends views_plugin_pager {
     $pager_id = $this->get_pager_id();
     for ($i = 0; $i <= $pager_id || $i < count($pager_page_array); $i++) {
       $pager_page_array[$i] = empty($page[$i]) ? 0 : $page[$i];
+      // Translate human readable page numbers to PHP offset logic.
+      $pager_page_array[$i]--;
     }
 
     $this->current_page = intval($pager_page_array[$pager_id]);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7166

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
