### PR TITLE
Fixed search results numbering across pages

### DIFF
--- a/core/modules/search/search.theme.inc
+++ b/core/modules/search/search.theme.inc
@@ -57,6 +57,14 @@ function template_preprocess_search_results(&$variables) {
     }
   }
 
+  // Calculate the starting number for the ordered list across pages. The
+  // pager stores the actual page size, so do not assume a fixed number of
+  // results per page here.
+  global $pager_page_array, $pager_limits;
+  $current_page = $pager_page_array[0] ?? 0;
+  $limit = $pager_limits[0] ?? 0;
+  $variables['ol_start'] = ($current_page * $limit) + 1;
+
   $pager_type = config_get('search.settings', 'search_pager_type');
   // @todo Move "views_mini_pager" out of Views namespace to just "mini_pager".
   if ($pager_type === 'mini') {

--- a/core/modules/search/search.theme.inc
+++ b/core/modules/search/search.theme.inc
@@ -22,7 +22,7 @@ function template_preprocess_search_results(&$variables) {
   }
   foreach ($variables['results'] as $result) {
     $info = array();
-    if (empty($result['attributes']))  {
+    if (empty($result['attributes'])) {
       $attributes = '';
     }
     else {

--- a/core/modules/search/search.theme.inc
+++ b/core/modules/search/search.theme.inc
@@ -77,4 +77,3 @@ function template_preprocess_search_results(&$variables) {
   $variables['pager'] = theme($pager_theme, array('tags' => NULL));
   $variables['theme_hook_suggestions'][] = 'search_results__' . $variables['module'];
 }
-

--- a/core/modules/search/templates/search-results.tpl.php
+++ b/core/modules/search/templates/search-results.tpl.php
@@ -25,10 +25,10 @@
  * @ingroup themeable
  */
 ?>
-<?php if (!empty($search_results)): ?>
-  <h2><?php print t('Search results');?></h2>
+<?php if (!empty($search_results)) : ?>
+  <h2><?php print t('Search results'); ?></h2>
   <ol class="search-results <?php print $module; ?>-results" start="<?php print $ol_start; ?>">
-    <?php foreach ($search_results as $result): ?>
+    <?php foreach ($search_results as $result) : ?>
       <li <?php print $result['attributes']; ?>>
         <?php print render($result['title_prefix']); ?>
         <h3 class="title">
@@ -36,10 +36,10 @@
         </h3>
         <?php print render($result['title_suffix']); ?>
         <div class="search-snippet-info">
-          <?php if ($result['snippet']): ?>
+          <?php if ($result['snippet']) : ?>
             <div class="search-snippet"><?php print $result['snippet']; ?></div>
           <?php endif; ?>
-          <?php if ($result['info']): ?>
+          <?php if ($result['info']) : ?>
             <p class="search-info"><?php print $result['info']; ?></p>
           <?php endif; ?>
         </div>
@@ -48,7 +48,7 @@
   </ol>
   <?php print $pager; ?>
 <?php else : ?>
-  <h2><?php print t('Your search yielded no results');?></h2>
+  <h2><?php print t('Your search yielded no results'); ?></h2>
   <ul>
     <li><?php print t('Check if your spelling is correct.'); ?></li>
     <li><?php print t('Remove quotes around phrases to search for each word individually. <em>bike shed</em> will often show more results than <em>&quot;bike shed&quot;</em>.'); ?></li>

--- a/core/modules/search/templates/search-results.tpl.php
+++ b/core/modules/search/templates/search-results.tpl.php
@@ -14,7 +14,8 @@
  * - $search_results: Array of data for each result
  * - $module: The machine-readable name of the module (tab) being searched, such
  *   as "node" or "user".
- *
+ * - $ol_start: The starting number for the ordered list, based on the current
+ *   pager page and the pager's configured number of items per page.
  *
  * @see template_preprocess_search_results()
  *
@@ -23,7 +24,7 @@
 ?>
 <?php if (!empty($search_results)): ?>
   <h2><?php print t('Search results');?></h2>
-  <ol class="search-results <?php print $module; ?>-results">
+  <ol class="search-results <?php print $module; ?>-results" start="<?php print $ol_start; ?>">
     <?php foreach ($search_results as $result): ?>
       <li <?php print $result['attributes']; ?>>
         <?php print render($result['title_prefix']); ?>

--- a/core/modules/search/templates/search-results.tpl.php
+++ b/core/modules/search/templates/search-results.tpl.php
@@ -18,7 +18,7 @@
  *   pager page and the pager's configured number of items per page so that
  *   numbering is sequential across pages.
  *
- * @since 1.34.4 Added ol_start attribute.
+ * @since 1.34.4 Added $ol_start attribute.
  *
  * @see template_preprocess_search_results()
  *

--- a/core/modules/search/templates/search-results.tpl.php
+++ b/core/modules/search/templates/search-results.tpl.php
@@ -15,7 +15,10 @@
  * - $module: The machine-readable name of the module (tab) being searched, such
  *   as "node" or "user".
  * - $ol_start: The starting number for the ordered list, based on the current
- *   pager page and the pager's configured number of items per page.
+ *   pager page and the pager's configured number of items per page so that
+ *   numbering is sequential across pages.
+ *
+ * @since 1.34.4 Added ol_start attribute.
  *
  * @see template_preprocess_search_results()
  *

--- a/core/modules/search/templates/search-results.tpl.php
+++ b/core/modules/search/templates/search-results.tpl.php
@@ -25,10 +25,10 @@
  * @ingroup themeable
  */
 ?>
-<?php if (!empty($search_results)) : ?>
+<?php if (!empty($search_results)): ?>
   <h2><?php print t('Search results'); ?></h2>
   <ol class="search-results <?php print $module; ?>-results" start="<?php print $ol_start; ?>">
-    <?php foreach ($search_results as $result) : ?>
+    <?php foreach ($search_results as $result): ?>
       <li <?php print $result['attributes']; ?>>
         <?php print render($result['title_prefix']); ?>
         <h3 class="title">
@@ -36,10 +36,10 @@
         </h3>
         <?php print render($result['title_suffix']); ?>
         <div class="search-snippet-info">
-          <?php if ($result['snippet']) : ?>
+          <?php if ($result['snippet']): ?>
             <div class="search-snippet"><?php print $result['snippet']; ?></div>
           <?php endif; ?>
-          <?php if ($result['info']) : ?>
+          <?php if ($result['info']): ?>
             <p class="search-info"><?php print $result['info']; ?></p>
           <?php endif; ?>
         </div>

--- a/core/modules/search/tests/search.test
+++ b/core/modules/search/tests/search.test
@@ -664,6 +664,25 @@ class SearchExactTestCase extends BackdropWebTestCase {
     $this->assertLinkByHref('page=3', 0, '4th page link is found for keyword search.');
     $this->assertNoLinkByHref('page=4', '5th page link is not found for keyword search.');
 
+    // Verify that result numbering continues on the next page without
+    // assuming a particular number of results per page.
+    $first_page_start = $this->xpath('//ol[contains(@class, "search-results")]/@start');
+    $this->assertEqual((string) $first_page_start[0], '1', 'Search results on the first page start at 1.');
+    $first_page_count = count($this->xpath('//ol[contains(@class, "search-results")]/li'));
+
+    $this->backdropGet('search/node', array(
+      'query' => array(
+        'keys' => 'love pizza',
+        'page' => 1,
+      ),
+    ));
+    $second_page_start = $this->xpath('//ol[contains(@class, "search-results")]/@start');
+    $this->assertEqual(
+      (string) $second_page_start[0],
+      (string) ($first_page_count + 1),
+      'Search result numbering continues on the second page.'
+    );
+
     // Test that the correct number of pager links are found for exact phrase search.
     $edit = array('keys' => '"love pizza"');
     $this->backdropPost('search/node', $edit, t('Search'));


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7160

This PR was created with AI assistance and has been reviewed and tested with phpcs changes added by me.

It introduces use of $ol_start attribute and relies on the fact that the Backdrop pager carries with it the limit of number of results per page, rather than using a fixed number of results per page. Automated tests have been added.