### PR TITLE
Hide version number of all JS files as a security hardening measure

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -4925,10 +4925,6 @@ function backdrop_add_js($data = NULL, $options = NULL) {
   }
   $options += backdrop_js_defaults($data);
 
-  // Intentionally hide the version number of the javascript file
-  // as a security measure.
-  $options['version'] = NULL;
-
   // Preprocess can only be set if caching is enabled and no attributes
   // nor defer tag are set.
   $options['preprocess'] = $options['cache'] && empty($options['attributes']) && empty($options['defer']) ? $options['preprocess'] : FALSE;
@@ -4974,6 +4970,7 @@ function backdrop_add_js($data = NULL, $options = NULL) {
           'defer' => FALSE,
           'attributes' => array(),
           'browsers' => array(),
+          'version' => BACKDROP_VERSION,
         ),
       );
       // Backwards-compatibility for JavaScript.
@@ -5217,7 +5214,7 @@ function backdrop_pre_render_scripts(array $elements) {
             break;
 
           case 'file':
-            $query_string = empty($item['version']) ? $default_query_string : 'v=' . $item['version'];
+            $query_string = $default_query_string;
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
             $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
             break;

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -4925,6 +4925,10 @@ function backdrop_add_js($data = NULL, $options = NULL) {
   }
   $options += backdrop_js_defaults($data);
 
+  // Intentionally hide the version number of the javascript file
+  // as a security measure.
+  $options['version'] = NULL;
+
   // Preprocess can only be set if caching is enabled and no attributes
   // nor defer tag are set.
   $options['preprocess'] = $options['cache'] && empty($options['attributes']) && empty($options['defer']) ? $options['preprocess'] : FALSE;
@@ -4970,7 +4974,6 @@ function backdrop_add_js($data = NULL, $options = NULL) {
           'defer' => FALSE,
           'attributes' => array(),
           'browsers' => array(),
-          'version' => BACKDROP_VERSION,
         ),
       );
       // Backwards-compatibility for JavaScript.

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5214,7 +5214,7 @@ function backdrop_pre_render_scripts(array $elements) {
             break;
 
           case 'file':
-            $query_string = $default_query_string;
+            $query_string = empty($item['version']) ? $default_query_string : 'v=' . $default_query_string;
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
             $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
             break;

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5214,7 +5214,7 @@ function backdrop_pre_render_scripts(array $elements) {
             break;
 
           case 'file':
-            $query_string = empty($item['version']) ? $default_query_string : 'v=' . $default_query_string;
+            $query_string = $default_query_string;
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
             $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
             break;

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1544,16 +1544,6 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   }
 
   /**
-   * Test JavaScript versioning.
-   */
-  function testVersionQueryString() {
-    backdrop_add_js('core/misc/collapse.js', array('version' => 'foo'));
-    backdrop_add_js('core/misc/ajax.js', array('version' => 'bar'));
-    $javascript = backdrop_get_js();
-    $this->assertTrue(strpos($javascript, 'core/misc/collapse.js?v=foo') > 0 && strpos($javascript, 'core/misc/ajax.js?v=bar') > 0 , t('JavaScript version identifiers correctly appended to URLs'));
-  }
-
-  /**
    * Test JavaScript grouping and aggregation.
    */
   function testAggregation() {


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7179

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
