### PR TITLE
Issue #7178: Fix PHP warnings when managed_file element has no #field_name

### DIFF
--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -1867,8 +1867,13 @@ function file_managed_file_browser_open($form, $form_state) {
       ));
     }
   }
-  $field = field_info_field($element['#field_name']);
-  $field_cardinality = $field['cardinality'];
+  $field_cardinality = 1;
+  if (!empty($element['#field_name'])) {
+    $field = field_info_field($element['#field_name']);
+    if (!empty($field['cardinality'])) {
+      $field_cardinality = $field['cardinality'];
+    }
+  }
 
   // Add JQuery UI selectable to allow drag and drop selection if the field
   // cardinality is set to multiple.

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -1874,6 +1874,9 @@ function file_managed_file_browser_open($form, $form_state) {
       $field_cardinality = $field['cardinality'];
     }
   }
+  elseif (!empty($element['#multiple'])) {
+    $field_cardinality = FIELD_CARDINALITY_UNLIMITED;
+  }
 
   // Add JQuery UI selectable to allow drag and drop selection if the field
   // cardinality is set to multiple.


### PR DESCRIPTION
Fixes file_managed_file_browser_open() throws PHP warnings when the managed_file element has no #field_name

Fixes https://github.com/backdrop/backdrop-issues/issues/7178

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
