### PR TITLE
Issue #7149: Third approach to prevent flashing HTML when submitting CKEditor forms

### DIFF
--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -123,7 +123,7 @@
       if (trigger !== 'serialize') {
         // If submitting the entire form, skip destroying the editor and let it
         //  be unloaded by the browser leaving the page.
-        if (trigger === 'submit') {
+        if (trigger !== 'submit') {
           editor.destroy();
         }
         Backdrop.ckeditor5.instances.delete(editor.id);

--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -101,7 +101,7 @@
         });
     },
 
-    detach: function (element, format, trigger, windowUnload) {
+    detach: function (element, format, trigger) {
       // Remove any content modification warning.
       if (element.ckeditor5AttachedWarning && trigger !== 'serialize') {
         element.ckeditor5AttachedWarning.remove();
@@ -123,7 +123,7 @@
       if (trigger !== 'serialize') {
         // If submitting the entire form, skip destroying the editor and let it
         //  be unloaded by the browser leaving the page.
-        if (!windowUnload) {
+        if (trigger === 'submit') {
           editor.destroy();
         }
         Backdrop.ckeditor5.instances.delete(editor.id);

--- a/core/modules/ckeditor5/js/ckeditor5.js
+++ b/core/modules/ckeditor5/js/ckeditor5.js
@@ -43,7 +43,7 @@
           let onEventsPattern = {
             'name': /.*/,
             'attributes': /^on.*/
-          }
+          };
           editorSettings.htmlSupport.disallow.push(onEventsPattern);
         }
         // If filter_html if off, allow all elements and attributes to be used.
@@ -53,7 +53,7 @@
             attributes: true,
             classes: true,
             styles: true
-          }
+          };
           editorSettings.htmlSupport.allow.push(patternAllowAll);
         }
       }
@@ -101,7 +101,7 @@
         });
     },
 
-    detach: function (element, format, trigger) {
+    detach: function (element, format, trigger, windowUnload) {
       // Remove any content modification warning.
       if (element.ckeditor5AttachedWarning && trigger !== 'serialize') {
         element.ckeditor5AttachedWarning.remove();
@@ -121,7 +121,11 @@
 
       // Destroy the instance if fully detaching.
       if (trigger !== 'serialize') {
-        editor.destroy();
+        // If submitting the entire form, skip destroying the editor and let it
+        //  be unloaded by the browser leaving the page.
+        if (!windowUnload) {
+          editor.destroy();
+        }
         Backdrop.ckeditor5.instances.delete(editor.id);
         delete element.ckeditor5AttachedEditor;
         delete element.ckeditor5Processed;

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -80,7 +80,9 @@ Backdrop.behaviors.filterEditors = {
         if (event.isDefaultPrevented()) {
           return;
         }
-        Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor]);
+        // Detach the editor with "windowUnload" set to true, as submitting
+        // the form will cause the window to unload.
+        Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor], 'unload', true);
       });
     });
   },
@@ -100,15 +102,42 @@ Backdrop.behaviors.filterEditors = {
   }
 };
 
+/**
+ * Attach an editor to a textarea field.
+ *
+ * @param {Element} field
+ *   The original textarea DOM element.
+ * @param {Object} format
+ *   The text format information.
+ */
 Backdrop.filterEditorAttach = function(field, format) {
   if (format.editor && Backdrop.editors[format.editor]) {
     Backdrop.editors[format.editor].attach(field, format);
   }
 };
 
-Backdrop.filterEditorDetach = function(field, format, trigger) {
+  /**
+   * Detach an editor from the page.
+   *
+   * @param {Element} field
+   *   The original textarea DOM element.
+   * @param {Object} format
+   *   The text format information.
+   * @param {string} trigger
+   *   A string with the value "unload", "move", or "serialize". See
+   *   Backdrop.detachBehaviors() for more information on these strings.
+   * @param {boolean} windowUnload
+   *   Boolean indicating if this detachment is happening right before leaving
+   *   the page. If so, there's no need to free up memory resources because
+   *   the editor will be destroyed by the window unloading.
+   *
+   * @see Backdrop.detachBehaviors()
+   */
+  Backdrop.filterEditorDetach = function(field, format, trigger, windowUnload) {
+  trigger = trigger || 'unload';
+  windowUnload = windowUnload || false;
   if (format.editor && Backdrop.editors[format.editor]) {
-    Backdrop.editors[format.editor].detach(field, format, trigger);
+    Backdrop.editors[format.editor].detach(field, format, trigger, windowUnload);
   }
 };
 

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -80,9 +80,8 @@ Backdrop.behaviors.filterEditors = {
         if (event.isDefaultPrevented()) {
           return;
         }
-        // Detach the editor with "windowUnload" set to true, as submitting
-        // the form will cause the window to unload.
-        Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor], 'unload', true);
+        // Detach the editor with "submit" when doing a non-AJAX submit.
+        Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor], 'submit');
       });
     });
   },
@@ -124,20 +123,18 @@ Backdrop.filterEditorAttach = function(field, format) {
    * @param {Object} format
    *   The text format information.
    * @param {string} trigger
-   *   A string with the value "unload", "move", or "serialize". See
-   *   Backdrop.detachBehaviors() for more information on these strings.
-   * @param {boolean} windowUnload
-   *   Boolean indicating if this detachment is happening right before leaving
-   *   the page. If so, there's no need to free up memory resources because
-   *   the editor will be destroyed by the window unloading.
+   *   A string with the value "unload", "move", "serialize" (see
+   *   Backdrop.detachBehaviors() for more information on these), or "submit".
+   *   Submit is used to detach editors when the complete form is submitted
+   *   with non-AJAX behavior, which may be useful to let the browser clean up
+   *   the editor's events and memory.
    *
    * @see Backdrop.detachBehaviors()
    */
-  Backdrop.filterEditorDetach = function(field, format, trigger, windowUnload) {
+  Backdrop.filterEditorDetach = function(field, format, trigger) {
   trigger = trigger || 'unload';
-  windowUnload = windowUnload || false;
   if (format.editor && Backdrop.editors[format.editor]) {
-    Backdrop.editors[format.editor].detach(field, format, trigger, windowUnload);
+    Backdrop.editors[format.editor].detach(field, format, trigger);
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7149

This is an alternative to my earlier PR https://github.com/backdrop/backdrop/pull/5299 and @swampopus's https://github.com/backdrop/backdrop/pull/5279.

Instead of using a new parameter like my previous PR, this uses the existing "trigger" parameter with the value set to "submit". I think this is okay because previously we were not using any value at all when calling this function, other than "serialize". So introducing a new option to differentiate between "unload" (which is what should have been used before but wasn't in place) and "submit" (new option for when non-AJAX submitting the form), seems safe.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
