### PR TITLE
Fixed comment storage presave to only use client IP when hostname empty

### DIFF
--- a/core/modules/comment/comment.entity.inc
+++ b/core/modules/comment/comment.entity.inc
@@ -327,7 +327,14 @@ class CommentStorageController extends EntityDatabaseStorageController {
       }
       // Add the values which aren't passed into the function.
       $comment->thread = $thread;
-      $comment->hostname = ip_address();
+      // Only default to the current request's client IP when a hostname has
+      // not already been set on the comment object. This allows code that
+      // creates comments programmatically (for example, import or migration
+      // tools) to preserve an explicit hostname instead of having it
+      // silently overwritten.
+      if (empty($comment->hostname)) {
+        $comment->hostname = ip_address();
+      }
     }
   }
 

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2064,6 +2064,47 @@ class CommentActionsTestCase extends CommentHelperCase {
 }
 
 /**
+ * Tests that the comment hostname is set correctly on save.
+ */
+class CommentHostnameTestCase extends CommentHelperCase {
+  /**
+   * Tests that an explicitly set hostname is preserved on save.
+   */
+  function testCommentPresetHostnamePreserved() {
+    $preset_hostname = '192.168.1.100';
+    $comment = entity_create('comment', array(
+      'nid' => $this->node->nid,
+      'uid' => $this->web_user->uid,
+      'subject' => $this->randomName(),
+      'comment_body' => array(LANGUAGE_NONE => array(array('value' => $this->randomName()))),
+      'node_type' => 'comment_node_post',
+      'hostname' => $preset_hostname,
+    ));
+    comment_save($comment);
+
+    $saved_comment = comment_load($comment->cid);
+    $this->assertEqual($saved_comment->hostname, $preset_hostname, 'The hostname explicitly set on the comment before saving was preserved.');
+  }
+
+  /**
+   * Tests that the hostname still defaults to the request IP when unset.
+   */
+  function testCommentDefaultHostnameFromRequest() {
+    $comment = entity_create('comment', array(
+      'nid' => $this->node->nid,
+      'uid' => $this->web_user->uid,
+      'subject' => $this->randomName(),
+      'comment_body' => array(LANGUAGE_NONE => array(array('value' => $this->randomName()))),
+      'node_type' => 'comment_node_post',
+    ));
+    comment_save($comment);
+
+    $saved_comment = comment_load($comment->cid);
+    $this->assertEqual($saved_comment->hostname, ip_address(), 'The hostname defaulted to the current request IP when not explicitly set.');
+  }
+}
+
+/**
  * Tests fields on comments.
  */
 class CommentFieldsTest extends CommentHelperCase {

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2070,7 +2070,7 @@ class CommentHostnameTestCase extends CommentHelperCase {
   /**
    * Tests that an explicitly set hostname is preserved on save.
    */
-  function testCommentPresetHostnamePreserved() {
+  public function testCommentPresetHostnamePreserved() {
     $preset_hostname = '192.168.1.100';
     $comment = entity_create('comment', array(
       'nid' => $this->node->nid,
@@ -2089,7 +2089,7 @@ class CommentHostnameTestCase extends CommentHelperCase {
   /**
    * Tests that the hostname still defaults to the request IP when unset.
    */
-  function testCommentDefaultHostnameFromRequest() {
+  public function testCommentDefaultHostnameFromRequest() {
     $comment = entity_create('comment', array(
       'nid' => $this->node->nid,
       'uid' => $this->web_user->uid,

--- a/core/modules/comment/tests/comment.tests.info
+++ b/core/modules/comment/tests/comment.tests.info
@@ -64,6 +64,12 @@ description = Test actions provided by the comment module.
 group = Comment
 file = comment.test
 
+[CommentHostnameTestCase]
+name = Comment hostname
+description = Test that the comment hostname is set correctly on save.
+group = Comment
+file = comment.test
+
 [CommentFieldsTest]
 name = Comment fields
 description = Tests fields on comments.


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7151

The development of this PR has been "Assisted-by: LLM". It includes additional tests and has been reviewed and tested by me.