### PR TITLE
Remove three duplicate array keys in core

### DIFF
--- a/core/modules/file/file.theme.inc
+++ b/core/modules/file/file.theme.inc
@@ -85,9 +85,6 @@ function theme_file_link($variables) {
   }
 
   $options = array(
-    'attributes' => array(
-      'type' => $file->filemime . '; length=' . $file->filesize,
-    ),
     'attributes' => $attributes,
   );
 

--- a/core/modules/search/search.module
+++ b/core/modules/search/search.module
@@ -72,7 +72,6 @@ function search_theme() {
   return array(
     'search_results' => array(
       'variables' => array('results' => NULL, 'module' => NULL),
-      'file' => 'search.pages.inc',
       'template' => 'templates/search-results',
       'file' => 'search.theme.inc',
     ),

--- a/core/modules/taxonomy/views/taxonomy.views.inc
+++ b/core/modules/taxonomy/views/taxonomy.views.inc
@@ -174,7 +174,6 @@ function taxonomy_views_data() {
   );
 
   $data['taxonomy_term_data']['vocabulary_label'] = array(
-    'title' => t('Vocabulary'),
     'real field' => 'vocabulary',
     'title' => t('Vocabulary label'),
     'field' => array(


### PR DESCRIPTION
Fixes https://github.com/backdrop/backdrop-issues/issues/7192

Three array literals in core set the same key twice, and in each of them the earlier entry is the leftover, so removing it keeps behaviour exactly as it is.

`search_theme()` gives `search_results` a `file` of `search.pages.inc` and then again of `search.theme.inc`. The later one is the one that has to stand, since `template_preprocess_search_results()` lives in `search.theme.inc`.

`theme_file_link()` builds `$options` with a hardcoded `attributes` array holding only `type`, then with `$attributes`. The lines just above it put that same `type` into `$attributes`, which is why the hardcoded copy was there and why nothing is lost by dropping it.

The Views data for `vocabulary_label` sets `title` to `t('Vocabulary')` and then to `t('Vocabulary label')`. The block right above it is the one that owns the plain `Vocabulary` title, so this reads as a copied block with one line left unedited.

