### PR TITLE
Issue #7179: Browser "view source" exposes Backdrop and other version numbers when js aggregation is turned off

### DIFF
--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5217,23 +5217,20 @@ function backdrop_pre_render_scripts(array $elements) {
             if (!empty($item['version'])) {
               $hash_algos = hash_algos();
               $seed = substr(backdrop_get_hash_salt(), 0, 8);
-
               if (in_array('xxh128', $hash_algos, TRUE)) {
                 // Convert the seed to a positive integer.
                 $seed[0] = chr(ord($seed[0]) & 0x7f);
                 $seed = unpack('J', $seed)[1];
-                $hash = hash('xxh128', $item['version'], FALSE, array('seed' => $seed));
+                $hash = base_convert(hash('xxh128', $item['version'], FALSE, array('seed' => $seed)), 16, 36);
               }
               else {
                 $hash = hash('crc32', $item['version'] . $seed);
               }
-
               $query_string = "v=$hash";
             }
             else {
               $query_string = $default_query_string;
             }
-
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
             $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
             break;

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5216,13 +5216,15 @@ function backdrop_pre_render_scripts(array $elements) {
           case 'file':
             if (!empty($item['version'])) {
               $hash_algos = hash_algos();
-              $seed = str_pad(substr(backdrop_get_hash_salt(), 0, 138), 138, "\x04\x00\xa0\x00");
+              $seed = substr(backdrop_get_hash_salt(), 0, 8);
 
               if (in_array('xxh128', $hash_algos, TRUE)) {
-                $hash = hash('xxh128', $item['version'], FALSE, array('secret' => $seed));
+                // Convert the seed to a positive integer.
+                $seed[0] = chr(ord($seed) & 0x7f);
+                $seed = unpack('J', $seed)[1];
+                $hash = hash('xxh128', $item['version'], FALSE, array('seed' => $seed));
               }
               else {
-                $seed = substr($seed, 0, 8);
                 $hash = hash('crc32', $item['version'] . $seed);
               }
 

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5214,12 +5214,7 @@ function backdrop_pre_render_scripts(array $elements) {
             break;
 
           case 'file':
-            if (!empty($item['version'])) {
-              $query_string = 'v=' . hash('crc32', $item['version'] . backdrop_get_hash_salt());
-            }
-            else {
-              $query_string = $default_query_string;
-            }
+            $query_string = empty($item['version']) ? $default_query_string : hash('crc32', $item['version'] . backdrop_get_hash_salt());
             $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
             $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
             break;

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5215,18 +5215,7 @@ function backdrop_pre_render_scripts(array $elements) {
 
           case 'file':
             if (!empty($item['version'])) {
-              $hash_algos = hash_algos();
-              $seed = substr(backdrop_get_hash_salt(), 0, 8);
-              if (in_array('xxh128', $hash_algos, TRUE)) {
-                // Convert the seed to a positive integer.
-                $seed[0] = chr(ord($seed[0]) & 0x7f);
-                $seed = unpack('J', $seed)[1];
-                $hash = base_convert(hash('xxh128', $item['version'], FALSE, array('seed' => $seed)), 16, 36);
-              }
-              else {
-                $hash = hash('crc32', $item['version'] . $seed);
-              }
-              $query_string = "v=$hash";
+              $query_string = 'v=' . hash('crc32', $item['version'] . backdrop_get_hash_salt());
             }
             else {
               $query_string = $default_query_string;

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5213,29 +5213,30 @@ function backdrop_pre_render_scripts(array $elements) {
             $element['#value'] = $item['data'];
             break;
 
-            case 'file':
-              if (!empty($item['version'])) {
-                $hash_algos = hash_algos();
-                $hash_salt = backdrop_get_hash_salt();
+          case 'file':
+            if (!empty($item['version'])) {
+              $hash_algos = hash_algos();
+              $hash_salt = backdrop_get_hash_salt();
 
-                if (in_array('murmur3f', $hash_algos, TRUE)) {
-                  $seed = hexdec(backdrop_substr($hash_salt, 0, 16));
-                  $hash = hash('murmur3f', $item['version'], FALSE, array('seed' => $seed));
-                }
-                else {
-                  $seed = backdrop_substr($hash_salt, 0, 8);
-                  $hash = hash('crc32', $item['version'] . $seed);
-                }
-
-                $query_string = "v=$hash";
+              if (in_array('murmur3f', $hash_algos, TRUE)) {
+                $seed = hexdec(backdrop_substr($hash_salt, 0, 16));
+                $hash = hash('murmur3f', $item['version'], FALSE, array('seed' => $seed));
               }
               else {
-                $query_string = $default_query_string;
+                $seed = backdrop_substr($hash_salt, 0, 8);
+                $hash = hash('crc32', $item['version'] . $seed);
               }
 
-              $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
-              $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
-              break;
+              $query_string = "v=$hash";
+            }
+            else {
+              $query_string = $default_query_string;
+            }
+
+            $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
+            $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
+            break;
+
           case 'external':
             $element['#attributes']['src'] = $item['data'];
             break;

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5216,7 +5216,7 @@ function backdrop_pre_render_scripts(array $elements) {
           case 'file':
             if (!empty($item['version'])) {
               $hash_algos = hash_algos();
-              $seed = substr(backdrop_get_hash_salt(), 0, 138);
+              $seed = str_pad(substr(backdrop_get_hash_salt(), 0, 138), 138, "\x04\x00\xa0\x00");
 
               if (in_array('xxh128', $hash_algos, TRUE)) {
                 $hash = hash('xxh128', $item['version'], FALSE, array('secret' => $seed));

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5220,7 +5220,7 @@ function backdrop_pre_render_scripts(array $elements) {
 
               if (in_array('xxh128', $hash_algos, TRUE)) {
                 // Convert the seed to a positive integer.
-                $seed[0] = chr(ord($seed) & 0x7f);
+                $seed[0] = chr(ord($seed[0]) & 0x7f);
                 $seed = unpack('J', $seed)[1];
                 $hash = hash('xxh128', $item['version'], FALSE, array('seed' => $seed));
               }

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5216,14 +5216,13 @@ function backdrop_pre_render_scripts(array $elements) {
           case 'file':
             if (!empty($item['version'])) {
               $hash_algos = hash_algos();
-              $hash_salt = backdrop_get_hash_salt();
+              $seed = substr(backdrop_get_hash_salt(), 0, 138);
 
-              if (in_array('murmur3f', $hash_algos, TRUE)) {
-                $seed = hexdec(backdrop_substr($hash_salt, 0, 16));
-                $hash = hash('murmur3f', $item['version'], FALSE, array('seed' => $seed));
+              if (in_array('xxh128', $hash_algos, TRUE)) {
+                  $hash = hash('xxh128', $item['version'], FALSE, array('segret' => $seed));
               }
               else {
-                $seed = backdrop_substr($hash_salt, 0, 8);
+                $seed = substr($seed, 0, 8);
                 $hash = hash('crc32', $item['version'] . $seed);
               }
 

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5219,7 +5219,7 @@ function backdrop_pre_render_scripts(array $elements) {
               $seed = substr(backdrop_get_hash_salt(), 0, 138);
 
               if (in_array('xxh128', $hash_algos, TRUE)) {
-                  $hash = hash('xxh128', $item['version'], FALSE, array('segret' => $seed));
+                $hash = hash('xxh128', $item['version'], FALSE, array('secret' => $seed));
               }
               else {
                 $seed = substr($seed, 0, 8);

--- a/core/includes/common.inc
+++ b/core/includes/common.inc
@@ -5213,12 +5213,29 @@ function backdrop_pre_render_scripts(array $elements) {
             $element['#value'] = $item['data'];
             break;
 
-          case 'file':
-            $query_string = empty($item['version']) ? $default_query_string : 'v=' . $item['version'];
-            $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
-            $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
-            break;
+            case 'file':
+              if (!empty($item['version'])) {
+                $hash_algos = hash_algos();
+                $hash_salt = backdrop_get_hash_salt();
 
+                if (in_array('murmur3f', $hash_algos, TRUE)) {
+                  $seed = hexdec(backdrop_substr($hash_salt, 0, 16));
+                  $hash = hash('murmur3f', $item['version'], FALSE, array('seed' => $seed));
+                }
+                else {
+                  $seed = backdrop_substr($hash_salt, 0, 8);
+                  $hash = hash('crc32', $item['version'] . $seed);
+                }
+
+                $query_string = "v=$hash";
+              }
+              else {
+                $query_string = $default_query_string;
+              }
+
+              $query_string_separator = (strpos($item['data'], '?') !== FALSE) ? '&' : '?';
+              $element['#attributes']['src'] = file_create_url($item['data']) . $query_string_separator . ($item['cache'] ? $query_string : REQUEST_TIME);
+              break;
           case 'external':
             $element['#attributes']['src'] = $item['data'];
             break;

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1562,8 +1562,8 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
       // Convert the seed to a positive integer.
       $seed[0] = chr(ord($seed[0]) & 0x7f);
       $seed = unpack('J', $seed)[1];
-      $expected['ajax'] = hash('xxh128', $version['ajax'], FALSE, array('seed' => $seed));
-      $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('seed' => $seed));
+      $expected['ajax'] = base_convert(hash('xxh128', $version['ajax'], FALSE, array('seed' => $seed)), 16, 36);
+      $expected['collapse'] = base_convert(hash('xxh128', $version['collapse'], FALSE, array('seed' => $seed)), 16, 36);
     }
     else {
       $seed = substr($seed, 0, 8);

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1548,8 +1548,6 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    */
   function testVersionQueryString() {
     $expected = array();
-    $hash_algos = hash_algos();
-    $seed = substr(backdrop_get_hash_salt(), 0, 8);
     $version = array(
       'ajax' => 'bar',
       'collapse' => 'foo',
@@ -1558,18 +1556,8 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     // The following code is the same code used by
     // backdrop_pre_render_scripts(). If the code in that function is changed,
     // the following code needs to be changed too.
-    if (in_array('xxh128', $hash_algos, TRUE)) {
-      // Convert the seed to a positive integer.
-      $seed[0] = chr(ord($seed[0]) & 0x7f);
-      $seed = unpack('J', $seed)[1];
-      $expected['ajax'] = base_convert(hash('xxh128', $version['ajax'], FALSE, array('seed' => $seed)), 16, 36);
-      $expected['collapse'] = base_convert(hash('xxh128', $version['collapse'], FALSE, array('seed' => $seed)), 16, 36);
-    }
-    else {
-      $seed = substr($seed, 0, 8);
-      $expected['ajax'] = hash('crc32', $version['ajax'] . $seed);
-      $expected['collapse'] = hash('crc32', $version['collapse'] . $seed);
-    }
+    $expected['ajax'] = hash('crc32', $version['ajax'] . backdrop_get_hash_salt());
+    $expected['collapse'] = hash('crc32', $version['collapse'] . backdrop_get_hash_salt());
 
     backdrop_add_js('core/misc/collapse.js', array('version' => $version['collapse']));
     backdrop_add_js('core/misc/ajax.js', array('version' => $version['ajax']));

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1562,7 +1562,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     backdrop_add_js('core/misc/collapse.js', array('version' => $version['collapse']));
     backdrop_add_js('core/misc/ajax.js', array('version' => $version['ajax']));
     $javascript = backdrop_get_js();
-    $this->assertTrue(strpos($javascript, "core/misc/collapse.js?v={$expected['collapse']}") > 0 && strpos($javascript, "core/misc/ajax.js?v={$expected['ajax']}") > 0, t('JavaScript version identifiers correctly appended to URLs'));
+    $this->assertTrue(strpos($javascript, "core/misc/collapse.js?{$expected['collapse']}") > 0 && strpos($javascript, "core/misc/ajax.js?{$expected['ajax']}") > 0, t('JavaScript version identifiers correctly appended to URLs'));
   }
 
   /**

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1549,7 +1549,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   function testVersionQueryString() {
     $expected = array();
     $hash_algos = hash_algos();
-    $seed = str_pad(substr(backdrop_get_hash_salt(), 0, 138), 138, "\x04\x00\xa0\x00");
+    $seed = substr(backdrop_get_hash_salt(), 0, 8);
     $version = array(
       'ajax' => 'bar',
       'collapse' => 'foo',
@@ -1559,8 +1559,11 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     // backdrop_pre_render_scripts(). If the code in that function is changed,
     // the following code needs to be changed too.
     if (in_array('xxh128', $hash_algos, TRUE)) {
-      $expected['ajax'] = hash('xxh128', $version['ajax'], FALSE, array('segret' => $seed));
-      $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('secret' => $seed));
+      // Convert the seed to a positive integer.
+      $seed[0] = chr(ord($seed) & 0x7f);
+      $seed = unpack('J', $seed)[1];
+      $expected['ajax'] = hash('xxh128', $version['ajax'], FALSE, array('seed' => $seed));
+      $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('seed' => $seed));
     }
     else {
       $seed = substr($seed, 0, 8);

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1560,7 +1560,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     // the following code needs to be changed too.
     if (in_array('xxh128', $hash_algos, TRUE)) {
       // Convert the seed to a positive integer.
-      $seed[0] = chr(ord($seed) & 0x7f);
+      $seed[0] = chr(ord($seed[0]) & 0x7f);
       $seed = unpack('J', $seed)[1];
       $expected['ajax'] = hash('xxh128', $version['ajax'], FALSE, array('seed' => $seed));
       $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('seed' => $seed));

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1547,10 +1547,27 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
    * Test JavaScript versioning.
    */
   function testVersionQueryString() {
-    backdrop_add_js('core/misc/collapse.js', array('version' => 'foo'));
-    backdrop_add_js('core/misc/ajax.js', array('version' => 'bar'));
+    $expected = array();
+    $hash_algos = hash_algos();
+    $hash_salt = backdrop_get_hash_salt();
+    $version = array(
+      'ajax' => 'bar',
+      'collapse' => 'foo',
+    );
+    if (in_array('murmur3f', $hash_algos, TRUE)) {
+      $seed = hexdec(backdrop_substr($hash_salt, 0, 16));
+      $expected['ajax'] = hash('murmur3f', $version['ajax'], FALSE, array('seed' => $seed));
+      $expected['collapse'] = hash('murmur3f', $version['collapse'], FALSE, array('seed' => $seed));
+    }
+    else {
+      $seed = backdrop_substr($hash_salt, 0, 8);
+      $expected['ajax'] = hash('crc32', $version['ajax'] . $seed);
+      $expected['collapse'] = hash('crc32', $version['collapse'] . $seed);
+    }
+    backdrop_add_js('core/misc/collapse.js', array('version' => $version['collapse']));
+    backdrop_add_js('core/misc/ajax.js', array('version' => $version['ajax']));
     $javascript = backdrop_get_js();
-    $this->assertTrue(strpos($javascript, 'core/misc/collapse.js?v=foo') > 0 && strpos($javascript, 'core/misc/ajax.js?v=bar') > 0 , t('JavaScript version identifiers correctly appended to URLs'));
+    $this->assertTrue(strpos($javascript, "core/misc/collapse.js?v={$expected['collapse']}") > 0 && strpos($javascript, "core/misc/ajax.js?v={$expected['ajax']}") > 0, t('JavaScript version identifiers correctly appended to URLs'));
   }
 
   /**

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1549,7 +1549,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   function testVersionQueryString() {
     $expected = array();
     $hash_algos = hash_algos();
-    $seed = substr(backdrop_get_hash_salt(), 0, 138);
+    $seed = str_pad(substr(backdrop_get_hash_salt(), 0, 138), 138, "\x04\x00\xa0\x00");
     $version = array(
       'ajax' => 'bar',
       'collapse' => 'foo',

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1549,21 +1549,25 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
   function testVersionQueryString() {
     $expected = array();
     $hash_algos = hash_algos();
-    $hash_salt = backdrop_get_hash_salt();
+    $seed = substr(backdrop_get_hash_salt(), 0, 138);
     $version = array(
       'ajax' => 'bar',
       'collapse' => 'foo',
     );
-    if (in_array('murmur3f', $hash_algos, TRUE)) {
-      $seed = hexdec(backdrop_substr($hash_salt, 0, 16));
-      $expected['ajax'] = hash('murmur3f', $version['ajax'], FALSE, array('seed' => $seed));
-      $expected['collapse'] = hash('murmur3f', $version['collapse'], FALSE, array('seed' => $seed));
+
+    // The following code is the same code used by
+    // backdrop_pre_render_scripts(). If the code in that function is changed,
+    // the following code needs to be changed too.
+    if (in_array('xxh128', $hash_algos, TRUE)) {
+      $expected['ajax'] = hash('xxh128', $version['ajax'], FALSE, array('segret' => $seed));
+      $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('segret' => $seed));
     }
     else {
-      $seed = backdrop_substr($hash_salt, 0, 8);
+      $seed = substr($seed, 0, 8);
       $expected['ajax'] = hash('crc32', $version['ajax'] . $seed);
       $expected['collapse'] = hash('crc32', $version['collapse'] . $seed);
     }
+
     backdrop_add_js('core/misc/collapse.js', array('version' => $version['collapse']));
     backdrop_add_js('core/misc/ajax.js', array('version' => $version['ajax']));
     $javascript = backdrop_get_js();

--- a/core/modules/simpletest/tests/common.test
+++ b/core/modules/simpletest/tests/common.test
@@ -1560,7 +1560,7 @@ class CommonJavaScriptTestCase extends BackdropWebTestCase {
     // the following code needs to be changed too.
     if (in_array('xxh128', $hash_algos, TRUE)) {
       $expected['ajax'] = hash('xxh128', $version['ajax'], FALSE, array('segret' => $seed));
-      $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('segret' => $seed));
+      $expected['collapse'] = hash('xxh128', $version['collapse'], FALSE, array('secret' => $seed));
     }
     else {
       $seed = substr($seed, 0, 8);


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7179

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
