### PR TITLE
2054 add lock and unlock aspect ratio to images in editor

### DIFF
--- a/core/includes/module.inc
+++ b/core/includes/module.inc
@@ -1030,6 +1030,7 @@ function backdrop_merged_modules() {
     'views_ajax_history', // Backdrop 1.34.0.
     'file_entity_inline', // Backdrop 1.34.0.
     'html5_upload', // Backdrop 1.34.0.
+    'editorimgdimensionsync', // Backdrop 1.35.0.
   );
 }
 

--- a/core/modules/filter/css/filter.css
+++ b/core/modules/filter/css/filter.css
@@ -184,7 +184,7 @@
   display: inline-block;
   width: 1.2em;
   margin-left: 10px;
-  top: 10px;
+  top: 5px;
   cursor: pointer;
 }
 .image-form-wrapper .image-ratio-icon.reset-orig-inactive {

--- a/core/modules/filter/css/filter.css
+++ b/core/modules/filter/css/filter.css
@@ -186,6 +186,9 @@
   margin-left: 10px;
   top: 5px;
   cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
 }
 .image-form-wrapper .image-ratio-icon.reset-orig-inactive {
   opacity: 0.6;

--- a/core/modules/filter/css/filter.css
+++ b/core/modules/filter/css/filter.css
@@ -179,6 +179,17 @@
   flex-grow: 0;
   padding-top: 0;
 }
+.image-form-wrapper .image-ratio-icon {
+  position: relative;
+  display: inline-block;
+  width: 1.2em;
+  margin-left: 10px;
+  top: 10px;
+  cursor: pointer;
+}
+.image-form-wrapper .image-ratio-icon.reset-orig-inactive {
+  opacity: 0.6;
+}
 .editor-image-library {
   padding: 0 0 0 20px; /* LTR */
   min-width: 525px;

--- a/core/modules/filter/filter.install
+++ b/core/modules/filter/filter.install
@@ -559,7 +559,7 @@ function filter_update_1004() {
   }
 }
 
-/*
+/**
  * Uninstall the editorimgdimensionsync contrib module, now part of core.
  */
 function filter_update_1005() {

--- a/core/modules/filter/filter.install
+++ b/core/modules/filter/filter.install
@@ -559,6 +559,27 @@ function filter_update_1004() {
   }
 }
 
+/*
+ * Uninstall the editorimgdimensionsync contrib module, now part of core.
+ */
+function filter_update_1005() {
+  $module = db_query("SELECT name FROM {system} WHERE name = 'editorimgdimensionsync' AND type = 'module'")->fetchField();
+  if ($module) {
+    $path = backdrop_get_path('module', 'editorimgdimensionsync');
+    backdrop_set_message(t('The contributed module <em>Editor Image Dimension Sync</em> has been located at %path. The module has been disabled, since its functionality is now provided by Backdrop core. It is recommended that you remove this module from your site.', array('%path' => BACKDROP_ROOT . '/' . $path)), 'warning');
+    // Remove the entry for the Editor Image Dimension Sync module from the system table.
+    // As this module does not provide any config or settings, there doesn't
+    // seem to be anything else left to clean up or migrate.
+    // While the contrib module remains in the filesystem, this entry will be
+    // recreated, but it will have status 0 (disabled), and schema -1
+    // (uninstalled), so it is safe to remove.
+    db_query("DELETE FROM {system} WHERE name = 'editorimgdimensionsync' AND type = 'module'");
+  }
+  else {
+    return t('<em>Editor Image Dimension Sync</em> not found. Nothing to be done.');
+  }
+}
+
 /**
  * @} End of "addtogroup updates-7.x-to-1.x"
  * The next series of updates should start at 2000.

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -216,7 +216,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#parents' => array('attributes', 'height'),
     '#field_suffix' => ' ' . t('pixels'),
   );
-  
+
   $ratio_icons = "";
   // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality:
   if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
@@ -225,10 +225,10 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     $ratio_icons .= '<div id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</div>';
   }
   $ratio_icons .= '<div id="reset-orig" class="image-ratio-icon reset-orig reset-orig-inactive" title="' . t('Reset to original size') . '">' . icon('arrows-clockwise-fill') . '</div>';
-  
+
   // Add ratio icons after the "height" field.
   $form['size']['height']['#field_suffix'] .= $ratio_icons;
-  
+
   // Original values used for reference in submit handler.
   $form['size']['previous_width'] = array(
     '#type' => 'value',

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -218,9 +218,8 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   );
 
   $ratio_icons = "";
-  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality:
-  if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
-    // Okay, I know using settings_get is kind of a kludge. It's here until a better UI location can be identified.
+  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality. (Can be set in settings.php by adding $settings['disable_image_aspect_ratio_unlock'] = TRUE;)
+  if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {    
     $ratio_icons .= '<div id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</div>';
     $ratio_icons .= '<div id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</div>';
   }

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -221,10 +221,10 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality.
   // Modify by adding "$settings['disable_image_aspect_ratio_unlock'] = TRUE;" to settings.php.
   if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
-    $ratio_icons .= '<div id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</div>';
-    $ratio_icons .= '<div id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</div>';
+    $ratio_icons .= '<button id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '" aria-label="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</button>';
+    $ratio_icons .= '<button id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '" aria-label="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</button>';
   }
-  $ratio_icons .= '<div id="reset-orig" class="image-ratio-icon reset-orig reset-orig-inactive" title="' . t('Reset to original size') . '">' . icon('arrows-clockwise-fill') . '</div>';
+  $ratio_icons .= '<button id="reset-orig" class="image-ratio-icon reset-orig reset-orig-inactive" title="' . t('Reset to original size') . '" aria-label="' . t('Reset to original size') . '">' . icon('arrows-clockwise-fill') . '</button>';
 
   // Add ratio icons after the "height" field.
   $form['size']['height']['#field_suffix'] .= $ratio_icons;
@@ -817,10 +817,10 @@ function _filter_get_file_id($href) {
   // Now find this file name in uri field to get fid.
   if (!empty($filename)) {
     $results = db_select('file_managed')
-      ->fields('file_managed', array('fid', 'uri'))
-      ->condition('uri', '%/' . $filename, 'LIKE')
-      ->orderBy('fid', 'DESC')
-      ->execute();
+    ->fields('file_managed', array('fid', 'uri'))
+    ->condition('uri', '%/' . $filename, 'LIKE')
+    ->orderBy('fid', 'DESC')
+    ->execute();
 
     foreach ($results as $found) {
       $result = $found->fid;

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -216,6 +216,22 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#parents' => array('attributes', 'height'),
     '#field_suffix' => ' ' . t('pixels'),
   );
+  
+  $ratio_icons = "";  
+  // skip these icons if the user is not allowed to unlock the aspect-ratio functionality:
+  
+  
+  if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
+    // Okay, I know using settings_get is kind of a kludge. It's here until a better UI location can be identified.
+    $ratio_icons .= '<div id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</div>';
+    $ratio_icons .= '<div id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</div>';
+  }  
+  $ratio_icons .= '<div id="reset-orig" class="image-ratio-icon reset-orig reset-orig-inactive" title="' . t('Reset to original size') . '">' . icon('arrows-clockwise-fill') . '</div>';
+  
+  // Add ratio icons after the "height" field
+  $form['size']['height']['#field_suffix'] .= $ratio_icons;
+  
+  
   // Original values used for reference in submit handler.
   $form['size']['previous_width'] = array(
     '#type' => 'value',

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -218,7 +218,7 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   );
 
   $ratio_icons = "";
-  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality.  
+  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality.
   // Modify by adding "$settings['disable_image_aspect_ratio_unlock'] = TRUE;" to settings.php.
   if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
     $ratio_icons .= '<div id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</div>';

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -217,20 +217,17 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
     '#field_suffix' => ' ' . t('pixels'),
   );
   
-  $ratio_icons = "";  
-  // skip these icons if the user is not allowed to unlock the aspect-ratio functionality:
-  
-  
+  $ratio_icons = "";
+  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality:
   if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
     // Okay, I know using settings_get is kind of a kludge. It's here until a better UI location can be identified.
     $ratio_icons .= '<div id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</div>';
     $ratio_icons .= '<div id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</div>';
-  }  
+  }
   $ratio_icons .= '<div id="reset-orig" class="image-ratio-icon reset-orig reset-orig-inactive" title="' . t('Reset to original size') . '">' . icon('arrows-clockwise-fill') . '</div>';
   
-  // Add ratio icons after the "height" field
+  // Add ratio icons after the "height" field.
   $form['size']['height']['#field_suffix'] .= $ratio_icons;
-  
   
   // Original values used for reference in submit handler.
   $form['size']['previous_width'] = array(

--- a/core/modules/filter/filter.pages.inc
+++ b/core/modules/filter/filter.pages.inc
@@ -218,8 +218,9 @@ function filter_format_editor_image_form($form, &$form_state, $format) {
   );
 
   $ratio_icons = "";
-  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality. (Can be set in settings.php by adding $settings['disable_image_aspect_ratio_unlock'] = TRUE;)
-  if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {    
+  // Skip these icons if the user is not allowed to unlock the aspect-ratio functionality.  
+  // Modify by adding "$settings['disable_image_aspect_ratio_unlock'] = TRUE;" to settings.php.
+  if (settings_get('disable_image_aspect_ratio_unlock', FALSE) !== TRUE) {
     $ratio_icons .= '<div id="unlock-aspect-ratio" class="image-ratio-icon unlock-aspect-ratio" title="' . t('Unlock aspect ratio') . '">' . icon('lock-simple-fill') . '</div>';
     $ratio_icons .= '<div id="lock-aspect-ratio" class="image-ratio-icon lock-aspect-ratio" style="display:none;" title="' . t('Lock aspect ratio') . '">' . icon('lock-simple-open-fill') . '</div>';
   }

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -27,6 +27,15 @@ Backdrop.filterAspectRatioLocked = true;
  */
 Backdrop.filterImageEditorDisplay = undefined;
 
+
+/**
+ * Keeps track of the original dimensions of the image we are manipulating
+ * in the image editor.
+ * // TODO: might need to be an array since we can have multiple images?
+ */
+Backdrop.filterImageOriginalDimensions = {width: null, height: null};
+
+
 /**
  * Displays the guidelines of the selected text format automatically.
  */
@@ -43,6 +52,7 @@ Backdrop.behaviors.filterGuidelines = {
       .trigger('change');
   }
 };
+
 
 /**
  * Enables an editor (if any) when the matching format is selected.
@@ -218,6 +228,15 @@ Backdrop.behaviors.editorImageDialog = {
       $(".editor-dialog").removeClass("editor-dialog-with-library");
       // Set the class for the left-hand part.
       $(".editor-image-fields").addClass("editor-image-fields-full");
+      // When we first open, we're always on the "upload" part of the dialog.
+      Backdrop.filterImageEditorDisplay = 'upload';
+      // If the image is stretched, we need to set the lock icon
+      // and locked status accordingly.
+      if (Backdrop.behaviors.editorImageLibrary.imageIsStretched() === true) {
+        $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').hide();
+        $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').show().focus();
+        Backdrop.filterAspectRatioLocked = false;
+      }
     }
 
     $newToggles.on('click', function(e) {
@@ -258,23 +277,23 @@ Backdrop.behaviors.editorImageDialog = {
         // our width and height fields with its width and height.
         var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
         if (typeof existingFile !== 'undefined') {
-          var originalDimensions = {
+          Backdrop.filterImageOriginalDimensions = {
             width: null,
             height: null
           };
 
           var img = new Image();
           img.onload = function() {
-            originalDimensions.width = this.width;
-            originalDimensions.height = this.height;
-            Backdrop.behaviors.editorImageLibrary.resetDataAttr(originalDimensions);
+            Backdrop.filterImageOriginalDimensions.width = this.width;
+            Backdrop.filterImageOriginalDimensions.height = this.height;
+            Backdrop.behaviors.editorImageLibrary.resetDataAttr(Backdrop.filterImageOriginalDimensions);
 
             if (!$('.filter-format-editor-image-form [name="attributes[width]"]').val().length) {
-              Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(originalDimensions);
+              Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(Backdrop.filterImageOriginalDimensions);
             }
 
-            Backdrop.behaviors.editorImageLibrary.syncAspectRatio(originalDimensions);
-            Backdrop.behaviors.editorImageLibrary.setButtonState(originalDimensions);
+            Backdrop.behaviors.editorImageLibrary.syncAspectRatio(Backdrop.filterImageOriginalDimensions);
+            Backdrop.behaviors.editorImageLibrary.updateResetButtonState();
           }
           // Actually perform the loading of the image last
           // just in case the listener functions are set yet.
@@ -353,6 +372,7 @@ Backdrop.behaviors.editorImageDialog = {
         $('.editor-dialog').removeClass('editor-dialog-with-library');
         // Set the class for the dialog part.
         $('.editor-image-fields').addClass('editor-image-fields-full');
+
       }
     });
   }
@@ -397,7 +417,8 @@ Backdrop.behaviors.editorImageLibrary = {
     if (!$sizeFormItems.length) {
       return;
     }
-    var naturalDimensions = {
+
+    Backdrop.filterImageOriginalDimensions = {
       width: null,
       height: null
     };
@@ -420,37 +441,51 @@ Backdrop.behaviors.editorImageLibrary = {
       $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').hide();
       $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show().focus();
       Backdrop.filterAspectRatioLocked = true;
+      // Because we have just re-locked the aspect ratio from a previously
+      // unlocked state, we need to resize the image, using width as the
+      // dimension to calculate from.
+      if (Backdrop.filterImageOriginalDimensions.width && Backdrop.filterImageOriginalDimensions.height) {
+        $('.filter-format-editor-image-form [name="attributes[width]"]').trigger('input');
+      }
     });
 
     $('.filter-format-editor-image-form .editor-image-size #reset-orig').off().on('click', function(e) {
       e.preventDefault();
       e.stopPropagation();
-
       Backdrop.behaviors.editorImageLibrary.imageDimensionsSet($(this).data('data-dimensions'));
-      Backdrop.behaviors.editorImageLibrary.setButtonState($(this).data('data-dimensions'));
+      Backdrop.behaviors.editorImageLibrary.updateResetButtonState();
     });
 
+
+    Backdrop.behaviors.editorImageLibrary.imageLoadExistingFile();
+
+
+  },
+  imageLoadExistingFile: function () {
     // When editing a previously added/selected image, or upload a new one.
-    var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
+    var existingFile = $('.filter-format-editor-image-form .form-managed-file .file a').attr('href');
     if (Backdrop.filterImageEditorDisplay === 'library') {
       existingFile = $('.filter-format-editor-image-form #edit-attributes-src').val();
     }
+
     if (typeof existingFile !== 'undefined' && existingFile !== '') {
       var img = new Image();
       // First, define functions for img.
       img.onload = function() {
-        naturalDimensions.width = this.width;
-        naturalDimensions.height = this.height;
-        Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
+
+
+        Backdrop.filterImageOriginalDimensions.width = this.width;
+        Backdrop.filterImageOriginalDimensions.height = this.height;
+        Backdrop.behaviors.editorImageLibrary.resetDataAttr(Backdrop.filterImageOriginalDimensions);
         if (!$('.filter-format-editor-image-form [name="attributes[width]"]').val().length) {
-          Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(naturalDimensions);
+          Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(Backdrop.filterImageOriginalDimensions);
         }
-        Backdrop.behaviors.editorImageLibrary.syncAspectRatio(naturalDimensions);
-        Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+        Backdrop.behaviors.editorImageLibrary.syncAspectRatio(Backdrop.filterImageOriginalDimensions);
+        Backdrop.behaviors.editorImageLibrary.updateResetButtonState();
       }
       img.onerror = function() {
-        naturalDimensions.width = null;
-        naturalDimensions.height = null;
+        Backdrop.filterImageOriginalDimensions.width = null;
+        Backdrop.filterImageOriginalDimensions.height = null;
       }
       // Perform the loading of the image last, just in case
       // the listener functions aren't set yet.
@@ -460,9 +495,9 @@ Backdrop.behaviors.editorImageLibrary = {
       // After an image has been removed via button, and the managed form item
       // reloads, reset width and height.
       if ($('.filter-format-editor-image-form [name="attributes[width]"]').val().length) {
-        naturalDimensions.width = null;
-        naturalDimensions.height = null;
-        Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
+        Backdrop.filterImageOriginalDimensions.width = null;
+        Backdrop.filterImageOriginalDimensions.height = null;
+        Backdrop.behaviors.editorImageLibrary.resetDataAttr(Backdrop.filterImageOriginalDimensions);
         Backdrop.behaviors.editorImageLibrary.imageDimensionsEmpty();
 
         // Change our default lock status to locked when we remove an image.
@@ -476,20 +511,21 @@ Backdrop.behaviors.editorImageLibrary = {
     $('.filter-format-editor-image-form [name="attributes[src]"]').once('filter-editor-img-src').on('change', function() {
       var img = new Image();
       img.onload = function() {
-        naturalDimensions.width = this.width;
-        naturalDimensions.height = this.height;
-        Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
-        Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(naturalDimensions);
-        Backdrop.behaviors.editorImageLibrary.syncAspectRatio(naturalDimensions);
-        Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+        Backdrop.filterImageOriginalDimensions.width = this.width;
+        Backdrop.filterImageOriginalDimensions.height = this.height;
+        Backdrop.behaviors.editorImageLibrary.resetDataAttr(Backdrop.filterImageOriginalDimensions);
+        Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(Backdrop.filterImageOriginalDimensions);
+        Backdrop.behaviors.editorImageLibrary.syncAspectRatio(Backdrop.filterImageOriginalDimensions);
+        Backdrop.behaviors.editorImageLibrary.updateResetButtonState();
       }
       img.onerror = function() {
-        naturalDimensions.width = null;
-        naturalDimensions.height = null;
+        Backdrop.filterImageOriginalDimensions.width = null;
+        Backdrop.filterImageOriginalDimensions.height = null;
         Backdrop.behaviors.editorImageLibrary.imageDimensionsEmpty();
       }
       img.src = this.value;
     });
+
   },
   /**
    * Helper function to empty the width and height form items.
@@ -502,42 +538,75 @@ Backdrop.behaviors.editorImageLibrary = {
   /**
    * Helper function to set width and height values.
    */
-  imageDimensionsSet: function(values) {
-    $('.filter-format-editor-image-form [name="attributes[width]"]').val(values.width);
-    $('.filter-format-editor-image-form [name="attributes[height]"]').val(values.height);
+  imageDimensionsSet: function(imgDimensions) {
+    $('.filter-format-editor-image-form [name="attributes[width]"]').val(imgDimensions.width);
+    $('.filter-format-editor-image-form [name="attributes[height]"]').val(imgDimensions.height);
+  },
+  /**
+   * Based on the aspect ratio of the original dimensions, when we look at
+   * the current dimensions, has this image been "stretched"?
+   *
+   * In other words, are the current dimensions no longer the same aspect
+   * ratio as the original dimensions?
+   *
+   */
+  imageIsStretched: function() {
+
+    if (!Backdrop.filterImageOriginalDimensions.height || Backdrop.filterImageOriginalDimensions.height == 0) {
+      return;
+    }
+
+    var curWidth = parseInt($('.filter-format-editor-image-form [name="attributes[width]"]').val());
+    var curHeight = parseInt($('.filter-format-editor-image-form [name="attributes[height]"]').val());
+
+    if (!curHeight || curHeight == 0) {
+      return;
+    }
+
+    var currentAspectRatio = curWidth / curHeight;
+    var originalAspectRatio = Backdrop.filterImageOriginalDimensions.width / Backdrop.filterImageOriginalDimensions.height;
+
+    if (Math.abs(currentAspectRatio - originalAspectRatio) > 0.01) {
+        // Different aspect ratios. (We have to be a little fuzzy
+        // due to rounding.)
+        return true;
+    }
+
+    return false;
+
   },
   /**
    * Remove previous event listeners, add new ones with current dimensions.
    *
-   * Keep width and height input values in sync based on the natural image
+   * Keep width and height input values in sync based on the supplied image
    * dimensions.
    */
-  syncAspectRatio: function(naturalDimensions) {
-    $('.filter-format-editor-image-form [name="attributes[width]"]').off('change').on('change', function() {
-      var newHeight = Math.round(this.value / naturalDimensions.width * naturalDimensions.height);
+  syncAspectRatio: function(imgDimensions) {
+    $('.filter-format-editor-image-form [name="attributes[width]"]').off('input').on('input', function() {
+      var newHeight = Math.round(this.value / imgDimensions.width * imgDimensions.height);
       if (Backdrop.filterAspectRatioLocked === true) {
         $('.filter-format-editor-image-form [name="attributes[height]"]').val(newHeight);
       }
-      Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+      Backdrop.behaviors.editorImageLibrary.updateResetButtonState();
     });
-    $('.filter-format-editor-image-form [name="attributes[height]"]').off('change').on('change', function() {
-      var newWidth = Math.round(this.value / naturalDimensions.height * naturalDimensions.width);
+    $('.filter-format-editor-image-form [name="attributes[height]"]').off('input').on('input', function() {
+      var newWidth = Math.round(this.value / imgDimensions.height * imgDimensions.width);
       if (Backdrop.filterAspectRatioLocked === true) {
         $('.filter-format-editor-image-form [name="attributes[width]"]').val(newWidth);
       }
-      Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+      Backdrop.behaviors.editorImageLibrary.updateResetButtonState();
     });
   },
   /**
    * Update the data-dimensions attribute value.
    */
-  resetDataAttr: function(naturalDimensions) {
-    $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', naturalDimensions);
+  resetDataAttr: function(imgDimensions) {
+    $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', imgDimensions);
   },
   /**
-   * Update the disabled state of the reset icon
+   * Determine and update the disabled state of the reset icon
    */
-  setButtonState: function(naturalDimensions) {
+  updateResetButtonState: function() {
     var $icon = $('.filter-format-editor-image-form .editor-image-size #reset-orig');
     var curWidth = $('.filter-format-editor-image-form [name="attributes[width]"]').val();
     var curHeight = $('.filter-format-editor-image-form [name="attributes[height]"]').val();

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -200,6 +200,16 @@ Backdrop.behaviors.editorImageDialog = {
       $newItem.find('input, textarea, select').filter(':focusable').first().trigger('focus');
       $newItem.trigger('editor-image-show');
 
+      if ($newItem.hasClass('form-item-fid')) {
+        // Clear any existing width and height, as well as
+        // previously recorded width and height for the "reset"
+        // button.
+        $('.filter-format-editor-image-form [name="attributes[width]"]').val('');
+        $('.filter-format-editor-image-form [name="attributes[height]"]').val('');
+        $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', {width: null, height: null});
+        $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
+      }
+
       return false;
     });
 
@@ -252,7 +262,7 @@ Backdrop.behaviors.editorImageDialog = {
           $(this).remove();
         });
 
-        // Restore the previous dialog position.
+        // Restore the preious dialog position.
         if (Backdrop.filterModalLeft) {
           $(".editor-dialog").css('left', Backdrop.filterModalLeft + 'px');
           // Re-center the dialog by triggering a window resize.

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -79,8 +79,7 @@ Backdrop.behaviors.filterEditors = {
         // Do not detach if the event was canceled.
         if (event.isDefaultPrevented()) {
           return;
-        }
-        Backdrop.settings.formIsSubmitting = true;
+        }        
         Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor]);
       });
     });

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -288,7 +288,7 @@ Backdrop.behaviors.editorImageLibrary = {
         $form.find('[name="attributes[src]"]').val(relativeImgSrc);
         $form.find('[name="fid[fid]"]').val($selectedImg.data('fid'));
 
-        // Reset width and height so image is not stretched to the any revious image's dimensions.
+        // Reset width and height so image is not stretched to the any previous image's dimensions.
         $form.find('[name="attributes[width]"]').val('');
         $form.find('[name="attributes[height]"]').val('');
         // Remove style from previous selection.

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -275,6 +275,7 @@ Backdrop.behaviors.editorImageLibrary = {
   attach: function (context, settings) {
     // The context may be the image library div itself, so include the context
     // element in the selector.
+
     $('[data-editor-library-view]')
       .once('editor-library-view')
       .on('click', '.image-library-choose-file', function() {
@@ -284,13 +285,9 @@ Backdrop.behaviors.editorImageLibrary = {
         var relativeImgSrc = Backdrop.relativeUrl(absoluteImgSrc);
 
         var $form = $('.filter-format-editor-image-form');
-        $form.find('[name="attributes[src]"]').val(relativeImgSrc);
+        $form.find('[name="attributes[src]"]').val(relativeImgSrc).trigger('change');
         $form.find('[name="fid[fid]"]').val($selectedImg.data('fid'));
 
-        // Reset width and height so image is not stretched to
-        // the any previous image's dimensions.
-        $form.find('[name="attributes[width]"]').val('');
-        $form.find('[name="attributes[height]"]').val('');
         // Remove style from previous selection.
         $('.image-library-image-selected').removeClass('image-library-image-selected');
         // Add style to this selection.
@@ -303,15 +300,6 @@ Backdrop.behaviors.editorImageLibrary = {
         var $submit = $form.find('.form-actions input[type=submit]:first');
         $submit.trigger('mousedown').trigger('click').trigger('mouseup');
       });
-
-    // Empty width and height input fields, when an existing file is removed,
-    // so a newly uploaded one does not inherit dimensions.
-    // See Backdrop.behaviors.fileButtons, which triggers mousedown.
-    const $imageForm = $('.image-form-wrapper');
-    $imageForm.find('.file-remove-button').once('remove-button-listener').on('mousedown', function () {
-      $imageForm.find('[name="attributes[width]"]').val('');
-      $imageForm.find('[name="attributes[height]"]').val('');
-    });
 
     // Lock image aspect ratio if the user manually changes width or height.
     var $sizeFormItems = $('.filter-format-editor-image-form .editor-image-size');

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -287,7 +287,7 @@ Backdrop.behaviors.editorImageLibrary = {
         $form.find('[name="attributes[src]"]').val(relativeImgSrc);
         $form.find('[name="fid[fid]"]').val($selectedImg.data('fid'));
 
-        // Reset width and height so image is not stretched to 
+        // Reset width and height so image is not stretched to
         // the any previous image's dimensions.
         $form.find('[name="attributes[width]"]').val('');
         $form.find('[name="attributes[height]"]').val('');
@@ -304,7 +304,7 @@ Backdrop.behaviors.editorImageLibrary = {
         $submit.trigger('mousedown').trigger('click').trigger('mouseup');
       });
 
-    // Empty width and height input fields, when an existing file is removed, 
+    // Empty width and height input fields, when an existing file is removed,
     // so a newly uploaded one does not inherit dimensions.
     // See Backdrop.behaviors.fileButtons, which triggers mousedown.
     const $imageForm = $('.image-form-wrapper');
@@ -326,19 +326,28 @@ Backdrop.behaviors.editorImageLibrary = {
 
     // Set global variable if we have locked the aspect ratio or not.
     Backdrop.settings.filter_img_aspectRatioLocked = true;
-    $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').on('click', function() {
+    $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').off().on('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
       $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').hide();
-      $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').show();
+      $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').show().focus();
       Backdrop.settings.filter_img_aspectRatioLocked = false;
     });
-    
-    $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').on('click', function() {
+
+    $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').off().on('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
       $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').hide();
-      $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show();
-      Backdrop.settings.filter_img_aspectRatioLocked = true;    
+      $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show().focus();
+      Backdrop.settings.filter_img_aspectRatioLocked = true;
     });
-        
-    $('.filter-format-editor-image-form .editor-image-size #reset-orig').on('click', function() {
+
+    $('.filter-format-editor-image-form .editor-image-size #reset-orig').off().on('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
       Backdrop.behaviors.editorImageLibrary.imageDimensionsSet($(this).data('data-dimensions'));
       Backdrop.behaviors.editorImageLibrary.setButtonState($(this).data('data-dimensions'));
     });
@@ -414,27 +423,27 @@ Backdrop.behaviors.editorImageLibrary = {
    * Keep width and height input values in sync based on the natural image
    * dimensions.
    */
-  syncAspectRatio: function(naturalDimensions) {    
-    $('.filter-format-editor-image-form [name="attributes[width]"]').off('change').on('change', function() {      
+  syncAspectRatio: function(naturalDimensions) {
+    $('.filter-format-editor-image-form [name="attributes[width]"]').off('change').on('change', function() {
       var newHeight = Math.round(this.value / naturalDimensions.width * naturalDimensions.height);
       if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
         $('.filter-format-editor-image-form [name="attributes[height]"]').val(newHeight);
       }
       Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
     });
-    $('.filter-format-editor-image-form [name="attributes[height]"]').off('change').on('change', function() {      
+    $('.filter-format-editor-image-form [name="attributes[height]"]').off('change').on('change', function() {
       var newWidth = Math.round(this.value / naturalDimensions.height * naturalDimensions.width);
       if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
         $('.filter-format-editor-image-form [name="attributes[width]"]').val(newWidth);
       }
       Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
-    });        
+    });
   },
   /**
    * Update the data-dimensions attribute value.
    */
   resetDataAttr: function(naturalDimensions) {
-    $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', naturalDimensions);    
+    $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', naturalDimensions);
   },
   /**
    * Update the disabled state of the reset icon
@@ -447,9 +456,9 @@ Backdrop.behaviors.editorImageLibrary = {
       $('.filter-format-editor-image-form .editor-image-size #reset-orig').removeClass('reset-orig-inactive');
     }
     else {
-      $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');      
+      $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
     }
-  }  
+  }
 };
 
 /**

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -79,7 +79,7 @@ Backdrop.behaviors.filterEditors = {
         // Do not detach if the event was canceled.
         if (event.isDefaultPrevented()) {
           return;
-        }        
+        }
         Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor]);
       });
     });
@@ -267,7 +267,7 @@ Backdrop.behaviors.editorImageDialog = {
     });
   }
 };
-  
+
 /**
  * Provides behavior for clicking on images within the library browser.
  */
@@ -287,7 +287,8 @@ Backdrop.behaviors.editorImageLibrary = {
         $form.find('[name="attributes[src]"]').val(relativeImgSrc);
         $form.find('[name="fid[fid]"]').val($selectedImg.data('fid'));
 
-        // Reset width and height so image is not stretched to the any previous image's dimensions.
+        // Reset width and height so image is not stretched to 
+        // the any previous image's dimensions.
         $form.find('[name="attributes[width]"]').val('');
         $form.find('[name="attributes[height]"]').val('');
         // Remove style from previous selection.
@@ -303,7 +304,8 @@ Backdrop.behaviors.editorImageLibrary = {
         $submit.trigger('mousedown').trigger('click').trigger('mouseup');
       });
 
-    // Empty width and height input fields, when an existing file is removed, so a newly uploaded one does not inherit dimensions.
+    // Empty width and height input fields, when an existing file is removed, 
+    // so a newly uploaded one does not inherit dimensions.
     // See Backdrop.behaviors.fileButtons, which triggers mousedown.
     const $imageForm = $('.image-form-wrapper');
     $imageForm.find('.file-remove-button').once('remove-button-listener').on('mousedown', function () {

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -450,8 +450,6 @@ Backdrop.behaviors.editorImageLibrary = {
   }  
 };
 
-
-
 /**
  * Command to save the contents of an editor-provided dialog.
  *

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -220,6 +220,11 @@ Backdrop.behaviors.editorImageDialog = {
       $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', {width: null, height: null});
       $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
 
+      // Change our default lock status to locked when we change "screens".
+      Backdrop.filterAspectRatioLocked = true;
+      $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show().focus();
+      $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').hide();
+
       if ($newItem.hasClass('form-item-fid')) {
         // The user is now viewing the "Upload an image" screen.
         Backdrop.filterImageEditorDisplay = 'upload';
@@ -429,6 +434,11 @@ Backdrop.behaviors.editorImageLibrary = {
         naturalDimensions.height = null;
         Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
         Backdrop.behaviors.editorImageLibrary.imageDimensionsEmpty();
+
+        // Change our default lock status to locked when we remove an image.
+        Backdrop.filterAspectRatioLocked = true;
+        $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show().focus();
+        $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').hide();
       }
     }
 

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -80,6 +80,7 @@ Backdrop.behaviors.filterEditors = {
         if (event.isDefaultPrevented()) {
           return;
         }
+        Backdrop.settings.formIsSubmitting = true;
         Backdrop.filterEditorDetach(field, Backdrop.settings.filter.formats[activeEditor]);
       });
     });
@@ -268,6 +269,10 @@ Backdrop.behaviors.editorImageDialog = {
   }
 };
 
+
+
+
+
 /**
  * Provides behavior for clicking on images within the library browser.
  */
@@ -312,8 +317,155 @@ Backdrop.behaviors.editorImageLibrary = {
       $imageForm.find('[name="attributes[width]"]').val('');
       $imageForm.find('[name="attributes[height]"]').val('');
     });
-  }
+    
+
+    // Lock image aspect ratio if the user manually changes width or height
+    var $sizeFormItems = $('.filter-format-editor-image-form .editor-image-size');
+    // But first make sure, the form items exist.
+    if (!$sizeFormItems.length) {
+      return;
+    }
+    var naturalDimensions = {
+      width: null,
+      height: null
+    };
+   
+    
+    // Set global variable if we have locked the aspect ratio or not
+    Backdrop.settings.filter_img_aspectRatioLocked = true;
+    $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').on('click', function() {
+      $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').hide();
+      $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').show();
+      Backdrop.settings.filter_img_aspectRatioLocked = false;
+    });
+    
+    $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').on('click', function() {
+      $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').hide();
+      $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show();
+      Backdrop.settings.filter_img_aspectRatioLocked = true;    
+    });
+    
+    
+    $('.filter-format-editor-image-form .editor-image-size #reset-orig').on('click', function() {
+      Backdrop.behaviors.editorImageLibrary.imageDimensionsSet($(this).data('data-dimensions'));
+      Backdrop.behaviors.editorImageLibrary.setButtonState($(this).data('data-dimensions'));
+    });
+    // When editing a previously added image or upload a new one.
+    var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
+    if (typeof existingFile !== 'undefined') {
+      var img = new Image();
+      img.onload = function() {
+        naturalDimensions.width = this.width;
+        naturalDimensions.height = this.height;
+        Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
+        if (!$('.filter-format-editor-image-form [name="attributes[width]"]').val().length) {
+          Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(naturalDimensions);
+        }
+        Backdrop.behaviors.editorImageLibrary.syncAspectRatio(naturalDimensions);
+        Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+
+      }
+      img.onerror = function() {
+        naturalDimensions.width = null;
+        naturalDimensions.height = null;
+      }
+      img.src = existingFile;
+    }
+    else if ($('.filter-format-editor-image-form [name="attributes[width]"]').length) {
+      // After an image has been removed via button, and the managed form item
+      // reloads, reset width and height.
+      if ($('.filter-format-editor-image-form [name="attributes[width]"]').val().length) {
+        naturalDimensions.width = null;
+        naturalDimensions.height = null;
+        Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
+        Backdrop.behaviors.editorImageLibrary.imageDimensionsEmpty();
+      }
+    }
+
+    // Selecting an image from library updates width and height values.
+    $('.filter-format-editor-image-form [name="attributes[src]"]').once('filter-editor-img-src').on('change', function() {
+      var img = new Image();
+      img.onload = function() {
+        naturalDimensions.width = this.width;
+        naturalDimensions.height = this.height;
+        Backdrop.behaviors.editorImageLibrary.resetDataAttr(naturalDimensions);
+        Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(naturalDimensions);
+        Backdrop.behaviors.editorImageLibrary.syncAspectRatio(naturalDimensions);
+        Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+      }
+      img.onerror = function() {
+        naturalDimensions.width = null;
+        naturalDimensions.height = null;
+        Backdrop.behaviors.editorImageLibrary.imageDimensionsEmpty();
+      }
+      img.src = this.value;
+    });    
+       
+    
+  },
+  /**
+   * Helper function to empty the width and height form items.
+   */
+  imageDimensionsEmpty: function() {
+    $('.filter-format-editor-image-form [name="attributes[width]"]').val('');
+    $('.filter-format-editor-image-form [name="attributes[height]"]').val('');
+    $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
+  },
+  /**
+   * Helper funtion to set width and height values.
+   */
+  imageDimensionsSet: function(values) {
+    $('.filter-format-editor-image-form [name="attributes[width]"]').val(values.width);
+    $('.filter-format-editor-image-form [name="attributes[height]"]').val(values.height);
+  },
+  /**
+   * Remove previous event listeners, add new ones with current dimensions.
+   *
+   * Keep width and height input values in sync based on the natural image
+   * dimensions.
+   */
+  syncAspectRatio: function(naturalDimensions) {
+    
+    $('.filter-format-editor-image-form [name="attributes[width]"]').off('change').on('change', function() {      
+      var newHeight = Math.round(this.value / naturalDimensions.width * naturalDimensions.height);
+      if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
+        $('.filter-format-editor-image-form [name="attributes[height]"]').val(newHeight);
+      }
+      Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+    });
+    $('.filter-format-editor-image-form [name="attributes[height]"]').off('change').on('change', function() {      
+      var newWidth = Math.round(this.value / naturalDimensions.height * naturalDimensions.width);
+      if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
+        $('.filter-format-editor-image-form [name="attributes[width]"]').val(newWidth);
+      }
+      Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
+    });
+    
+    
+  },
+  /**
+   * Update the data-dimensions attribute value.
+   */
+  resetDataAttr: function(naturalDimensions) {
+    $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', naturalDimensions);    
+  },
+  /**
+   * Update the disabled state of the reset icon
+   */
+  setButtonState: function(naturalDimensions) {
+    var $icon = $('.filter-format-editor-image-form .editor-image-size #reset-orig');
+    var curWidth = $('.filter-format-editor-image-form [name="attributes[width]"]').val();
+    var curHeight = $('.filter-format-editor-image-form [name="attributes[height]"]').val();
+    if ((curWidth.length && $icon.data('data-dimensions').width != curWidth) || (curHeight.length && $icon.data('data-dimensions').height != curHeight))  {
+      $('.filter-format-editor-image-form .editor-image-size #reset-orig').removeClass('reset-orig-inactive');
+    }
+    else {
+      $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');      
+    }
+  }  
 };
+
+
 
 /**
  * Command to save the contents of an editor-provided dialog.

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -16,6 +16,18 @@ Backdrop.editors = {};
 Backdrop.filterModalLeft = undefined;
 
 /**
+ * Keep track of whether the image editor has its aspect ratio
+ * "locked" or not.
+ */
+Backdrop.filterAspectRatioLocked = true;
+
+/**
+ * In the image editor, keep track of which "screen" is being
+ * displayed (e.g., the Upload screen or the Select from library screen).
+ */
+Backdrop.filterImageEditorDisplay = undefined;
+
+/**
  * Displays the guidelines of the selected text format automatically.
  */
 Backdrop.behaviors.filterGuidelines = {
@@ -209,8 +221,8 @@ Backdrop.behaviors.editorImageDialog = {
       $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
 
       if ($newItem.hasClass('form-item-fid')) {
-        // The user is now viewing the Upload an image screen.
-        Backdrop.settings.filter_img_display = 'upload';
+        // The user is now viewing the "Upload an image" screen.
+        Backdrop.filterImageEditorDisplay = 'upload';
         // Check if we had previously uploaded an image. If so, populate
         // our width and height fields with its width and height.
         var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
@@ -221,7 +233,6 @@ Backdrop.behaviors.editorImageDialog = {
           };
 
           var img = new Image();
-          img.src = existingFile;
           img.onload = function() {
             originalDimensions.width = this.width;
             originalDimensions.height = this.height;
@@ -233,13 +244,15 @@ Backdrop.behaviors.editorImageDialog = {
 
             Backdrop.behaviors.editorImageLibrary.syncAspectRatio(originalDimensions);
             Backdrop.behaviors.editorImageLibrary.setButtonState(originalDimensions);
-
           }
+          // Actually perform the loading of the image last
+          // just in case the listener functions are set yet.
+          img.src = existingFile;
         }
       }
       else if ($newItem.hasClass('form-item-attributes-src')) {
-        // The user is now viewing the Select from library screen.
-        Backdrop.settings.filter_img_display = 'library';
+        // The user is now viewing the "Select from library" screen.
+        Backdrop.filterImageEditorDisplay = 'library';
       }
 
       return false;
@@ -354,15 +367,15 @@ Backdrop.behaviors.editorImageLibrary = {
       height: null
     };
 
-    // Set global variable if we have locked the aspect ratio or not.
-    Backdrop.settings.filter_img_aspectRatioLocked = true;
+    // Set variable if we have locked the aspect ratio or not.
+    Backdrop.filterAspectRatioLocked = true;
     $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').off().on('click', function(e) {
       e.preventDefault();
       e.stopPropagation();
 
       $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').hide();
       $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').show().focus();
-      Backdrop.settings.filter_img_aspectRatioLocked = false;
+      Backdrop.filterAspectRatioLocked = false;
     });
 
     $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').off().on('click', function(e) {
@@ -371,7 +384,7 @@ Backdrop.behaviors.editorImageLibrary = {
 
       $('.filter-format-editor-image-form .editor-image-size #lock-aspect-ratio').hide();
       $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show().focus();
-      Backdrop.settings.filter_img_aspectRatioLocked = true;
+      Backdrop.filterAspectRatioLocked = true;
     });
 
     $('.filter-format-editor-image-form .editor-image-size #reset-orig').off().on('click', function(e) {
@@ -384,12 +397,12 @@ Backdrop.behaviors.editorImageLibrary = {
 
     // When editing a previously added/selected image, or upload a new one.
     var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
-    if (Backdrop.settings.filter_img_display === 'library') {
+    if (Backdrop.filterImageEditorDisplay === 'library') {
       existingFile = $('.filter-format-editor-image-form #edit-attributes-src').val();
     }
     if (typeof existingFile !== 'undefined' && existingFile !== '') {
       var img = new Image();
-      img.src = existingFile;
+      // First, define functions for img.
       img.onload = function() {
         naturalDimensions.width = this.width;
         naturalDimensions.height = this.height;
@@ -404,6 +417,9 @@ Backdrop.behaviors.editorImageLibrary = {
         naturalDimensions.width = null;
         naturalDimensions.height = null;
       }
+      // Perform the loading of the image last, just in case
+      // the listener functions aren't set yet.
+      img.src = existingFile;
     }
     else if ($('.filter-format-editor-image-form [name="attributes[width]"]').length) {
       // After an image has been removed via button, and the managed form item
@@ -459,14 +475,14 @@ Backdrop.behaviors.editorImageLibrary = {
   syncAspectRatio: function(naturalDimensions) {
     $('.filter-format-editor-image-form [name="attributes[width]"]').off('change').on('change', function() {
       var newHeight = Math.round(this.value / naturalDimensions.width * naturalDimensions.height);
-      if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
+      if (Backdrop.filterAspectRatioLocked === true) {
         $('.filter-format-editor-image-form [name="attributes[height]"]').val(newHeight);
       }
       Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
     });
     $('.filter-format-editor-image-form [name="attributes[height]"]').off('change').on('change', function() {
       var newWidth = Math.round(this.value / naturalDimensions.height * naturalDimensions.width);
-      if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
+      if (Backdrop.filterAspectRatioLocked === true) {
         $('.filter-format-editor-image-form [name="attributes[width]"]').val(newWidth);
       }
       Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -200,14 +200,46 @@ Backdrop.behaviors.editorImageDialog = {
       $newItem.find('input, textarea, select').filter(':focusable').first().trigger('focus');
       $newItem.trigger('editor-image-show');
 
+      // Clear any existing width and height, as well as
+      // previously recorded width and height for the "reset"
+      // button.
+      $('.filter-format-editor-image-form [name="attributes[width]"]').val('');
+      $('.filter-format-editor-image-form [name="attributes[height]"]').val('');
+      $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', {width: null, height: null});
+      $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
+
       if ($newItem.hasClass('form-item-fid')) {
-        // Clear any existing width and height, as well as
-        // previously recorded width and height for the "reset"
-        // button.
-        $('.filter-format-editor-image-form [name="attributes[width]"]').val('');
-        $('.filter-format-editor-image-form [name="attributes[height]"]').val('');
-        $('.filter-format-editor-image-form .editor-image-size #reset-orig').data('data-dimensions', {width: null, height: null});
-        $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
+        // The user is now viewing the Upload an image screen.
+        Backdrop.settings.filter_img_display = 'upload';
+        // Check if we had previously uploaded an image. If so, populate
+        // our width and height fields with its width and height.
+        var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
+        if (typeof existingFile !== 'undefined') {
+          var originalDimensions = {
+            width: null,
+            height: null
+          };
+
+          var img = new Image();
+          img.src = existingFile;
+          img.onload = function() {
+            originalDimensions.width = this.width;
+            originalDimensions.height = this.height;
+            Backdrop.behaviors.editorImageLibrary.resetDataAttr(originalDimensions);
+
+            if (!$('.filter-format-editor-image-form [name="attributes[width]"]').val().length) {
+              Backdrop.behaviors.editorImageLibrary.imageDimensionsSet(originalDimensions);
+            }
+
+            Backdrop.behaviors.editorImageLibrary.syncAspectRatio(originalDimensions);
+            Backdrop.behaviors.editorImageLibrary.setButtonState(originalDimensions);
+
+          }
+        }
+      }
+      else if ($newItem.hasClass('form-item-attributes-src')) {
+        // The user is now viewing the Select from library screen.
+        Backdrop.settings.filter_img_display = 'library';
       }
 
       return false;
@@ -349,10 +381,15 @@ Backdrop.behaviors.editorImageLibrary = {
       Backdrop.behaviors.editorImageLibrary.imageDimensionsSet($(this).data('data-dimensions'));
       Backdrop.behaviors.editorImageLibrary.setButtonState($(this).data('data-dimensions'));
     });
-    // When editing a previously added image or upload a new one.
+
+    // When editing a previously added/selected image, or upload a new one.
     var existingFile = $('.filter-format-editor-image-form .form-managed-file a').attr('href');
-    if (typeof existingFile !== 'undefined') {
+    if (Backdrop.settings.filter_img_display === 'library') {
+      existingFile = $('.filter-format-editor-image-form #edit-attributes-src').val();
+    }
+    if (typeof existingFile !== 'undefined' && existingFile !== '') {
       var img = new Image();
+      img.src = existingFile;
       img.onload = function() {
         naturalDimensions.width = this.width;
         naturalDimensions.height = this.height;
@@ -362,13 +399,11 @@ Backdrop.behaviors.editorImageLibrary = {
         }
         Backdrop.behaviors.editorImageLibrary.syncAspectRatio(naturalDimensions);
         Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
-
       }
       img.onerror = function() {
         naturalDimensions.width = null;
         naturalDimensions.height = null;
       }
-      img.src = existingFile;
     }
     else if ($('.filter-format-editor-image-form [name="attributes[width]"]').length) {
       // After an image has been removed via button, and the managed form item

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -268,11 +268,7 @@ Backdrop.behaviors.editorImageDialog = {
     });
   }
 };
-
-
-
-
-
+  
 /**
  * Provides behavior for clicking on images within the library browser.
  */
@@ -292,8 +288,7 @@ Backdrop.behaviors.editorImageLibrary = {
         $form.find('[name="attributes[src]"]').val(relativeImgSrc);
         $form.find('[name="fid[fid]"]').val($selectedImg.data('fid'));
 
-        // Reset width and height so image is not stretched to the any
-        // previous image's dimensions.
+        // Reset width and height so image is not stretched to the any revious image's dimensions.
         $form.find('[name="attributes[width]"]').val('');
         $form.find('[name="attributes[height]"]').val('');
         // Remove style from previous selection.
@@ -309,17 +304,15 @@ Backdrop.behaviors.editorImageLibrary = {
         $submit.trigger('mousedown').trigger('click').trigger('mouseup');
       });
 
-    // Empty width and height input fields, when an existing file is removed,
-    // so a newly uploaded one does not inherit dimensions.
+    // Empty width and height input fields, when an existing file is removed, so a newly uploaded one does not inherit dimensions.
     // See Backdrop.behaviors.fileButtons, which triggers mousedown.
     const $imageForm = $('.image-form-wrapper');
     $imageForm.find('.file-remove-button').once('remove-button-listener').on('mousedown', function () {
       $imageForm.find('[name="attributes[width]"]').val('');
       $imageForm.find('[name="attributes[height]"]').val('');
     });
-    
 
-    // Lock image aspect ratio if the user manually changes width or height
+    // Lock image aspect ratio if the user manually changes width or height.
     var $sizeFormItems = $('.filter-format-editor-image-form .editor-image-size');
     // But first make sure, the form items exist.
     if (!$sizeFormItems.length) {
@@ -329,9 +322,8 @@ Backdrop.behaviors.editorImageLibrary = {
       width: null,
       height: null
     };
-   
-    
-    // Set global variable if we have locked the aspect ratio or not
+
+    // Set global variable if we have locked the aspect ratio or not.
     Backdrop.settings.filter_img_aspectRatioLocked = true;
     $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').on('click', function() {
       $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').hide();
@@ -344,8 +336,7 @@ Backdrop.behaviors.editorImageLibrary = {
       $('.filter-format-editor-image-form .editor-image-size #unlock-aspect-ratio').show();
       Backdrop.settings.filter_img_aspectRatioLocked = true;    
     });
-    
-    
+        
     $('.filter-format-editor-image-form .editor-image-size #reset-orig').on('click', function() {
       Backdrop.behaviors.editorImageLibrary.imageDimensionsSet($(this).data('data-dimensions'));
       Backdrop.behaviors.editorImageLibrary.setButtonState($(this).data('data-dimensions'));
@@ -399,9 +390,7 @@ Backdrop.behaviors.editorImageLibrary = {
         Backdrop.behaviors.editorImageLibrary.imageDimensionsEmpty();
       }
       img.src = this.value;
-    });    
-       
-    
+    });
   },
   /**
    * Helper function to empty the width and height form items.
@@ -412,7 +401,7 @@ Backdrop.behaviors.editorImageLibrary = {
     $('.filter-format-editor-image-form .editor-image-size #reset-orig').addClass('reset-orig-inactive');
   },
   /**
-   * Helper funtion to set width and height values.
+   * Helper function to set width and height values.
    */
   imageDimensionsSet: function(values) {
     $('.filter-format-editor-image-form [name="attributes[width]"]').val(values.width);
@@ -424,8 +413,7 @@ Backdrop.behaviors.editorImageLibrary = {
    * Keep width and height input values in sync based on the natural image
    * dimensions.
    */
-  syncAspectRatio: function(naturalDimensions) {
-    
+  syncAspectRatio: function(naturalDimensions) {    
     $('.filter-format-editor-image-form [name="attributes[width]"]').off('change').on('change', function() {      
       var newHeight = Math.round(this.value / naturalDimensions.width * naturalDimensions.height);
       if (Backdrop.settings.filter_img_aspectRatioLocked === true) {
@@ -439,9 +427,7 @@ Backdrop.behaviors.editorImageLibrary = {
         $('.filter-format-editor-image-form [name="attributes[width]"]').val(newWidth);
       }
       Backdrop.behaviors.editorImageLibrary.setButtonState(naturalDimensions);
-    });
-    
-    
+    });        
   },
   /**
    * Update the data-dimensions attribute value.

--- a/core/modules/filter/js/filter.js
+++ b/core/modules/filter/js/filter.js
@@ -262,7 +262,7 @@ Backdrop.behaviors.editorImageDialog = {
           $(this).remove();
         });
 
-        // Restore the preious dialog position.
+        // Restore the previous dialog position.
         if (Backdrop.filterModalLeft) {
           $(".editor-dialog").css('left', Backdrop.filterModalLeft + 'px');
           // Re-center the dialog by triggering a window resize.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/2054

Note: To globally disable the ability to "unlock" the aspect ratio, add this to settings.php:
```php
$settings['disable_image_aspect_ratio_unlock'] = TRUE;
```


<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
